### PR TITLE
feat(git): add write operations (add, commit, push, pull, checkout)

### DIFF
--- a/packages/server-git/__tests__/add.test.ts
+++ b/packages/server-git/__tests__/add.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { parseAdd } from "../src/lib/parsers.js";
+import { formatAdd } from "../src/lib/formatters.js";
+import type { GitAdd } from "../src/schemas/index.js";
+
+describe("parseAdd", () => {
+  it("parses staged files from porcelain status output", () => {
+    const statusOutput = [
+      "A  src/new-file.ts",
+      "M  src/index.ts",
+      "?? untracked.log",
+    ].join("\n");
+
+    const result = parseAdd(statusOutput);
+
+    expect(result.staged).toBe(2);
+    expect(result.files).toEqual(["src/new-file.ts", "src/index.ts"]);
+  });
+
+  it("handles no staged files", () => {
+    const statusOutput = ["?? untracked.log", " M not-staged.ts"].join("\n");
+
+    const result = parseAdd(statusOutput);
+
+    expect(result.staged).toBe(0);
+    expect(result.files).toEqual([]);
+  });
+
+  it("handles empty status output", () => {
+    const result = parseAdd("");
+
+    expect(result.staged).toBe(0);
+    expect(result.files).toEqual([]);
+  });
+
+  it("handles renamed files", () => {
+    const statusOutput = "R  old-name.ts -> new-name.ts";
+
+    const result = parseAdd(statusOutput);
+
+    expect(result.staged).toBe(1);
+    expect(result.files).toEqual(["new-name.ts"]);
+  });
+
+  it("handles deleted files", () => {
+    const statusOutput = "D  removed-file.ts";
+
+    const result = parseAdd(statusOutput);
+
+    expect(result.staged).toBe(1);
+    expect(result.files).toEqual(["removed-file.ts"]);
+  });
+
+  it("handles mix of staged and unstaged changes", () => {
+    const statusOutput = [
+      "M  staged.ts",
+      " M unstaged.ts",
+      "A  added.ts",
+      "?? untracked.ts",
+      " D deleted-unstaged.ts",
+    ].join("\n");
+
+    const result = parseAdd(statusOutput);
+
+    expect(result.staged).toBe(2);
+    expect(result.files).toEqual(["staged.ts", "added.ts"]);
+  });
+
+  it("handles all files staged via git add -A", () => {
+    const statusOutput = [
+      "A  src/a.ts",
+      "A  src/b.ts",
+      "M  src/c.ts",
+      "D  src/old.ts",
+    ].join("\n");
+
+    const result = parseAdd(statusOutput);
+
+    expect(result.staged).toBe(4);
+    expect(result.files).toEqual(["src/a.ts", "src/b.ts", "src/c.ts", "src/old.ts"]);
+  });
+});
+
+describe("formatAdd", () => {
+  it("formats staged files", () => {
+    const data: GitAdd = { staged: 2, files: ["src/a.ts", "src/b.ts"] };
+    expect(formatAdd(data)).toBe("Staged 2 file(s): src/a.ts, src/b.ts");
+  });
+
+  it("formats no staged files", () => {
+    const data: GitAdd = { staged: 0, files: [] };
+    expect(formatAdd(data)).toBe("No files staged");
+  });
+
+  it("formats single staged file", () => {
+    const data: GitAdd = { staged: 1, files: ["README.md"] };
+    expect(formatAdd(data)).toBe("Staged 1 file(s): README.md");
+  });
+});

--- a/packages/server-git/__tests__/checkout.test.ts
+++ b/packages/server-git/__tests__/checkout.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { parseCheckout } from "../src/lib/parsers.js";
+import { formatCheckout } from "../src/lib/formatters.js";
+import type { GitCheckout } from "../src/schemas/index.js";
+
+describe("parseCheckout", () => {
+  it("parses branch switch", () => {
+    const result = parseCheckout(
+      "",
+      "Switched to branch 'feature'",
+      "feature",
+      "main",
+      false,
+    );
+
+    expect(result.ref).toBe("feature");
+    expect(result.previousRef).toBe("main");
+    expect(result.created).toBe(false);
+  });
+
+  it("parses new branch creation", () => {
+    const result = parseCheckout(
+      "",
+      "Switched to a new branch 'feature/new'",
+      "feature/new",
+      "main",
+      true,
+    );
+
+    expect(result.ref).toBe("feature/new");
+    expect(result.previousRef).toBe("main");
+    expect(result.created).toBe(true);
+  });
+
+  it("handles detached HEAD as previous ref", () => {
+    const result = parseCheckout(
+      "",
+      "Switched to branch 'main'",
+      "main",
+      "HEAD",
+      false,
+    );
+
+    expect(result.ref).toBe("main");
+    expect(result.previousRef).toBe("HEAD");
+    expect(result.created).toBe(false);
+  });
+
+  it("handles unknown previous ref", () => {
+    const result = parseCheckout(
+      "",
+      "Switched to branch 'dev'",
+      "dev",
+      "unknown",
+      false,
+    );
+
+    expect(result.ref).toBe("dev");
+    expect(result.previousRef).toBe("unknown");
+  });
+});
+
+describe("formatCheckout", () => {
+  it("formats branch switch", () => {
+    const data: GitCheckout = {
+      ref: "feature",
+      previousRef: "main",
+      created: false,
+    };
+    expect(formatCheckout(data)).toBe("Switched to 'feature' (was main)");
+  });
+
+  it("formats new branch creation", () => {
+    const data: GitCheckout = {
+      ref: "feature/new",
+      previousRef: "main",
+      created: true,
+    };
+    expect(formatCheckout(data)).toBe(
+      "Created and switched to new branch 'feature/new' (was main)",
+    );
+  });
+});

--- a/packages/server-git/__tests__/commit.test.ts
+++ b/packages/server-git/__tests__/commit.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { parseCommit } from "../src/lib/parsers.js";
+import { formatCommit } from "../src/lib/formatters.js";
+import type { GitCommit } from "../src/schemas/index.js";
+
+describe("parseCommit", () => {
+  it("parses standard commit output", () => {
+    const stdout = `[main abc1234] Fix the bug
+ 1 file changed, 2 insertions(+), 1 deletion(-)`;
+
+    const result = parseCommit(stdout);
+
+    expect(result.hash).toBe("abc1234");
+    expect(result.hashShort).toBe("abc1234");
+    expect(result.message).toBe("Fix the bug");
+    expect(result.filesChanged).toBe(1);
+    expect(result.insertions).toBe(2);
+    expect(result.deletions).toBe(1);
+  });
+
+  it("parses commit with multiple files changed", () => {
+    const stdout = `[feature/auth def5678] Add authentication
+ 3 files changed, 150 insertions(+), 10 deletions(-)`;
+
+    const result = parseCommit(stdout);
+
+    expect(result.hash).toBe("def5678");
+    expect(result.hashShort).toBe("def5678");
+    expect(result.message).toBe("Add authentication");
+    expect(result.filesChanged).toBe(3);
+    expect(result.insertions).toBe(150);
+    expect(result.deletions).toBe(10);
+  });
+
+  it("parses root commit", () => {
+    const stdout = `[main (root-commit) aaa1111] Initial commit
+ 1 file changed, 1 insertion(+)`;
+
+    const result = parseCommit(stdout);
+
+    expect(result.hash).toBe("aaa1111");
+    expect(result.hashShort).toBe("aaa1111");
+    expect(result.message).toBe("Initial commit");
+    expect(result.filesChanged).toBe(1);
+    expect(result.insertions).toBe(1);
+    expect(result.deletions).toBe(0);
+  });
+
+  it("parses commit with only insertions", () => {
+    const stdout = `[main bbb2222] Add new file
+ 1 file changed, 25 insertions(+)`;
+
+    const result = parseCommit(stdout);
+
+    expect(result.insertions).toBe(25);
+    expect(result.deletions).toBe(0);
+  });
+
+  it("parses commit with only deletions", () => {
+    const stdout = `[main ccc3333] Remove old code
+ 1 file changed, 15 deletions(-)`;
+
+    const result = parseCommit(stdout);
+
+    expect(result.insertions).toBe(0);
+    expect(result.deletions).toBe(15);
+  });
+
+  it("parses commit with long hash", () => {
+    const stdout = `[main abcdef1234567] Refactor
+ 2 files changed, 10 insertions(+), 5 deletions(-)`;
+
+    const result = parseCommit(stdout);
+
+    expect(result.hash).toBe("abcdef1234567");
+    expect(result.hashShort).toBe("abcdef1");
+  });
+
+  it("handles branch names with slashes", () => {
+    const stdout = `[feat/git-ops abc1234] Add write tools
+ 5 files changed, 200 insertions(+), 10 deletions(-)`;
+
+    const result = parseCommit(stdout);
+
+    expect(result.hash).toBe("abc1234");
+    expect(result.message).toBe("Add write tools");
+    expect(result.filesChanged).toBe(5);
+  });
+
+  it("handles empty/unparseable output gracefully", () => {
+    const result = parseCommit("");
+
+    expect(result.hash).toBe("");
+    expect(result.hashShort).toBe("");
+    expect(result.message).toBe("");
+    expect(result.filesChanged).toBe(0);
+    expect(result.insertions).toBe(0);
+    expect(result.deletions).toBe(0);
+  });
+});
+
+describe("formatCommit", () => {
+  it("formats commit data", () => {
+    const data: GitCommit = {
+      hash: "abc1234567890",
+      hashShort: "abc1234",
+      message: "Fix the bug",
+      filesChanged: 1,
+      insertions: 2,
+      deletions: 1,
+    };
+    const output = formatCommit(data);
+
+    expect(output).toContain("[abc1234] Fix the bug");
+    expect(output).toContain("1 file(s) changed, +2, -1");
+  });
+
+  it("formats commit with zero changes", () => {
+    const data: GitCommit = {
+      hash: "abc1234",
+      hashShort: "abc1234",
+      message: "Empty commit",
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0,
+    };
+    const output = formatCommit(data);
+
+    expect(output).toContain("[abc1234] Empty commit");
+    expect(output).toContain("0 file(s) changed, +0, -0");
+  });
+});

--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -26,10 +26,21 @@ describe("@paretools/git integration", () => {
     await transport.close();
   });
 
-  it("lists all 5 tools", async () => {
+  it("lists all 10 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
-    expect(names).toEqual(["branch", "diff", "log", "show", "status"]);
+    expect(names).toEqual([
+      "add",
+      "branch",
+      "checkout",
+      "commit",
+      "diff",
+      "log",
+      "pull",
+      "push",
+      "show",
+      "status",
+    ]);
   });
 
   describe("status", () => {

--- a/packages/server-git/__tests__/pull.test.ts
+++ b/packages/server-git/__tests__/pull.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { parsePull } from "../src/lib/parsers.js";
+import { formatPull } from "../src/lib/formatters.js";
+import type { GitPull } from "../src/schemas/index.js";
+
+describe("parsePull", () => {
+  it("parses successful pull with changes", () => {
+    const stdout = `Updating abc1234..def5678
+Fast-forward
+ src/index.ts | 10 +++++++---
+ 2 files changed, 7 insertions(+), 3 deletions(-)`;
+
+    const result = parsePull(stdout, "");
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(2);
+    expect(result.insertions).toBe(7);
+    expect(result.deletions).toBe(3);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("parses already up to date", () => {
+    const stdout = "Already up to date.";
+
+    const result = parsePull(stdout, "");
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("Already up to date");
+    expect(result.filesChanged).toBe(0);
+    expect(result.insertions).toBe(0);
+    expect(result.deletions).toBe(0);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("parses pull with merge conflicts", () => {
+    const stdout = `Auto-merging src/index.ts
+CONFLICT (content): Merge conflict in src/index.ts
+Auto-merging src/utils.ts
+CONFLICT (content): Merge conflict in src/utils.ts
+Automatic merge failed; fix conflicts and then commit the result.`;
+
+    const result = parsePull(stdout, "");
+
+    expect(result.success).toBe(false);
+    expect(result.conflicts).toEqual(["src/index.ts", "src/utils.ts"]);
+    expect(result.summary).toContain("2 conflict(s)");
+  });
+
+  it("parses pull with single conflict", () => {
+    const stdout = `Auto-merging README.md
+CONFLICT (content): Merge conflict in README.md
+Automatic merge failed; fix conflicts and then commit the result.`;
+
+    const result = parsePull(stdout, "");
+
+    expect(result.success).toBe(false);
+    expect(result.conflicts).toEqual(["README.md"]);
+  });
+
+  it("parses rebase pull output", () => {
+    const stdout = `Successfully rebased and updated refs/heads/main.
+ 3 files changed, 15 insertions(+), 5 deletions(-)`;
+
+    const result = parsePull(stdout, "");
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(3);
+    expect(result.insertions).toBe(15);
+    expect(result.deletions).toBe(5);
+  });
+
+  it("handles empty output", () => {
+    const result = parsePull("", "");
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("parses pull with only insertions", () => {
+    const stdout = `Updating abc1234..def5678
+Fast-forward
+ 1 file changed, 10 insertions(+)`;
+
+    const result = parsePull(stdout, "");
+
+    expect(result.filesChanged).toBe(1);
+    expect(result.insertions).toBe(10);
+    expect(result.deletions).toBe(0);
+  });
+
+  it("parses conflict with add/add type", () => {
+    const stdout = `CONFLICT (add/add): Merge conflict in new-file.ts`;
+
+    const result = parsePull(stdout, "");
+
+    expect(result.success).toBe(false);
+    expect(result.conflicts).toEqual(["new-file.ts"]);
+  });
+});
+
+describe("formatPull", () => {
+  it("formats successful pull with changes", () => {
+    const data: GitPull = {
+      success: true,
+      summary: "Fast-forward",
+      filesChanged: 2,
+      insertions: 7,
+      deletions: 3,
+      conflicts: [],
+    };
+    const output = formatPull(data);
+
+    expect(output).toContain("Fast-forward");
+    expect(output).toContain("2 file(s) changed, +7 -3");
+  });
+
+  it("formats pull with conflicts", () => {
+    const data: GitPull = {
+      success: false,
+      summary: "Pull completed with 2 conflict(s)",
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0,
+      conflicts: ["src/index.ts", "src/utils.ts"],
+    };
+    const output = formatPull(data);
+
+    expect(output).toContain("2 conflict(s)");
+    expect(output).toContain("Conflicts: src/index.ts, src/utils.ts");
+  });
+
+  it("formats already up to date", () => {
+    const data: GitPull = {
+      success: true,
+      summary: "Already up to date",
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0,
+      conflicts: [],
+    };
+    const output = formatPull(data);
+
+    expect(output).toBe("Already up to date");
+  });
+});

--- a/packages/server-git/__tests__/push.test.ts
+++ b/packages/server-git/__tests__/push.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { parsePush } from "../src/lib/parsers.js";
+import { formatPush } from "../src/lib/formatters.js";
+import type { GitPush } from "../src/schemas/index.js";
+
+describe("parsePush", () => {
+  it("parses successful push with branch info", () => {
+    const stderr = `To github.com:user/repo.git
+   abc1234..def5678  main -> main`;
+
+    const result = parsePush("", stderr, "origin", "main");
+
+    expect(result.success).toBe(true);
+    expect(result.remote).toBe("origin");
+    expect(result.branch).toBe("main");
+    expect(result.summary).toContain("main -> main");
+  });
+
+  it("parses new branch push", () => {
+    const stderr = `To github.com:user/repo.git
+ * [new branch]      feature -> feature`;
+
+    const result = parsePush("", stderr, "origin", "feature");
+
+    expect(result.success).toBe(true);
+    expect(result.remote).toBe("origin");
+    expect(result.branch).toBe("feature");
+  });
+
+  it("resolves branch from output when not provided", () => {
+    const stderr = `To github.com:user/repo.git
+   abc1234..def5678  develop -> develop`;
+
+    const result = parsePush("", stderr, "origin", "");
+
+    expect(result.branch).toBe("develop");
+  });
+
+  it("handles empty output gracefully", () => {
+    const result = parsePush("", "", "origin", "main");
+
+    expect(result.success).toBe(true);
+    expect(result.remote).toBe("origin");
+    expect(result.branch).toBe("main");
+  });
+
+  it("preserves force push output", () => {
+    const stderr = `To github.com:user/repo.git
+ + abc1234...def5678 main -> main (forced update)`;
+
+    const result = parsePush("", stderr, "origin", "main");
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain("forced update");
+  });
+});
+
+describe("formatPush", () => {
+  it("formats push result", () => {
+    const data: GitPush = {
+      success: true,
+      remote: "origin",
+      branch: "main",
+      summary: "abc1234..def5678  main -> main",
+    };
+    const output = formatPush(data);
+
+    expect(output).toBe("Pushed to origin/main: abc1234..def5678  main -> main");
+  });
+});

--- a/packages/server-git/src/index.ts
+++ b/packages/server-git/src/index.ts
@@ -8,7 +8,7 @@ const server = new McpServer(
   { name: "@paretools/git", version: "0.2.0" },
   {
     instructions:
-      "Structured git operations (status, log, diff, branch, show). Use instead of running git commands via bash. Returns typed JSON with significantly fewer tokens than raw CLI output.",
+      "Structured git operations (status, log, diff, branch, show, add, commit, push, pull, checkout). Use instead of running git commands via bash. Returns typed JSON with significantly fewer tokens than raw CLI output.",
   },
 );
 

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -1,4 +1,15 @@
-import type { GitStatus, GitLog, GitDiff, GitBranch, GitShow } from "../schemas/index.js";
+import type {
+  GitStatus,
+  GitLog,
+  GitDiff,
+  GitBranch,
+  GitShow,
+  GitAdd,
+  GitCommit,
+  GitPush,
+  GitPull,
+  GitCheckout,
+} from "../schemas/index.js";
 
 /** Formats structured git status data into a human-readable summary string. */
 export function formatStatus(s: GitStatus): string {
@@ -42,4 +53,45 @@ export function formatShow(s: GitShow): string {
   const header = `${s.hash.slice(0, 8)} ${s.message}\nAuthor: ${s.author} <${s.email}>\nDate: ${s.date}`;
   const diff = formatDiff(s.diff);
   return `${header}\n\n${diff}`;
+}
+
+/** Formats structured git add data into a human-readable summary of staged files. */
+export function formatAdd(a: GitAdd): string {
+  if (a.staged === 0) return "No files staged";
+  return `Staged ${a.staged} file(s): ${a.files.join(", ")}`;
+}
+
+/** Formats structured git commit data into a human-readable commit summary. */
+export function formatCommit(c: GitCommit): string {
+  const stats = [
+    `${c.filesChanged} file(s) changed`,
+    `+${c.insertions}`,
+    `-${c.deletions}`,
+  ].join(", ");
+  return `[${c.hashShort}] ${c.message}\n${stats}`;
+}
+
+/** Formats structured git push data into a human-readable push summary. */
+export function formatPush(p: GitPush): string {
+  return `Pushed to ${p.remote}/${p.branch}: ${p.summary}`;
+}
+
+/** Formats structured git pull data into a human-readable pull summary. */
+export function formatPull(p: GitPull): string {
+  const parts = [p.summary];
+  if (p.filesChanged > 0) {
+    parts.push(`${p.filesChanged} file(s) changed, +${p.insertions} -${p.deletions}`);
+  }
+  if (p.conflicts.length > 0) {
+    parts.push(`Conflicts: ${p.conflicts.join(", ")}`);
+  }
+  return parts.join("\n");
+}
+
+/** Formats structured git checkout data into a human-readable checkout summary. */
+export function formatCheckout(c: GitCheckout): string {
+  if (c.created) {
+    return `Created and switched to new branch '${c.ref}' (was ${c.previousRef})`;
+  }
+  return `Switched to '${c.ref}' (was ${c.previousRef})`;
 }

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -99,3 +99,54 @@ export const GitShowSchema = z.object({
 });
 
 export type GitShow = z.infer<typeof GitShowSchema>;
+
+/** Zod schema for structured git add output with count and list of staged files. */
+export const GitAddSchema = z.object({
+  staged: z.number(),
+  files: z.array(z.string()),
+});
+
+export type GitAdd = z.infer<typeof GitAddSchema>;
+
+/** Zod schema for structured git commit output with hash, message, and change statistics. */
+export const GitCommitSchema = z.object({
+  hash: z.string(),
+  hashShort: z.string(),
+  message: z.string(),
+  filesChanged: z.number(),
+  insertions: z.number(),
+  deletions: z.number(),
+});
+
+export type GitCommit = z.infer<typeof GitCommitSchema>;
+
+/** Zod schema for structured git push output with success status, remote, branch, and summary. */
+export const GitPushSchema = z.object({
+  success: z.boolean(),
+  remote: z.string(),
+  branch: z.string(),
+  summary: z.string(),
+});
+
+export type GitPush = z.infer<typeof GitPushSchema>;
+
+/** Zod schema for structured git pull output with success status, summary, change stats, and conflicts. */
+export const GitPullSchema = z.object({
+  success: z.boolean(),
+  summary: z.string(),
+  filesChanged: z.number(),
+  insertions: z.number(),
+  deletions: z.number(),
+  conflicts: z.array(z.string()),
+});
+
+export type GitPull = z.infer<typeof GitPullSchema>;
+
+/** Zod schema for structured git checkout output with ref, previous ref, and whether a new branch was created. */
+export const GitCheckoutSchema = z.object({
+  ref: z.string(),
+  previousRef: z.string(),
+  created: z.boolean(),
+});
+
+export type GitCheckout = z.infer<typeof GitCheckoutSchema>;

--- a/packages/server-git/src/tools/add.ts
+++ b/packages/server-git/src/tools/add.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseAdd } from "../lib/parsers.js";
+import { formatAdd } from "../lib/formatters.js";
+import { GitAddSchema } from "../schemas/index.js";
+
+export function registerAddTool(server: McpServer) {
+  server.registerTool(
+    "add",
+    {
+      title: "Git Add",
+      description:
+        "Stages files for commit. Returns structured data with count and list of staged files. Use instead of running `git add` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Repository path (default: cwd)"),
+        files: z
+          .array(z.string())
+          .optional()
+          .describe("File paths to stage (required unless all is true)"),
+        all: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Stage all changes (git add -A)"),
+      },
+      outputSchema: GitAddSchema,
+    },
+    async ({ path, files, all }) => {
+      const cwd = path || process.cwd();
+
+      if (!all && (!files || files.length === 0)) {
+        throw new Error("Either 'files' must be provided or 'all' must be true");
+      }
+
+      // Build args
+      let args: string[];
+      if (all) {
+        args = ["add", "-A"];
+      } else {
+        // Validate each file path
+        for (const file of files!) {
+          assertNoFlagInjection(file, "file path");
+        }
+        args = ["add", "--", ...files!];
+      }
+
+      const result = await git(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`git add failed: ${result.stderr}`);
+      }
+
+      // Run git status to get the list of staged files
+      const statusResult = await git(["status", "--porcelain=v1"], cwd);
+      if (statusResult.exitCode !== 0) {
+        throw new Error(`git status failed after add: ${statusResult.stderr}`);
+      }
+
+      const addResult = parseAdd(statusResult.stdout);
+      return dualOutput(addResult, formatAdd);
+    },
+  );
+}

--- a/packages/server-git/src/tools/checkout.ts
+++ b/packages/server-git/src/tools/checkout.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseCheckout } from "../lib/parsers.js";
+import { formatCheckout } from "../lib/formatters.js";
+import { GitCheckoutSchema } from "../schemas/index.js";
+
+export function registerCheckoutTool(server: McpServer) {
+  server.registerTool(
+    "checkout",
+    {
+      title: "Git Checkout",
+      description:
+        "Switches branches or restores files. Returns structured data with ref, previous ref, and whether a new branch was created. Use instead of running `git checkout` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Repository path (default: cwd)"),
+        ref: z
+          .string()
+          .describe("Branch name, tag, or commit to checkout"),
+        create: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Create a new branch (-b)"),
+      },
+      outputSchema: GitCheckoutSchema,
+    },
+    async ({ path, ref, create }) => {
+      const cwd = path || process.cwd();
+
+      assertNoFlagInjection(ref, "ref");
+
+      // Get current branch/ref before checkout
+      const prevResult = await git(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+      const previousRef = prevResult.exitCode === 0 ? prevResult.stdout.trim() : "unknown";
+
+      // Build checkout args
+      const args = ["checkout"];
+      if (create) args.push("-b");
+      args.push(ref);
+
+      const result = await git(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`git checkout failed: ${result.stderr}`);
+      }
+
+      const checkoutResult = parseCheckout(
+        result.stdout,
+        result.stderr,
+        ref,
+        previousRef,
+        create,
+      );
+      return dualOutput(checkoutResult, formatCheckout);
+    },
+  );
+}

--- a/packages/server-git/src/tools/index.ts
+++ b/packages/server-git/src/tools/index.ts
@@ -4,6 +4,11 @@ import { registerLogTool } from "./log.js";
 import { registerDiffTool } from "./diff.js";
 import { registerBranchTool } from "./branch.js";
 import { registerShowTool } from "./show.js";
+import { registerAddTool } from "./add.js";
+import { registerCommitTool } from "./commit.js";
+import { registerPushTool } from "./push.js";
+import { registerPullTool } from "./pull.js";
+import { registerCheckoutTool } from "./checkout.js";
 
 export function registerAllTools(server: McpServer) {
   registerStatusTool(server);
@@ -11,4 +16,9 @@ export function registerAllTools(server: McpServer) {
   registerDiffTool(server);
   registerBranchTool(server);
   registerShowTool(server);
+  registerAddTool(server);
+  registerCommitTool(server);
+  registerPushTool(server);
+  registerPullTool(server);
+  registerCheckoutTool(server);
 }

--- a/packages/server-git/src/tools/pull.ts
+++ b/packages/server-git/src/tools/pull.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parsePull } from "../lib/parsers.js";
+import { formatPull } from "../lib/formatters.js";
+import { GitPullSchema } from "../schemas/index.js";
+
+export function registerPullTool(server: McpServer) {
+  server.registerTool(
+    "pull",
+    {
+      title: "Git Pull",
+      description:
+        "Pulls changes from a remote repository. Returns structured data with success status, summary, change statistics, and any conflicts. Use instead of running `git pull` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Repository path (default: cwd)"),
+        remote: z
+          .string()
+          .optional()
+          .default("origin")
+          .describe('Remote name (default: "origin")'),
+        branch: z.string().optional().describe("Branch to pull (default: current tracking branch)"),
+        rebase: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Use rebase instead of merge (--rebase)"),
+      },
+      outputSchema: GitPullSchema,
+    },
+    async ({ path, remote, branch, rebase }) => {
+      const cwd = path || process.cwd();
+
+      assertNoFlagInjection(remote, "remote");
+      if (branch) {
+        assertNoFlagInjection(branch, "branch");
+      }
+
+      const args = ["pull"];
+      if (rebase) args.push("--rebase");
+      args.push(remote);
+      if (branch) args.push(branch);
+
+      const result = await git(args, cwd);
+
+      // Pull can exit non-zero for conflicts but still produce useful output
+      if (result.exitCode !== 0) {
+        // Check if it's a conflict situation (still parseable)
+        const combined = `${result.stdout}\n${result.stderr}`;
+        if (/CONFLICT/.test(combined)) {
+          const pullResult = parsePull(result.stdout, result.stderr);
+          return dualOutput(pullResult, formatPull);
+        }
+        throw new Error(`git pull failed: ${result.stderr}`);
+      }
+
+      const pullResult = parsePull(result.stdout, result.stderr);
+      return dualOutput(pullResult, formatPull);
+    },
+  );
+}

--- a/packages/server-git/src/tools/push.ts
+++ b/packages/server-git/src/tools/push.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parsePush } from "../lib/parsers.js";
+import { formatPush } from "../lib/formatters.js";
+import { GitPushSchema } from "../schemas/index.js";
+
+export function registerPushTool(server: McpServer) {
+  server.registerTool(
+    "push",
+    {
+      title: "Git Push",
+      description:
+        "Pushes commits to a remote repository. Returns structured data with success status, remote, branch, and summary. Use instead of running `git push` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Repository path (default: cwd)"),
+        remote: z
+          .string()
+          .optional()
+          .default("origin")
+          .describe('Remote name (default: "origin")'),
+        branch: z.string().optional().describe("Branch to push (default: current branch)"),
+        force: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Force push (--force)"),
+        setUpstream: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Set upstream tracking (-u)"),
+      },
+      outputSchema: GitPushSchema,
+    },
+    async ({ path, remote, branch, force, setUpstream }) => {
+      const cwd = path || process.cwd();
+
+      assertNoFlagInjection(remote, "remote");
+      if (branch) {
+        assertNoFlagInjection(branch, "branch");
+      }
+
+      const args = ["push"];
+      if (force) args.push("--force");
+      if (setUpstream) args.push("-u");
+      args.push(remote);
+      if (branch) args.push(branch);
+
+      const result = await git(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`git push failed: ${result.stderr}`);
+      }
+
+      const pushResult = parsePush(result.stdout, result.stderr, remote, branch || "");
+      return dualOutput(pushResult, formatPush);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds 5 new git write tools: `add`, `commit`, `push`, `pull`, `checkout`
- All tools follow existing Pare patterns (schemas, parsers, formatters, dualOutput)
- Input validation with `assertNoFlagInjection` for security
- Comprehensive test coverage (43 new tests across 5 test files)

Closes #32

## Test plan
- [x] Parser tests for all 5 tools (add, commit, push, pull, checkout)
- [x] Formatter tests for all 5 tools
- [x] Edge case coverage (empty inputs, conflicts, rename handling, detached HEAD)
- [x] Integration test updated for 10 tools (was 5)
- [x] Build passes (`pnpm build --filter @paretools/git`)
- [x] All 120 tests pass (`pnpm test --filter @paretools/git`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)