### PR TITLE
ci: add pnpm audit security check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,18 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm audit --audit-level=high


### PR DESCRIPTION
## Summary
- Adds a new `audit` job to the CI pipeline that runs `pnpm audit --audit-level=high` on every push to main and every PR
- Uses `--audit-level=high` so low/moderate severity issues do not block CI
- Runs as a standalone job (no dependency on `build-and-test`) on ubuntu-latest with Node 22

## Test plan
- [ ] Verify the new `audit` job appears in the GitHub Actions workflow run triggered by this PR
- [ ] Confirm the job installs dependencies and runs `pnpm audit --audit-level=high` successfully
- [ ] Confirm existing `build-and-test` and `lint` jobs are unaffected

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)