### PR TITLE
feat(go): add run, mod-tidy, fmt, and generate tools

### DIFF
--- a/packages/server-go/__tests__/fmt.test.ts
+++ b/packages/server-go/__tests__/fmt.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { parseGoFmtOutput } from "../src/lib/parsers.js";
+import { formatGoFmt } from "../src/lib/formatters.js";
+import type { GoFmtResult } from "../src/schemas/index.js";
+
+describe("parseGoFmtOutput", () => {
+  describe("check mode (-l)", () => {
+    it("parses files needing formatting", () => {
+      const stdout = "main.go\nutil.go\nhandler.go\n";
+      const result = parseGoFmtOutput(stdout, "", 0, true);
+
+      expect(result.success).toBe(false);
+      expect(result.filesChanged).toBe(3);
+      expect(result.files).toEqual(["main.go", "util.go", "handler.go"]);
+    });
+
+    it("parses no files needing formatting", () => {
+      const result = parseGoFmtOutput("", "", 0, true);
+
+      expect(result.success).toBe(true);
+      expect(result.filesChanged).toBe(0);
+      expect(result.files).toEqual([]);
+    });
+
+    it("parses single file needing formatting", () => {
+      const stdout = "main.go\n";
+      const result = parseGoFmtOutput(stdout, "", 0, true);
+
+      expect(result.success).toBe(false);
+      expect(result.filesChanged).toBe(1);
+      expect(result.files).toEqual(["main.go"]);
+    });
+
+    it("handles files with path separators", () => {
+      const stdout = "pkg/server/handler.go\ncmd/main.go\n";
+      const result = parseGoFmtOutput(stdout, "", 0, true);
+
+      expect(result.success).toBe(false);
+      expect(result.filesChanged).toBe(2);
+      expect(result.files).toEqual(["pkg/server/handler.go", "cmd/main.go"]);
+    });
+  });
+
+  describe("fix mode (-w)", () => {
+    it("parses successful fix with no output", () => {
+      const result = parseGoFmtOutput("", "", 0, false);
+
+      expect(result.success).toBe(true);
+      expect(result.filesChanged).toBe(0);
+      expect(result.files).toEqual([]);
+    });
+
+    it("handles error exit code", () => {
+      const result = parseGoFmtOutput("", "error: could not parse file.go", 2, false);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("error cases", () => {
+    it("handles gofmt error with non-zero exit code", () => {
+      const stderr = "main.go:5:1: expected declaration, got '}'";
+      const result = parseGoFmtOutput("", stderr, 2, true);
+
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("formatGoFmt", () => {
+  it("formats all files formatted (success)", () => {
+    const data: GoFmtResult = {
+      success: true,
+      filesChanged: 0,
+      files: [],
+    };
+    const output = formatGoFmt(data);
+    expect(output).toBe("gofmt: all files formatted.");
+  });
+
+  it("formats files needing changes", () => {
+    const data: GoFmtResult = {
+      success: false,
+      filesChanged: 2,
+      files: ["main.go", "util.go"],
+    };
+    const output = formatGoFmt(data);
+    expect(output).toContain("gofmt: 2 files");
+    expect(output).toContain("main.go");
+    expect(output).toContain("util.go");
+  });
+
+  it("formats single file needing changes", () => {
+    const data: GoFmtResult = {
+      success: false,
+      filesChanged: 1,
+      files: ["main.go"],
+    };
+    const output = formatGoFmt(data);
+    expect(output).toContain("gofmt: 1 files");
+    expect(output).toContain("main.go");
+  });
+});

--- a/packages/server-go/__tests__/generate.test.ts
+++ b/packages/server-go/__tests__/generate.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { parseGoGenerateOutput } from "../src/lib/parsers.js";
+import { formatGoGenerate } from "../src/lib/formatters.js";
+import type { GoGenerateResult } from "../src/schemas/index.js";
+
+describe("parseGoGenerateOutput", () => {
+  it("parses successful generate with no output", () => {
+    const result = parseGoGenerateOutput("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("");
+  });
+
+  it("parses successful generate with output", () => {
+    const stdout = "generating mocks for service.go\ngenerating stringer for types.go\n";
+    const result = parseGoGenerateOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("generating mocks for service.go");
+    expect(result.output).toContain("generating stringer for types.go");
+  });
+
+  it("parses failed generate", () => {
+    const stderr = "main.go:3: running \"mockgen\": exec: \"mockgen\": executable file not found in $PATH\n";
+    const result = parseGoGenerateOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("mockgen");
+    expect(result.output).toContain("executable file not found");
+  });
+
+  it("parses generate with both stdout and stderr", () => {
+    const stdout = "generating...\n";
+    const stderr = "warning: deprecated directive\n";
+    const result = parseGoGenerateOutput(stdout, stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("generating...");
+    expect(result.output).toContain("warning: deprecated directive");
+  });
+
+  it("parses generate error with no output", () => {
+    const result = parseGoGenerateOutput("", "", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.output).toBe("");
+  });
+
+  it("parses generate with syntax error in directive", () => {
+    const stderr = "main.go:3: bad flag syntax in //go:generate directive\n";
+    const result = parseGoGenerateOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("bad flag syntax");
+  });
+});
+
+describe("formatGoGenerate", () => {
+  it("formats successful generate with no output", () => {
+    const data: GoGenerateResult = {
+      success: true,
+      output: "",
+    };
+    const output = formatGoGenerate(data);
+    expect(output).toBe("go generate: success.");
+  });
+
+  it("formats successful generate with output", () => {
+    const data: GoGenerateResult = {
+      success: true,
+      output: "generated mock_service.go",
+    };
+    const output = formatGoGenerate(data);
+    expect(output).toContain("go generate: success.");
+    expect(output).toContain("generated mock_service.go");
+  });
+
+  it("formats failed generate", () => {
+    const data: GoGenerateResult = {
+      success: false,
+      output: "mockgen: command not found",
+    };
+    const output = formatGoGenerate(data);
+    expect(output).toContain("go generate: FAIL");
+    expect(output).toContain("mockgen: command not found");
+  });
+});

--- a/packages/server-go/__tests__/integration.test.ts
+++ b/packages/server-go/__tests__/integration.test.ts
@@ -26,10 +26,10 @@ describe("@paretools/go integration", () => {
     await transport.close();
   });
 
-  it("lists all 3 tools", async () => {
+  it("lists all 7 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
-    expect(names).toEqual(["build", "test", "vet"]);
+    expect(names).toEqual(["build", "fmt", "generate", "mod-tidy", "run", "test", "vet"]);
   });
 
   it("each tool has an outputSchema", async () => {

--- a/packages/server-go/__tests__/mod-tidy.test.ts
+++ b/packages/server-go/__tests__/mod-tidy.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { parseGoModTidyOutput } from "../src/lib/parsers.js";
+import { formatGoModTidy } from "../src/lib/formatters.js";
+import type { GoModTidyResult } from "../src/schemas/index.js";
+
+describe("parseGoModTidyOutput", () => {
+  it("parses successful tidy with no output (already tidy)", () => {
+    const result = parseGoModTidyOutput("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("go.mod and go.sum are already tidy.");
+  });
+
+  it("parses successful tidy with output", () => {
+    const stderr = "go: downloading github.com/pkg/errors v0.9.1\n";
+    const result = parseGoModTidyOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain("downloading github.com/pkg/errors");
+  });
+
+  it("parses failed tidy (no go.mod found)", () => {
+    const stderr = "go: go.mod file not found in current directory or any parent directory\n";
+    const result = parseGoModTidyOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.summary).toContain("go.mod file not found");
+  });
+
+  it("parses failed tidy with version conflict", () => {
+    const stderr =
+      "go: example.com/foo@v1.2.3 requires\n\texample.com/bar@v2.0.0: version \"v2.0.0\" invalid\n";
+    const result = parseGoModTidyOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.summary).toContain("example.com/foo@v1.2.3");
+  });
+
+  it("parses failed tidy with empty stderr", () => {
+    const result = parseGoModTidyOutput("", "", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.summary).toBe("go mod tidy failed.");
+  });
+});
+
+describe("formatGoModTidy", () => {
+  it("formats successful tidy", () => {
+    const data: GoModTidyResult = {
+      success: true,
+      summary: "go.mod and go.sum are already tidy.",
+    };
+    const output = formatGoModTidy(data);
+    expect(output).toBe("go mod tidy: go.mod and go.sum are already tidy.");
+  });
+
+  it("formats failed tidy", () => {
+    const data: GoModTidyResult = {
+      success: false,
+      summary: "go.mod file not found",
+    };
+    const output = formatGoModTidy(data);
+    expect(output).toContain("go mod tidy: FAIL");
+    expect(output).toContain("go.mod file not found");
+  });
+});

--- a/packages/server-go/__tests__/run-tool.test.ts
+++ b/packages/server-go/__tests__/run-tool.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { parseGoRunOutput } from "../src/lib/parsers.js";
+import { formatGoRun } from "../src/lib/formatters.js";
+import type { GoRunResult } from "../src/schemas/index.js";
+
+describe("parseGoRunOutput", () => {
+  it("parses successful run with stdout", () => {
+    const result = parseGoRunOutput("Hello, World!\n", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("Hello, World!");
+    expect(result.stderr).toBe("");
+  });
+
+  it("parses failed run with stderr", () => {
+    const stderr = "main.go:5:2: undefined: fmt.Prinln\n";
+    const result = parseGoRunOutput("", stderr, 2);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("main.go:5:2: undefined: fmt.Prinln");
+  });
+
+  it("parses run with both stdout and stderr", () => {
+    const result = parseGoRunOutput("output line\n", "warning: something\n", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.stdout).toBe("output line");
+    expect(result.stderr).toBe("warning: something");
+  });
+
+  it("parses run with non-zero exit code (runtime panic)", () => {
+    const stderr = [
+      "goroutine 1 [running]:",
+      "main.main()",
+      "\t/app/main.go:10 +0x40",
+      "exit status 2",
+    ].join("\n");
+
+    const result = parseGoRunOutput("", stderr, 2);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("goroutine 1 [running]:");
+  });
+
+  it("parses empty output on success", () => {
+    const result = parseGoRunOutput("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+  });
+
+  it("parses file not found error", () => {
+    const stderr = "stat main.go: no such file or directory\n";
+    const result = parseGoRunOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("no such file or directory");
+  });
+});
+
+describe("formatGoRun", () => {
+  it("formats successful run with output", () => {
+    const data: GoRunResult = {
+      success: true,
+      exitCode: 0,
+      stdout: "Hello, World!",
+      stderr: "",
+    };
+    const output = formatGoRun(data);
+    expect(output).toContain("go run: success.");
+    expect(output).toContain("Hello, World!");
+  });
+
+  it("formats failed run", () => {
+    const data: GoRunResult = {
+      success: false,
+      exitCode: 2,
+      stdout: "",
+      stderr: "main.go:5:2: undefined: foo",
+    };
+    const output = formatGoRun(data);
+    expect(output).toContain("go run: exit code 2.");
+    expect(output).toContain("main.go:5:2: undefined: foo");
+  });
+
+  it("formats run with no output", () => {
+    const data: GoRunResult = {
+      success: true,
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    };
+    const output = formatGoRun(data);
+    expect(output).toBe("go run: success.");
+  });
+
+  it("formats run with both stdout and stderr", () => {
+    const data: GoRunResult = {
+      success: true,
+      exitCode: 0,
+      stdout: "result: 42",
+      stderr: "debug info",
+    };
+    const output = formatGoRun(data);
+    expect(output).toContain("go run: success.");
+    expect(output).toContain("result: 42");
+    expect(output).toContain("debug info");
+  });
+});

--- a/packages/server-go/package.json
+++ b/packages/server-go/package.json
@@ -2,7 +2,7 @@
   "name": "@paretools/go",
   "version": "0.3.0",
   "mcpName": "io.github.Dave-London/go",
-  "description": "MCP server for Go tools (build, test, vet) with structured, token-efficient output",
+  "description": "MCP server for Go tools (build, test, vet, run, mod-tidy, fmt, generate) with structured, token-efficient output",
   "license": "MIT",
   "keywords": [
     "mcp",

--- a/packages/server-go/src/index.ts
+++ b/packages/server-go/src/index.ts
@@ -8,7 +8,7 @@ const server = new McpServer(
   { name: "@paretools/go", version: "0.2.0" },
   {
     instructions:
-      "Structured Go toolchain operations (build, test, vet). Use instead of running go commands via bash. Returns typed JSON with structured compiler errors, test results, and vet warnings.",
+      "Structured Go toolchain operations (build, test, vet, run, mod-tidy, fmt, generate). Use instead of running go commands via bash. Returns typed JSON with structured compiler errors, test results, vet warnings, run output, and more.",
   },
 );
 

--- a/packages/server-go/src/lib/formatters.ts
+++ b/packages/server-go/src/lib/formatters.ts
@@ -1,4 +1,12 @@
-import type { GoBuildResult, GoTestResult, GoVetResult } from "../schemas/index.js";
+import type {
+  GoBuildResult,
+  GoTestResult,
+  GoVetResult,
+  GoRunResult,
+  GoModTidyResult,
+  GoFmtResult,
+  GoGenerateResult,
+} from "../schemas/index.js";
 
 /** Formats structured go build results into a human-readable error summary. */
 export function formatGoBuild(data: GoBuildResult): string {
@@ -35,4 +43,42 @@ export function formatGoVet(data: GoVetResult): string {
     lines.push(`  ${d.file}:${d.line}${col}: ${d.message}`);
   }
   return lines.join("\n");
+}
+
+/** Formats structured go run results into a human-readable output summary. */
+export function formatGoRun(data: GoRunResult): string {
+  const lines: string[] = [];
+  if (data.success) {
+    lines.push("go run: success.");
+  } else {
+    lines.push(`go run: exit code ${data.exitCode}.`);
+  }
+  if (data.stdout) lines.push(data.stdout);
+  if (data.stderr) lines.push(data.stderr);
+  return lines.join("\n");
+}
+
+/** Formats structured go mod tidy results into a human-readable summary. */
+export function formatGoModTidy(data: GoModTidyResult): string {
+  if (data.success) return `go mod tidy: ${data.summary}`;
+  return `go mod tidy: FAIL\n  ${data.summary}`;
+}
+
+/** Formats structured gofmt results into a human-readable file listing. */
+export function formatGoFmt(data: GoFmtResult): string {
+  if (data.success && data.filesChanged === 0) return "gofmt: all files formatted.";
+
+  const lines = [`gofmt: ${data.filesChanged} files`];
+  for (const f of data.files) {
+    lines.push(`  ${f}`);
+  }
+  return lines.join("\n");
+}
+
+/** Formats structured go generate results into a human-readable summary. */
+export function formatGoGenerate(data: GoGenerateResult): string {
+  if (data.success) {
+    return data.output ? `go generate: success.\n${data.output}` : "go generate: success.";
+  }
+  return `go generate: FAIL\n${data.output}`;
 }

--- a/packages/server-go/src/lib/go-runner.ts
+++ b/packages/server-go/src/lib/go-runner.ts
@@ -4,3 +4,7 @@ export async function goCmd(args: string[], cwd?: string): Promise<RunResult> {
   // go build/test can take minutes for large projects
   return run("go", args, { cwd, timeout: 300_000 });
 }
+
+export async function gofmtCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("gofmt", args, { cwd, timeout: 120_000 });
+}

--- a/packages/server-go/src/schemas/index.ts
+++ b/packages/server-go/src/schemas/index.ts
@@ -53,3 +53,38 @@ export const GoVetResultSchema = z.object({
 });
 
 export type GoVetResult = z.infer<typeof GoVetResultSchema>;
+
+/** Zod schema for structured go run output with stdout, stderr, and exit code. */
+export const GoRunResultSchema = z.object({
+  exitCode: z.number(),
+  stdout: z.string(),
+  stderr: z.string(),
+  success: z.boolean(),
+});
+
+export type GoRunResult = z.infer<typeof GoRunResultSchema>;
+
+/** Zod schema for structured go mod tidy output with success status and summary. */
+export const GoModTidyResultSchema = z.object({
+  success: z.boolean(),
+  summary: z.string(),
+});
+
+export type GoModTidyResult = z.infer<typeof GoModTidyResultSchema>;
+
+/** Zod schema for structured gofmt output with file list and count. */
+export const GoFmtResultSchema = z.object({
+  success: z.boolean(),
+  filesChanged: z.number(),
+  files: z.array(z.string()),
+});
+
+export type GoFmtResult = z.infer<typeof GoFmtResultSchema>;
+
+/** Zod schema for structured go generate output with success status and output text. */
+export const GoGenerateResultSchema = z.object({
+  success: z.boolean(),
+  output: z.string(),
+});
+
+export type GoGenerateResult = z.infer<typeof GoGenerateResultSchema>;

--- a/packages/server-go/src/tools/fmt.ts
+++ b/packages/server-go/src/tools/fmt.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { gofmtCmd } from "../lib/go-runner.js";
+import { parseGoFmtOutput } from "../lib/parsers.js";
+import { formatGoFmt } from "../lib/formatters.js";
+import { GoFmtResultSchema } from "../schemas/index.js";
+
+export function registerFmtTool(server: McpServer) {
+  server.registerTool(
+    "fmt",
+    {
+      title: "Go Fmt",
+      description:
+        "Checks or fixes Go source formatting using gofmt. In check mode (-l), lists unformatted files. In fix mode (-w), rewrites files. Use instead of running `gofmt` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Project root path (default: cwd)"),
+        patterns: z
+          .array(z.string())
+          .optional()
+          .default(["."])
+          .describe("File patterns to format (default: ['.'])"),
+        check: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Check mode: list unformatted files without fixing (default: false)"),
+      },
+      outputSchema: GoFmtResultSchema,
+    },
+    async ({ path, patterns, check }) => {
+      const cwd = path || process.cwd();
+      const flag = check ? "-l" : "-w";
+      const args = [flag, ...(patterns || ["."])];
+      const result = await gofmtCmd(args, cwd);
+      const data = parseGoFmtOutput(result.stdout, result.stderr, result.exitCode, !!check);
+      return dualOutput(data, formatGoFmt);
+    },
+  );
+}

--- a/packages/server-go/src/tools/generate.ts
+++ b/packages/server-go/src/tools/generate.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { goCmd } from "../lib/go-runner.js";
+import { parseGoGenerateOutput } from "../lib/parsers.js";
+import { formatGoGenerate } from "../lib/formatters.js";
+import { GoGenerateResultSchema } from "../schemas/index.js";
+
+export function registerGenerateTool(server: McpServer) {
+  server.registerTool(
+    "generate",
+    {
+      title: "Go Generate",
+      description:
+        "Runs go generate directives in Go source files. Use instead of running `go generate` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Project root path (default: cwd)"),
+        patterns: z
+          .array(z.string())
+          .optional()
+          .default(["./..."])
+          .describe("Packages to generate (default: ./...)"),
+      },
+      outputSchema: GoGenerateResultSchema,
+    },
+    async ({ path, patterns }) => {
+      const cwd = path || process.cwd();
+      const result = await goCmd(["generate", ...(patterns || ["./..."])], cwd);
+      const data = parseGoGenerateOutput(result.stdout, result.stderr, result.exitCode);
+      return dualOutput(data, formatGoGenerate);
+    },
+  );
+}

--- a/packages/server-go/src/tools/index.ts
+++ b/packages/server-go/src/tools/index.ts
@@ -2,9 +2,17 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerBuildTool } from "./build.js";
 import { registerTestTool } from "./test.js";
 import { registerVetTool } from "./vet.js";
+import { registerRunTool } from "./run.js";
+import { registerModTidyTool } from "./mod-tidy.js";
+import { registerFmtTool } from "./fmt.js";
+import { registerGenerateTool } from "./generate.js";
 
 export function registerAllTools(server: McpServer) {
   registerBuildTool(server);
   registerTestTool(server);
   registerVetTool(server);
+  registerRunTool(server);
+  registerModTidyTool(server);
+  registerFmtTool(server);
+  registerGenerateTool(server);
 }

--- a/packages/server-go/src/tools/mod-tidy.ts
+++ b/packages/server-go/src/tools/mod-tidy.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { goCmd } from "../lib/go-runner.js";
+import { parseGoModTidyOutput } from "../lib/parsers.js";
+import { formatGoModTidy } from "../lib/formatters.js";
+import { GoModTidyResultSchema } from "../schemas/index.js";
+
+export function registerModTidyTool(server: McpServer) {
+  server.registerTool(
+    "mod-tidy",
+    {
+      title: "Go Mod Tidy",
+      description:
+        "Runs go mod tidy to add missing and remove unused module dependencies. Use instead of running `go mod tidy` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Project root path (default: cwd)"),
+      },
+      outputSchema: GoModTidyResultSchema,
+    },
+    async ({ path }) => {
+      const cwd = path || process.cwd();
+      const result = await goCmd(["mod", "tidy"], cwd);
+      const data = parseGoModTidyOutput(result.stdout, result.stderr, result.exitCode);
+      return dualOutput(data, formatGoModTidy);
+    },
+  );
+}

--- a/packages/server-go/src/tools/run.ts
+++ b/packages/server-go/src/tools/run.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput } from "@paretools/shared";
+import { goCmd } from "../lib/go-runner.js";
+import { parseGoRunOutput } from "../lib/parsers.js";
+import { formatGoRun } from "../lib/formatters.js";
+import { GoRunResultSchema } from "../schemas/index.js";
+
+export function registerRunTool(server: McpServer) {
+  server.registerTool(
+    "run",
+    {
+      title: "Go Run",
+      description:
+        "Runs a Go program and returns structured output (stdout, stderr, exit code). Use instead of running `go run` in the terminal.",
+      inputSchema: {
+        path: z.string().optional().describe("Project root path (default: cwd)"),
+        file: z
+          .string()
+          .optional()
+          .default(".")
+          .describe("Go file or package to run (default: .)"),
+        args: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe("Arguments to pass to the program"),
+        buildArgs: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe("Build flags to pass to go run (e.g., -race, -tags)"),
+      },
+      outputSchema: GoRunResultSchema,
+    },
+    async ({ path, file, args, buildArgs }) => {
+      const cwd = path || process.cwd();
+      const cmdArgs = ["run", ...(buildArgs || []), file || "."];
+      const programArgs = args || [];
+      if (programArgs.length > 0) {
+        cmdArgs.push("--", ...programArgs);
+      }
+      const result = await goCmd(cmdArgs, cwd);
+      const data = parseGoRunOutput(result.stdout, result.stderr, result.exitCode);
+      return dualOutput(data, formatGoRun);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds 4 new high-priority Go tools to `@paretools/go`: **run**, **mod-tidy**, **fmt**, and **generate**
- Each tool follows the established architecture: schema -> parser -> formatter -> tool file -> dualOutput
- Server now exposes 7 tools (up from 3): build, test, vet, run, mod-tidy, fmt, generate

## New Tools

| Tool | Command | Description |
|---|---|---|
| `run` | `go run` | Run a Go program, returns stdout/stderr/exitCode |
| `mod-tidy` | `go mod tidy` | Tidy go.mod/go.sum, returns success/summary |
| `fmt` | `gofmt -l/-w` | Check or fix Go formatting, returns file list |
| `generate` | `go generate` | Run go generate directives, returns output |

## Changes
- `src/schemas/index.ts` - Added GoRunResultSchema, GoModTidyResultSchema, GoFmtResultSchema, GoGenerateResultSchema
- `src/lib/parsers.ts` - Added parseGoRunOutput, parseGoModTidyOutput, parseGoFmtOutput, parseGoGenerateOutput
- `src/lib/formatters.ts` - Added formatGoRun, formatGoModTidy, formatGoFmt, formatGoGenerate
- `src/lib/go-runner.ts` - Added gofmtCmd for direct gofmt execution
- `src/tools/run.ts`, `mod-tidy.ts`, `fmt.ts`, `generate.ts` - New tool registrations
- `src/tools/index.ts` - Registers all 4 new tools
- `__tests__/` - 4 new test files with 30+ tests covering parsers, formatters, and edge cases

## Test plan
- [x] All 75 tests pass (`pnpm test --filter @paretools/go`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Integration test updated to verify 7 tools listed with outputSchemas
- [ ] CI should pass on Ubuntu (no Go toolchain needed for unit tests)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)