### PR TITLE
fix(git): replace \x1f delimiter with printable @@ for Windows

### DIFF
--- a/packages/server-git/__tests__/fidelity.test.ts
+++ b/packages/server-git/__tests__/fidelity.test.ts
@@ -100,7 +100,7 @@ describe("fidelity: git status", () => {
 
 describe("fidelity: git log", () => {
   it("preserves every commit hash from raw log", () => {
-    const DELIMITER = "\x1f";
+    const DELIMITER = "@@";
     const FORMAT = `%H${DELIMITER}%h${DELIMITER}%an${DELIMITER}%ae${DELIMITER}%ar${DELIMITER}%D${DELIMITER}%s`;
     const rawFormatted = gitRaw(["log", `--format=${FORMAT}`, "--max-count=5"]);
 
@@ -126,7 +126,7 @@ describe("fidelity: git log", () => {
   });
 
   it("preserves commit messages", () => {
-    const DELIMITER = "\x1f";
+    const DELIMITER = "@@";
     const FORMAT = `%H${DELIMITER}%h${DELIMITER}%an${DELIMITER}%ae${DELIMITER}%ar${DELIMITER}%D${DELIMITER}%s`;
     const rawFormatted = gitRaw(["log", `--format=${FORMAT}`, "--max-count=5"]);
 
@@ -144,7 +144,7 @@ describe("fidelity: git log", () => {
   });
 
   it("preserves author name and email", () => {
-    const DELIMITER = "\x1f";
+    const DELIMITER = "@@";
     const FORMAT = `%H${DELIMITER}%h${DELIMITER}%an${DELIMITER}%ae${DELIMITER}%ar${DELIMITER}%D${DELIMITER}%s`;
     const rawFormatted = gitRaw(["log", `--format=${FORMAT}`, "--max-count=3"]);
 
@@ -277,7 +277,7 @@ describe("fidelity: git branch", () => {
 
 describe("fidelity: git show", () => {
   it("preserves commit metadata from raw show", () => {
-    const DELIMITER = "\x1f";
+    const DELIMITER = "@@";
     const FORMAT = `%H${DELIMITER}%an${DELIMITER}%ae${DELIMITER}%ar${DELIMITER}%B`;
 
     const rawFormatted = gitRaw(["show", "--no-patch", `--format=${FORMAT}`, "HEAD"]);
@@ -296,7 +296,7 @@ describe("fidelity: git show", () => {
   });
 
   it("preserves file list from show diff", () => {
-    const DELIMITER = "\x1f";
+    const DELIMITER = "@@";
     const FORMAT = `%H${DELIMITER}%an${DELIMITER}%ae${DELIMITER}%ar${DELIMITER}%B`;
 
     const rawFormatted = gitRaw(["show", "--no-patch", `--format=${FORMAT}`, "HEAD"]);
@@ -366,7 +366,7 @@ describe("fidelity: edge cases", () => {
   });
 
   it("parseLog handles commit message with special characters", () => {
-    const DELIMITER = "\x1f";
+    const DELIMITER = "@@";
     const line = `abc123${DELIMITER}abc${DELIMITER}Author${DELIMITER}a@b.com${DELIMITER}1 day ago${DELIMITER}HEAD -> main${DELIMITER}fix: handle "quotes" & <brackets>`;
     const log = parseLog(line);
     expect(log.commits[0].message).toBe('fix: handle "quotes" & <brackets>');

--- a/packages/server-git/__tests__/parsers.test.ts
+++ b/packages/server-git/__tests__/parsers.test.ts
@@ -84,7 +84,7 @@ describe("parseStatus", () => {
 
 describe("parseLog", () => {
   it("parses formatted log output", () => {
-    const DELIM = "\x1f";
+    const DELIM = "@@";
     const stdout = [
       `abc1234567890${DELIM}abc1234${DELIM}Jane Doe${DELIM}jane@example.com${DELIM}2 hours ago${DELIM}HEAD -> main${DELIM}Fix the bug`,
       `def5678901234${DELIM}def5678${DELIM}John Smith${DELIM}john@example.com${DELIM}1 day ago${DELIM}${DELIM}Add feature X`,
@@ -169,7 +169,7 @@ describe("parseBranch", () => {
 
 describe("parseShow", () => {
   it("parses commit info and diff stats", () => {
-    const DELIM = "\x1f";
+    const DELIM = "@@";
     const commitInfo = `abc123${DELIM}Jane Doe${DELIM}jane@example.com${DELIM}2 hours ago${DELIM}Fix critical bug in parser`;
     const diffStat = "5\t2\tsrc/parser.ts\n1\t1\ttests/parser.test.ts";
 

--- a/packages/server-git/src/lib/parsers.ts
+++ b/packages/server-git/src/lib/parsers.ts
@@ -98,7 +98,7 @@ function parseBranchFromPorcelain(line: string): {
 
 export function parseLog(stdout: string): GitLog {
   // Format: hash|hashShort|author|email|date|refs|message
-  const DELIMITER = "\x1f";
+  const DELIMITER = "@@";
   const lines = stdout.trim().split("\n").filter(Boolean);
   const commits = lines.map((line) => {
     const [hash, hashShort, author, email, date, refs, ...messageParts] = line.split(DELIMITER);
@@ -170,7 +170,7 @@ export function parseBranch(stdout: string): GitBranch {
 
 export function parseShow(stdout: string, diffStdout: string): GitShow {
   // stdout is the formatted commit info, diffStdout is the numstat
-  const DELIMITER = "\x1f";
+  const DELIMITER = "@@";
   const parts = stdout.trim().split(DELIMITER);
   const [hash, author, email, date, ...messageParts] = parts;
   const diff = parseDiffStat(diffStdout);

--- a/packages/server-git/src/tools/log.ts
+++ b/packages/server-git/src/tools/log.ts
@@ -7,7 +7,7 @@ import { parseLog } from "../lib/parsers.js";
 import { formatLog } from "../lib/formatters.js";
 import { GitLogSchema } from "../schemas/index.js";
 
-const DELIMITER = "\x1f";
+const DELIMITER = "@@";
 const LOG_FORMAT = `%H${DELIMITER}%h${DELIMITER}%an${DELIMITER}%ae${DELIMITER}%ar${DELIMITER}%D${DELIMITER}%s`;
 
 export function registerLogTool(server: McpServer) {

--- a/packages/server-git/src/tools/show.ts
+++ b/packages/server-git/src/tools/show.ts
@@ -7,7 +7,7 @@ import { parseShow } from "../lib/parsers.js";
 import { formatShow } from "../lib/formatters.js";
 import { GitShowSchema } from "../schemas/index.js";
 
-const DELIMITER = "\x1f";
+const DELIMITER = "@@";
 const SHOW_FORMAT = `%H${DELIMITER}%an${DELIMITER}%ae${DELIMITER}%ar${DELIMITER}%B`;
 
 export function registerShowTool(server: McpServer) {


### PR DESCRIPTION
## Summary
- Replaces `\x1f` (Unit Separator) delimiter in git `--format` strings with printable `@@` delimiter
- Fixes `log` and `show` tools failing on Windows due to null byte corruption in `execFile` args
- Updates parsers and all related tests to use the new delimiter

## Root Cause
On Windows with `shell: true`, the `\x1f` character in `execFile` args gets corrupted to `\x00` (null byte), which Node.js rejects.

## Test plan
- [x] All 49 git package tests pass
- [x] Build succeeds
- [ ] Manual test: `mcp__pare-git__log` on Windows
- [ ] Manual test: `mcp__pare-git__show` on Windows

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)