### PR TITLE
ci: add Windows and macOS to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,11 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [20, 22]
 
     steps:


### PR DESCRIPTION
## Summary
- Add `os: [ubuntu-latest, windows-latest, macos-latest]` to the `build-and-test` job matrix, expanding CI from 2 jobs (Ubuntu + Node 20/22) to 6 jobs (3 OSes x 2 Node versions)
- Set `fail-fast: false` so all platform/version combinations run to completion even if one fails
- Keep the `lint` job on `ubuntu-latest` only, since linting is platform-independent

Closes #50

## Test plan
- [ ] Verify CI triggers on this PR and all 6 matrix jobs appear (ubuntu/windows/macos x node 20/22)
- [ ] Confirm `fail-fast: false` allows all jobs to complete independently
- [ ] Confirm the `lint` job still runs on ubuntu-latest only
- [ ] Check that build, test, and format-check steps pass on all three platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)