### PR TITLE
chore: Pare branding + package READMEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to pare
+# Contributing to Pare
 
-Thanks for your interest in contributing! pare is designed to make contributing easy — each server is a self-contained package that wraps a single dev tool.
+Thanks for your interest in contributing! Pare is designed to make contributing easy — each server is a self-contained package that wraps a single dev tool.
 
 ## Development Setup
 
@@ -120,7 +120,7 @@ Select your new package, choose `minor` version bump, and write a brief descript
 
 ## Key Principles
 
-1. **Always use `outputSchema` + `structuredContent`** — This is pare's core differentiator.
+1. **Always use `outputSchema` + `structuredContent`** — This is Pare's core differentiator.
 2. **Always include human-readable `content`** — Fallback for clients without structuredContent support.
 3. **Strip aggressively** — Only include data an agent would act on. No hints, no decorations.
 4. **Use `execFile`, not `exec`** — Prevents shell injection.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# pare
+# Pare
 
 **Dev tools, optimized for agents. ~85% fewer tokens, 100% structured output.**
 
-pare is a collection of [MCP](https://modelcontextprotocol.io) servers that wrap popular developer tools with structured, token-efficient, schema-validated output optimized for AI coding agents.
+Pare is a collection of [MCP](https://modelcontextprotocol.io) servers that wrap popular developer tools with structured, token-efficient, schema-validated output optimized for AI coding agents.
 
 ## The Problem
 
 AI coding agents spend most of their tokens reading tool output designed for humans — ANSI colors, progress bars, ASCII art, instructional hints. This is wasteful and expensive.
 
-| Tool Command                  | Raw Tokens | pare Tokens | Reduction |
+| Tool Command                  | Raw Tokens | Pare Tokens | Reduction |
 | ----------------------------- | ---------: | ----------: | --------: |
 | `pytest` (47 tests, all pass) |        186 |           8 |   **96%** |
 | `pytest` (47 tests, 1 fail)   |      1,008 |          46 |   **95%** |
@@ -19,12 +19,12 @@ AI coding agents spend most of their tokens reading tool output designed for hum
 
 ## How It Works
 
-Every pare tool returns dual output:
+Every Pare tool returns dual output:
 
 - **`content`** — Human-readable text (for MCP clients that display it)
 - **`structuredContent`** — Typed, schema-validated JSON (for agents)
 
-pare uses MCP's `structuredContent` + `outputSchema` spec features to deliver type-safe, validated structured output that agents can consume directly.
+Pare uses MCP's `structuredContent` + `outputSchema` spec features to deliver type-safe, validated structured output that agents can consume directly.
 
 ## Available Servers
 
@@ -83,7 +83,7 @@ Untracked files:
         temp.log
 ```
 
-**pare structured output (28 tokens):**
+**Pare structured output (28 tokens):**
 
 ```json
 {

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,4 @@ This policy covers all packages published under the `@paretools` npm scope.
 
 | Package                      | Supported |
 | ---------------------------- | --------- |
-| `@paretools/git` >= 0.1.0    | Yes       |
-| `@paretools/test` >= 0.1.0   | Yes       |
-| `@paretools/shared` >= 0.1.0 | Yes       |
+| `@paretools/*` >= 0.2.0 | Yes |

--- a/packages/server-build/README.md
+++ b/packages/server-build/README.md
@@ -1,0 +1,54 @@
+# @paretools/build
+
+Pare MCP server for **build tools**. Returns structured diagnostics from TypeScript and generic build commands.
+
+## Tools
+
+| Tool    | Description                                                  |
+| ------- | ------------------------------------------------------------ |
+| `tsc`   | TypeScript compiler diagnostics (file, line, column, code)   |
+| `build` | Generic build command with structured error/warning output   |
+
+## Setup
+
+```json
+{
+  "mcpServers": {
+    "pare-build": {
+      "command": "npx",
+      "args": ["@paretools/build"]
+    }
+  }
+}
+```
+
+## Example
+
+**`tsc` output:**
+
+```json
+{
+  "success": false,
+  "errors": [
+    {
+      "file": "src/index.ts",
+      "line": 42,
+      "column": 5,
+      "code": 2322,
+      "severity": "error",
+      "message": "Type 'string' is not assignable to type 'number'."
+    }
+  ],
+  "errorCount": 1,
+  "warningCount": 0
+}
+```
+
+## Links
+
+- [Pare monorepo](https://github.com/Dave-London/pare)
+- [MCP protocol](https://modelcontextprotocol.io)
+
+## License
+
+[MIT](https://github.com/Dave-London/pare/blob/main/LICENSE)

--- a/packages/server-cargo/README.md
+++ b/packages/server-cargo/README.md
@@ -1,0 +1,50 @@
+# @paretools/cargo
+
+Pare MCP server for **Rust/Cargo**. Returns structured output from cargo build, test, and clippy.
+
+## Tools
+
+| Tool     | Description                                                |
+| -------- | ---------------------------------------------------------- |
+| `build`  | Build diagnostics (file, line, code, severity, message)    |
+| `test`   | Test results (name, status, pass/fail counts)              |
+| `clippy` | Lint diagnostics from clippy                               |
+
+## Setup
+
+```json
+{
+  "mcpServers": {
+    "pare-cargo": {
+      "command": "npx",
+      "args": ["@paretools/cargo"]
+    }
+  }
+}
+```
+
+## Example
+
+**`test` output:**
+
+```json
+{
+  "passed": 24,
+  "failed": 1,
+  "ignored": 2,
+  "total": 27,
+  "tests": [
+    { "name": "test_parse_input", "status": "ok" },
+    { "name": "test_edge_case", "status": "FAILED" }
+  ]
+}
+```
+
+## Links
+
+- [Pare monorepo](https://github.com/Dave-London/pare)
+- [MCP protocol](https://modelcontextprotocol.io)
+
+## License
+
+[MIT](https://github.com/Dave-London/pare/blob/main/LICENSE)

--- a/packages/server-docker/README.md
+++ b/packages/server-docker/README.md
@@ -1,0 +1,53 @@
+# @paretools/docker
+
+Pare MCP server for **Docker**. Returns structured output from Docker commands.
+
+## Tools
+
+| Tool     | Description                                         |
+| -------- | --------------------------------------------------- |
+| `ps`     | List containers with status, ports, and state       |
+| `build`  | Build image, returns image ID, duration, and errors |
+| `logs`   | Retrieve container logs as structured line arrays   |
+| `images` | List images with repository, tag, and size info     |
+
+## Setup
+
+```json
+{
+  "mcpServers": {
+    "pare-docker": {
+      "command": "npx",
+      "args": ["@paretools/docker"]
+    }
+  }
+}
+```
+
+## Example
+
+**`ps` output:**
+
+```json
+{
+  "containers": [
+    {
+      "id": "abc123",
+      "name": "my-app",
+      "image": "node:22-alpine",
+      "state": "running",
+      "status": "Up 2 hours",
+      "ports": ["0.0.0.0:3000->3000/tcp"]
+    }
+  ]
+}
+```
+
+## Links
+
+- [Pare monorepo](https://github.com/Dave-London/pare)
+- [MCP protocol](https://modelcontextprotocol.io)
+
+## License
+
+[MIT](https://github.com/Dave-London/pare/blob/main/LICENSE)

--- a/packages/server-git/README.md
+++ b/packages/server-git/README.md
@@ -1,0 +1,55 @@
+# @paretools/git
+
+Pare MCP server for **git**. Returns structured, token-efficient output from git commands.
+
+## Tools
+
+| Tool       | Description                                          |
+| ---------- | ---------------------------------------------------- |
+| `status`   | Working tree status (branch, staged, modified, etc.) |
+| `log`      | Commit history                                       |
+| `diff`     | File-level diff stats, optional full patch content   |
+| `branch`   | List, create, or delete branches                     |
+| `show`     | Commit details and diff stats for a given ref        |
+
+## Setup
+
+Add to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "pare-git": {
+      "command": "npx",
+      "args": ["@paretools/git"]
+    }
+  }
+}
+```
+
+## Example
+
+**`status` output:**
+
+```json
+{
+  "branch": "main",
+  "upstream": "origin/main",
+  "ahead": 2,
+  "staged": [
+    { "file": "src/index.ts", "status": "modified" }
+  ],
+  "modified": ["README.md"],
+  "untracked": ["temp.log"],
+  "clean": false
+}
+```
+
+## Links
+
+- [Pare monorepo](https://github.com/Dave-London/pare)
+- [MCP protocol](https://modelcontextprotocol.io)
+
+## License
+
+[MIT](https://github.com/Dave-London/pare/blob/main/LICENSE)

--- a/packages/server-go/README.md
+++ b/packages/server-go/README.md
@@ -1,0 +1,54 @@
+# @paretools/go
+
+Pare MCP server for **Go**. Returns structured output from go build, test, and vet.
+
+## Tools
+
+| Tool    | Description                                            |
+| ------- | ------------------------------------------------------ |
+| `build` | Build errors (file, line, column, message)             |
+| `test`  | Test results (name, status, package, elapsed)          |
+| `vet`   | Static analysis diagnostics                            |
+
+## Setup
+
+```json
+{
+  "mcpServers": {
+    "pare-go": {
+      "command": "npx",
+      "args": ["@paretools/go"]
+    }
+  }
+}
+```
+
+## Example
+
+**`test` output:**
+
+```json
+{
+  "passed": 15,
+  "failed": 0,
+  "skipped": 1,
+  "total": 16,
+  "tests": [
+    {
+      "name": "TestParseConfig",
+      "package": "github.com/myapp/config",
+      "status": "pass",
+      "elapsed": 0.003
+    }
+  ]
+}
+```
+
+## Links
+
+- [Pare monorepo](https://github.com/Dave-London/pare)
+- [MCP protocol](https://modelcontextprotocol.io)
+
+## License
+
+[MIT](https://github.com/Dave-London/pare/blob/main/LICENSE)

--- a/packages/server-lint/README.md
+++ b/packages/server-lint/README.md
@@ -1,0 +1,57 @@
+# @paretools/lint
+
+Pare MCP server for **linters**. Returns structured output from ESLint and Prettier.
+
+## Tools
+
+| Tool           | Description                                              |
+| -------------- | -------------------------------------------------------- |
+| `lint`         | ESLint diagnostics (file, line, rule, severity, message) |
+| `format-check` | Prettier check — list of files needing formatting       |
+
+## Setup
+
+```json
+{
+  "mcpServers": {
+    "pare-lint": {
+      "command": "npx",
+      "args": ["@paretools/lint"]
+    }
+  }
+}
+```
+
+## Example
+
+**`lint` output:**
+
+```json
+{
+  "files": [
+    {
+      "file": "src/index.ts",
+      "messages": [
+        {
+          "line": 10,
+          "column": 3,
+          "severity": "error",
+          "rule": "no-unused-vars",
+          "message": "'foo' is defined but never used."
+        }
+      ]
+    }
+  ],
+  "errorCount": 1,
+  "warningCount": 0
+}
+```
+
+## Links
+
+- [Pare monorepo](https://github.com/Dave-London/pare)
+- [MCP protocol](https://modelcontextprotocol.io)
+
+## License
+
+[MIT](https://github.com/Dave-London/pare/blob/main/LICENSE)

--- a/packages/server-npm/README.md
+++ b/packages/server-npm/README.md
@@ -1,0 +1,56 @@
+# @paretools/npm
+
+Pare MCP server for **npm**. Returns structured output from npm commands.
+
+## Tools
+
+| Tool       | Description                                        |
+| ---------- | -------------------------------------------------- |
+| `install`  | Install packages, returns added/removed summary    |
+| `audit`    | Security audit, returns structured vulnerabilities |
+| `outdated` | Check for outdated packages                        |
+| `list`     | List installed packages as structured data         |
+
+## Setup
+
+```json
+{
+  "mcpServers": {
+    "pare-npm": {
+      "command": "npx",
+      "args": ["@paretools/npm"]
+    }
+  }
+}
+```
+
+## Example
+
+**`audit` output:**
+
+```json
+{
+  "vulnerabilities": [
+    {
+      "name": "lodash",
+      "severity": "high",
+      "title": "Prototype Pollution",
+      "fixAvailable": true
+    }
+  ],
+  "total": 1,
+  "critical": 0,
+  "high": 1,
+  "moderate": 0,
+  "low": 0
+}
+```
+
+## Links
+
+- [Pare monorepo](https://github.com/Dave-London/pare)
+- [MCP protocol](https://modelcontextprotocol.io)
+
+## License
+
+[MIT](https://github.com/Dave-London/pare/blob/main/LICENSE)

--- a/packages/server-python/README.md
+++ b/packages/server-python/README.md
@@ -1,0 +1,56 @@
+# @paretools/python
+
+Pare MCP server for **Python tools**. Returns structured output from pip, mypy, ruff, and pip-audit.
+
+## Tools
+
+| Tool          | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| `pip-install` | Install packages, returns summary of installed items   |
+| `mypy`        | Type-check diagnostics (file, line, severity, message) |
+| `ruff-check`  | Lint diagnostics (file, line, code, message)           |
+| `pip-audit`   | Vulnerability report for installed packages            |
+
+## Setup
+
+```json
+{
+  "mcpServers": {
+    "pare-python": {
+      "command": "npx",
+      "args": ["@paretools/python"]
+    }
+  }
+}
+```
+
+## Example
+
+**`mypy` output:**
+
+```json
+{
+  "success": false,
+  "errors": [
+    {
+      "file": "app/main.py",
+      "line": 15,
+      "severity": "error",
+      "message": "Argument 1 to \"process\" has incompatible type \"str\"; expected \"int\"",
+      "code": "arg-type"
+    }
+  ],
+  "errorCount": 1,
+  "warningCount": 0,
+  "noteCount": 0
+}
+```
+
+## Links
+
+- [Pare monorepo](https://github.com/Dave-London/pare)
+- [MCP protocol](https://modelcontextprotocol.io)
+
+## License
+
+[MIT](https://github.com/Dave-London/pare/blob/main/LICENSE)

--- a/packages/server-test/README.md
+++ b/packages/server-test/README.md
@@ -1,0 +1,53 @@
+# @paretools/test
+
+Pare MCP server for **test runners**. Auto-detects pytest, jest, or vitest and returns structured results.
+
+## Tools
+
+| Tool       | Description                                            |
+| ---------- | ------------------------------------------------------ |
+| `run`      | Run tests, returns pass/fail counts and failure details |
+| `coverage` | Run tests with coverage, returns per-file summary       |
+
+## Setup
+
+```json
+{
+  "mcpServers": {
+    "pare-test": {
+      "command": "npx",
+      "args": ["@paretools/test"]
+    }
+  }
+}
+```
+
+## Example
+
+**`run` output:**
+
+```json
+{
+  "framework": "vitest",
+  "passed": 46,
+  "failed": 1,
+  "skipped": 0,
+  "total": 47,
+  "failures": [
+    {
+      "name": "parseOutput > handles empty input",
+      "file": "src/__tests__/parsers.test.ts",
+      "message": "expected true to be false"
+    }
+  ]
+}
+```
+
+## Links
+
+- [Pare monorepo](https://github.com/Dave-London/pare)
+- [MCP protocol](https://modelcontextprotocol.io)
+
+## License
+
+[MIT](https://github.com/Dave-London/pare/blob/main/LICENSE)

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,25 @@
+# @paretools/shared
+
+Shared utilities for Pare MCP servers.
+
+## Exports
+
+- **`run(command, args, options)`** — Executes a CLI command via `execFile` (no shell injection) and returns `{ stdout, stderr, exitCode }`
+- **`dualOutput(data, formatter)`** — Returns both `structuredContent` (typed JSON) and `content` (human-readable text) for MCP tool responses
+- **`stripAnsi(text)`** — Removes ANSI escape codes from CLI output
+
+## Usage
+
+This package is used internally by all `@paretools/*` server packages. You generally don't need to install it directly unless you're building a custom Pare server.
+
+```typescript
+import { run, dualOutput, stripAnsi } from "@paretools/shared";
+```
+
+## Links
+
+- [Pare monorepo](https://github.com/Dave-London/pare)
+
+## License
+
+[MIT](https://github.com/Dave-London/pare/blob/main/LICENSE)

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@paretools/shared",
   "version": "0.2.0",
-  "description": "Shared utilities for pare MCP servers",
+  "description": "Shared utilities for Pare MCP servers",
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Rename "pare" to "Pare" across README, CONTRIBUTING, SECURITY docs
- Add README.md to all 10 publishable packages for npm registry pages
- Update SECURITY.md supported versions to `@paretools/* >= 0.2.0`
- Update GitHub repo description

## Test plan
- [x] All 141 tests pass
- [x] `npx @paretools/git` downloads and starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)