### PR TITLE
test(shared): add fidelity tests for shared utilities

### DIFF
--- a/packages/server-test/__tests__/fidelity-extractjson.test.ts
+++ b/packages/server-test/__tests__/fidelity-extractjson.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Fidelity tests for extractJson: realistic noisy output samples that
+ * simulate real-world test runner and tool output with JSON embedded
+ * in various kinds of surrounding noise.
+ */
+import { describe, it, expect } from "vitest";
+import { extractJson } from "../src/tools/run.js";
+
+describe("fidelity: extractJson with real-world output", () => {
+  it("extracts vitest JSON with ANSI color noise before the JSON block", () => {
+    const output = [
+      "\x1b[32m\u2713\x1b[39m src/utils.test.ts (5 tests) 42ms",
+      "\x1b[32m\u2713\x1b[39m src/core.test.ts (3 tests) 18ms",
+      "",
+      " \x1b[1mTest Files\x1b[22m  2 passed (2)",
+      " \x1b[1m     Tests\x1b[22m  8 passed (8)",
+      "",
+      '{"numTotalTests":8,"numPassedTests":8,"numFailedTests":0,"numPendingTests":0,"testResults":[]}',
+    ].join("\n");
+
+    const result = extractJson(output);
+    const parsed = JSON.parse(result);
+    expect(parsed.numTotalTests).toBe(8);
+    expect(parsed.numPassedTests).toBe(8);
+    expect(parsed.testResults).toEqual([]);
+  });
+
+  it("extracts npm audit JSON with npm banner and warning lines", () => {
+    const output = [
+      "npm warn config global `--global`, `--local` are deprecated. Use `--location=global` instead.",
+      "npm warn audit No fix available for package-x@1.2.3",
+      "",
+      '{"auditReportVersion":2,"vulnerabilities":{"lodash":{"severity":"high","via":["Prototype Pollution"]}},"metadata":{"totalDependencies":142}}',
+      "",
+      "found 1 high severity vulnerability",
+    ].join("\n");
+
+    const result = extractJson(output);
+    const parsed = JSON.parse(result);
+    expect(parsed.auditReportVersion).toBe(2);
+    expect(parsed.vulnerabilities.lodash.severity).toBe("high");
+    expect(parsed.metadata.totalDependencies).toBe(142);
+  });
+
+  it("extracts JSON with console.log noise before and after", () => {
+    const output = [
+      "Debugger attached.",
+      "Waiting for the debugger to disconnect...",
+      "console.log: Starting test suite...",
+      "console.log: DB connected",
+      '{"framework":"jest","summary":{"total":12,"passed":11,"failed":1},"failures":[{"name":"auth test","message":"timeout"}]}',
+      "console.log: DB disconnected",
+      "Done in 3.45s.",
+    ].join("\n");
+
+    const result = extractJson(output);
+    const parsed = JSON.parse(result);
+    expect(parsed.framework).toBe("jest");
+    expect(parsed.summary.total).toBe(12);
+    expect(parsed.failures).toHaveLength(1);
+    expect(parsed.failures[0].name).toBe("auth test");
+  });
+
+  it("handles very deeply nested JSON (10+ levels deep)", () => {
+    const deepObj = {
+      l1: {
+        l2: {
+          l3: {
+            l4: {
+              l5: {
+                l6: {
+                  l7: {
+                    l8: {
+                      l9: {
+                        l10: {
+                          l11: { value: "deep-leaf" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const output = `noise prefix\n${JSON.stringify(deepObj)}\nnoise suffix`;
+
+    const result = extractJson(output);
+    const parsed = JSON.parse(result);
+    expect(parsed.l1.l2.l3.l4.l5.l6.l7.l8.l9.l10.l11.value).toBe(
+      "deep-leaf",
+    );
+  });
+
+  it("handles JSON with escaped characters inside strings", () => {
+    const obj = {
+      error: 'Expected "hello\\nworld" to equal "hello\\tworld"',
+      path: "C:\\Users\\dev\\project\\test.ts",
+      message: 'Line contains "quotes" and \\backslashes\\',
+      unicode: "\u2713 passed \u2717 failed",
+    };
+    const output = `runner output:\n${JSON.stringify(obj)}\ndone`;
+
+    const result = extractJson(output);
+    const parsed = JSON.parse(result);
+    expect(parsed.error).toContain("hello\\nworld");
+    expect(parsed.path).toContain("C:\\Users\\dev");
+    expect(parsed.message).toContain('"quotes"');
+    expect(parsed.unicode).toContain("\u2713");
+  });
+
+  it("extracts JSON from output with CRLF line endings", () => {
+    const output =
+      'Starting...\r\n{"result":"ok","count":5}\r\nFinished.\r\n';
+
+    const result = extractJson(output);
+    const parsed = JSON.parse(result);
+    expect(parsed.result).toBe("ok");
+    expect(parsed.count).toBe(5);
+  });
+
+  it("handles real vitest failure JSON with stack traces in strings", () => {
+    const output = [
+      " DEV  v4.0.18",
+      "",
+      JSON.stringify({
+        numTotalTests: 3,
+        numPassedTests: 2,
+        numFailedTests: 1,
+        numPendingTests: 0,
+        success: false,
+        testResults: [
+          {
+            name: "/home/user/project/src/math.test.ts",
+            assertionResults: [
+              {
+                fullName: "add > returns sum of two numbers",
+                status: "passed",
+                failureMessages: [],
+              },
+              {
+                fullName: "add > handles negative numbers",
+                status: "passed",
+                failureMessages: [],
+              },
+              {
+                fullName: "divide > throws on division by zero",
+                status: "failed",
+                failureMessages: [
+                  "AssertionError: expected [Function] to throw an error\n    at /home/user/project/src/math.test.ts:15:22\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)",
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+      "",
+      " Test Files  1 failed (1)",
+      "      Tests  1 failed | 2 passed (3)",
+    ].join("\n");
+
+    const result = extractJson(output);
+    const parsed = JSON.parse(result);
+    expect(parsed.numTotalTests).toBe(3);
+    expect(parsed.numFailedTests).toBe(1);
+    expect(parsed.testResults[0].assertionResults).toHaveLength(3);
+    expect(parsed.testResults[0].assertionResults[2].status).toBe("failed");
+    expect(
+      parsed.testResults[0].assertionResults[2].failureMessages[0],
+    ).toContain("AssertionError");
+  });
+});

--- a/packages/shared/__tests__/fidelity.test.ts
+++ b/packages/shared/__tests__/fidelity.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Fidelity tests for shared utilities: stripAnsi, dualOutput, run, assertNoFlagInjection.
+ *
+ * These tests use real-world ANSI sequences and live command execution
+ * to verify that Pare's shared helpers behave correctly with production inputs.
+ */
+import { describe, it, expect } from "vitest";
+import { stripAnsi } from "../src/ansi.js";
+import { dualOutput } from "../src/output.js";
+import { run } from "../src/runner.js";
+import { assertNoFlagInjection } from "../src/validation.js";
+
+// ---------------------------------------------------------------------------
+// stripAnsi — fidelity tests
+// ---------------------------------------------------------------------------
+describe("fidelity: stripAnsi", () => {
+  it("strips real SGR color codes from test-runner output", () => {
+    // Simulates vitest-style "checkmark green, then reset" output
+    const input = "\x1b[32m\u2713\x1b[39m test passed";
+    expect(stripAnsi(input)).toBe("\u2713 test passed");
+  });
+
+  it("strips bold, underline, and reset sequences", () => {
+    // Bold on, underline on, text, underline off, bold off, reset
+    const input = "\x1b[1m\x1b[4mHeading\x1b[24m\x1b[22m\x1b[0m";
+    expect(stripAnsi(input)).toBe("Heading");
+  });
+
+  it("strips cursor movement sequences", () => {
+    // Cursor up 2, cursor forward 5, then text
+    const input = "\x1b[2A\x1b[5CProgress: 100%";
+    expect(stripAnsi(input)).toBe("Progress: 100%");
+  });
+
+  it("strips nested/interleaved ANSI codes correctly", () => {
+    // Red bg, white fg, bold text with interspersed resets
+    const input =
+      "\x1b[41m\x1b[37m\x1b[1m FAIL \x1b[22m\x1b[39m\x1b[49m src/app.test.ts";
+    expect(stripAnsi(input)).toBe(" FAIL  src/app.test.ts");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(stripAnsi("")).toBe("");
+  });
+
+  it("returns plain text without ANSI codes unchanged", () => {
+    const plain = "No special characters here! Just text (123).";
+    expect(stripAnsi(plain)).toBe(plain);
+  });
+
+  it("strips OSC (Operating System Command) sequences", () => {
+    // OSC hyperlink sequence used by some terminals
+    const input = "\x1b]8;;https://example.com\x07Click here\x1b]8;;\x07";
+    expect(stripAnsi(input)).toBe("Click here");
+  });
+
+  it("strips real npm warning output ANSI codes", () => {
+    // npm often wraps warnings in yellow
+    const input = "\x1b[33mnpm warn\x1b[39m deprecated package@1.0.0";
+    expect(stripAnsi(input)).toBe("npm warn deprecated package@1.0.0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dualOutput — fidelity tests
+// ---------------------------------------------------------------------------
+describe("fidelity: dualOutput", () => {
+  it("returns both content (text) and structuredContent (typed JSON)", () => {
+    const data = { total: 10, passed: 8, failed: 2 };
+    const formatter = (d: typeof data) => `Tests: ${d.passed}/${d.total}`;
+
+    const result = dualOutput(data, formatter);
+
+    expect(result.content).toEqual([{ type: "text", text: "Tests: 8/10" }]);
+    expect(result.structuredContent).toEqual(data);
+  });
+
+  it("calls the formatter function with the exact data object", () => {
+    const data = { files: ["a.ts", "b.ts"], count: 2 };
+    let receivedData: unknown = null;
+    const formatter = (d: typeof data) => {
+      receivedData = d;
+      return "formatted";
+    };
+
+    dualOutput(data, formatter);
+
+    expect(receivedData).toBe(data); // same reference
+  });
+
+  it("structuredContent is the exact same reference as input data", () => {
+    const data = { branch: "main", ahead: 0, behind: 3 };
+    const result = dualOutput(data, () => "branch info");
+
+    expect(result.structuredContent).toBe(data);
+  });
+
+  it("handles complex nested data structures", () => {
+    const data = {
+      summary: { lines: 85.5, branches: 72.1 },
+      files: [
+        { file: "index.ts", lines: 90 },
+        { file: "utils.ts", lines: 80 },
+      ],
+    };
+    const formatter = (d: typeof data) =>
+      `Coverage: ${d.summary.lines}% lines, ${d.files.length} files`;
+
+    const result = dualOutput(data, formatter);
+
+    expect(result.content[0].text).toBe("Coverage: 85.5% lines, 2 files");
+    expect(result.structuredContent.files).toHaveLength(2);
+    expect(result.structuredContent.summary.lines).toBe(85.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run — fidelity tests (uses real cross-platform commands via node -e)
+// Uses single-quoted JS inside -e for Windows cmd.exe compatibility
+// (shell: true wraps args in double quotes, so inner single quotes work).
+// ---------------------------------------------------------------------------
+describe("fidelity: run", () => {
+  it("captures stdout from a successful command (exitCode 0)", async () => {
+    const result = await run("node", ["-e", "console.log('hello')"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("hello");
+  });
+
+  it("returns non-zero exitCode from a failing command", async () => {
+    const result = await run("node", ["-e", "process.exit(42)"]);
+
+    expect(result.exitCode).toBe(42);
+  });
+
+  it("strips ANSI codes from command output", async () => {
+    // Matches the pattern used by the existing runner.test.ts that works cross-platform
+    const result = await run("node", ["-e", "console.log('\\x1b[31mred\\x1b[0m')"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("red");
+    expect(result.stdout).not.toContain("\x1b[");
+  });
+
+  it("rejects with a clear message for a non-existent command", async () => {
+    await expect(
+      run("__nonexistent_command_that_does_not_exist__", ["--version"]),
+    ).rejects.toThrow(/[Cc]ommand not found|is not recognized/);
+  });
+
+  it("respects the cwd option", async () => {
+    const result = await run("node", ["-e", "console.log(process.cwd())"], {
+      cwd: process.env.TEMP || "/tmp",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertNoFlagInjection — fidelity tests
+// ---------------------------------------------------------------------------
+describe("fidelity: assertNoFlagInjection", () => {
+  it("allows a normal value without throwing", () => {
+    expect(() => assertNoFlagInjection("main", "ref")).not.toThrow();
+  });
+
+  it("allows values with hyphens in the middle", () => {
+    expect(() => assertNoFlagInjection("feature-branch", "ref")).not.toThrow();
+  });
+
+  it("throws for a value starting with single dash", () => {
+    expect(() => assertNoFlagInjection("-v", "flag")).toThrow(
+      /must not start with "-"/,
+    );
+  });
+
+  it("throws for a value starting with double dash", () => {
+    expect(() => assertNoFlagInjection("--output=/etc/passwd", "ref")).toThrow(
+      /must not start with "-"/,
+    );
+  });
+
+  it("includes the parameter name in the error message", () => {
+    expect(() => assertNoFlagInjection("-x", "myParam")).toThrow(/myParam/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `packages/shared/__tests__/fidelity.test.ts` with 22 fidelity tests covering `stripAnsi` (8 tests), `dualOutput` (4 tests), `run` (5 tests), and `assertNoFlagInjection` (5 tests)
- Add `packages/server-test/__tests__/fidelity-extractjson.test.ts` with 7 real-world fidelity tests for `extractJson` using realistic noisy output samples (ANSI color noise, npm banners, console.log pollution, deeply nested JSON, escaped characters, CRLF line endings, vitest failure JSON with stack traces)
- Total: 29 new tests across both files

## Test plan
- [x] Run `pnpm test --filter @paretools/shared` — all 86 tests pass (22 new fidelity + 64 existing)
- [x] Run `pnpm test --filter @paretools/test` — all 55 tests pass (7 new fidelity + 48 existing)
- [ ] CI passes on Ubuntu

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)