### PR TITLE
feat(npm): add run, test, and init tools

### DIFF
--- a/packages/server-npm/__tests__/init.test.ts
+++ b/packages/server-npm/__tests__/init.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { parseInitOutput } from "../src/lib/parsers.js";
+import { formatInit } from "../src/lib/formatters.js";
+import type { NpmInit } from "../src/schemas/index.js";
+
+describe("parseInitOutput", () => {
+  it("parses successful init result", () => {
+    const result = parseInitOutput(true, "my-project", "1.0.0", "/tmp/my-project/package.json");
+
+    expect(result.success).toBe(true);
+    expect(result.packageName).toBe("my-project");
+    expect(result.version).toBe("1.0.0");
+    expect(result.path).toBe("/tmp/my-project/package.json");
+  });
+
+  it("parses failed init result", () => {
+    const result = parseInitOutput(false, "unknown", "0.0.0", "/tmp/bad-dir/package.json");
+
+    expect(result.success).toBe(false);
+    expect(result.packageName).toBe("unknown");
+    expect(result.version).toBe("0.0.0");
+    expect(result.path).toBe("/tmp/bad-dir/package.json");
+  });
+
+  it("parses scoped package init result", () => {
+    const result = parseInitOutput(true, "@myorg/utils", "1.0.0", "/tmp/utils/package.json");
+
+    expect(result.success).toBe(true);
+    expect(result.packageName).toBe("@myorg/utils");
+    expect(result.version).toBe("1.0.0");
+  });
+
+  it("preserves the full package.json path", () => {
+    const longPath = "/home/user/projects/deep/nested/dir/package.json";
+    const result = parseInitOutput(true, "nested-project", "0.1.0", longPath);
+
+    expect(result.path).toBe(longPath);
+  });
+
+  it("handles default version from npm init -y", () => {
+    const result = parseInitOutput(true, "my-app", "1.0.0", "/tmp/my-app/package.json");
+
+    expect(result.version).toBe("1.0.0");
+  });
+});
+
+describe("formatInit", () => {
+  it("formats successful init", () => {
+    const data: NpmInit = {
+      success: true,
+      packageName: "my-project",
+      version: "1.0.0",
+      path: "/tmp/my-project/package.json",
+    };
+    const output = formatInit(data);
+    expect(output).toBe("Created my-project@1.0.0 at /tmp/my-project/package.json");
+  });
+
+  it("formats failed init", () => {
+    const data: NpmInit = {
+      success: false,
+      packageName: "unknown",
+      version: "0.0.0",
+      path: "/tmp/bad-dir/package.json",
+    };
+    const output = formatInit(data);
+    expect(output).toBe("Failed to initialize package.json at /tmp/bad-dir/package.json");
+  });
+
+  it("formats scoped package init", () => {
+    const data: NpmInit = {
+      success: true,
+      packageName: "@myorg/utils",
+      version: "1.0.0",
+      path: "/tmp/utils/package.json",
+    };
+    const output = formatInit(data);
+    expect(output).toBe("Created @myorg/utils@1.0.0 at /tmp/utils/package.json");
+  });
+});

--- a/packages/server-npm/__tests__/integration.test.ts
+++ b/packages/server-npm/__tests__/integration.test.ts
@@ -26,10 +26,10 @@ describe("@paretools/npm integration", () => {
     await transport.close();
   });
 
-  it("lists all 4 tools", async () => {
+  it("lists all 7 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
-    expect(names).toEqual(["audit", "install", "list", "outdated"]);
+    expect(names).toEqual(["audit", "init", "install", "list", "outdated", "run", "test"]);
   });
 
   describe("list", () => {

--- a/packages/server-npm/__tests__/run.test.ts
+++ b/packages/server-npm/__tests__/run.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { parseRunOutput } from "../src/lib/parsers.js";
+import { formatRun } from "../src/lib/formatters.js";
+import type { NpmRun } from "../src/schemas/index.js";
+
+describe("parseRunOutput", () => {
+  it("parses successful script output", () => {
+    const result = parseRunOutput("build", 0, "Build complete\nFiles emitted: 5", "", 2.3);
+
+    expect(result.script).toBe("build");
+    expect(result.exitCode).toBe(0);
+    expect(result.success).toBe(true);
+    expect(result.stdout).toBe("Build complete\nFiles emitted: 5");
+    expect(result.stderr).toBe("");
+    expect(result.duration).toBe(2.3);
+  });
+
+  it("parses failed script output", () => {
+    const result = parseRunOutput(
+      "build",
+      1,
+      "",
+      "Error: Cannot find module './missing'\nnpm error code ELIFECYCLE",
+      1.5,
+    );
+
+    expect(result.script).toBe("build");
+    expect(result.exitCode).toBe(1);
+    expect(result.success).toBe(false);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Cannot find module");
+    expect(result.duration).toBe(1.5);
+  });
+
+  it("trims whitespace from stdout and stderr", () => {
+    const result = parseRunOutput("lint", 0, "\n  output here  \n\n", "\n  warn  \n", 0.8);
+
+    expect(result.stdout).toBe("output here");
+    expect(result.stderr).toBe("warn");
+  });
+
+  it("handles script with arguments", () => {
+    const result = parseRunOutput("test", 0, "Tests passed: 42", "Coverage: 95%", 5.0);
+
+    expect(result.script).toBe("test");
+    expect(result.success).toBe(true);
+    expect(result.stdout).toBe("Tests passed: 42");
+    expect(result.stderr).toBe("Coverage: 95%");
+  });
+
+  it("handles script not found (exit code 1 with error message)", () => {
+    const result = parseRunOutput(
+      "nonexistent",
+      1,
+      "",
+      'npm error Missing script: "nonexistent"\nnpm error\nnpm error To see a list of scripts, run:\nnpm error   npm run',
+      0.2,
+    );
+
+    expect(result.script).toBe("nonexistent");
+    expect(result.exitCode).toBe(1);
+    expect(result.success).toBe(false);
+    expect(result.stderr).toContain("Missing script");
+  });
+
+  it("handles empty output from a successful script", () => {
+    const result = parseRunOutput("clean", 0, "", "", 0.1);
+
+    expect(result.script).toBe("clean");
+    expect(result.exitCode).toBe(0);
+    expect(result.success).toBe(true);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+  });
+
+  it("handles non-zero exit codes other than 1", () => {
+    const result = parseRunOutput("deploy", 2, "Deploying...", "SIGINT received", 10.5);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("formatRun", () => {
+  it("formats successful script execution", () => {
+    const data: NpmRun = {
+      script: "build",
+      exitCode: 0,
+      stdout: "Build complete",
+      stderr: "",
+      success: true,
+      duration: 2.3,
+    };
+    const output = formatRun(data);
+    expect(output).toContain('Script "build" completed successfully in 2.3s');
+    expect(output).toContain("stdout:");
+    expect(output).toContain("Build complete");
+    expect(output).not.toContain("stderr:");
+  });
+
+  it("formats failed script execution", () => {
+    const data: NpmRun = {
+      script: "test",
+      exitCode: 1,
+      stdout: "",
+      stderr: "Test failed: assertion error",
+      success: false,
+      duration: 5.0,
+    };
+    const output = formatRun(data);
+    expect(output).toContain('Script "test" failed (exit code 1) in 5s');
+    expect(output).toContain("stderr:");
+    expect(output).toContain("Test failed: assertion error");
+    expect(output).not.toContain("stdout:");
+  });
+
+  it("formats script with both stdout and stderr", () => {
+    const data: NpmRun = {
+      script: "lint",
+      exitCode: 0,
+      stdout: "All files passed linting",
+      stderr: "Warning: deprecated rule",
+      success: true,
+      duration: 1.2,
+    };
+    const output = formatRun(data);
+    expect(output).toContain("stdout:");
+    expect(output).toContain("stderr:");
+  });
+
+  it("formats script with no output", () => {
+    const data: NpmRun = {
+      script: "clean",
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      success: true,
+      duration: 0.1,
+    };
+    const output = formatRun(data);
+    expect(output).toBe('Script "clean" completed successfully in 0.1s');
+  });
+});

--- a/packages/server-npm/__tests__/test-tool.test.ts
+++ b/packages/server-npm/__tests__/test-tool.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { parseTestOutput } from "../src/lib/parsers.js";
+import { formatTest } from "../src/lib/formatters.js";
+import type { NpmTest } from "../src/schemas/index.js";
+
+describe("parseTestOutput", () => {
+  it("parses successful test output", () => {
+    const result = parseTestOutput(
+      0,
+      "Tests: 42 passed, 42 total\nTime: 3.5s",
+      "",
+      3.5,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.success).toBe(true);
+    expect(result.stdout).toContain("42 passed");
+    expect(result.stderr).toBe("");
+    expect(result.duration).toBe(3.5);
+  });
+
+  it("parses failed test output", () => {
+    const result = parseTestOutput(
+      1,
+      "Tests: 3 failed, 39 passed, 42 total",
+      "FAIL src/index.test.ts\n  Expected: true\n  Received: false",
+      4.2,
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.success).toBe(false);
+    expect(result.stdout).toContain("3 failed");
+    expect(result.stderr).toContain("FAIL");
+    expect(result.duration).toBe(4.2);
+  });
+
+  it("handles no test script defined", () => {
+    const result = parseTestOutput(
+      1,
+      "",
+      'npm error Missing script: "test"\nnpm error\nnpm error To see a list of scripts, run:\nnpm error   npm run',
+      0.3,
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.success).toBe(false);
+    expect(result.stderr).toContain("Missing script");
+    expect(result.stdout).toBe("");
+  });
+
+  it("trims whitespace from output", () => {
+    const result = parseTestOutput(0, "\n  All tests passed  \n\n", "\n", 1.0);
+
+    expect(result.stdout).toBe("All tests passed");
+    expect(result.stderr).toBe("");
+  });
+
+  it("handles test with coverage output in stderr", () => {
+    const result = parseTestOutput(
+      0,
+      "Tests: 10 passed\nStatements: 95%",
+      "Warning: experimental coverage feature",
+      2.1,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.stdout).toContain("10 passed");
+    expect(result.stderr).toContain("experimental coverage");
+  });
+
+  it("handles exit code other than 0 or 1", () => {
+    const result = parseTestOutput(2, "", "SIGTERM", 60.0);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("formatTest", () => {
+  it("formats passing tests", () => {
+    const data: NpmTest = {
+      exitCode: 0,
+      stdout: "Tests: 42 passed",
+      stderr: "",
+      success: true,
+      duration: 3.5,
+    };
+    const output = formatTest(data);
+    expect(output).toContain("Tests passed in 3.5s");
+    expect(output).toContain("stdout:");
+    expect(output).toContain("42 passed");
+    expect(output).not.toContain("stderr:");
+  });
+
+  it("formats failing tests", () => {
+    const data: NpmTest = {
+      exitCode: 1,
+      stdout: "Tests: 1 failed",
+      stderr: "AssertionError: expected true to be false",
+      success: false,
+      duration: 4.2,
+    };
+    const output = formatTest(data);
+    expect(output).toContain("Tests failed (exit code 1) in 4.2s");
+    expect(output).toContain("stderr:");
+    expect(output).toContain("AssertionError");
+  });
+
+  it("formats test with no output", () => {
+    const data: NpmTest = {
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      success: true,
+      duration: 0.5,
+    };
+    const output = formatTest(data);
+    expect(output).toBe("Tests passed in 0.5s");
+  });
+
+  it("formats test with both stdout and stderr", () => {
+    const data: NpmTest = {
+      exitCode: 0,
+      stdout: "All tests passed",
+      stderr: "Deprecation warning",
+      success: true,
+      duration: 2.0,
+    };
+    const output = formatTest(data);
+    expect(output).toContain("stdout:");
+    expect(output).toContain("stderr:");
+  });
+});

--- a/packages/server-npm/src/index.ts
+++ b/packages/server-npm/src/index.ts
@@ -8,7 +8,7 @@ const server = new McpServer(
   { name: "@paretools/npm", version: "0.2.0" },
   {
     instructions:
-      "Structured npm/pnpm operations (install, audit, outdated, list). Use instead of running npm commands via bash. Returns typed JSON with structured dependency and vulnerability data.",
+      "Structured npm/pnpm operations (install, audit, outdated, list, run, test, init). Use instead of running npm commands via bash. Returns typed JSON with structured dependency, vulnerability, and script execution data.",
   },
 );
 

--- a/packages/server-npm/src/lib/formatters.ts
+++ b/packages/server-npm/src/lib/formatters.ts
@@ -1,4 +1,4 @@
-import type { NpmInstall, NpmAudit, NpmOutdated, NpmList } from "../schemas/index.js";
+import type { NpmInstall, NpmAudit, NpmOutdated, NpmList, NpmRun, NpmTest, NpmInit } from "../schemas/index.js";
 
 /** Formats structured npm install data into a human-readable summary of added/removed packages. */
 export function formatInstall(data: NpmInstall): string {
@@ -55,4 +55,38 @@ export function formatList(data: NpmList): string {
     lines.push(`  ${name}@${dep.version}`);
   }
   return lines.join("\n");
+}
+
+/** Formats structured npm run output into a human-readable script execution summary. */
+export function formatRun(data: NpmRun): string {
+  const status = data.success ? "completed successfully" : `failed (exit code ${data.exitCode})`;
+  const lines = [`Script "${data.script}" ${status} in ${data.duration}s`];
+  if (data.stdout) {
+    lines.push("", "stdout:", data.stdout);
+  }
+  if (data.stderr) {
+    lines.push("", "stderr:", data.stderr);
+  }
+  return lines.join("\n");
+}
+
+/** Formats structured npm test output into a human-readable test result summary. */
+export function formatTest(data: NpmTest): string {
+  const status = data.success ? "passed" : `failed (exit code ${data.exitCode})`;
+  const lines = [`Tests ${status} in ${data.duration}s`];
+  if (data.stdout) {
+    lines.push("", "stdout:", data.stdout);
+  }
+  if (data.stderr) {
+    lines.push("", "stderr:", data.stderr);
+  }
+  return lines.join("\n");
+}
+
+/** Formats structured npm init output into a human-readable initialization summary. */
+export function formatInit(data: NpmInit): string {
+  if (!data.success) {
+    return `Failed to initialize package.json at ${data.path}`;
+  }
+  return `Created ${data.packageName}@${data.version} at ${data.path}`;
 }

--- a/packages/server-npm/src/lib/npm-runner.ts
+++ b/packages/server-npm/src/lib/npm-runner.ts
@@ -1,7 +1,14 @@
 import { run, type RunResult } from "@paretools/shared";
 
 export async function npm(args: string[], cwd?: string): Promise<RunResult> {
-  // npm install can take minutes for large dependency trees
-  const isInstall = args[0] === "install" || args[0] === "i" || args[0] === "ci";
-  return run("npm", args, { cwd, timeout: isInstall ? 300_000 : 60_000 });
+  // npm install, run, and test can take minutes for large operations
+  const isLongRunning =
+    args[0] === "install" ||
+    args[0] === "i" ||
+    args[0] === "ci" ||
+    args[0] === "run" ||
+    args[0] === "run-script" ||
+    args[0] === "test" ||
+    args[0] === "t";
+  return run("npm", args, { cwd, timeout: isLongRunning ? 300_000 : 60_000 });
 }

--- a/packages/server-npm/src/lib/parsers.ts
+++ b/packages/server-npm/src/lib/parsers.ts
@@ -1,4 +1,4 @@
-import type { NpmInstall, NpmAudit, NpmOutdated, NpmList } from "../schemas/index.js";
+import type { NpmInstall, NpmAudit, NpmOutdated, NpmList, NpmRun, NpmTest, NpmInit } from "../schemas/index.js";
 
 /** Parses `npm install` summary output into structured data with package counts and vulnerability info. */
 export function parseInstallOutput(stdout: string, duration: number): NpmInstall {
@@ -104,5 +104,54 @@ export function parseListJson(jsonStr: string): NpmList {
     version: data.version ?? "0.0.0",
     dependencies: deps,
     total: Object.keys(deps).length,
+  };
+}
+
+/** Parses `npm run <script>` output into structured data with exit code, stdout/stderr, and duration. */
+export function parseRunOutput(
+  script: string,
+  exitCode: number,
+  stdout: string,
+  stderr: string,
+  duration: number,
+): NpmRun {
+  return {
+    script,
+    exitCode,
+    stdout: stdout.trim(),
+    stderr: stderr.trim(),
+    success: exitCode === 0,
+    duration,
+  };
+}
+
+/** Parses `npm test` output into structured data with exit code, stdout/stderr, and duration. */
+export function parseTestOutput(
+  exitCode: number,
+  stdout: string,
+  stderr: string,
+  duration: number,
+): NpmTest {
+  return {
+    exitCode,
+    stdout: stdout.trim(),
+    stderr: stderr.trim(),
+    success: exitCode === 0,
+    duration,
+  };
+}
+
+/** Parses `npm init` result by reading the generated package.json. */
+export function parseInitOutput(
+  success: boolean,
+  packageName: string,
+  version: string,
+  packageJsonPath: string,
+): NpmInit {
+  return {
+    success,
+    packageName,
+    version,
+    path: packageJsonPath,
   };
 }

--- a/packages/server-npm/src/schemas/index.ts
+++ b/packages/server-npm/src/schemas/index.ts
@@ -86,3 +86,36 @@ export const NpmListSchema = z.object({
 });
 
 export type NpmList = z.infer<typeof NpmListSchema>;
+
+/** Zod schema for structured npm run output with script name, exit code, and captured output. */
+export const NpmRunSchema = z.object({
+  script: z.string().describe("The script that was executed"),
+  exitCode: z.number().describe("Process exit code (0 = success)"),
+  stdout: z.string().describe("Standard output from the script"),
+  stderr: z.string().describe("Standard error from the script"),
+  success: z.boolean().describe("Whether the script exited with code 0"),
+  duration: z.number().describe("Execution duration in seconds"),
+});
+
+export type NpmRun = z.infer<typeof NpmRunSchema>;
+
+/** Zod schema for structured npm test output with exit code and captured output. */
+export const NpmTestSchema = z.object({
+  exitCode: z.number().describe("Process exit code (0 = success)"),
+  stdout: z.string().describe("Standard output from the test run"),
+  stderr: z.string().describe("Standard error from the test run"),
+  success: z.boolean().describe("Whether tests passed (exit code 0)"),
+  duration: z.number().describe("Execution duration in seconds"),
+});
+
+export type NpmTest = z.infer<typeof NpmTestSchema>;
+
+/** Zod schema for structured npm init output with package metadata. */
+export const NpmInitSchema = z.object({
+  success: z.boolean().describe("Whether package.json was created successfully"),
+  packageName: z.string().describe("The name field from the generated package.json"),
+  version: z.string().describe("The version field from the generated package.json"),
+  path: z.string().describe("Path to the generated package.json"),
+});
+
+export type NpmInit = z.infer<typeof NpmInitSchema>;

--- a/packages/server-npm/src/tools/index.ts
+++ b/packages/server-npm/src/tools/index.ts
@@ -3,10 +3,16 @@ import { registerInstallTool } from "./install.js";
 import { registerAuditTool } from "./audit.js";
 import { registerOutdatedTool } from "./outdated.js";
 import { registerListTool } from "./list.js";
+import { registerRunTool } from "./run.js";
+import { registerTestTool } from "./test.js";
+import { registerInitTool } from "./init.js";
 
 export function registerAllTools(server: McpServer) {
   registerInstallTool(server);
   registerAuditTool(server);
   registerOutdatedTool(server);
   registerListTool(server);
+  registerRunTool(server);
+  registerTestTool(server);
+  registerInitTool(server);
 }

--- a/packages/server-npm/src/tools/init.ts
+++ b/packages/server-npm/src/tools/init.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { npm } from "../lib/npm-runner.js";
+import { parseInitOutput } from "../lib/parsers.js";
+import { formatInit } from "../lib/formatters.js";
+import { NpmInitSchema } from "../schemas/index.js";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export function registerInitTool(server: McpServer) {
+  server.registerTool(
+    "init",
+    {
+      title: "npm Init",
+      description:
+        "Initializes a new package.json in the target directory. Returns structured output with the package name, version, and path.",
+      inputSchema: {
+        path: z.string().optional().describe("Directory to initialize (default: cwd)"),
+        yes: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Use -y flag for non-interactive init with defaults (default: true)"),
+        scope: z
+          .string()
+          .optional()
+          .describe("npm scope for the package (e.g., '@myorg')"),
+      },
+      outputSchema: NpmInitSchema,
+    },
+    async ({ path, yes, scope }) => {
+      const cwd = path || process.cwd();
+
+      const npmArgs = ["init"];
+      if (scope) {
+        npmArgs.push(`--scope=${scope}`);
+      }
+      if (yes !== false) {
+        npmArgs.push("-y");
+      }
+
+      const result = await npm(npmArgs, cwd);
+      const packageJsonPath = join(cwd, "package.json");
+
+      let packageName = "unknown";
+      let version = "0.0.0";
+      let success = result.exitCode === 0;
+
+      if (success) {
+        try {
+          const raw = await readFile(packageJsonPath, "utf-8");
+          const pkg = JSON.parse(raw);
+          packageName = pkg.name ?? "unknown";
+          version = pkg.version ?? "0.0.0";
+        } catch {
+          // package.json might not exist if init failed silently
+          success = false;
+        }
+      }
+
+      const data = parseInitOutput(success, packageName, version, packageJsonPath);
+      return dualOutput(data, formatInit);
+    },
+  );
+}

--- a/packages/server-npm/src/tools/run.ts
+++ b/packages/server-npm/src/tools/run.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { npm } from "../lib/npm-runner.js";
+import { parseRunOutput } from "../lib/parsers.js";
+import { formatRun } from "../lib/formatters.js";
+import { NpmRunSchema } from "../schemas/index.js";
+
+export function registerRunTool(server: McpServer) {
+  server.registerTool(
+    "run",
+    {
+      title: "npm Run",
+      description:
+        "Runs a package.json script via `npm run <script>` and returns structured output with exit code, stdout, stderr, and duration. Use instead of running `npm run` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Project root path (default: cwd)"),
+        script: z.string().describe("The package.json script name to run"),
+        args: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe("Additional arguments passed after -- to the script"),
+      },
+      outputSchema: NpmRunSchema,
+    },
+    async ({ path, script, args }) => {
+      const cwd = path || process.cwd();
+      assertNoFlagInjection(script, "script");
+
+      const npmArgs = ["run", script];
+      if (args && args.length > 0) {
+        npmArgs.push("--");
+        npmArgs.push(...args);
+      }
+
+      const start = Date.now();
+      const result = await npm(npmArgs, cwd);
+      const duration = Math.round(((Date.now() - start) / 1000) * 10) / 10;
+
+      const data = parseRunOutput(script, result.exitCode, result.stdout, result.stderr, duration);
+      return dualOutput(data, formatRun);
+    },
+  );
+}

--- a/packages/server-npm/src/tools/test.ts
+++ b/packages/server-npm/src/tools/test.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { npm } from "../lib/npm-runner.js";
+import { parseTestOutput } from "../lib/parsers.js";
+import { formatTest } from "../lib/formatters.js";
+import { NpmTestSchema } from "../schemas/index.js";
+
+export function registerTestTool(server: McpServer) {
+  server.registerTool(
+    "test",
+    {
+      title: "npm Test",
+      description:
+        "Runs `npm test` and returns structured output with exit code, stdout, stderr, and duration. Shorthand for running the test script defined in package.json.",
+      inputSchema: {
+        path: z.string().optional().describe("Project root path (default: cwd)"),
+        args: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe("Additional arguments passed after -- to the test script"),
+      },
+      outputSchema: NpmTestSchema,
+    },
+    async ({ path, args }) => {
+      const cwd = path || process.cwd();
+
+      const npmArgs = ["test"];
+      if (args && args.length > 0) {
+        npmArgs.push("--");
+        npmArgs.push(...args);
+      }
+
+      const start = Date.now();
+      const result = await npm(npmArgs, cwd);
+      const duration = Math.round(((Date.now() - start) / 1000) * 10) / 10;
+
+      const data = parseTestOutput(result.exitCode, result.stdout, result.stderr, duration);
+      return dualOutput(data, formatTest);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `run` tool: execute package.json scripts via `npm run <script>` with structured output (exit code, stdout, stderr, duration)
- Adds `test` tool: shorthand for `npm test` with structured test result output
- Adds `init` tool: initialize a new package.json with structured output (package name, version, path)

All three tools follow the established Pare pattern: Zod output schemas, parsers, formatters, dual output, and comprehensive tests.

## Changes
- **Schemas**: `NpmRunSchema`, `NpmTestSchema`, `NpmInitSchema` in `src/schemas/index.ts`
- **Parsers**: `parseRunOutput`, `parseTestOutput`, `parseInitOutput` in `src/lib/parsers.ts`
- **Formatters**: `formatRun`, `formatTest`, `formatInit` in `src/lib/formatters.ts`
- **Tools**: `src/tools/run.ts`, `src/tools/test.ts`, `src/tools/init.ts`
- **Runner**: Updated `npm-runner.ts` to use 300s timeout for `run` and `test` commands
- **Registration**: Updated `src/tools/index.ts` to register all 7 tools
- **Integration test**: Updated tool count assertion from 4 to 7

## Test plan
- [x] 72 tests pass across 7 test files (29 new tests for run, test, init)
- [x] Parser tests cover: success, failure, empty output, whitespace trimming, missing scripts, non-zero exit codes
- [x] Formatter tests cover: success/failure formatting, both/neither stdout/stderr, scoped packages
- [x] Integration test verifies all 7 tools are registered
- [x] TypeScript build succeeds with no errors

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)