### PR TITLE
fix: remove ignore list from changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@paretools/tsconfig", "@paretools/eslint-config"]
+  "ignore": []
 }


### PR DESCRIPTION
## Summary
- Remove `@paretools/tsconfig` and `@paretools/eslint-config` from changeset `ignore` list
- Private packages are automatically excluded from publishing — the explicit ignore was causing a validation error

Fixes Release workflow failure on the previous merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)