### PR TITLE
feat(lint): add Prettier format and Biome tools

### DIFF
--- a/packages/server-lint/__tests__/biome-check.test.ts
+++ b/packages/server-lint/__tests__/biome-check.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import { parseBiomeJson } from "../src/lib/parsers.js";
+
+describe("parseBiomeJson", () => {
+  it("parses Biome JSON diagnostics with errors and warnings", () => {
+    const json = JSON.stringify({
+      diagnostics: [
+        {
+          category: "lint/suspicious/noDoubleEquals",
+          severity: "error",
+          description: "Use === instead of ==.",
+          location: {
+            path: { file: "src/index.ts" },
+            span: { start: 100, end: 102 },
+            sourceCode: { lineNumber: 5, columnNumber: 10 },
+          },
+          tags: ["fixable"],
+        },
+        {
+          category: "lint/style/useConst",
+          severity: "warning",
+          description: "Use const instead of let.",
+          location: {
+            path: { file: "src/utils.ts" },
+            span: { start: 200, end: 203 },
+            sourceCode: { lineNumber: 12, columnNumber: 1 },
+          },
+          tags: [],
+        },
+      ],
+    });
+
+    const result = parseBiomeJson(json);
+
+    expect(result.total).toBe(2);
+    expect(result.errors).toBe(1);
+    expect(result.warnings).toBe(1);
+    expect(result.fixable).toBe(1);
+    expect(result.filesChecked).toBe(2);
+
+    expect(result.diagnostics[0]).toEqual({
+      file: "src/index.ts",
+      line: 5,
+      column: 10,
+      severity: "error",
+      rule: "lint/suspicious/noDoubleEquals",
+      message: "Use === instead of ==.",
+      fixable: true,
+    });
+
+    expect(result.diagnostics[1]).toEqual({
+      file: "src/utils.ts",
+      line: 12,
+      column: 1,
+      severity: "warning",
+      rule: "lint/style/useConst",
+      message: "Use const instead of let.",
+      fixable: false,
+    });
+  });
+
+  it("parses clean Biome output (no diagnostics)", () => {
+    const json = JSON.stringify({ diagnostics: [] });
+
+    const result = parseBiomeJson(json);
+
+    expect(result.total).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(result.warnings).toBe(0);
+    expect(result.fixable).toBe(0);
+    expect(result.filesChecked).toBe(0);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("handles invalid JSON gracefully", () => {
+    const result = parseBiomeJson("not json");
+
+    expect(result.total).toBe(0);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("handles missing diagnostics field", () => {
+    const json = JSON.stringify({});
+
+    const result = parseBiomeJson(json);
+
+    expect(result.total).toBe(0);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("maps Biome severity levels correctly", () => {
+    const json = JSON.stringify({
+      diagnostics: [
+        {
+          category: "rule-error",
+          severity: "error",
+          description: "Error diagnostic",
+          location: { path: { file: "a.ts" } },
+          tags: [],
+        },
+        {
+          category: "rule-fatal",
+          severity: "fatal",
+          description: "Fatal diagnostic",
+          location: { path: { file: "b.ts" } },
+          tags: [],
+        },
+        {
+          category: "rule-warning",
+          severity: "warning",
+          description: "Warning diagnostic",
+          location: { path: { file: "c.ts" } },
+          tags: [],
+        },
+        {
+          category: "rule-info",
+          severity: "information",
+          description: "Info diagnostic",
+          location: { path: { file: "d.ts" } },
+          tags: [],
+        },
+        {
+          category: "rule-hint",
+          severity: "hint",
+          description: "Hint diagnostic",
+          location: { path: { file: "e.ts" } },
+          tags: [],
+        },
+      ],
+    });
+
+    const result = parseBiomeJson(json);
+
+    expect(result.diagnostics[0].severity).toBe("error");
+    expect(result.diagnostics[1].severity).toBe("error"); // fatal -> error
+    expect(result.diagnostics[2].severity).toBe("warning");
+    expect(result.diagnostics[3].severity).toBe("info"); // information -> info
+    expect(result.diagnostics[4].severity).toBe("info"); // hint -> info
+  });
+
+  it("handles diagnostics without location info", () => {
+    const json = JSON.stringify({
+      diagnostics: [
+        {
+          category: "parse/error",
+          severity: "error",
+          description: "Unexpected token.",
+          tags: [],
+        },
+      ],
+    });
+
+    const result = parseBiomeJson(json);
+
+    expect(result.diagnostics[0].file).toBe("unknown");
+    expect(result.diagnostics[0].line).toBe(0);
+    expect(result.diagnostics[0].column).toBe(0);
+  });
+
+  it("handles mixed lint and format diagnostics", () => {
+    const json = JSON.stringify({
+      diagnostics: [
+        {
+          category: "lint/suspicious/noDoubleEquals",
+          severity: "error",
+          description: "Use === instead of ==.",
+          location: {
+            path: { file: "src/index.ts" },
+            sourceCode: { lineNumber: 5, columnNumber: 10 },
+          },
+          tags: ["fixable"],
+        },
+        {
+          category: "format",
+          severity: "error",
+          description: "File not formatted.",
+          location: {
+            path: { file: "src/index.ts" },
+            sourceCode: { lineNumber: 1, columnNumber: 1 },
+          },
+          tags: ["fixable"],
+        },
+        {
+          category: "lint/style/useConst",
+          severity: "warning",
+          description: "Use const.",
+          location: {
+            path: { file: "src/other.ts" },
+            sourceCode: { lineNumber: 3, columnNumber: 5 },
+          },
+          tags: [],
+        },
+      ],
+    });
+
+    const result = parseBiomeJson(json);
+
+    expect(result.total).toBe(3);
+    expect(result.errors).toBe(2);
+    expect(result.warnings).toBe(1);
+    expect(result.fixable).toBe(2);
+    // Both src/index.ts entries count as one file
+    expect(result.filesChecked).toBe(2);
+  });
+
+  it("uses message field as fallback when description is missing", () => {
+    const json = JSON.stringify({
+      diagnostics: [
+        {
+          category: "parse/error",
+          severity: "error",
+          message: "Fallback message text",
+          location: { path: { file: "a.ts" } },
+          tags: [],
+        },
+      ],
+    });
+
+    const result = parseBiomeJson(json);
+    expect(result.diagnostics[0].message).toBe("Fallback message text");
+  });
+});

--- a/packages/server-lint/__tests__/biome-format.test.ts
+++ b/packages/server-lint/__tests__/biome-format.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { parseBiomeFormat } from "../src/lib/parsers.js";
+import { formatFormatWrite } from "../src/lib/formatters.js";
+import type { FormatWriteResult } from "../src/schemas/index.js";
+
+describe("parseBiomeFormat", () => {
+  it("parses file paths from Biome format --write output", () => {
+    const stdout = ["src/index.ts", "src/utils.ts"].join("\n");
+
+    const result = parseBiomeFormat(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(2);
+    expect(result.files).toEqual(["src/index.ts", "src/utils.ts"]);
+  });
+
+  it("returns empty files when no files were formatted", () => {
+    const result = parseBiomeFormat("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.files).toEqual([]);
+  });
+
+  it("handles exit code failure", () => {
+    const result = parseBiomeFormat("", "biome not found", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.filesChanged).toBe(0);
+  });
+
+  it("filters out summary lines from Biome output", () => {
+    const stdout = [
+      "src/index.ts",
+      "src/utils.ts",
+      "Formatted 2 files in 50ms.",
+      "Fixed 2 files.",
+    ].join("\n");
+
+    const result = parseBiomeFormat(stdout, "", 0);
+
+    expect(result.files).toEqual(["src/index.ts", "src/utils.ts"]);
+    expect(result.filesChanged).toBe(2);
+  });
+
+  it("filters out Checked summary lines", () => {
+    const stdout = [
+      "src/app.tsx",
+      "Checked 5 files in 20ms. No fixes needed.",
+    ].join("\n");
+
+    const result = parseBiomeFormat(stdout, "", 0);
+
+    expect(result.files).toEqual(["src/app.tsx"]);
+    expect(result.filesChanged).toBe(1);
+  });
+
+  it("handles various file extensions", () => {
+    const stdout = [
+      "src/app.tsx",
+      "styles/main.css",
+      "config.json",
+      "lib/helpers.js",
+    ].join("\n");
+
+    const result = parseBiomeFormat(stdout, "", 0);
+
+    expect(result.filesChanged).toBe(4);
+    expect(result.files).toEqual([
+      "src/app.tsx",
+      "styles/main.css",
+      "config.json",
+      "lib/helpers.js",
+    ]);
+  });
+});
+
+describe("formatFormatWrite (biome context)", () => {
+  it("formats successful biome format result", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 3,
+      files: ["src/a.ts", "src/b.ts", "src/c.ts"],
+      success: true,
+    };
+
+    const output = formatFormatWrite(data);
+    expect(output).toContain("Formatted 3 files:");
+    expect(output).toContain("src/a.ts");
+    expect(output).toContain("src/b.ts");
+    expect(output).toContain("src/c.ts");
+  });
+
+  it("formats when nothing needed formatting", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 0,
+      files: [],
+      success: true,
+    };
+
+    expect(formatFormatWrite(data)).toBe("All files already formatted.");
+  });
+
+  it("formats failure", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 0,
+      files: [],
+      success: false,
+    };
+
+    expect(formatFormatWrite(data)).toBe("Format failed.");
+  });
+});

--- a/packages/server-lint/__tests__/integration.test.ts
+++ b/packages/server-lint/__tests__/integration.test.ts
@@ -26,10 +26,10 @@ describe("@paretools/lint integration", () => {
     await transport.close();
   });
 
-  it("lists all 2 tools", async () => {
+  it("lists all 5 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
-    expect(names).toEqual(["format-check", "lint"]);
+    expect(names).toEqual(["biome-check", "biome-format", "format-check", "lint", "prettier-format"]);
   });
 
   it("each tool has an outputSchema", async () => {

--- a/packages/server-lint/__tests__/prettier-format.test.ts
+++ b/packages/server-lint/__tests__/prettier-format.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { parsePrettierWrite } from "../src/lib/parsers.js";
+import { formatFormatWrite } from "../src/lib/formatters.js";
+import type { FormatWriteResult } from "../src/schemas/index.js";
+
+describe("parsePrettierWrite", () => {
+  it("parses file paths from Prettier --write output", () => {
+    const stdout = ["src/index.ts", "src/utils.ts", "src/config.ts"].join("\n");
+
+    const result = parsePrettierWrite(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(3);
+    expect(result.files).toEqual(["src/index.ts", "src/utils.ts", "src/config.ts"]);
+  });
+
+  it("returns empty files when no files were changed", () => {
+    const result = parsePrettierWrite("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.files).toEqual([]);
+  });
+
+  it("handles exit code failure", () => {
+    const result = parsePrettierWrite("", "error: no parser found", 2);
+
+    expect(result.success).toBe(false);
+    expect(result.filesChanged).toBe(0);
+  });
+
+  it("filters out non-file-path lines", () => {
+    const stdout = [
+      "src/index.ts",
+      "[warn] some warning message",
+      "src/utils.ts",
+      "Checking formatting...",
+      "All matched files use Prettier code style!",
+    ].join("\n");
+
+    const result = parsePrettierWrite(stdout, "", 0);
+
+    expect(result.files).toEqual(["src/index.ts", "src/utils.ts"]);
+    expect(result.filesChanged).toBe(2);
+  });
+
+  it("handles files with various extensions", () => {
+    const stdout = [
+      "src/app.tsx",
+      "styles/main.css",
+      "config/settings.json",
+      "docs/readme.md",
+    ].join("\n");
+
+    const result = parsePrettierWrite(stdout, "", 0);
+
+    expect(result.filesChanged).toBe(4);
+    expect(result.files).toEqual([
+      "src/app.tsx",
+      "styles/main.css",
+      "config/settings.json",
+      "docs/readme.md",
+    ]);
+  });
+});
+
+describe("formatFormatWrite", () => {
+  it("formats successful result with changed files", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 2,
+      files: ["src/index.ts", "src/utils.ts"],
+      success: true,
+    };
+
+    const output = formatFormatWrite(data);
+    expect(output).toContain("Formatted 2 files:");
+    expect(output).toContain("src/index.ts");
+    expect(output).toContain("src/utils.ts");
+  });
+
+  it("formats result when all files already formatted", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 0,
+      files: [],
+      success: true,
+    };
+
+    expect(formatFormatWrite(data)).toBe("All files already formatted.");
+  });
+
+  it("formats failure result", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 0,
+      files: [],
+      success: false,
+    };
+
+    expect(formatFormatWrite(data)).toBe("Format failed.");
+  });
+});

--- a/packages/server-lint/src/index.ts
+++ b/packages/server-lint/src/index.ts
@@ -8,7 +8,7 @@ const server = new McpServer(
   { name: "@paretools/lint", version: "0.2.0" },
   {
     instructions:
-      "Structured linting operations (ESLint, Prettier format check). Use instead of running lint commands via bash. Returns typed JSON with structured violation details and counts.",
+      "Structured linting and formatting operations (ESLint, Prettier, Biome). Use instead of running lint/format commands via bash. Returns typed JSON with structured violation details and counts.",
   },
 );
 

--- a/packages/server-lint/src/lib/formatters.ts
+++ b/packages/server-lint/src/lib/formatters.ts
@@ -1,4 +1,4 @@
-import type { LintResult, FormatCheckResult } from "../schemas/index.js";
+import type { LintResult, FormatCheckResult, FormatWriteResult } from "../schemas/index.js";
 
 /** Formats structured ESLint results into a human-readable diagnostic summary with file locations. */
 export function formatLint(data: LintResult): string {
@@ -18,6 +18,18 @@ export function formatFormatCheck(data: FormatCheckResult): string {
   if (data.formatted) return "All files are formatted.";
 
   const lines = [`${data.total} files need formatting:`];
+  for (const f of data.files) {
+    lines.push(`  ${f}`);
+  }
+  return lines.join("\n");
+}
+
+/** Formats structured format-write results into a human-readable summary. */
+export function formatFormatWrite(data: FormatWriteResult): string {
+  if (!data.success) return "Format failed.";
+  if (data.filesChanged === 0) return "All files already formatted.";
+
+  const lines = [`Formatted ${data.filesChanged} files:`];
   for (const f of data.files) {
     lines.push(`  ${f}`);
   }

--- a/packages/server-lint/src/lib/lint-runner.ts
+++ b/packages/server-lint/src/lib/lint-runner.ts
@@ -7,3 +7,7 @@ export async function eslint(args: string[], cwd?: string): Promise<RunResult> {
 export async function prettier(args: string[], cwd?: string): Promise<RunResult> {
   return run("npx", ["prettier", ...args], { cwd });
 }
+
+export async function biome(args: string[], cwd?: string): Promise<RunResult> {
+  return run("npx", ["@biomejs/biome", ...args], { cwd });
+}

--- a/packages/server-lint/src/lib/parsers.ts
+++ b/packages/server-lint/src/lib/parsers.ts
@@ -1,4 +1,9 @@
-import type { LintResult, LintDiagnostic, FormatCheckResult } from "../schemas/index.js";
+import type {
+  LintResult,
+  LintDiagnostic,
+  FormatCheckResult,
+  FormatWriteResult,
+} from "../schemas/index.js";
 
 /**
  * Parses ESLint JSON output (from `eslint --format json`).
@@ -88,5 +93,175 @@ export function parsePrettierCheck(
     formatted: exitCode === 0,
     files,
     total: files.length,
+  };
+}
+
+/**
+ * Parses Prettier `--write` output.
+ *
+ * Prettier --write outputs one file path per line for each file it rewrites.
+ * If all files are already formatted, output may be empty or just the file names
+ * with no changes. We detect changed files from the output lines.
+ */
+export function parsePrettierWrite(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): FormatWriteResult {
+  const output = stdout + "\n" + stderr;
+  const lines = output.split("\n").filter(Boolean);
+
+  const files: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    // Prettier --write outputs file paths for files it processes.
+    // Skip lines that don't look like file paths.
+    if (
+      trimmed &&
+      !trimmed.startsWith("[") &&
+      !trimmed.startsWith("Checking") &&
+      !trimmed.startsWith("All ") &&
+      /\.\w+$/.test(trimmed)
+    ) {
+      files.push(trimmed);
+    }
+  }
+
+  return {
+    filesChanged: files.length,
+    files,
+    success: exitCode === 0,
+  };
+}
+
+/**
+ * Parses Biome `check --reporter=json` output.
+ *
+ * Biome JSON reporter outputs an object with a `diagnostics` array:
+ * { diagnostics: [{ category, severity, description, location: { path: { file }, span }, advices }] }
+ */
+export function parseBiomeJson(stdout: string): LintResult {
+  let biomeOutput: BiomeJsonOutput;
+  try {
+    biomeOutput = JSON.parse(stdout);
+  } catch {
+    return { diagnostics: [], total: 0, errors: 0, warnings: 0, fixable: 0, filesChecked: 0 };
+  }
+
+  const diagnostics: LintDiagnostic[] = [];
+  const filesSet = new Set<string>();
+
+  const rawDiags = biomeOutput.diagnostics ?? [];
+
+  for (const diag of rawDiags) {
+    const file = diag.location?.path?.file ?? "unknown";
+    filesSet.add(file);
+
+    const severity = mapBiomeSeverity(diag.severity);
+    const rule = diag.category ?? "unknown";
+    const message =
+      typeof diag.description === "string"
+        ? diag.description
+        : (diag.message ?? "unknown diagnostic");
+
+    // Biome spans are byte offsets, not line/column. We extract from sourceCode if available,
+    // but default to 0 if line info is not in the JSON output.
+    const line = diag.location?.sourceCode?.lineNumber ?? 0;
+    const column = diag.location?.sourceCode?.columnNumber ?? 0;
+
+    const fixable = diag.tags?.includes("fixable") ?? false;
+
+    diagnostics.push({
+      file,
+      line,
+      column,
+      severity,
+      rule,
+      message,
+      fixable,
+    });
+  }
+
+  const errors = diagnostics.filter((d) => d.severity === "error").length;
+  const warnings = diagnostics.filter((d) => d.severity === "warning").length;
+  const fixable = diagnostics.filter((d) => d.fixable).length;
+
+  return {
+    diagnostics,
+    total: diagnostics.length,
+    errors,
+    warnings,
+    fixable,
+    filesChecked: filesSet.size,
+  };
+}
+
+function mapBiomeSeverity(severity: string | undefined): "error" | "warning" | "info" {
+  switch (severity) {
+    case "error":
+    case "fatal":
+      return "error";
+    case "warning":
+      return "warning";
+    case "information":
+    case "hint":
+      return "info";
+    default:
+      return "warning";
+  }
+}
+
+interface BiomeJsonOutput {
+  diagnostics?: BiomeDiagnostic[];
+}
+
+interface BiomeDiagnostic {
+  category?: string;
+  severity?: string;
+  description?: string;
+  message?: string;
+  location?: {
+    path?: { file?: string };
+    span?: { start?: number; end?: number };
+    sourceCode?: { lineNumber?: number; columnNumber?: number };
+  };
+  tags?: string[];
+  advices?: unknown;
+}
+
+/**
+ * Parses Biome `format --write` output.
+ *
+ * Biome format --write outputs lines like:
+ * "Formatted 3 files in 50ms. Fixed 2 files."
+ * It also outputs individual file paths that were formatted.
+ */
+export function parseBiomeFormat(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): FormatWriteResult {
+  const output = stdout + "\n" + stderr;
+  const lines = output.split("\n").filter(Boolean);
+
+  const files: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    // Skip summary lines and empty lines. File paths end with an extension.
+    if (
+      trimmed &&
+      !trimmed.startsWith("Formatted ") &&
+      !trimmed.startsWith("Fixed ") &&
+      !trimmed.startsWith("Checked ") &&
+      /\.\w+$/.test(trimmed)
+    ) {
+      files.push(trimmed);
+    }
+  }
+
+  return {
+    filesChanged: files.length,
+    files,
+    success: exitCode === 0,
   };
 }

--- a/packages/server-lint/src/schemas/index.ts
+++ b/packages/server-lint/src/schemas/index.ts
@@ -34,3 +34,12 @@ export const FormatCheckResultSchema = z.object({
 });
 
 export type FormatCheckResult = z.infer<typeof FormatCheckResultSchema>;
+
+/** Zod schema for structured format-write output (Prettier --write, Biome format --write). */
+export const FormatWriteResultSchema = z.object({
+  filesChanged: z.number(),
+  files: z.array(z.string()),
+  success: z.boolean(),
+});
+
+export type FormatWriteResult = z.infer<typeof FormatWriteResultSchema>;

--- a/packages/server-lint/src/tools/biome-check.ts
+++ b/packages/server-lint/src/tools/biome-check.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { biome } from "../lib/lint-runner.js";
+import { parseBiomeJson } from "../lib/parsers.js";
+import { formatLint } from "../lib/formatters.js";
+import { LintResultSchema } from "../schemas/index.js";
+
+export function registerBiomeCheckTool(server: McpServer) {
+  server.registerTool(
+    "biome-check",
+    {
+      title: "Biome Check",
+      description:
+        "Runs Biome check (lint + format) and returns structured diagnostics (file, line, rule, severity, message). Use instead of running `biome check` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Project root path (default: cwd)"),
+        patterns: z
+          .array(z.string())
+          .optional()
+          .default(["."])
+          .describe("File patterns to check (default: ['.'])"),
+      },
+      outputSchema: LintResultSchema,
+    },
+    async ({ path, patterns }) => {
+      const cwd = path || process.cwd();
+      const args = ["check", "--reporter=json", ...(patterns || ["."])];
+
+      const result = await biome(args, cwd);
+      const data = parseBiomeJson(result.stdout);
+      return dualOutput(data, formatLint);
+    },
+  );
+}

--- a/packages/server-lint/src/tools/biome-format.ts
+++ b/packages/server-lint/src/tools/biome-format.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { biome } from "../lib/lint-runner.js";
+import { parseBiomeFormat } from "../lib/parsers.js";
+import { formatFormatWrite } from "../lib/formatters.js";
+import { FormatWriteResultSchema } from "../schemas/index.js";
+
+export function registerBiomeFormatTool(server: McpServer) {
+  server.registerTool(
+    "biome-format",
+    {
+      title: "Biome Format",
+      description:
+        "Formats files with Biome (format --write) and returns a structured list of changed files. Use instead of running `biome format --write` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Project root path (default: cwd)"),
+        patterns: z
+          .array(z.string())
+          .optional()
+          .default(["."])
+          .describe("File patterns to format (default: ['.'])"),
+      },
+      outputSchema: FormatWriteResultSchema,
+    },
+    async ({ path, patterns }) => {
+      const cwd = path || process.cwd();
+      const args = ["format", "--write", ...(patterns || ["."])];
+
+      const result = await biome(args, cwd);
+      const data = parseBiomeFormat(result.stdout, result.stderr, result.exitCode);
+      return dualOutput(data, formatFormatWrite);
+    },
+  );
+}

--- a/packages/server-lint/src/tools/index.ts
+++ b/packages/server-lint/src/tools/index.ts
@@ -1,8 +1,14 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerLintTool } from "./lint.js";
 import { registerFormatCheckTool } from "./format-check.js";
+import { registerPrettierFormatTool } from "./prettier-format.js";
+import { registerBiomeCheckTool } from "./biome-check.js";
+import { registerBiomeFormatTool } from "./biome-format.js";
 
 export function registerAllTools(server: McpServer) {
   registerLintTool(server);
   registerFormatCheckTool(server);
+  registerPrettierFormatTool(server);
+  registerBiomeCheckTool(server);
+  registerBiomeFormatTool(server);
 }

--- a/packages/server-lint/src/tools/prettier-format.ts
+++ b/packages/server-lint/src/tools/prettier-format.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { prettier } from "../lib/lint-runner.js";
+import { parsePrettierWrite } from "../lib/parsers.js";
+import { formatFormatWrite } from "../lib/formatters.js";
+import { FormatWriteResultSchema } from "../schemas/index.js";
+
+export function registerPrettierFormatTool(server: McpServer) {
+  server.registerTool(
+    "prettier-format",
+    {
+      title: "Prettier Format",
+      description:
+        "Formats files with Prettier (--write) and returns a structured list of changed files. Use instead of running `prettier --write` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Project root path (default: cwd)"),
+        patterns: z
+          .array(z.string())
+          .optional()
+          .default(["."])
+          .describe("File patterns to format (default: ['.'])"),
+      },
+      outputSchema: FormatWriteResultSchema,
+    },
+    async ({ path, patterns }) => {
+      const cwd = path || process.cwd();
+      const args = ["--write", ...(patterns || ["."])];
+
+      const result = await prettier(args, cwd);
+      const data = parsePrettierWrite(result.stdout, result.stderr, result.exitCode);
+      return dualOutput(data, formatFormatWrite);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `prettier-format` tool: formats files with Prettier `--write` and returns structured list of changed files
- Adds `biome-check` tool: runs Biome check (lint + format) with `--reporter=json` and returns structured diagnostics using the existing `LintResultSchema`
- Adds `biome-format` tool: formats files with Biome `format --write` and returns structured list of changed files
- Adds shared `FormatWriteResultSchema` used by both prettier-format and biome-format
- Adds `biome` runner to `lint-runner.ts`
- Adds parsers: `parsePrettierWrite`, `parseBiomeJson`, `parseBiomeFormat`
- Adds formatter: `formatFormatWrite`
- 25 new tests across 3 test files (54 total, all passing)

## New tools

| Tool | Description | Output Schema |
|------|-------------|---------------|
| `prettier-format` | Format files with Prettier --write | `FormatWriteResultSchema` |
| `biome-check` | Biome check (lint + format diagnostics) | `LintResultSchema` |
| `biome-format` | Format files with Biome format --write | `FormatWriteResultSchema` |

Note: ESLint `--fix` is already supported via the existing `lint` tool's `fix` boolean parameter.

## Test plan
- [x] Parser tests for `parsePrettierWrite` (5 cases including edge cases)
- [x] Parser tests for `parseBiomeJson` (8 cases: errors/warnings, clean, invalid JSON, severity mapping, mixed diagnostics, missing location, fallback message)
- [x] Parser tests for `parseBiomeFormat` (6 cases including summary line filtering)
- [x] Formatter tests for `formatFormatWrite` (3 cases each in prettier-format and biome-format)
- [x] Integration test updated for 5 tools (was 2)
- [x] Build passes (`pnpm build --filter @paretools/lint`)
- [x] All 54 tests pass (`pnpm test --filter @paretools/lint`)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)