### PR TITLE
docs: add root CHANGELOG.md with aggregation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,452 @@
+# Changelog
+
+This is a monorepo with independent package versioning managed by [changesets](https://github.com/changesets/changesets).
+
+Each package maintains its own changelog:
+
+| Package                                                                | Changelog                                                                  |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| [`@paretools/build`](https://www.npmjs.com/package/@paretools/build)   | [packages/server-build/CHANGELOG.md](packages/server-build/CHANGELOG.md)   |
+| [`@paretools/cargo`](https://www.npmjs.com/package/@paretools/cargo)   | [packages/server-cargo/CHANGELOG.md](packages/server-cargo/CHANGELOG.md)   |
+| [`@paretools/docker`](https://www.npmjs.com/package/@paretools/docker) | [packages/server-docker/CHANGELOG.md](packages/server-docker/CHANGELOG.md) |
+| [`@paretools/git`](https://www.npmjs.com/package/@paretools/git)       | [packages/server-git/CHANGELOG.md](packages/server-git/CHANGELOG.md)       |
+| [`@paretools/go`](https://www.npmjs.com/package/@paretools/go)         | [packages/server-go/CHANGELOG.md](packages/server-go/CHANGELOG.md)         |
+| [`@paretools/lint`](https://www.npmjs.com/package/@paretools/lint)     | [packages/server-lint/CHANGELOG.md](packages/server-lint/CHANGELOG.md)     |
+| [`@paretools/npm`](https://www.npmjs.com/package/@paretools/npm)       | [packages/server-npm/CHANGELOG.md](packages/server-npm/CHANGELOG.md)       |
+| [`@paretools/python`](https://www.npmjs.com/package/@paretools/python) | [packages/server-python/CHANGELOG.md](packages/server-python/CHANGELOG.md) |
+| [`@paretools/test`](https://www.npmjs.com/package/@paretools/test)     | [packages/server-test/CHANGELOG.md](packages/server-test/CHANGELOG.md)     |
+| [`@paretools/shared`](https://www.npmjs.com/package/@paretools/shared) | [packages/shared/CHANGELOG.md](packages/shared/CHANGELOG.md)               |
+
+## Aggregated changelog
+
+Run `pnpm changelog` to regenerate the sections below from per-package changelogs.
+
+<!-- BEGIN AGGREGATED CHANGELOG -->
+
+### 0.3.0
+
+#### @paretools/build
+
+### Minor Changes
+
+- [#31](https://github.com/Dave-London/pare/pull/31) [`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547) Thanks [@Dave-London](https://github.com/Dave-London)! - Security, discoverability, and test coverage improvements.
+
+  ### Security
+  - Fix git argument injection: block ref/branch params starting with `-`
+  - Fix build command injection: allowlist of 24 known build tools
+  - New `assertNoFlagInjection` and `assertAllowedCommand` validation utilities
+
+  ### Features
+  - Add MCP `instructions` field to all 9 servers for better client guidance
+  - Optimize tool descriptions with "Use instead of" phrasing for agent discoverability
+  - Increase default timeouts for build/install operations (5 min for docker, npm, cargo, go)
+
+  ### Testing
+  - Expand test suite from 146 to 305 tests
+  - Add fidelity tests proving no information loss in git and vitest parsers
+  - Add formatter, integration, and validation tests across all packages
+
+  ### Infrastructure
+  - Add `mcpName` field for Official MCP Registry compatibility
+  - Add Smithery registry configs for all 9 servers
+  - Add Dependabot, CODEOWNERS, FUNDING.yml, feature-request template
+  - Expand README with per-client configs, agent snippets, and troubleshooting
+
+### Patch Changes
+
+- Updated dependencies [[`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547)]:
+  - @paretools/shared@0.3.0
+
+#### @paretools/cargo
+
+### Minor Changes
+
+- [#31](https://github.com/Dave-London/pare/pull/31) [`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547) Thanks [@Dave-London](https://github.com/Dave-London)! - Security, discoverability, and test coverage improvements.
+
+  ### Security
+  - Fix git argument injection: block ref/branch params starting with `-`
+  - Fix build command injection: allowlist of 24 known build tools
+  - New `assertNoFlagInjection` and `assertAllowedCommand` validation utilities
+
+  ### Features
+  - Add MCP `instructions` field to all 9 servers for better client guidance
+  - Optimize tool descriptions with "Use instead of" phrasing for agent discoverability
+  - Increase default timeouts for build/install operations (5 min for docker, npm, cargo, go)
+
+  ### Testing
+  - Expand test suite from 146 to 305 tests
+  - Add fidelity tests proving no information loss in git and vitest parsers
+  - Add formatter, integration, and validation tests across all packages
+
+  ### Infrastructure
+  - Add `mcpName` field for Official MCP Registry compatibility
+  - Add Smithery registry configs for all 9 servers
+  - Add Dependabot, CODEOWNERS, FUNDING.yml, feature-request template
+  - Expand README with per-client configs, agent snippets, and troubleshooting
+
+### Patch Changes
+
+- Updated dependencies [[`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547)]:
+  - @paretools/shared@0.3.0
+
+#### @paretools/docker
+
+### Minor Changes
+
+- [#31](https://github.com/Dave-London/pare/pull/31) [`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547) Thanks [@Dave-London](https://github.com/Dave-London)! - Security, discoverability, and test coverage improvements.
+
+  ### Security
+  - Fix git argument injection: block ref/branch params starting with `-`
+  - Fix build command injection: allowlist of 24 known build tools
+  - New `assertNoFlagInjection` and `assertAllowedCommand` validation utilities
+
+  ### Features
+  - Add MCP `instructions` field to all 9 servers for better client guidance
+  - Optimize tool descriptions with "Use instead of" phrasing for agent discoverability
+  - Increase default timeouts for build/install operations (5 min for docker, npm, cargo, go)
+
+  ### Testing
+  - Expand test suite from 146 to 305 tests
+  - Add fidelity tests proving no information loss in git and vitest parsers
+  - Add formatter, integration, and validation tests across all packages
+
+  ### Infrastructure
+  - Add `mcpName` field for Official MCP Registry compatibility
+  - Add Smithery registry configs for all 9 servers
+  - Add Dependabot, CODEOWNERS, FUNDING.yml, feature-request template
+  - Expand README with per-client configs, agent snippets, and troubleshooting
+
+### Patch Changes
+
+- Updated dependencies [[`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547)]:
+  - @paretools/shared@0.3.0
+
+#### @paretools/git
+
+### Minor Changes
+
+- [#31](https://github.com/Dave-London/pare/pull/31) [`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547) Thanks [@Dave-London](https://github.com/Dave-London)! - Security, discoverability, and test coverage improvements.
+
+  ### Security
+  - Fix git argument injection: block ref/branch params starting with `-`
+  - Fix build command injection: allowlist of 24 known build tools
+  - New `assertNoFlagInjection` and `assertAllowedCommand` validation utilities
+
+  ### Features
+  - Add MCP `instructions` field to all 9 servers for better client guidance
+  - Optimize tool descriptions with "Use instead of" phrasing for agent discoverability
+  - Increase default timeouts for build/install operations (5 min for docker, npm, cargo, go)
+
+  ### Testing
+  - Expand test suite from 146 to 305 tests
+  - Add fidelity tests proving no information loss in git and vitest parsers
+  - Add formatter, integration, and validation tests across all packages
+
+  ### Infrastructure
+  - Add `mcpName` field for Official MCP Registry compatibility
+  - Add Smithery registry configs for all 9 servers
+  - Add Dependabot, CODEOWNERS, FUNDING.yml, feature-request template
+  - Expand README with per-client configs, agent snippets, and troubleshooting
+
+### Patch Changes
+
+- Updated dependencies [[`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547)]:
+  - @paretools/shared@0.3.0
+
+#### @paretools/go
+
+### Minor Changes
+
+- [#31](https://github.com/Dave-London/pare/pull/31) [`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547) Thanks [@Dave-London](https://github.com/Dave-London)! - Security, discoverability, and test coverage improvements.
+
+  ### Security
+  - Fix git argument injection: block ref/branch params starting with `-`
+  - Fix build command injection: allowlist of 24 known build tools
+  - New `assertNoFlagInjection` and `assertAllowedCommand` validation utilities
+
+  ### Features
+  - Add MCP `instructions` field to all 9 servers for better client guidance
+  - Optimize tool descriptions with "Use instead of" phrasing for agent discoverability
+  - Increase default timeouts for build/install operations (5 min for docker, npm, cargo, go)
+
+  ### Testing
+  - Expand test suite from 146 to 305 tests
+  - Add fidelity tests proving no information loss in git and vitest parsers
+  - Add formatter, integration, and validation tests across all packages
+
+  ### Infrastructure
+  - Add `mcpName` field for Official MCP Registry compatibility
+  - Add Smithery registry configs for all 9 servers
+  - Add Dependabot, CODEOWNERS, FUNDING.yml, feature-request template
+  - Expand README with per-client configs, agent snippets, and troubleshooting
+
+### Patch Changes
+
+- Updated dependencies [[`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547)]:
+  - @paretools/shared@0.3.0
+
+#### @paretools/lint
+
+### Minor Changes
+
+- [#31](https://github.com/Dave-London/pare/pull/31) [`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547) Thanks [@Dave-London](https://github.com/Dave-London)! - Security, discoverability, and test coverage improvements.
+
+  ### Security
+  - Fix git argument injection: block ref/branch params starting with `-`
+  - Fix build command injection: allowlist of 24 known build tools
+  - New `assertNoFlagInjection` and `assertAllowedCommand` validation utilities
+
+  ### Features
+  - Add MCP `instructions` field to all 9 servers for better client guidance
+  - Optimize tool descriptions with "Use instead of" phrasing for agent discoverability
+  - Increase default timeouts for build/install operations (5 min for docker, npm, cargo, go)
+
+  ### Testing
+  - Expand test suite from 146 to 305 tests
+  - Add fidelity tests proving no information loss in git and vitest parsers
+  - Add formatter, integration, and validation tests across all packages
+
+  ### Infrastructure
+  - Add `mcpName` field for Official MCP Registry compatibility
+  - Add Smithery registry configs for all 9 servers
+  - Add Dependabot, CODEOWNERS, FUNDING.yml, feature-request template
+  - Expand README with per-client configs, agent snippets, and troubleshooting
+
+### Patch Changes
+
+- Updated dependencies [[`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547)]:
+  - @paretools/shared@0.3.0
+
+#### @paretools/npm
+
+### Minor Changes
+
+- [#31](https://github.com/Dave-London/pare/pull/31) [`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547) Thanks [@Dave-London](https://github.com/Dave-London)! - Security, discoverability, and test coverage improvements.
+
+  ### Security
+  - Fix git argument injection: block ref/branch params starting with `-`
+  - Fix build command injection: allowlist of 24 known build tools
+  - New `assertNoFlagInjection` and `assertAllowedCommand` validation utilities
+
+  ### Features
+  - Add MCP `instructions` field to all 9 servers for better client guidance
+  - Optimize tool descriptions with "Use instead of" phrasing for agent discoverability
+  - Increase default timeouts for build/install operations (5 min for docker, npm, cargo, go)
+
+  ### Testing
+  - Expand test suite from 146 to 305 tests
+  - Add fidelity tests proving no information loss in git and vitest parsers
+  - Add formatter, integration, and validation tests across all packages
+
+  ### Infrastructure
+  - Add `mcpName` field for Official MCP Registry compatibility
+  - Add Smithery registry configs for all 9 servers
+  - Add Dependabot, CODEOWNERS, FUNDING.yml, feature-request template
+  - Expand README with per-client configs, agent snippets, and troubleshooting
+
+### Patch Changes
+
+- Updated dependencies [[`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547)]:
+  - @paretools/shared@0.3.0
+
+#### @paretools/python
+
+### Minor Changes
+
+- [#31](https://github.com/Dave-London/pare/pull/31) [`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547) Thanks [@Dave-London](https://github.com/Dave-London)! - Security, discoverability, and test coverage improvements.
+
+  ### Security
+  - Fix git argument injection: block ref/branch params starting with `-`
+  - Fix build command injection: allowlist of 24 known build tools
+  - New `assertNoFlagInjection` and `assertAllowedCommand` validation utilities
+
+  ### Features
+  - Add MCP `instructions` field to all 9 servers for better client guidance
+  - Optimize tool descriptions with "Use instead of" phrasing for agent discoverability
+  - Increase default timeouts for build/install operations (5 min for docker, npm, cargo, go)
+
+  ### Testing
+  - Expand test suite from 146 to 305 tests
+  - Add fidelity tests proving no information loss in git and vitest parsers
+  - Add formatter, integration, and validation tests across all packages
+
+  ### Infrastructure
+  - Add `mcpName` field for Official MCP Registry compatibility
+  - Add Smithery registry configs for all 9 servers
+  - Add Dependabot, CODEOWNERS, FUNDING.yml, feature-request template
+  - Expand README with per-client configs, agent snippets, and troubleshooting
+
+### Patch Changes
+
+- Updated dependencies [[`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547)]:
+  - @paretools/shared@0.3.0
+
+#### @paretools/shared
+
+### Minor Changes
+
+- [#31](https://github.com/Dave-London/pare/pull/31) [`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547) Thanks [@Dave-London](https://github.com/Dave-London)! - Security, discoverability, and test coverage improvements.
+
+  ### Security
+  - Fix git argument injection: block ref/branch params starting with `-`
+  - Fix build command injection: allowlist of 24 known build tools
+  - New `assertNoFlagInjection` and `assertAllowedCommand` validation utilities
+
+  ### Features
+  - Add MCP `instructions` field to all 9 servers for better client guidance
+  - Optimize tool descriptions with "Use instead of" phrasing for agent discoverability
+  - Increase default timeouts for build/install operations (5 min for docker, npm, cargo, go)
+
+  ### Testing
+  - Expand test suite from 146 to 305 tests
+  - Add fidelity tests proving no information loss in git and vitest parsers
+  - Add formatter, integration, and validation tests across all packages
+
+  ### Infrastructure
+  - Add `mcpName` field for Official MCP Registry compatibility
+  - Add Smithery registry configs for all 9 servers
+  - Add Dependabot, CODEOWNERS, FUNDING.yml, feature-request template
+  - Expand README with per-client configs, agent snippets, and troubleshooting
+
+#### @paretools/test
+
+### Minor Changes
+
+- [#31](https://github.com/Dave-London/pare/pull/31) [`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547) Thanks [@Dave-London](https://github.com/Dave-London)! - Security, discoverability, and test coverage improvements.
+
+  ### Security
+  - Fix git argument injection: block ref/branch params starting with `-`
+  - Fix build command injection: allowlist of 24 known build tools
+  - New `assertNoFlagInjection` and `assertAllowedCommand` validation utilities
+
+  ### Features
+  - Add MCP `instructions` field to all 9 servers for better client guidance
+  - Optimize tool descriptions with "Use instead of" phrasing for agent discoverability
+  - Increase default timeouts for build/install operations (5 min for docker, npm, cargo, go)
+
+  ### Testing
+  - Expand test suite from 146 to 305 tests
+  - Add fidelity tests proving no information loss in git and vitest parsers
+  - Add formatter, integration, and validation tests across all packages
+
+  ### Infrastructure
+  - Add `mcpName` field for Official MCP Registry compatibility
+  - Add Smithery registry configs for all 9 servers
+  - Add Dependabot, CODEOWNERS, FUNDING.yml, feature-request template
+  - Expand README with per-client configs, agent snippets, and troubleshooting
+
+### Patch Changes
+
+- Updated dependencies [[`2ccda44`](https://github.com/Dave-London/pare/commit/2ccda44c5118a91692da215d968ef1b178b4a547)]:
+  - @paretools/shared@0.3.0
+
+---
+
+### 0.2.0
+
+#### @paretools/build
+
+### Minor Changes
+
+- [#10](https://github.com/Dave-London/pare/pull/10) [`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d) Thanks [@Dave-London](https://github.com/Dave-London)! - Initial release of all Pare MCP servers
+
+### Patch Changes
+
+- Updated dependencies [[`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d)]:
+  - @paretools/shared@0.2.0
+
+#### @paretools/cargo
+
+### Minor Changes
+
+- [#10](https://github.com/Dave-London/pare/pull/10) [`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d) Thanks [@Dave-London](https://github.com/Dave-London)! - Initial release of all Pare MCP servers
+
+### Patch Changes
+
+- Updated dependencies [[`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d)]:
+  - @paretools/shared@0.2.0
+
+#### @paretools/docker
+
+### Minor Changes
+
+- [#10](https://github.com/Dave-London/pare/pull/10) [`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d) Thanks [@Dave-London](https://github.com/Dave-London)! - Initial release of all Pare MCP servers
+
+### Patch Changes
+
+- Updated dependencies [[`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d)]:
+  - @paretools/shared@0.2.0
+
+#### @paretools/git
+
+### Minor Changes
+
+- [#10](https://github.com/Dave-London/pare/pull/10) [`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d) Thanks [@Dave-London](https://github.com/Dave-London)! - Initial release of all Pare MCP servers
+
+### Patch Changes
+
+- Updated dependencies [[`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d)]:
+  - @paretools/shared@0.2.0
+
+#### @paretools/go
+
+### Minor Changes
+
+- [#10](https://github.com/Dave-London/pare/pull/10) [`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d) Thanks [@Dave-London](https://github.com/Dave-London)! - Initial release of all Pare MCP servers
+
+### Patch Changes
+
+- Updated dependencies [[`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d)]:
+  - @paretools/shared@0.2.0
+
+#### @paretools/lint
+
+### Minor Changes
+
+- [#10](https://github.com/Dave-London/pare/pull/10) [`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d) Thanks [@Dave-London](https://github.com/Dave-London)! - Initial release of all Pare MCP servers
+
+### Patch Changes
+
+- Updated dependencies [[`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d)]:
+  - @paretools/shared@0.2.0
+
+#### @paretools/npm
+
+### Minor Changes
+
+- [#10](https://github.com/Dave-London/pare/pull/10) [`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d) Thanks [@Dave-London](https://github.com/Dave-London)! - Initial release of all Pare MCP servers
+
+### Patch Changes
+
+- Updated dependencies [[`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d)]:
+  - @paretools/shared@0.2.0
+
+#### @paretools/python
+
+### Minor Changes
+
+- [#10](https://github.com/Dave-London/pare/pull/10) [`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d) Thanks [@Dave-London](https://github.com/Dave-London)! - Initial release of all Pare MCP servers
+
+### Patch Changes
+
+- Updated dependencies [[`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d)]:
+  - @paretools/shared@0.2.0
+
+#### @paretools/shared
+
+### Minor Changes
+
+- [#10](https://github.com/Dave-London/pare/pull/10) [`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d) Thanks [@Dave-London](https://github.com/Dave-London)! - Initial release of all Pare MCP servers
+
+#### @paretools/test
+
+### Minor Changes
+
+- [#10](https://github.com/Dave-London/pare/pull/10) [`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d) Thanks [@Dave-London](https://github.com/Dave-London)! - Initial release of all Pare MCP servers
+
+### Patch Changes
+
+- Updated dependencies [[`d08cf3d`](https://github.com/Dave-London/pare/commit/d08cf3d967e6a8ff9d65928aeed767fcf13f024d)]:
+  - @paretools/shared@0.2.0
+
+<!-- END AGGREGATED CHANGELOG -->

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo run build && changeset publish",
+    "changelog": "tsx scripts/aggregate-changelog.ts",
     "benchmark": "tsx scripts/benchmark.ts",
     "docs:api": "typedoc"
   },

--- a/scripts/aggregate-changelog.ts
+++ b/scripts/aggregate-changelog.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env npx tsx
+/**
+ * Aggregate per-package CHANGELOGs into the root CHANGELOG.md.
+ *
+ * Reads each package's CHANGELOG.md, extracts version entries, groups them
+ * by version number, and writes the combined result between the sentinel
+ * markers in the root CHANGELOG.md.
+ *
+ * Usage: pnpm changelog
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const ROOT = resolve(__dirname, "..");
+const ROOT_CHANGELOG = resolve(ROOT, "CHANGELOG.md");
+
+const BEGIN_MARKER = "<!-- BEGIN AGGREGATED CHANGELOG -->";
+const END_MARKER = "<!-- END AGGREGATED CHANGELOG -->";
+
+/** Package directories that may contain a CHANGELOG.md. */
+const PACKAGES: { dir: string; name: string }[] = [
+  { dir: "packages/server-build", name: "@paretools/build" },
+  { dir: "packages/server-cargo", name: "@paretools/cargo" },
+  { dir: "packages/server-docker", name: "@paretools/docker" },
+  { dir: "packages/server-git", name: "@paretools/git" },
+  { dir: "packages/server-go", name: "@paretools/go" },
+  { dir: "packages/server-lint", name: "@paretools/lint" },
+  { dir: "packages/server-npm", name: "@paretools/npm" },
+  { dir: "packages/server-python", name: "@paretools/python" },
+  { dir: "packages/server-test", name: "@paretools/test" },
+  { dir: "packages/shared", name: "@paretools/shared" },
+];
+
+interface VersionEntry {
+  version: string;
+  packageName: string;
+  body: string;
+}
+
+/**
+ * Parse a changesets-generated CHANGELOG.md into version entries.
+ *
+ * Each version section starts with `## <version>` (h2). Everything until the
+ * next h2 (or EOF) is that version's body.
+ */
+function parseChangelog(content: string, packageName: string): VersionEntry[] {
+  const entries: VersionEntry[] = [];
+  const lines = content.split("\n");
+
+  let currentVersion: string | null = null;
+  let bodyLines: string[] = [];
+
+  for (const line of lines) {
+    const versionMatch = line.match(/^## (\d+\.\d+\.\d+.*)$/);
+    if (versionMatch) {
+      // Save previous entry
+      if (currentVersion) {
+        entries.push({
+          version: currentVersion,
+          packageName,
+          body: bodyLines.join("\n").trim(),
+        });
+      }
+      currentVersion = versionMatch[1];
+      bodyLines = [];
+    } else if (currentVersion) {
+      bodyLines.push(line);
+    }
+  }
+
+  // Save last entry
+  if (currentVersion) {
+    entries.push({
+      version: currentVersion,
+      packageName,
+      body: bodyLines.join("\n").trim(),
+    });
+  }
+
+  return entries;
+}
+
+/**
+ * Group entries by version, then format as markdown.
+ *
+ * Versions are sorted in descending semver order. Within each version,
+ * packages are listed alphabetically.
+ */
+function formatAggregated(allEntries: VersionEntry[]): string {
+  // Group by version
+  const byVersion = new Map<string, VersionEntry[]>();
+  for (const entry of allEntries) {
+    const group = byVersion.get(entry.version) ?? [];
+    group.push(entry);
+    byVersion.set(entry.version, group);
+  }
+
+  // Sort versions descending (simple semver sort)
+  const sortedVersions = [...byVersion.keys()].sort((a, b) => {
+    const pa = a.split(".").map(Number);
+    const pb = b.split(".").map(Number);
+    for (let i = 0; i < 3; i++) {
+      if ((pa[i] ?? 0) !== (pb[i] ?? 0)) return (pb[i] ?? 0) - (pa[i] ?? 0);
+    }
+    return 0;
+  });
+
+  const sections: string[] = [];
+
+  for (const version of sortedVersions) {
+    const entries = byVersion.get(version)!;
+    entries.sort((a, b) => a.packageName.localeCompare(b.packageName));
+
+    const lines: string[] = [`### ${version}`, ""];
+
+    for (const entry of entries) {
+      lines.push(`#### ${entry.packageName}`, "");
+      if (entry.body) {
+        lines.push(entry.body, "");
+      }
+    }
+
+    sections.push(lines.join("\n"));
+  }
+
+  return sections.join("\n---\n\n");
+}
+
+function main() {
+  // Read all package changelogs
+  const allEntries: VersionEntry[] = [];
+  let found = 0;
+  let skipped = 0;
+
+  for (const pkg of PACKAGES) {
+    const changelogPath = resolve(ROOT, pkg.dir, "CHANGELOG.md");
+    if (!existsSync(changelogPath)) {
+      console.log(`  skip: ${pkg.name} (no CHANGELOG.md)`);
+      skipped++;
+      continue;
+    }
+
+    const content = readFileSync(changelogPath, "utf-8");
+    const entries = parseChangelog(content, pkg.name);
+    allEntries.push(...entries);
+    found++;
+    console.log(`  read: ${pkg.name} (${entries.length} version(s))`);
+  }
+
+  if (allEntries.length === 0) {
+    console.log("\nNo changelog entries found. Nothing to aggregate.");
+    return;
+  }
+
+  // Format the aggregated content
+  const aggregated = formatAggregated(allEntries);
+
+  // Read root CHANGELOG.md and replace between markers
+  if (!existsSync(ROOT_CHANGELOG)) {
+    console.error(`Error: ${ROOT_CHANGELOG} not found.`);
+    process.exit(1);
+  }
+
+  const rootContent = readFileSync(ROOT_CHANGELOG, "utf-8");
+  const beginIdx = rootContent.indexOf(BEGIN_MARKER);
+  const endIdx = rootContent.indexOf(END_MARKER);
+
+  if (beginIdx === -1 || endIdx === -1) {
+    console.error(`Error: Could not find sentinel markers in ${ROOT_CHANGELOG}.`);
+    console.error(`Expected: ${BEGIN_MARKER} and ${END_MARKER}`);
+    process.exit(1);
+  }
+
+  const before = rootContent.slice(0, beginIdx + BEGIN_MARKER.length);
+  const after = rootContent.slice(endIdx);
+  const newContent = `${before}\n\n${aggregated}\n\n${after}`;
+
+  writeFileSync(ROOT_CHANGELOG, newContent, "utf-8");
+
+  console.log(`\nAggregated ${allEntries.length} entries from ${found} packages into CHANGELOG.md`);
+  if (skipped > 0) {
+    console.log(`Skipped ${skipped} packages without changelogs.`);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add a root `CHANGELOG.md` with a table linking to each package's individual changelog
- Add `scripts/aggregate-changelog.ts` that reads all 10 package CHANGELOGs, groups entries by version, and writes a combined view between sentinel markers in the root file
- Add `pnpm changelog` script to root `package.json` to run the aggregation

## Details

Changesets manages per-package changelogs independently but does not natively aggregate them into a root file. This PR adds:

1. **`CHANGELOG.md`** at the repo root with:
   - An overview explaining this is a monorepo with independent versioning
   - A table linking to each package's CHANGELOG.md
   - An auto-generated aggregated section (between `<!-- BEGIN/END AGGREGATED CHANGELOG -->` markers)

2. **`scripts/aggregate-changelog.ts`** that:
   - Reads CHANGELOG.md from all 10 packages
   - Parses version sections from the changesets format
   - Groups entries by version (descending semver order), then by package name
   - Writes the combined output between sentinel markers in the root CHANGELOG.md
   - Handles missing CHANGELOGs gracefully (logs a skip message)

3. **`pnpm changelog`** script in root `package.json` to run the aggregation on demand

## Test plan
- [x] Script runs successfully and aggregates 20 entries (2 versions x 10 packages)
- [x] All files pass `prettier --check`
- [ ] Verify the root CHANGELOG.md renders correctly on GitHub

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)