### PR TITLE
feat(docker): add run, exec, compose, and pull tools

### DIFF
--- a/packages/server-docker/__tests__/compose.test.ts
+++ b/packages/server-docker/__tests__/compose.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { parseComposeUpOutput, parseComposeDownOutput } from "../src/lib/parsers.js";
+import { formatComposeUp, formatComposeDown } from "../src/lib/formatters.js";
+import type { DockerComposeUp, DockerComposeDown } from "../src/schemas/index.js";
+
+describe("parseComposeUpOutput", () => {
+  it("parses compose up with multiple started services", () => {
+    const stderr = [
+      " ✔ Network myapp_default  Created",
+      " ✔ Container myapp-db-1   Started",
+      " ✔ Container myapp-web-1  Started",
+      " ✔ Container myapp-redis-1  Started",
+    ].join("\n");
+
+    const result = parseComposeUpOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.services).toContain("myapp-db-1");
+    expect(result.services).toContain("myapp-web-1");
+    expect(result.services).toContain("myapp-redis-1");
+    expect(result.started).toBe(3);
+  });
+
+  it("parses compose up with already running services", () => {
+    const stderr = [
+      " ✔ Container myapp-db-1   Running",
+      " ✔ Container myapp-web-1  Started",
+    ].join("\n");
+
+    const result = parseComposeUpOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.services).toContain("myapp-db-1");
+    expect(result.services).toContain("myapp-web-1");
+    expect(result.started).toBe(2);
+  });
+
+  it("parses compose up failure", () => {
+    const stderr = 'no configuration file provided: not found';
+
+    const result = parseComposeUpOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.started).toBe(0);
+    expect(result.services).toEqual([]);
+  });
+
+  it("parses compose up with Created status", () => {
+    const stderr = [
+      " ✔ Container myapp-init-1  Created",
+    ].join("\n");
+
+    const result = parseComposeUpOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.services).toContain("myapp-init-1");
+    expect(result.started).toBe(1);
+  });
+
+  it("handles empty output", () => {
+    const result = parseComposeUpOutput("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.started).toBe(0);
+    expect(result.services).toEqual([]);
+  });
+
+  it("does not double-count duplicate service entries", () => {
+    const stderr = [
+      " ✔ Container myapp-web-1  Created",
+      " ✔ Container myapp-web-1  Started",
+    ].join("\n");
+
+    const result = parseComposeUpOutput("", stderr, 0);
+
+    expect(result.services).toContain("myapp-web-1");
+    // Set deduplication means it should appear only once
+    expect(result.services.filter((s) => s === "myapp-web-1")).toHaveLength(1);
+  });
+});
+
+describe("parseComposeDownOutput", () => {
+  it("parses compose down with stopped and removed containers", () => {
+    const stderr = [
+      " ✔ Container myapp-web-1    Stopped",
+      " ✔ Container myapp-db-1     Stopped",
+      " ✔ Container myapp-web-1    Removed",
+      " ✔ Container myapp-db-1     Removed",
+      " ✔ Network myapp_default    Removed",
+    ].join("\n");
+
+    const result = parseComposeDownOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.stopped).toBe(2);
+    expect(result.removed).toBe(3); // 2 containers + 1 network
+  });
+
+  it("parses compose down with no containers", () => {
+    const stderr = " ✔ Network myapp_default  Removed\n";
+
+    const result = parseComposeDownOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.stopped).toBe(0);
+    expect(result.removed).toBe(1);
+  });
+
+  it("parses compose down failure", () => {
+    const stderr = "no configuration file provided: not found";
+
+    const result = parseComposeDownOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.stopped).toBe(0);
+    expect(result.removed).toBe(0);
+  });
+
+  it("handles empty output", () => {
+    const result = parseComposeDownOutput("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.stopped).toBe(0);
+    expect(result.removed).toBe(0);
+  });
+});
+
+describe("formatComposeUp", () => {
+  it("formats successful compose up with services", () => {
+    const data: DockerComposeUp = {
+      success: true,
+      services: ["myapp-web-1", "myapp-db-1"],
+      started: 2,
+    };
+    const output = formatComposeUp(data);
+    expect(output).toBe("Compose up: 2 services started (myapp-web-1, myapp-db-1)");
+  });
+
+  it("formats compose up with no new services", () => {
+    const data: DockerComposeUp = {
+      success: true,
+      services: [],
+      started: 0,
+    };
+    const output = formatComposeUp(data);
+    expect(output).toBe("Compose up succeeded (no new services started)");
+  });
+
+  it("formats failed compose up", () => {
+    const data: DockerComposeUp = {
+      success: false,
+      services: [],
+      started: 0,
+    };
+    const output = formatComposeUp(data);
+    expect(output).toBe("Compose up failed");
+  });
+});
+
+describe("formatComposeDown", () => {
+  it("formats successful compose down", () => {
+    const data: DockerComposeDown = {
+      success: true,
+      stopped: 3,
+      removed: 4,
+    };
+    const output = formatComposeDown(data);
+    expect(output).toBe("Compose down: 3 stopped, 4 removed");
+  });
+
+  it("formats compose down with nothing to stop", () => {
+    const data: DockerComposeDown = {
+      success: true,
+      stopped: 0,
+      removed: 0,
+    };
+    const output = formatComposeDown(data);
+    expect(output).toBe("Compose down: 0 stopped, 0 removed");
+  });
+
+  it("formats failed compose down", () => {
+    const data: DockerComposeDown = {
+      success: false,
+      stopped: 0,
+      removed: 0,
+    };
+    const output = formatComposeDown(data);
+    expect(output).toBe("Compose down failed");
+  });
+});

--- a/packages/server-docker/__tests__/exec.test.ts
+++ b/packages/server-docker/__tests__/exec.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { parseExecOutput } from "../src/lib/parsers.js";
+import { formatExec } from "../src/lib/formatters.js";
+import type { DockerExec } from "../src/schemas/index.js";
+
+describe("parseExecOutput", () => {
+  it("parses successful exec", () => {
+    const result = parseExecOutput("bin\ndev\netc\nhome\n", "", 0);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("bin\ndev\netc\nhome\n");
+    expect(result.stderr).toBe("");
+    expect(result.success).toBe(true);
+  });
+
+  it("parses failed exec", () => {
+    const result = parseExecOutput("", "ls: cannot access '/nonexistent': No such file or directory", 2);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("No such file or directory");
+    expect(result.success).toBe(false);
+  });
+
+  it("parses exec with both stdout and stderr", () => {
+    const result = parseExecOutput("output data", "warning: something", 0);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("output data");
+    expect(result.stderr).toBe("warning: something");
+    expect(result.success).toBe(true);
+  });
+
+  it("parses exec with exit code 1", () => {
+    const result = parseExecOutput("", "command not found: foo", 1);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.success).toBe(false);
+  });
+
+  it("parses exec with exit code 126 (permission denied)", () => {
+    const result = parseExecOutput("", "permission denied", 126);
+
+    expect(result.exitCode).toBe(126);
+    expect(result.success).toBe(false);
+  });
+
+  it("handles empty output", () => {
+    const result = parseExecOutput("", "", 0);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("formatExec", () => {
+  it("formats successful exec with stdout", () => {
+    const data: DockerExec = {
+      exitCode: 0,
+      stdout: "hello world",
+      stderr: "",
+      success: true,
+    };
+    const output = formatExec(data);
+    expect(output).toContain("Exec succeeded");
+    expect(output).toContain("hello world");
+  });
+
+  it("formats failed exec with stderr", () => {
+    const data: DockerExec = {
+      exitCode: 1,
+      stdout: "",
+      stderr: "command not found",
+      success: false,
+    };
+    const output = formatExec(data);
+    expect(output).toContain("Exec failed (exit code 1)");
+    expect(output).toContain("stderr: command not found");
+  });
+
+  it("formats exec with empty output", () => {
+    const data: DockerExec = {
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      success: true,
+    };
+    const output = formatExec(data);
+    expect(output).toBe("Exec succeeded");
+  });
+
+  it("formats exec with both stdout and stderr", () => {
+    const data: DockerExec = {
+      exitCode: 0,
+      stdout: "result data",
+      stderr: "debug info",
+      success: true,
+    };
+    const output = formatExec(data);
+    expect(output).toContain("Exec succeeded");
+    expect(output).toContain("result data");
+    expect(output).toContain("stderr: debug info");
+  });
+});

--- a/packages/server-docker/__tests__/integration.test.ts
+++ b/packages/server-docker/__tests__/integration.test.ts
@@ -29,7 +29,7 @@ describe("@paretools/docker integration", () => {
   it("lists all 4 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
-    expect(names).toEqual(["build", "images", "logs", "ps"]);
+    expect(names).toEqual(["build", "compose-down", "compose-up", "exec", "images", "logs", "ps", "pull", "run"]);
   });
 
   it("each tool has an outputSchema", async () => {

--- a/packages/server-docker/__tests__/pull.test.ts
+++ b/packages/server-docker/__tests__/pull.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { parsePullOutput } from "../src/lib/parsers.js";
+import { formatPull } from "../src/lib/formatters.js";
+import type { DockerPull } from "../src/schemas/index.js";
+
+describe("parsePullOutput", () => {
+  it("parses successful pull with digest", () => {
+    const stdout = [
+      "Using default tag: latest",
+      "latest: Pulling from library/nginx",
+      "a2abf6c4d29d: Pull complete",
+      "Digest: sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+      "Status: Downloaded newer image for nginx:latest",
+      "docker.io/library/nginx:latest",
+    ].join("\n");
+
+    const result = parsePullOutput(stdout, "", 0, "nginx:latest");
+
+    expect(result.image).toBe("nginx");
+    expect(result.tag).toBe("latest");
+    expect(result.digest).toBe(
+      "sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("parses pull without explicit tag (defaults to latest)", () => {
+    const stdout = [
+      "Using default tag: latest",
+      "latest: Pulling from library/ubuntu",
+      "Digest: sha256:fedcba987654fedcba987654fedcba987654fedcba987654fedcba987654fedc",
+      "Status: Image is up to date for ubuntu:latest",
+    ].join("\n");
+
+    const result = parsePullOutput(stdout, "", 0, "ubuntu");
+
+    expect(result.image).toBe("ubuntu");
+    expect(result.tag).toBe("latest");
+    expect(result.digest).toBe(
+      "sha256:fedcba987654fedcba987654fedcba987654fedcba987654fedcba987654fedc",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("parses pull with specific tag", () => {
+    const stdout = [
+      "22.04: Pulling from library/ubuntu",
+      "Digest: sha256:1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff",
+      "Status: Downloaded newer image for ubuntu:22.04",
+    ].join("\n");
+
+    const result = parsePullOutput(stdout, "", 0, "ubuntu:22.04");
+
+    expect(result.image).toBe("ubuntu");
+    expect(result.tag).toBe("22.04");
+    expect(result.success).toBe(true);
+  });
+
+  it("parses failed pull (image not found)", () => {
+    const stderr =
+      "Error response from daemon: pull access denied for nonexistent/image, repository does not exist";
+
+    const result = parsePullOutput("", stderr, 1, "nonexistent/image:v1");
+
+    expect(result.image).toBe("nonexistent/image");
+    expect(result.tag).toBe("v1");
+    expect(result.success).toBe(false);
+    expect(result.digest).toBeUndefined();
+  });
+
+  it("parses pull from private registry with port", () => {
+    const stdout = [
+      "v1: Pulling from myapp",
+      "Digest: sha256:aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344",
+      "Status: Downloaded newer image",
+    ].join("\n");
+
+    const result = parsePullOutput(stdout, "", 0, "registry.example.com:5000/myapp:v1");
+
+    expect(result.image).toBe("registry.example.com:5000/myapp");
+    expect(result.tag).toBe("v1");
+    expect(result.success).toBe(true);
+  });
+
+  it("handles pull with digest in stderr", () => {
+    const stderr =
+      "Digest: sha256:deadbeef1234deadbeef1234deadbeef1234deadbeef1234deadbeef1234dead";
+
+    const result = parsePullOutput("", stderr, 0, "alpine:3.19");
+
+    expect(result.digest).toBe(
+      "sha256:deadbeef1234deadbeef1234deadbeef1234deadbeef1234deadbeef1234dead",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("handles pull with no digest info", () => {
+    const result = parsePullOutput("Already up to date", "", 0, "myimage:dev");
+
+    expect(result.image).toBe("myimage");
+    expect(result.tag).toBe("dev");
+    expect(result.digest).toBeUndefined();
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("formatPull", () => {
+  it("formats successful pull with digest", () => {
+    const data: DockerPull = {
+      image: "nginx",
+      tag: "latest",
+      digest: "sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+      success: true,
+    };
+    const output = formatPull(data);
+    expect(output).toBe("Pulled nginx:latest (sha256:abc123def456...)");
+  });
+
+  it("formats successful pull without digest", () => {
+    const data: DockerPull = {
+      image: "ubuntu",
+      tag: "22.04",
+      success: true,
+    };
+    const output = formatPull(data);
+    expect(output).toBe("Pulled ubuntu:22.04");
+  });
+
+  it("formats failed pull", () => {
+    const data: DockerPull = {
+      image: "nonexistent/image",
+      tag: "v1",
+      success: false,
+    };
+    const output = formatPull(data);
+    expect(output).toBe("Pull failed for nonexistent/image:v1");
+  });
+});

--- a/packages/server-docker/__tests__/run-tool.test.ts
+++ b/packages/server-docker/__tests__/run-tool.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { parseRunOutput } from "../src/lib/parsers.js";
+import { formatRun } from "../src/lib/formatters.js";
+import type { DockerRun } from "../src/schemas/index.js";
+
+describe("parseRunOutput", () => {
+  it("parses detached container output", () => {
+    const stdout =
+      "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4\n";
+    const result = parseRunOutput(stdout, "nginx:latest", true, "my-web");
+
+    expect(result.containerId).toBe("a1b2c3d4e5f6");
+    expect(result.image).toBe("nginx:latest");
+    expect(result.detached).toBe(true);
+    expect(result.name).toBe("my-web");
+  });
+
+  it("parses output without container name", () => {
+    const stdout = "abc123def456abc123def456abc123def456abc123def456abc123def456abc123de\n";
+    const result = parseRunOutput(stdout, "ubuntu:22.04", true);
+
+    expect(result.containerId).toBe("abc123def456");
+    expect(result.image).toBe("ubuntu:22.04");
+    expect(result.detached).toBe(true);
+    expect(result.name).toBeUndefined();
+  });
+
+  it("parses attached mode output", () => {
+    const stdout = "Hello from container\nfedcba987654fedcba987654\n";
+    const result = parseRunOutput(stdout, "alpine", false);
+
+    expect(result.containerId).toBe("fedcba987654");
+    expect(result.detached).toBe(false);
+  });
+
+  it("handles empty output gracefully", () => {
+    const result = parseRunOutput("", "nginx", true);
+
+    expect(result.containerId).toBe("");
+    expect(result.image).toBe("nginx");
+    expect(result.detached).toBe(true);
+  });
+
+  it("truncates container ID to 12 chars", () => {
+    const longId = "a".repeat(64);
+    const result = parseRunOutput(longId, "myapp:v1", true);
+
+    expect(result.containerId).toBe("aaaaaaaaaaaa");
+    expect(result.containerId.length).toBe(12);
+  });
+});
+
+describe("formatRun", () => {
+  it("formats detached container with name", () => {
+    const data: DockerRun = {
+      containerId: "a1b2c3d4e5f6",
+      image: "nginx:latest",
+      detached: true,
+      name: "my-web",
+    };
+    const output = formatRun(data);
+    expect(output).toBe("Container a1b2c3d4e5f6 (my-web) started from nginx:latest [detached]");
+  });
+
+  it("formats attached container without name", () => {
+    const data: DockerRun = {
+      containerId: "abc123def456",
+      image: "ubuntu:22.04",
+      detached: false,
+    };
+    const output = formatRun(data);
+    expect(output).toBe("Container abc123def456 started from ubuntu:22.04 [attached]");
+  });
+});

--- a/packages/server-docker/src/index.ts
+++ b/packages/server-docker/src/index.ts
@@ -8,7 +8,7 @@ const server = new McpServer(
   { name: "@paretools/docker", version: "0.2.0" },
   {
     instructions:
-      "Structured Docker operations (ps, build, logs, images). Use instead of running docker commands via bash. Returns typed JSON with structured container, image, and build data.",
+      "Structured Docker operations (ps, build, logs, images, run, exec, compose-up, compose-down, pull). Use instead of running docker commands via bash. Returns typed JSON with structured container, image, and build data.",
   },
 );
 

--- a/packages/server-docker/src/lib/docker-runner.ts
+++ b/packages/server-docker/src/lib/docker-runner.ts
@@ -1,7 +1,8 @@
 import { run, type RunResult } from "@paretools/shared";
 
 export async function docker(args: string[], cwd?: string): Promise<RunResult> {
-  // Docker build/pull operations can take minutes; use 5-minute timeout
-  const isBuild = args[0] === "build" || args[0] === "pull";
-  return run("docker", args, { cwd, timeout: isBuild ? 300_000 : 30_000 });
+  // Docker build/pull/run/compose operations can take minutes; use 5-minute timeout
+  const longOps = new Set(["build", "pull", "run", "compose"]);
+  const isLong = longOps.has(args[0]);
+  return run("docker", args, { cwd, timeout: isLong ? 300_000 : 30_000 });
 }

--- a/packages/server-docker/src/lib/formatters.ts
+++ b/packages/server-docker/src/lib/formatters.ts
@@ -1,4 +1,14 @@
-import type { DockerPs, DockerBuild, DockerLogs, DockerImages } from "../schemas/index.js";
+import type {
+  DockerPs,
+  DockerBuild,
+  DockerLogs,
+  DockerImages,
+  DockerRun,
+  DockerExec,
+  DockerComposeUp,
+  DockerComposeDown,
+  DockerPull,
+} from "../schemas/index.js";
 
 /** Formats structured Docker container data into a human-readable listing with state and ports. */
 export function formatPs(data: DockerPs): string {
@@ -43,4 +53,40 @@ export function formatImages(data: DockerImages): string {
     lines.push(`  ${img.repository}${tag} (${img.size}, ${img.created})`);
   }
   return lines.join("\n");
+}
+
+/** Formats structured Docker run output into a human-readable summary. */
+export function formatRun(data: DockerRun): string {
+  const name = data.name ? ` (${data.name})` : "";
+  const mode = data.detached ? "detached" : "attached";
+  return `Container ${data.containerId}${name} started from ${data.image} [${mode}]`;
+}
+
+/** Formats structured Docker exec output into a human-readable summary. */
+export function formatExec(data: DockerExec): string {
+  const status = data.success ? "succeeded" : `failed (exit code ${data.exitCode})`;
+  const lines = [`Exec ${status}`];
+  if (data.stdout) lines.push(data.stdout);
+  if (data.stderr) lines.push(`stderr: ${data.stderr}`);
+  return lines.join("\n");
+}
+
+/** Formats structured Docker Compose up output into a human-readable summary. */
+export function formatComposeUp(data: DockerComposeUp): string {
+  if (!data.success) return "Compose up failed";
+  if (data.started === 0) return "Compose up succeeded (no new services started)";
+  return `Compose up: ${data.started} services started (${data.services.join(", ")})`;
+}
+
+/** Formats structured Docker Compose down output into a human-readable summary. */
+export function formatComposeDown(data: DockerComposeDown): string {
+  if (!data.success) return "Compose down failed";
+  return `Compose down: ${data.stopped} stopped, ${data.removed} removed`;
+}
+
+/** Formats structured Docker pull output into a human-readable summary. */
+export function formatPull(data: DockerPull): string {
+  if (!data.success) return `Pull failed for ${data.image}:${data.tag}`;
+  const digest = data.digest ? ` (${data.digest.slice(0, 19)}...)` : "";
+  return `Pulled ${data.image}:${data.tag}${digest}`;
 }

--- a/packages/server-docker/src/lib/parsers.ts
+++ b/packages/server-docker/src/lib/parsers.ts
@@ -1,4 +1,14 @@
-import type { DockerPs, DockerBuild, DockerLogs, DockerImages } from "../schemas/index.js";
+import type {
+  DockerPs,
+  DockerBuild,
+  DockerLogs,
+  DockerImages,
+  DockerRun,
+  DockerExec,
+  DockerComposeUp,
+  DockerComposeDown,
+  DockerPull,
+} from "../schemas/index.js";
 
 /** Parses `docker ps --format json` output into structured container data with ports and state. */
 export function parsePsJson(stdout: string): DockerPs {
@@ -114,4 +124,130 @@ export function parseImagesJson(stdout: string): DockerImages {
   });
 
   return { images, total: images.length };
+}
+
+/** Parses `docker run` output into structured data with container ID and image info. */
+export function parseRunOutput(
+  stdout: string,
+  image: string,
+  detached: boolean,
+  name?: string,
+): DockerRun {
+  // When detached, docker run outputs the full container ID
+  const containerId = stdout.trim().split("\n").pop()?.trim() ?? "";
+  return {
+    containerId: containerId.slice(0, 12),
+    image,
+    detached,
+    ...(name ? { name } : {}),
+  };
+}
+
+/** Parses `docker exec` output into structured data with exit code, stdout, stderr, and success. */
+export function parseExecOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): DockerExec {
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    success: exitCode === 0,
+  };
+}
+
+/** Parses `docker compose up` output into structured data with service names and started count. */
+export function parseComposeUpOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): DockerComposeUp {
+  // Compose v2 outputs to stderr; service names appear in lines like:
+  //  ✔ Container myapp-web-1  Started
+  //  ✔ Container myapp-db-1   Started
+  // Or: Container myapp-web-1  Creating / Created / Starting / Started
+  const combined = stdout + "\n" + stderr;
+  const serviceSet = new Set<string>();
+
+  // Match "Container <name>  Started" or "Container <name>  Running"
+  const startedPattern = /Container\s+(\S+)\s+(?:Started|Running|Created)/g;
+  let match: RegExpExecArray | null;
+  while ((match = startedPattern.exec(combined)) !== null) {
+    serviceSet.add(match[1]);
+  }
+
+  // Also match "service "<name>" started" pattern (older compose output)
+  const servicePattern = /[Ss]ervice\s+"?(\S+?)"?\s+(?:started|created)/g;
+  while ((match = servicePattern.exec(combined)) !== null) {
+    serviceSet.add(match[1]);
+  }
+
+  const services = [...serviceSet];
+  return {
+    success: exitCode === 0,
+    services,
+    started: services.length,
+  };
+}
+
+/** Parses `docker compose down` output into structured data with stopped and removed counts. */
+export function parseComposeDownOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): DockerComposeDown {
+  const combined = stdout + "\n" + stderr;
+  let stopped = 0;
+  let removed = 0;
+
+  // Match "Container <name>  Stopped"
+  const stoppedPattern = /Container\s+\S+\s+Stopped/g;
+  while (stoppedPattern.exec(combined) !== null) {
+    stopped++;
+  }
+
+  // Match "Container <name>  Removed"
+  const removedPattern = /Container\s+\S+\s+Removed/g;
+  while (removedPattern.exec(combined) !== null) {
+    removed++;
+  }
+
+  // Also count network/volume removals as part of removed
+  const networkPattern = /Network\s+\S+\s+Removed/g;
+  while (networkPattern.exec(combined) !== null) {
+    removed++;
+  }
+
+  return {
+    success: exitCode === 0,
+    stopped,
+    removed,
+  };
+}
+
+/** Parses `docker pull` output into structured data with image, tag, digest, and success flag. */
+export function parsePullOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  image: string,
+): DockerPull {
+  const combined = stdout + "\n" + stderr;
+
+  // Extract tag from image string (e.g., "nginx:latest" -> "latest", "nginx" -> "latest")
+  const parts = image.split(":");
+  const tag = parts.length > 1 ? parts[parts.length - 1] : "latest";
+  const imageName = parts.length > 1 ? parts.slice(0, -1).join(":") : image;
+
+  // Extract digest from "Digest: sha256:abc123..."
+  const digestMatch = combined.match(/Digest:\s*(sha256:[a-f0-9]+)/);
+  const digest = digestMatch?.[1];
+
+  return {
+    image: imageName,
+    tag,
+    ...(digest ? { digest } : {}),
+    success: exitCode === 0,
+  };
 }

--- a/packages/server-docker/src/schemas/index.ts
+++ b/packages/server-docker/src/schemas/index.ts
@@ -63,3 +63,51 @@ export const DockerImagesSchema = z.object({
 });
 
 export type DockerImages = z.infer<typeof DockerImagesSchema>;
+
+/** Zod schema for structured docker run output with container ID, image, and detach status. */
+export const DockerRunSchema = z.object({
+  containerId: z.string(),
+  image: z.string(),
+  detached: z.boolean(),
+  name: z.string().optional(),
+});
+
+export type DockerRun = z.infer<typeof DockerRunSchema>;
+
+/** Zod schema for structured docker exec output with exit code, stdout, stderr, and success flag. */
+export const DockerExecSchema = z.object({
+  exitCode: z.number(),
+  stdout: z.string(),
+  stderr: z.string(),
+  success: z.boolean(),
+});
+
+export type DockerExec = z.infer<typeof DockerExecSchema>;
+
+/** Zod schema for structured docker compose up output with service list and started count. */
+export const DockerComposeUpSchema = z.object({
+  success: z.boolean(),
+  services: z.array(z.string()),
+  started: z.number(),
+});
+
+export type DockerComposeUp = z.infer<typeof DockerComposeUpSchema>;
+
+/** Zod schema for structured docker compose down output with stopped and removed counts. */
+export const DockerComposeDownSchema = z.object({
+  success: z.boolean(),
+  stopped: z.number(),
+  removed: z.number(),
+});
+
+export type DockerComposeDown = z.infer<typeof DockerComposeDownSchema>;
+
+/** Zod schema for structured docker pull output with image, tag, digest, and success flag. */
+export const DockerPullSchema = z.object({
+  image: z.string(),
+  tag: z.string(),
+  digest: z.string().optional(),
+  success: z.boolean(),
+});
+
+export type DockerPull = z.infer<typeof DockerPullSchema>;

--- a/packages/server-docker/src/tools/compose-down.ts
+++ b/packages/server-docker/src/tools/compose-down.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { docker } from "../lib/docker-runner.js";
+import { parseComposeDownOutput } from "../lib/parsers.js";
+import { formatComposeDown } from "../lib/formatters.js";
+import { DockerComposeDownSchema } from "../schemas/index.js";
+
+export function registerComposeDownTool(server: McpServer) {
+  server.registerTool(
+    "compose-down",
+    {
+      title: "Docker Compose Down",
+      description:
+        "Stops Docker Compose services and returns structured status. Use instead of running `docker compose down` in the terminal.",
+      inputSchema: {
+        path: z.string().describe("Directory containing docker-compose.yml"),
+        volumes: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Also remove named volumes (default: false)"),
+        removeOrphans: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Remove orphan containers (default: false)"),
+        file: z
+          .string()
+          .optional()
+          .describe("Compose file path (default: docker-compose.yml)"),
+      },
+      outputSchema: DockerComposeDownSchema,
+    },
+    async ({ path, volumes, removeOrphans, file }) => {
+      const args = ["compose"];
+      if (file) args.push("-f", file);
+      args.push("down");
+      if (volumes) args.push("--volumes");
+      if (removeOrphans) args.push("--remove-orphans");
+
+      const result = await docker(args, path);
+      const data = parseComposeDownOutput(result.stdout, result.stderr, result.exitCode);
+
+      if (result.exitCode !== 0 && data.stopped === 0 && data.removed === 0) {
+        const errorMsg = result.stderr || result.stdout || "Unknown error";
+        throw new Error(`docker compose down failed: ${errorMsg.trim()}`);
+      }
+
+      return dualOutput(data, formatComposeDown);
+    },
+  );
+}

--- a/packages/server-docker/src/tools/compose-up.ts
+++ b/packages/server-docker/src/tools/compose-up.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { docker } from "../lib/docker-runner.js";
+import { parseComposeUpOutput } from "../lib/parsers.js";
+import { formatComposeUp } from "../lib/formatters.js";
+import { DockerComposeUpSchema } from "../schemas/index.js";
+
+export function registerComposeUpTool(server: McpServer) {
+  server.registerTool(
+    "compose-up",
+    {
+      title: "Docker Compose Up",
+      description:
+        "Starts Docker Compose services and returns structured status. Use instead of running `docker compose up` in the terminal.",
+      inputSchema: {
+        path: z.string().describe("Directory containing docker-compose.yml"),
+        services: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe("Specific services to start (default: all)"),
+        detach: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Run in background (default: true)"),
+        build: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Build images before starting (default: false)"),
+        file: z
+          .string()
+          .optional()
+          .describe("Compose file path (default: docker-compose.yml)"),
+      },
+      outputSchema: DockerComposeUpSchema,
+    },
+    async ({ path, services, detach, build, file }) => {
+      const args = ["compose"];
+      if (file) args.push("-f", file);
+      args.push("up");
+      if (detach) args.push("-d");
+      if (build) args.push("--build");
+      if (services && services.length > 0) {
+        args.push(...services);
+      }
+
+      const result = await docker(args, path);
+      const data = parseComposeUpOutput(result.stdout, result.stderr, result.exitCode);
+
+      if (result.exitCode !== 0 && data.started === 0) {
+        const errorMsg = result.stderr || result.stdout || "Unknown error";
+        throw new Error(`docker compose up failed: ${errorMsg.trim()}`);
+      }
+
+      return dualOutput(data, formatComposeUp);
+    },
+  );
+}

--- a/packages/server-docker/src/tools/exec.ts
+++ b/packages/server-docker/src/tools/exec.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { docker } from "../lib/docker-runner.js";
+import { parseExecOutput } from "../lib/parsers.js";
+import { formatExec } from "../lib/formatters.js";
+import { DockerExecSchema } from "../schemas/index.js";
+
+export function registerExecTool(server: McpServer) {
+  server.registerTool(
+    "exec",
+    {
+      title: "Docker Exec",
+      description:
+        "Executes a command in a running Docker container and returns structured output. Use instead of running `docker exec` in the terminal.",
+      inputSchema: {
+        container: z.string().describe("Container name or ID"),
+        command: z.array(z.string()).describe('Command to execute (e.g., ["ls", "-la"])'),
+        workdir: z
+          .string()
+          .optional()
+          .describe("Working directory inside the container"),
+        env: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe('Environment variables (e.g., ["KEY=VALUE"])'),
+        path: z.string().optional().describe("Host working directory (default: cwd)"),
+      },
+      outputSchema: DockerExecSchema,
+    },
+    async ({ container, command, workdir, env, path }) => {
+      assertNoFlagInjection(container, "container");
+
+      const args = ["exec"];
+      if (workdir) args.push("-w", workdir);
+      for (const e of env ?? []) {
+        args.push("-e", e);
+      }
+      args.push(container, ...command);
+
+      const result = await docker(args, path);
+      const data = parseExecOutput(result.stdout, result.stderr, result.exitCode);
+      return dualOutput(data, formatExec);
+    },
+  );
+}

--- a/packages/server-docker/src/tools/index.ts
+++ b/packages/server-docker/src/tools/index.ts
@@ -3,10 +3,20 @@ import { registerPsTool } from "./ps.js";
 import { registerBuildTool } from "./build.js";
 import { registerLogsTool } from "./logs.js";
 import { registerImagesTool } from "./images.js";
+import { registerRunTool } from "./run.js";
+import { registerExecTool } from "./exec.js";
+import { registerComposeUpTool } from "./compose-up.js";
+import { registerComposeDownTool } from "./compose-down.js";
+import { registerPullTool } from "./pull.js";
 
 export function registerAllTools(server: McpServer) {
   registerPsTool(server);
   registerBuildTool(server);
   registerLogsTool(server);
   registerImagesTool(server);
+  registerRunTool(server);
+  registerExecTool(server);
+  registerComposeUpTool(server);
+  registerComposeDownTool(server);
+  registerPullTool(server);
 }

--- a/packages/server-docker/src/tools/pull.ts
+++ b/packages/server-docker/src/tools/pull.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { docker } from "../lib/docker-runner.js";
+import { parsePullOutput } from "../lib/parsers.js";
+import { formatPull } from "../lib/formatters.js";
+import { DockerPullSchema } from "../schemas/index.js";
+
+export function registerPullTool(server: McpServer) {
+  server.registerTool(
+    "pull",
+    {
+      title: "Docker Pull",
+      description:
+        "Pulls a Docker image from a registry and returns structured result with digest info. Use instead of running `docker pull` in the terminal.",
+      inputSchema: {
+        image: z.string().describe("Image to pull (e.g., nginx:latest, ubuntu:22.04)"),
+        platform: z
+          .string()
+          .optional()
+          .describe('Target platform (e.g., "linux/amd64", "linux/arm64")'),
+        path: z.string().optional().describe("Working directory (default: cwd)"),
+      },
+      outputSchema: DockerPullSchema,
+    },
+    async ({ image, platform, path }) => {
+      assertNoFlagInjection(image, "image");
+
+      const args = ["pull"];
+      if (platform) args.push("--platform", platform);
+      args.push(image);
+
+      const result = await docker(args, path);
+
+      if (result.exitCode !== 0) {
+        const errorMsg = result.stderr || result.stdout || "Unknown error";
+        throw new Error(`docker pull failed: ${errorMsg.trim()}`);
+      }
+
+      const data = parsePullOutput(result.stdout, result.stderr, result.exitCode, image);
+      return dualOutput(data, formatPull);
+    },
+  );
+}

--- a/packages/server-docker/src/tools/run.ts
+++ b/packages/server-docker/src/tools/run.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { docker } from "../lib/docker-runner.js";
+import { parseRunOutput } from "../lib/parsers.js";
+import { formatRun } from "../lib/formatters.js";
+import { DockerRunSchema } from "../schemas/index.js";
+
+export function registerRunTool(server: McpServer) {
+  server.registerTool(
+    "run",
+    {
+      title: "Docker Run",
+      description:
+        "Runs a Docker container from an image and returns structured container ID and status. Use instead of running `docker run` in the terminal.",
+      inputSchema: {
+        image: z.string().describe("Docker image to run (e.g., nginx:latest)"),
+        name: z.string().optional().describe("Container name"),
+        ports: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe('Port mappings (e.g., ["8080:80", "443:443"])'),
+        volumes: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe('Volume mounts (e.g., ["/host/path:/container/path"])'),
+        env: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe('Environment variables (e.g., ["KEY=VALUE"])'),
+        detach: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Run container in background (default: true)"),
+        rm: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Remove container after exit (default: false)"),
+        command: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe("Command to run in the container"),
+        path: z.string().optional().describe("Working directory (default: cwd)"),
+      },
+      outputSchema: DockerRunSchema,
+    },
+    async ({ image, name, ports, volumes, env, detach, rm, command, path }) => {
+      assertNoFlagInjection(image, "image");
+
+      const args = ["run"];
+      if (detach) args.push("-d");
+      if (rm) args.push("--rm");
+      if (name) args.push("--name", name);
+      for (const p of ports ?? []) {
+        args.push("-p", p);
+      }
+      for (const v of volumes ?? []) {
+        args.push("-v", v);
+      }
+      for (const e of env ?? []) {
+        args.push("-e", e);
+      }
+      args.push(image);
+      if (command && command.length > 0) {
+        args.push(...command);
+      }
+
+      const result = await docker(args, path);
+
+      if (result.exitCode !== 0) {
+        const errorMsg = result.stderr || result.stdout || "Unknown error";
+        throw new Error(`docker run failed: ${errorMsg.trim()}`);
+      }
+
+      const data = parseRunOutput(result.stdout, image, detach ?? true, name);
+      return dualOutput(data, formatRun);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds 5 new high-priority Docker tools: `run`, `exec`, `compose-up`, `compose-down`, `pull`
- Each tool follows the standard Pare pattern: Zod output schema, parser, formatter, `dualOutput()` return
- Input validation via `assertNoFlagInjection` on user-supplied image names and container identifiers
- Updated `docker-runner.ts` timeout handling to cover `run` and `compose` long-running operations

## New Tools

| Tool | Description |
|---|---|
| `run` | Start a container from an image with ports, volumes, env vars, detach/rm flags |
| `exec` | Execute a command in a running container, returns stdout/stderr/exit code |
| `compose-up` | Start Docker Compose services, returns started service names |
| `compose-down` | Stop Docker Compose services, returns stopped/removed counts |
| `pull` | Pull an image from registry, returns tag/digest info |

## Test plan
- [x] 43 new unit tests across 4 test files (run-tool, exec, compose, pull)
- [x] Parser tests with realistic Docker output fixtures
- [x] Formatter tests for all human-readable output cases
- [x] Edge cases: empty output, failed commands, duplicate services, permission errors
- [x] Updated integration test to verify all 9 tools register correctly
- [x] All 92 tests pass, build succeeds with `tsc`

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)