### PR TITLE
chore: npm publish setup

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -1,0 +1,14 @@
+---
+"@paretools/shared": minor
+"@paretools/git": minor
+"@paretools/test": minor
+"@paretools/npm": minor
+"@paretools/docker": minor
+"@paretools/build": minor
+"@paretools/lint": minor
+"@paretools/python": minor
+"@paretools/cargo": minor
+"@paretools/go": minor
+---
+
+Initial release of all Pare MCP servers

--- a/packages/server-build/package.json
+++ b/packages/server-build/package.json
@@ -13,6 +13,14 @@
       "default": "./dist/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/pare.git",
+    "directory": "packages/server-build"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-cargo/package.json
+++ b/packages/server-cargo/package.json
@@ -13,6 +13,14 @@
       "default": "./dist/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/pare.git",
+    "directory": "packages/server-cargo"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-docker/package.json
+++ b/packages/server-docker/package.json
@@ -13,6 +13,14 @@
       "default": "./dist/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/pare.git",
+    "directory": "packages/server-docker"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-git/package.json
+++ b/packages/server-git/package.json
@@ -13,6 +13,14 @@
       "default": "./dist/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/pare.git",
+    "directory": "packages/server-git"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-go/package.json
+++ b/packages/server-go/package.json
@@ -13,6 +13,14 @@
       "default": "./dist/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/pare.git",
+    "directory": "packages/server-go"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-lint/package.json
+++ b/packages/server-lint/package.json
@@ -13,6 +13,14 @@
       "default": "./dist/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/pare.git",
+    "directory": "packages/server-lint"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-npm/package.json
+++ b/packages/server-npm/package.json
@@ -13,6 +13,14 @@
       "default": "./dist/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/pare.git",
+    "directory": "packages/server-npm"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-python/package.json
+++ b/packages/server-python/package.json
@@ -13,6 +13,14 @@
       "default": "./dist/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/pare.git",
+    "directory": "packages/server-python"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-test/package.json
+++ b/packages/server-test/package.json
@@ -13,6 +13,14 @@
       "default": "./dist/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/pare.git",
+    "directory": "packages/server-test"
+  },
   "files": [
     "dist"
   ],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,6 +10,14 @@
       "default": "./dist/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/pare.git",
+    "directory": "packages/shared"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary
- Add `publishConfig: { access: "public" }` to all 10 publishable packages
- Add `repository` metadata pointing to correct monorepo directory
- Create initial changeset for v0.1.0 release of all packages

## What happens on merge
The Release workflow will detect the changeset and create a "Version Packages" PR. Merging that PR triggers the actual npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)