### PR TITLE
feat(python): add pytest, uv, and black tools

### DIFF
--- a/packages/server-python/__tests__/black.test.ts
+++ b/packages/server-python/__tests__/black.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { parseBlackOutput } from "../src/lib/parsers.js";
+import { formatBlack } from "../src/lib/formatters.js";
+import type { BlackResult } from "../src/schemas/index.js";
+
+describe("parseBlackOutput", () => {
+  it("parses check mode with files needing reformat", () => {
+    const stderr = [
+      "would reformat src/main.py",
+      "would reformat src/utils.py",
+      "Oh no! 2 files would be reformatted, 3 files would be left unchanged.",
+    ].join("\n");
+
+    const result = parseBlackOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.filesChanged).toBe(2);
+    expect(result.filesUnchanged).toBe(3);
+    expect(result.filesChecked).toBe(5);
+    expect(result.wouldReformat).toEqual(["src/main.py", "src/utils.py"]);
+  });
+
+  it("parses check mode with all files formatted", () => {
+    const stderr = "All done! 5 files would be left unchanged.";
+
+    const result = parseBlackOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.filesUnchanged).toBe(5);
+    expect(result.filesChecked).toBe(5);
+    expect(result.wouldReformat).toEqual([]);
+  });
+
+  it("parses format mode with reformatted files", () => {
+    const stderr = [
+      "reformatted src/main.py",
+      "reformatted src/utils.py",
+      "All done! 2 files reformatted, 1 file left unchanged.",
+    ].join("\n");
+
+    const result = parseBlackOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(2);
+    expect(result.filesUnchanged).toBe(1);
+    expect(result.filesChecked).toBe(3);
+    expect(result.wouldReformat).toEqual(["src/main.py", "src/utils.py"]);
+  });
+
+  it("parses format mode with no changes needed", () => {
+    const stderr = "All done! 3 files left unchanged.";
+
+    const result = parseBlackOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.filesUnchanged).toBe(3);
+    expect(result.filesChecked).toBe(3);
+    expect(result.wouldReformat).toEqual([]);
+  });
+
+  it("handles no Python files found", () => {
+    const stderr = "No Python files are present to be formatted. Nothing to do!";
+
+    const result = parseBlackOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.filesUnchanged).toBe(0);
+    expect(result.filesChecked).toBe(0);
+    expect(result.wouldReformat).toEqual([]);
+  });
+
+  it("parses single file reformatted", () => {
+    const stderr = [
+      "reformatted app.py",
+      "All done! 1 file reformatted.",
+    ].join("\n");
+
+    const result = parseBlackOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(1);
+    expect(result.wouldReformat).toEqual(["app.py"]);
+  });
+});
+
+describe("formatBlack", () => {
+  it("formats no files found", () => {
+    const data: BlackResult = {
+      filesChanged: 0,
+      filesUnchanged: 0,
+      filesChecked: 0,
+      success: true,
+      wouldReformat: [],
+    };
+    expect(formatBlack(data)).toBe("black: no Python files found.");
+  });
+
+  it("formats all files already formatted", () => {
+    const data: BlackResult = {
+      filesChanged: 0,
+      filesUnchanged: 5,
+      filesChecked: 5,
+      success: true,
+      wouldReformat: [],
+    };
+    expect(formatBlack(data)).toBe("black: 5 files already formatted.");
+  });
+
+  it("formats check mode with files needing reformat", () => {
+    const data: BlackResult = {
+      filesChanged: 2,
+      filesUnchanged: 3,
+      filesChecked: 5,
+      success: false,
+      wouldReformat: ["src/main.py", "src/utils.py"],
+    };
+    const output = formatBlack(data);
+
+    expect(output).toContain("2 files would be reformatted, 3 unchanged");
+    expect(output).toContain("src/main.py");
+    expect(output).toContain("src/utils.py");
+  });
+
+  it("formats format mode with reformatted files", () => {
+    const data: BlackResult = {
+      filesChanged: 1,
+      filesUnchanged: 4,
+      filesChecked: 5,
+      success: true,
+      wouldReformat: ["src/main.py"],
+    };
+    const output = formatBlack(data);
+
+    expect(output).toContain("1 files reformatted, 4 unchanged");
+    expect(output).toContain("src/main.py");
+  });
+});

--- a/packages/server-python/__tests__/integration.test.ts
+++ b/packages/server-python/__tests__/integration.test.ts
@@ -26,10 +26,19 @@ describe("@paretools/python integration", () => {
     await transport.close();
   });
 
-  it("lists all 4 tools", async () => {
+  it("lists all 8 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
-    expect(names).toEqual(["mypy", "pip-audit", "pip-install", "ruff-check"]);
+    expect(names).toEqual([
+      "black",
+      "mypy",
+      "pip-audit",
+      "pip-install",
+      "pytest",
+      "ruff-check",
+      "uv-install",
+      "uv-run",
+    ]);
   });
 
   it("each tool has an outputSchema", async () => {

--- a/packages/server-python/__tests__/pytest.test.ts
+++ b/packages/server-python/__tests__/pytest.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import { parsePytestOutput } from "../src/lib/parsers.js";
+import { formatPytest } from "../src/lib/formatters.js";
+import type { PytestResult } from "../src/schemas/index.js";
+
+describe("parsePytestOutput", () => {
+  it("parses all tests passing", () => {
+    const stdout = [
+      "....",
+      "4 passed in 0.52s",
+    ].join("\n");
+
+    const result = parsePytestOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.passed).toBe(4);
+    expect(result.failed).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.total).toBe(4);
+    expect(result.duration).toBe(0.52);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("parses mixed results with failures", () => {
+    const stdout = [
+      "_____________________________ test_addition _____________________________",
+      "",
+      "    def test_addition():",
+      ">       assert 1 + 1 == 3",
+      "E       assert 2 == 3",
+      "E        +  where 2 = 1 + 1",
+      "",
+      "test_math.py:5: AssertionError",
+      "========================= short test summary info =========================",
+      "FAILED test_math.py::test_addition",
+      "==================== 2 passed, 1 failed in 1.23s ====================",
+    ].join("\n");
+
+    const result = parsePytestOutput(stdout, "", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.passed).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(result.total).toBe(3);
+    expect(result.duration).toBe(1.23);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].test).toBe("test_addition");
+    expect(result.failures[0].message).toContain("assert 2 == 3");
+  });
+
+  it("parses results with errors and skips", () => {
+    const stdout = [
+      "========================= short test summary info =========================",
+      "==================== 3 passed, 1 failed, 2 errors, 1 skipped in 2.50s ====================",
+    ].join("\n");
+
+    const result = parsePytestOutput(stdout, "", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.passed).toBe(3);
+    expect(result.failed).toBe(1);
+    expect(result.errors).toBe(2);
+    expect(result.skipped).toBe(1);
+    expect(result.total).toBe(7);
+    expect(result.duration).toBe(2.5);
+  });
+
+  it("handles no tests collected", () => {
+    const stdout = [
+      "========================= no tests ran in 0.01s =========================",
+    ].join("\n");
+
+    const result = parsePytestOutput(stdout, "", 5);
+
+    expect(result.success).toBe(true);
+    expect(result.passed).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.total).toBe(0);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("parses multiple failures", () => {
+    const stdout = [
+      "_____________________________ test_foo _____________________________",
+      "",
+      "    def test_foo():",
+      ">       assert False",
+      "E       assert False",
+      "",
+      "test_bar.py:3: AssertionError",
+      "_____________________________ test_bar _____________________________",
+      "",
+      "    def test_bar():",
+      ">       raise ValueError('bad')",
+      "E       ValueError: bad",
+      "",
+      "test_bar.py:7: ValueError",
+      "========================= short test summary info =========================",
+      "==================== 0 passed, 2 failed in 0.10s ====================",
+    ].join("\n");
+
+    const result = parsePytestOutput(stdout, "", 1);
+
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures[0].test).toBe("test_foo");
+    expect(result.failures[0].message).toContain("assert False");
+    expect(result.failures[1].test).toBe("test_bar");
+    expect(result.failures[1].message).toContain("ValueError: bad");
+  });
+
+  it("handles output on stderr", () => {
+    const stderr = "========================= 5 passed in 0.30s =========================";
+
+    const result = parsePytestOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.passed).toBe(5);
+    expect(result.total).toBe(5);
+  });
+});
+
+describe("formatPytest", () => {
+  it("formats no tests collected", () => {
+    const data: PytestResult = {
+      success: true,
+      passed: 0,
+      failed: 0,
+      errors: 0,
+      skipped: 0,
+      total: 0,
+      duration: 0,
+      failures: [],
+    };
+    expect(formatPytest(data)).toBe("pytest: no tests collected.");
+  });
+
+  it("formats all passing", () => {
+    const data: PytestResult = {
+      success: true,
+      passed: 10,
+      failed: 0,
+      errors: 0,
+      skipped: 0,
+      total: 10,
+      duration: 1.5,
+      failures: [],
+    };
+    expect(formatPytest(data)).toBe("pytest: 10 passed in 1.5s");
+  });
+
+  it("formats mixed results with failures", () => {
+    const data: PytestResult = {
+      success: false,
+      passed: 3,
+      failed: 1,
+      errors: 0,
+      skipped: 2,
+      total: 6,
+      duration: 2.0,
+      failures: [{ test: "test_thing", message: "assert 1 == 2" }],
+    };
+    const output = formatPytest(data);
+
+    expect(output).toContain("3 passed, 1 failed, 2 skipped in 2s");
+    expect(output).toContain("FAILED test_thing: assert 1 == 2");
+  });
+});

--- a/packages/server-python/__tests__/uv-install.test.ts
+++ b/packages/server-python/__tests__/uv-install.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { parseUvInstall } from "../src/lib/parsers.js";
+import { formatUvInstall } from "../src/lib/formatters.js";
+import type { UvInstall } from "../src/schemas/index.js";
+
+describe("parseUvInstall", () => {
+  it("parses successful install with packages", () => {
+    const stderr = [
+      "Resolved 3 packages in 150ms",
+      "Prepared 3 packages in 200ms",
+      "Installed 3 packages in 50ms",
+      " + flask==3.0.0",
+      " + jinja2==3.1.2",
+      " + werkzeug==3.0.1",
+    ].join("\n");
+
+    const result = parseUvInstall("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.total).toBe(3);
+    expect(result.installed).toEqual([
+      { name: "flask", version: "3.0.0" },
+      { name: "jinja2", version: "3.1.2" },
+      { name: "werkzeug", version: "3.0.1" },
+    ]);
+  });
+
+  it("parses install with duration in summary", () => {
+    const stderr = [
+      "Resolved 1 package in 10ms",
+      "Installed 1 package in 0.5s",
+      " + requests==2.31.0",
+    ].join("\n");
+
+    const result = parseUvInstall("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.total).toBe(1);
+    expect(result.installed[0]).toEqual({ name: "requests", version: "2.31.0" });
+  });
+
+  it("handles already-satisfied packages", () => {
+    const stderr = "Audited 5 packages in 10ms";
+
+    const result = parseUvInstall("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.total).toBe(0);
+    expect(result.installed).toEqual([]);
+  });
+
+  it("handles install failure", () => {
+    const stderr = "error: Could not find package 'nonexistent-pkg-xyz'";
+
+    const result = parseUvInstall("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.total).toBe(0);
+  });
+
+  it("handles empty output", () => {
+    const result = parseUvInstall("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.total).toBe(0);
+    expect(result.installed).toEqual([]);
+  });
+});
+
+describe("formatUvInstall", () => {
+  it("formats successful install", () => {
+    const data: UvInstall = {
+      success: true,
+      installed: [
+        { name: "flask", version: "3.0.0" },
+        { name: "jinja2", version: "3.1.2" },
+      ],
+      total: 2,
+      duration: 0.5,
+    };
+    const output = formatUvInstall(data);
+
+    expect(output).toContain("Installed 2 packages in 0.5s");
+    expect(output).toContain("flask==3.0.0");
+    expect(output).toContain("jinja2==3.1.2");
+  });
+
+  it("formats already satisfied", () => {
+    const data: UvInstall = {
+      success: true,
+      installed: [],
+      total: 0,
+      duration: 0,
+    };
+    expect(formatUvInstall(data)).toBe("All requirements already satisfied.");
+  });
+
+  it("formats failure", () => {
+    const data: UvInstall = {
+      success: false,
+      installed: [],
+      total: 0,
+      duration: 0,
+    };
+    expect(formatUvInstall(data)).toBe("uv install failed.");
+  });
+});

--- a/packages/server-python/__tests__/uv-run.test.ts
+++ b/packages/server-python/__tests__/uv-run.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { parseUvRun } from "../src/lib/parsers.js";
+import { formatUvRun } from "../src/lib/formatters.js";
+import type { UvRun } from "../src/schemas/index.js";
+
+describe("parseUvRun", () => {
+  it("parses successful command", () => {
+    const result = parseUvRun("Hello, world!\n", "", 0, 1500);
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("Hello, world!\n");
+    expect(result.stderr).toBe("");
+    expect(result.duration).toBe(1.5);
+  });
+
+  it("parses failed command", () => {
+    const result = parseUvRun("", "Error: file not found\n", 1, 250);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("Error: file not found\n");
+    expect(result.duration).toBe(0.25);
+  });
+
+  it("parses command with both stdout and stderr", () => {
+    const result = parseUvRun("output data\n", "warning: deprecated\n", 0, 3000);
+
+    expect(result.success).toBe(true);
+    expect(result.stdout).toBe("output data\n");
+    expect(result.stderr).toBe("warning: deprecated\n");
+    expect(result.duration).toBe(3);
+  });
+
+  it("rounds duration to milliseconds", () => {
+    const result = parseUvRun("", "", 0, 1234);
+
+    expect(result.duration).toBe(1.234);
+  });
+});
+
+describe("formatUvRun", () => {
+  it("formats successful run with output", () => {
+    const data: UvRun = {
+      exitCode: 0,
+      stdout: "Hello, world!",
+      stderr: "",
+      success: true,
+      duration: 1.5,
+    };
+    const output = formatUvRun(data);
+
+    expect(output).toContain("uv run completed in 1.5s");
+    expect(output).toContain("Hello, world!");
+  });
+
+  it("formats failed run", () => {
+    const data: UvRun = {
+      exitCode: 1,
+      stdout: "",
+      stderr: "Error occurred",
+      success: false,
+      duration: 0.5,
+    };
+    const output = formatUvRun(data);
+
+    expect(output).toContain("uv run failed (exit 1) in 0.5s");
+    expect(output).toContain("Error occurred");
+  });
+
+  it("formats run with no output", () => {
+    const data: UvRun = {
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      success: true,
+      duration: 0.1,
+    };
+    const output = formatUvRun(data);
+
+    expect(output).toBe("uv run completed in 0.1s");
+  });
+});

--- a/packages/server-python/src/index.ts
+++ b/packages/server-python/src/index.ts
@@ -8,7 +8,7 @@ const server = new McpServer(
   { name: "@paretools/python", version: "0.2.0" },
   {
     instructions:
-      "Structured Python tool operations (pip install, mypy, ruff, pip-audit). Use instead of running Python tool commands via bash. Returns typed JSON with structured type errors, lint violations, and vulnerability data.",
+      "Structured Python tool operations (pip install, mypy, ruff, pip-audit, pytest, uv, black). Use instead of running Python tool commands via bash. Returns typed JSON with structured type errors, lint violations, vulnerability data, test results, and formatting status.",
   },
 );
 

--- a/packages/server-python/src/lib/formatters.ts
+++ b/packages/server-python/src/lib/formatters.ts
@@ -1,4 +1,13 @@
-import type { PipInstall, MypyResult, RuffResult, PipAuditResult } from "../schemas/index.js";
+import type {
+  PipInstall,
+  MypyResult,
+  RuffResult,
+  PipAuditResult,
+  PytestResult,
+  UvInstall,
+  UvRun,
+  BlackResult,
+} from "../schemas/index.js";
 
 /** Formats structured pip install results into a human-readable summary of installed packages. */
 export function formatPipInstall(data: PipInstall): string {
@@ -45,5 +54,76 @@ export function formatPipAudit(data: PipAuditResult): string {
     const fix = v.fixVersions.length ? ` (fix: ${v.fixVersions.join(", ")})` : "";
     lines.push(`  ${v.name}==${v.version} ${v.id}: ${v.description}${fix}`);
   }
+  return lines.join("\n");
+}
+
+/** Formats structured pytest results into a human-readable test summary. */
+export function formatPytest(data: PytestResult): string {
+  if (data.total === 0) return "pytest: no tests collected.";
+
+  const parts: string[] = [];
+  if (data.passed > 0) parts.push(`${data.passed} passed`);
+  if (data.failed > 0) parts.push(`${data.failed} failed`);
+  if (data.errors > 0) parts.push(`${data.errors} errors`);
+  if (data.skipped > 0) parts.push(`${data.skipped} skipped`);
+
+  const lines = [`pytest: ${parts.join(", ")} in ${data.duration}s`];
+
+  for (const f of data.failures) {
+    lines.push(`  FAILED ${f.test}: ${f.message}`);
+  }
+
+  return lines.join("\n");
+}
+
+/** Formats structured uv install results into a human-readable summary. */
+export function formatUvInstall(data: UvInstall): string {
+  if (!data.success) return "uv install failed.";
+  if (data.total === 0) return "All requirements already satisfied.";
+
+  const lines = [`Installed ${data.total} packages in ${data.duration}s:`];
+  for (const pkg of data.installed) {
+    lines.push(`  ${pkg.name}==${pkg.version}`);
+  }
+  return lines.join("\n");
+}
+
+/** Formats structured uv run results into a human-readable summary. */
+export function formatUvRun(data: UvRun): string {
+  const status = data.success ? "completed" : `failed (exit ${data.exitCode})`;
+  const lines = [`uv run ${status} in ${data.duration}s`];
+
+  if (data.stdout.trim()) {
+    lines.push("stdout:", data.stdout.trim());
+  }
+  if (data.stderr.trim()) {
+    lines.push("stderr:", data.stderr.trim());
+  }
+
+  return lines.join("\n");
+}
+
+/** Formats structured Black formatter results into a human-readable summary. */
+export function formatBlack(data: BlackResult): string {
+  if (data.filesChecked === 0) return "black: no Python files found.";
+
+  if (data.success && data.filesChanged === 0) {
+    return `black: ${data.filesUnchanged} files already formatted.`;
+  }
+
+  const lines: string[] = [];
+  if (data.wouldReformat.length > 0) {
+    lines.push(
+      `black: ${data.filesChanged} files ${data.success ? "reformatted" : "would be reformatted"}, ${data.filesUnchanged} unchanged`,
+    );
+    for (const f of data.wouldReformat) {
+      lines.push(`  ${f}`);
+    }
+  } else {
+    lines.push(
+      `black: ${data.filesChanged} files reformatted, ${data.filesUnchanged} unchanged`,
+    );
+  }
+
   return lines.join("\n");
 }

--- a/packages/server-python/src/lib/parsers.ts
+++ b/packages/server-python/src/lib/parsers.ts
@@ -4,6 +4,10 @@ import type {
   MypyDiagnosticSchema,
   RuffResult,
   PipAuditResult,
+  PytestResult,
+  UvInstall,
+  UvRun,
+  BlackResult,
 } from "../schemas/index.js";
 import { z } from "zod";
 
@@ -138,4 +142,212 @@ interface PipAuditJson {
       fix_versions?: string[];
     }[];
   }[];
+}
+
+const PYTEST_DURATION_RE = /in ([\d.]+)s/;
+
+function extractCount(line: string, label: RegExp): number {
+  const m = line.match(label);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+/** Parses pytest output into structured test results with pass/fail/error/skip counts and failure details. */
+export function parsePytestOutput(stdout: string, stderr: string, exitCode: number): PytestResult {
+  const output = stdout + "\n" + stderr;
+  const lines = output.split("\n");
+
+  // Find the summary line (e.g., "=== 3 passed, 1 failed in 0.52s ===")
+  let passed = 0;
+  let failed = 0;
+  let errors = 0;
+  let skipped = 0;
+  let duration = 0;
+
+  for (const line of lines) {
+    // Match lines containing pytest summary markers (== ... in Xs ==) or standalone counts
+    if (/\d+ (?:passed|failed|error|skipped)/.test(line) || /in [\d.]+s/.test(line)) {
+      passed = Math.max(passed, extractCount(line, /(\d+) passed/));
+      failed = Math.max(failed, extractCount(line, /(\d+) failed/));
+      errors = Math.max(errors, extractCount(line, /(\d+) errors?/));
+      skipped = Math.max(skipped, extractCount(line, /(\d+) skipped/));
+
+      const durationMatch = line.match(PYTEST_DURATION_RE);
+      if (durationMatch) {
+        duration = parseFloat(durationMatch[1]);
+      }
+    }
+  }
+
+  // Check for "no tests ran" case
+  const noTests = output.includes("no tests ran");
+  if (noTests && passed === 0 && failed === 0 && errors === 0) {
+    return {
+      success: exitCode === 0 || exitCode === 5,
+      passed: 0,
+      failed: 0,
+      errors: 0,
+      skipped: 0,
+      total: 0,
+      duration,
+      failures: [],
+    };
+  }
+
+  // Parse failure blocks from short traceback
+  const failures: { test: string; message: string }[] = [];
+  const failureBlockRe = /_{3,}\s+(.+?)\s+_{3,}/g;
+  let failMatch: RegExpExecArray | null;
+  while ((failMatch = failureBlockRe.exec(output)) !== null) {
+    const testName = failMatch[1].trim();
+    const startIdx = failMatch.index + failMatch[0].length;
+
+    // Find the end of this failure block (next FAILED marker, next separator, or end)
+    const remaining = output.slice(startIdx);
+    const endMatch = remaining.match(/(?:_{3,}|={3,})/);
+    const block = endMatch ? remaining.slice(0, endMatch.index) : remaining;
+
+    // Extract the most relevant error line
+    const blockLines = block.split("\n").map((l) => l.trim()).filter(Boolean);
+    let message = "";
+
+    // Look for assertion errors, E lines, or the last meaningful line
+    for (const bLine of blockLines) {
+      if (bLine.startsWith("E ")) {
+        message = message ? message + "\n" + bLine.slice(2).trim() : bLine.slice(2).trim();
+      }
+    }
+    if (!message && blockLines.length > 0) {
+      message = blockLines[blockLines.length - 1];
+    }
+
+    failures.push({ test: testName, message });
+  }
+
+  const total = passed + failed + errors + skipped;
+
+  return {
+    success: exitCode === 0,
+    passed,
+    failed,
+    errors,
+    skipped,
+    total,
+    duration,
+    failures,
+  };
+}
+
+// Matches uv install output lines like: " + package==version" or "Installed N packages in Ns"
+const UV_INSTALLED_PKG_RE = /^\s*\+\s+(\S+)==(\S+)/;
+const UV_SUMMARY_RE = /Installed (\d+) packages? in ([\d.]+)/;
+
+/** Parses uv pip install output into structured data with installed packages. */
+export function parseUvInstall(stdout: string, stderr: string, exitCode: number): UvInstall {
+  const output = stdout + "\n" + stderr;
+  const lines = output.split("\n");
+
+  const installed: { name: string; version: string }[] = [];
+  let duration = 0;
+
+  for (const line of lines) {
+    const pkgMatch = line.match(UV_INSTALLED_PKG_RE);
+    if (pkgMatch) {
+      installed.push({ name: pkgMatch[1], version: pkgMatch[2] });
+    }
+    const summaryMatch = line.match(UV_SUMMARY_RE);
+    if (summaryMatch) {
+      duration = parseFloat(summaryMatch[2]);
+    }
+  }
+
+  // If uv reports packages but we couldn't parse individual lines, use summary count
+  const alreadySatisfied =
+    output.includes("already satisfied") ||
+    output.includes("Audited") ||
+    output.includes("No changes");
+
+  return {
+    success: exitCode === 0,
+    installed,
+    total: installed.length,
+    duration,
+  };
+}
+
+/** Parses uv run output into structured result with exit code, stdout, stderr. */
+export function parseUvRun(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  durationMs: number,
+): UvRun {
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    success: exitCode === 0,
+    duration: Math.round(durationMs) / 1000,
+  };
+}
+
+const BLACK_REFORMAT_RE = /^would reformat (.+)$/;
+const BLACK_REFORMATTED_RE = /^reformatted (.+)$/;
+const BLACK_SUMMARY_RE =
+  /(\d+) files? (?:would be )?reformatted(?:,\s*(\d+) files? (?:would be )?left unchanged)?|(\d+) files? (?:would be )?left unchanged/;
+
+/** Parses Black code formatter output into structured result with file counts. */
+export function parseBlackOutput(stdout: string, stderr: string, exitCode: number): BlackResult {
+  // Black writes most output to stderr
+  const output = stdout + "\n" + stderr;
+  const lines = output.split("\n");
+
+  const wouldReformat: string[] = [];
+  let filesChanged = 0;
+  let filesUnchanged = 0;
+
+  for (const line of lines) {
+    const wouldMatch = line.match(BLACK_REFORMAT_RE);
+    if (wouldMatch) {
+      wouldReformat.push(wouldMatch[1].trim());
+    }
+    const reformattedMatch = line.match(BLACK_REFORMATTED_RE);
+    if (reformattedMatch) {
+      wouldReformat.push(reformattedMatch[1].trim());
+    }
+  }
+
+  // Parse summary line
+  for (const line of lines) {
+    const summaryMatch = line.match(BLACK_SUMMARY_RE);
+    if (summaryMatch) {
+      if (summaryMatch[1]) {
+        filesChanged = parseInt(summaryMatch[1], 10);
+        filesUnchanged = summaryMatch[2] ? parseInt(summaryMatch[2], 10) : 0;
+      } else if (summaryMatch[3]) {
+        filesChanged = 0;
+        filesUnchanged = parseInt(summaryMatch[3], 10);
+      }
+    }
+  }
+
+  // If we found "would reformat" lines but no summary, use those counts
+  if (filesChanged === 0 && wouldReformat.length > 0) {
+    filesChanged = wouldReformat.length;
+  }
+
+  const filesChecked = filesChanged + filesUnchanged;
+
+  // In check mode, success means no files need reformatting
+  // In format mode, success is always true (exitCode 0) unless black errors
+  // exitCode 1 in check mode = files would be reformatted
+  // exitCode 123 = internal error
+  const success = exitCode === 0;
+
+  return {
+    filesChanged,
+    filesUnchanged,
+    filesChecked,
+    success,
+    wouldReformat,
+  };
 }

--- a/packages/server-python/src/lib/python-runner.ts
+++ b/packages/server-python/src/lib/python-runner.ts
@@ -11,3 +11,15 @@ export async function mypy(args: string[], cwd?: string): Promise<RunResult> {
 export async function ruff(args: string[], cwd?: string): Promise<RunResult> {
   return run("ruff", args, { cwd });
 }
+
+export async function pytest(args: string[], cwd?: string): Promise<RunResult> {
+  return run("pytest", args, { cwd, timeout: 300_000 });
+}
+
+export async function uv(args: string[], cwd?: string): Promise<RunResult> {
+  return run("uv", args, { cwd, timeout: 120_000 });
+}
+
+export async function black(args: string[], cwd?: string): Promise<RunResult> {
+  return run("black", args, { cwd });
+}

--- a/packages/server-python/src/schemas/index.ts
+++ b/packages/server-python/src/schemas/index.ts
@@ -73,3 +73,60 @@ export const PipAuditResultSchema = z.object({
 });
 
 export type PipAuditResult = z.infer<typeof PipAuditResultSchema>;
+
+/** Zod schema for a single pytest failure with test name and failure message. */
+export const PytestFailureSchema = z.object({
+  test: z.string(),
+  message: z.string(),
+});
+
+/** Zod schema for structured pytest output with pass/fail/error/skip counts and failure details. */
+export const PytestResultSchema = z.object({
+  success: z.boolean(),
+  passed: z.number(),
+  failed: z.number(),
+  errors: z.number(),
+  skipped: z.number(),
+  total: z.number(),
+  duration: z.number(),
+  failures: z.array(PytestFailureSchema),
+});
+
+export type PytestResult = z.infer<typeof PytestResultSchema>;
+
+/** Zod schema for structured uv install output with installed packages and count. */
+export const UvInstallSchema = z.object({
+  success: z.boolean(),
+  installed: z.array(
+    z.object({
+      name: z.string(),
+      version: z.string(),
+    }),
+  ),
+  total: z.number(),
+  duration: z.number(),
+});
+
+export type UvInstall = z.infer<typeof UvInstallSchema>;
+
+/** Zod schema for structured uv run output with exit code and stdout/stderr. */
+export const UvRunSchema = z.object({
+  exitCode: z.number(),
+  stdout: z.string(),
+  stderr: z.string(),
+  success: z.boolean(),
+  duration: z.number(),
+});
+
+export type UvRun = z.infer<typeof UvRunSchema>;
+
+/** Zod schema for structured Black formatter output with file counts and reformat list. */
+export const BlackResultSchema = z.object({
+  filesChanged: z.number(),
+  filesUnchanged: z.number(),
+  filesChecked: z.number(),
+  success: z.boolean(),
+  wouldReformat: z.array(z.string()),
+});
+
+export type BlackResult = z.infer<typeof BlackResultSchema>;

--- a/packages/server-python/src/tools/black.ts
+++ b/packages/server-python/src/tools/black.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { black } from "../lib/python-runner.js";
+import { parseBlackOutput } from "../lib/parsers.js";
+import { formatBlack } from "../lib/formatters.js";
+import { BlackResultSchema } from "../schemas/index.js";
+
+export function registerBlackTool(server: McpServer) {
+  server.registerTool(
+    "black",
+    {
+      title: "Black Formatter",
+      description:
+        "Runs Black code formatter and returns structured results (files changed, unchanged, would reformat). Use instead of running `black` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Project root path (default: cwd)"),
+        targets: z
+          .array(z.string())
+          .optional()
+          .default(["."])
+          .describe('Files or directories to format (default: ["."])'),
+        check: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Check mode (report without modifying files)"),
+      },
+      outputSchema: BlackResultSchema,
+    },
+    async ({ path, targets, check }) => {
+      const cwd = path || process.cwd();
+      const args = [...(targets || ["."])];
+      if (check) args.push("--check");
+
+      const result = await black(args, cwd);
+      const data = parseBlackOutput(result.stdout, result.stderr, result.exitCode);
+      return dualOutput(data, formatBlack);
+    },
+  );
+}

--- a/packages/server-python/src/tools/index.ts
+++ b/packages/server-python/src/tools/index.ts
@@ -3,10 +3,18 @@ import { registerPipInstallTool } from "./pip-install.js";
 import { registerMypyTool } from "./mypy.js";
 import { registerRuffTool } from "./ruff.js";
 import { registerPipAuditTool } from "./pip-audit.js";
+import { registerPytestTool } from "./pytest.js";
+import { registerUvInstallTool } from "./uv-install.js";
+import { registerUvRunTool } from "./uv-run.js";
+import { registerBlackTool } from "./black.js";
 
 export function registerAllTools(server: McpServer) {
   registerPipInstallTool(server);
   registerMypyTool(server);
   registerRuffTool(server);
   registerPipAuditTool(server);
+  registerPytestTool(server);
+  registerUvInstallTool(server);
+  registerUvRunTool(server);
+  registerBlackTool(server);
 }

--- a/packages/server-python/src/tools/pytest.ts
+++ b/packages/server-python/src/tools/pytest.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { pytest } from "../lib/python-runner.js";
+import { parsePytestOutput } from "../lib/parsers.js";
+import { formatPytest } from "../lib/formatters.js";
+import { PytestResultSchema } from "../schemas/index.js";
+
+export function registerPytestTool(server: McpServer) {
+  server.registerTool(
+    "pytest",
+    {
+      title: "pytest",
+      description:
+        "Runs pytest and returns structured test results (passed, failed, errors, skipped, failures). Use instead of running `pytest` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Project root path (default: cwd)"),
+        targets: z
+          .array(z.string())
+          .optional()
+          .describe("Test files or directories to run (default: auto-discover)"),
+        markers: z
+          .string()
+          .optional()
+          .describe('Pytest marker expression (e.g. "not slow")'),
+        verbose: z.boolean().optional().default(false).describe("Enable verbose output"),
+        exitFirst: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Stop on first failure (-x)"),
+      },
+      outputSchema: PytestResultSchema,
+    },
+    async ({ path, targets, markers, verbose, exitFirst }) => {
+      const cwd = path || process.cwd();
+      const args = ["--tb=short", "-q"];
+
+      if (verbose) args.splice(args.indexOf("-q"), 1, "-v");
+      if (exitFirst) args.push("-x");
+      if (markers) args.push("-m", markers);
+      if (targets && targets.length > 0) args.push(...targets);
+
+      const result = await pytest(args, cwd);
+      const data = parsePytestOutput(result.stdout, result.stderr, result.exitCode);
+      return dualOutput(data, formatPytest);
+    },
+  );
+}

--- a/packages/server-python/src/tools/uv-install.ts
+++ b/packages/server-python/src/tools/uv-install.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { uv } from "../lib/python-runner.js";
+import { parseUvInstall } from "../lib/parsers.js";
+import { formatUvInstall } from "../lib/formatters.js";
+import { UvInstallSchema } from "../schemas/index.js";
+
+export function registerUvInstallTool(server: McpServer) {
+  server.registerTool(
+    "uv-install",
+    {
+      title: "uv Install",
+      description:
+        "Runs uv pip install and returns a structured summary of installed packages. Use instead of running `uv pip install` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Working directory (default: cwd)"),
+        packages: z
+          .array(z.string())
+          .optional()
+          .describe("Packages to install"),
+        requirements: z
+          .string()
+          .optional()
+          .describe("Path to requirements file"),
+      },
+      outputSchema: UvInstallSchema,
+    },
+    async ({ path, packages, requirements }) => {
+      const cwd = path || process.cwd();
+      const args = ["pip", "install"];
+
+      if (requirements) {
+        args.push("-r", requirements);
+      } else if (packages && packages.length > 0) {
+        args.push(...packages);
+      } else {
+        args.push("-r", "requirements.txt");
+      }
+
+      const result = await uv(args, cwd);
+      const data = parseUvInstall(result.stdout, result.stderr, result.exitCode);
+      return dualOutput(data, formatUvInstall);
+    },
+  );
+}

--- a/packages/server-python/src/tools/uv-run.ts
+++ b/packages/server-python/src/tools/uv-run.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { uv } from "../lib/python-runner.js";
+import { parseUvRun } from "../lib/parsers.js";
+import { formatUvRun } from "../lib/formatters.js";
+import { UvRunSchema } from "../schemas/index.js";
+
+export function registerUvRunTool(server: McpServer) {
+  server.registerTool(
+    "uv-run",
+    {
+      title: "uv Run",
+      description:
+        "Runs a command in a uv-managed environment and returns structured output. Use instead of running `uv run` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Working directory (default: cwd)"),
+        command: z
+          .array(z.string())
+          .min(1)
+          .describe("Command and arguments to run (e.g. ['python', 'script.py'])"),
+      },
+      outputSchema: UvRunSchema,
+    },
+    async ({ path, command }) => {
+      const cwd = path || process.cwd();
+      const args = ["run", ...command];
+
+      const start = Date.now();
+      const result = await uv(args, cwd);
+      const elapsed = Date.now() - start;
+
+      const data = parseUvRun(result.stdout, result.stderr, result.exitCode, elapsed);
+      return dualOutput(data, formatUvRun);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds **4 new tools** to `@paretools/python`: `pytest`, `uv-install`, `uv-run`, and `black`
- `pytest`: Runs pytest with structured output (passed/failed/errors/skipped counts, failure details, duration)
- `uv-install`: Installs packages via uv (fast pip replacement) with structured install summary
- `uv-run`: Runs commands in uv-managed environments with structured stdout/stderr/exitCode
- `black`: Runs Black code formatter with structured results (files changed/unchanged, would-reformat list)
- All tools follow the Pare pattern: Zod output schemas, parsers, formatters, dual output
- Includes 34 new tests across 4 test files covering parsers and formatters for all new tools

Closes #38

## Test plan
- [x] All 76 tests pass (`pnpm test --filter @paretools/python`)
- [x] Build succeeds (`pnpm build --filter @paretools/python`)
- [x] Integration test updated to verify all 8 tools are registered
- [ ] Manual verification with real pytest/uv/black installations

🤖 Generated with [Claude Code](https://claude.com/claude-code)