### PR TITLE
fix: error handling for missing CLI tools + real benchmark data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pare
 
-**Dev tools, optimized for agents. ~85% fewer tokens, 100% structured output.**
+**Dev tools, optimized for agents. Up to 92% fewer tokens, 100% structured output.**
 
 Pare is a collection of [MCP](https://modelcontextprotocol.io) servers that wrap popular developer tools with structured, token-efficient, schema-validated output optimized for AI coding agents.
 
@@ -8,14 +8,14 @@ Pare is a collection of [MCP](https://modelcontextprotocol.io) servers that wrap
 
 AI coding agents spend most of their tokens reading tool output designed for humans — ANSI colors, progress bars, ASCII art, instructional hints. This is wasteful and expensive.
 
-| Tool Command                  | Raw Tokens | Pare Tokens | Reduction |
-| ----------------------------- | ---------: | ----------: | --------: |
-| `pytest` (47 tests, all pass) |        186 |           8 |   **96%** |
-| `pytest` (47 tests, 1 fail)   |      1,008 |          46 |   **95%** |
-| `npm install` (large project) |        526 |          55 |   **90%** |
-| `git log` (3 commits)         |        501 |          71 |   **86%** |
-| `git status` (dirty)          |        118 |          28 |   **76%** |
-| **Weighted average**          |          — |           — |  **~85%** |
+| Tool Command                             | Raw Tokens | Pare Tokens | Reduction |
+| ---------------------------------------- | ---------: | ----------: | --------: |
+| `git log --stat` (5 commits, verbose)    |      4,992 |         382 |   **92%** |
+| `vitest run` (28 tests, all pass)        |        196 |          39 |   **80%** |
+| `git status` (working tree)              |         62 |          51 |   **18%** |
+| `git log --oneline` (5 commits, compact) |         59 |         382 |     -547% |
+
+> Token counts measured with `~4 chars/token` approximation. Savings are highest on verbose, human-formatted output (test runners, build logs, detailed git history). Compact output like `--oneline` is already token-efficient — structured JSON adds overhead there.
 
 ## How It Works
 
@@ -61,7 +61,7 @@ Add to your MCP client config (e.g., Claude Code `~/.claude.json`):
 
 ## Example: `git status`
 
-**Raw git output (118 tokens):**
+**Raw git output (~118 tokens):**
 
 ```
 On branch main
@@ -83,7 +83,7 @@ Untracked files:
         temp.log
 ```
 
-**Pare structured output (28 tokens):**
+**Pare structured output (~59 tokens):**
 
 ```json
 {
@@ -102,7 +102,7 @@ Untracked files:
 }
 ```
 
-76% fewer tokens. Zero information lost. Fully typed.
+50% fewer tokens. Zero information lost. Fully typed. Savings scale with output verbosity — test runners and build logs see 80–92% reduction.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,6 @@ This policy covers all packages published under the `@paretools` npm scope.
 
 ## Supported Versions
 
-| Package                      | Supported |
-| ---------------------------- | --------- |
-| `@paretools/*` >= 0.2.0 | Yes |
+| Package                 | Supported |
+| ----------------------- | --------- |
+| `@paretools/*` >= 0.2.0 | Yes       |

--- a/packages/server-build/README.md
+++ b/packages/server-build/README.md
@@ -4,10 +4,10 @@ Pare MCP server for **build tools**. Returns structured diagnostics from TypeScr
 
 ## Tools
 
-| Tool    | Description                                                  |
-| ------- | ------------------------------------------------------------ |
-| `tsc`   | TypeScript compiler diagnostics (file, line, column, code)   |
-| `build` | Generic build command with structured error/warning output   |
+| Tool    | Description                                                |
+| ------- | ---------------------------------------------------------- |
+| `tsc`   | TypeScript compiler diagnostics (file, line, column, code) |
+| `build` | Generic build command with structured error/warning output |
 
 ## Setup
 

--- a/packages/server-cargo/README.md
+++ b/packages/server-cargo/README.md
@@ -4,11 +4,11 @@ Pare MCP server for **Rust/Cargo**. Returns structured output from cargo build, 
 
 ## Tools
 
-| Tool     | Description                                                |
-| -------- | ---------------------------------------------------------- |
-| `build`  | Build diagnostics (file, line, code, severity, message)    |
-| `test`   | Test results (name, status, pass/fail counts)              |
-| `clippy` | Lint diagnostics from clippy                               |
+| Tool     | Description                                             |
+| -------- | ------------------------------------------------------- |
+| `build`  | Build diagnostics (file, line, code, severity, message) |
+| `test`   | Test results (name, status, pass/fail counts)           |
+| `clippy` | Lint diagnostics from clippy                            |
 
 ## Setup
 

--- a/packages/server-git/README.md
+++ b/packages/server-git/README.md
@@ -4,13 +4,13 @@ Pare MCP server for **git**. Returns structured, token-efficient output from git
 
 ## Tools
 
-| Tool       | Description                                          |
-| ---------- | ---------------------------------------------------- |
-| `status`   | Working tree status (branch, staged, modified, etc.) |
-| `log`      | Commit history                                       |
-| `diff`     | File-level diff stats, optional full patch content   |
-| `branch`   | List, create, or delete branches                     |
-| `show`     | Commit details and diff stats for a given ref        |
+| Tool     | Description                                          |
+| -------- | ---------------------------------------------------- |
+| `status` | Working tree status (branch, staged, modified, etc.) |
+| `log`    | Commit history                                       |
+| `diff`   | File-level diff stats, optional full patch content   |
+| `branch` | List, create, or delete branches                     |
+| `show`   | Commit details and diff stats for a given ref        |
 
 ## Setup
 
@@ -36,9 +36,7 @@ Add to your MCP client config:
   "branch": "main",
   "upstream": "origin/main",
   "ahead": 2,
-  "staged": [
-    { "file": "src/index.ts", "status": "modified" }
-  ],
+  "staged": [{ "file": "src/index.ts", "status": "modified" }],
   "modified": ["README.md"],
   "untracked": ["temp.log"],
   "clean": false

--- a/packages/server-go/README.md
+++ b/packages/server-go/README.md
@@ -4,11 +4,11 @@ Pare MCP server for **Go**. Returns structured output from go build, test, and v
 
 ## Tools
 
-| Tool    | Description                                            |
-| ------- | ------------------------------------------------------ |
-| `build` | Build errors (file, line, column, message)             |
-| `test`  | Test results (name, status, package, elapsed)          |
-| `vet`   | Static analysis diagnostics                            |
+| Tool    | Description                                   |
+| ------- | --------------------------------------------- |
+| `build` | Build errors (file, line, column, message)    |
+| `test`  | Test results (name, status, package, elapsed) |
+| `vet`   | Static analysis diagnostics                   |
 
 ## Setup
 

--- a/packages/server-lint/README.md
+++ b/packages/server-lint/README.md
@@ -7,7 +7,7 @@ Pare MCP server for **linters**. Returns structured output from ESLint and Prett
 | Tool           | Description                                              |
 | -------------- | -------------------------------------------------------- |
 | `lint`         | ESLint diagnostics (file, line, rule, severity, message) |
-| `format-check` | Prettier check — list of files needing formatting       |
+| `format-check` | Prettier check — list of files needing formatting        |
 
 ## Setup
 

--- a/packages/server-test/README.md
+++ b/packages/server-test/README.md
@@ -4,8 +4,8 @@ Pare MCP server for **test runners**. Auto-detects pytest, jest, or vitest and r
 
 ## Tools
 
-| Tool       | Description                                            |
-| ---------- | ------------------------------------------------------ |
+| Tool       | Description                                             |
+| ---------- | ------------------------------------------------------- |
 | `run`      | Run tests, returns pass/fail counts and failure details |
 | `coverage` | Run tests with coverage, returns per-file summary       |
 

--- a/packages/shared/__tests__/runner.test.ts
+++ b/packages/shared/__tests__/runner.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { run } from "../src/runner.js";
+
+describe("run", () => {
+  it("returns stdout and stderr with exit code 0 on success", async () => {
+    const result = await run("node", ["-e", "console.log('hello')"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("hello");
+  });
+
+  it("returns non-zero exit code for failing commands", async () => {
+    const result = await run("node", ["-e", "process.exit(42)"]);
+    expect(result.exitCode).toBe(42);
+  });
+
+  it("strips ANSI codes from output", async () => {
+    const result = await run("node", ["-e", "console.log('\\x1b[31mred\\x1b[0m')"]);
+    expect(result.stdout.trim()).toBe("red");
+  });
+
+  it("throws on command not found (ENOENT)", async () => {
+    await expect(run("__nonexistent_command_that_does_not_exist__", ["arg"])).rejects.toThrow(
+      /[Cc]ommand not found|is not recognized/,
+    );
+  });
+
+  it("respects cwd option", async () => {
+    const result = await run("node", ["-e", "console.log(process.cwd())"], {
+      cwd: process.env.TEMP || "/tmp",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBeTruthy();
+  });
+});

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -219,7 +219,7 @@ async function benchmarkTest(): Promise<BenchmarkResult[]> {
 
 function printTable(results: BenchmarkResult[]) {
   console.log("\n## Token Benchmark Results\n");
-  console.log("| Command | Description | Raw Tokens | pare Tokens | Reduction |");
+  console.log("| Command | Description | Raw Tokens | Pare Tokens | Reduction |");
   console.log("|---|---|---:|---:|---:|");
 
   let totalRaw = 0;
@@ -247,7 +247,7 @@ function printDetails(results: BenchmarkResult[]) {
     console.log(r.rawOutput.slice(0, 2000));
     if (r.rawOutput.length > 2000) console.log("... (truncated)");
     console.log("```\n");
-    console.log(`**pare output (${r.pareTokens} tokens, ${r.pareOutput.length} chars):**`);
+    console.log(`**Pare output (${r.pareTokens} tokens, ${r.pareOutput.length} chars):**`);
     console.log("```json");
     console.log(r.pareOutput.slice(0, 2000));
     console.log("```\n");
@@ -255,7 +255,7 @@ function printDetails(results: BenchmarkResult[]) {
 }
 
 async function main() {
-  console.log("# pare Token Benchmark\n");
+  console.log("# Pare Token Benchmark\n");
   console.log(`Date: ${new Date().toISOString().split("T")[0]}`);
   console.log(`Platform: ${process.platform}`);
   console.log(`Node: ${process.version}\n`);


### PR DESCRIPTION
## Summary
- **Error handling**: Shared runner now throws clear `Command not found: "cargo"` errors when a CLI tool isn't installed, instead of returning `exitCode: NaN` or a cryptic parse failure
  - Handles `ENOENT` on Unix (direct execFile error)
  - Handles `"is not recognized"` on Windows (cmd.exe masks ENOENT behind shell: true)
  - Also catches `EACCES`/`EPERM` permission errors
  - Fixed type casting bug — `error.code` was unsafely cast as `number` even when it's a string like `'ENOENT'`
- **README benchmarks**: Replaced theoretical token estimates with real measured data from the benchmark script
  - Tagline updated: "~85% fewer tokens" → "Up to 92% fewer tokens"
  - Table shows honest results including cases where structured JSON is larger (-547% for `git log --oneline`)
  - Example section token counts corrected
- **Formatting**: Fixed prettier issues across 7 package READMEs and SECURITY.md

## Test plan
- [x] 146 tests pass (15 shared + 131 servers), including 5 new runner tests
- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes (only pre-existing warnings)

Closes #3 (error handling for missing tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)