### PR TITLE
feat(test): add Mocha support and snapshot updates

### DIFF
--- a/packages/server-test/__tests__/detect.test.ts
+++ b/packages/server-test/__tests__/detect.test.ts
@@ -76,6 +76,36 @@ describe("detectFramework", () => {
     await cleanup();
   });
 
+  it("detects mocha from .mocharc.yml", async () => {
+    const dir = await createTempDir();
+    await writeFile(join(dir, ".mocharc.yml"), "timeout: 5000");
+
+    const result = await detectFramework(dir);
+    expect(result).toBe("mocha");
+    await cleanup();
+  });
+
+  it("detects mocha from .mocharc.json", async () => {
+    const dir = await createTempDir();
+    await writeFile(join(dir, ".mocharc.json"), JSON.stringify({ timeout: 5000 }));
+
+    const result = await detectFramework(dir);
+    expect(result).toBe("mocha");
+    await cleanup();
+  });
+
+  it("detects mocha from package.json dependency", async () => {
+    const dir = await createTempDir();
+    await writeFile(
+      join(dir, "package.json"),
+      JSON.stringify({ devDependencies: { mocha: "^10.0.0" } }),
+    );
+
+    const result = await detectFramework(dir);
+    expect(result).toBe("mocha");
+    await cleanup();
+  });
+
   it("throws for unknown framework", async () => {
     const dir = await createTempDir();
     // Empty dir — no framework markers
@@ -93,6 +123,18 @@ describe("detectFramework", () => {
 
     const result = await detectFramework(dir);
     expect(result).toBe("vitest");
+    await cleanup();
+  });
+
+  it("prioritizes jest over mocha when both present", async () => {
+    const dir = await createTempDir();
+    await writeFile(
+      join(dir, "package.json"),
+      JSON.stringify({ devDependencies: { jest: "^29.0.0", mocha: "^10.0.0" } }),
+    );
+
+    const result = await detectFramework(dir);
+    expect(result).toBe("jest");
     await cleanup();
   });
 });

--- a/packages/server-test/__tests__/fixtures/mocha-json.json
+++ b/packages/server-test/__tests__/fixtures/mocha-json.json
@@ -1,0 +1,73 @@
+{
+  "stats": {
+    "suites": 3,
+    "tests": 8,
+    "passes": 5,
+    "failures": 2,
+    "pending": 1,
+    "duration": 1250
+  },
+  "passes": [
+    {
+      "title": "should connect to database",
+      "fullTitle": "Database should connect to database",
+      "file": "test/db.test.js",
+      "duration": 45
+    },
+    {
+      "title": "should insert a record",
+      "fullTitle": "Database should insert a record",
+      "file": "test/db.test.js",
+      "duration": 12
+    },
+    {
+      "title": "should return 200",
+      "fullTitle": "API GET /health should return 200",
+      "file": "test/api.test.js",
+      "duration": 8
+    },
+    {
+      "title": "should require auth",
+      "fullTitle": "API POST /data should require auth",
+      "file": "test/api.test.js",
+      "duration": 5
+    },
+    {
+      "title": "should format date",
+      "fullTitle": "Utils should format date",
+      "file": "test/utils.test.js",
+      "duration": 2
+    }
+  ],
+  "failures": [
+    {
+      "title": "should delete a record",
+      "fullTitle": "Database should delete a record",
+      "file": "test/db.test.js",
+      "duration": 30,
+      "err": {
+        "message": "expected 0 to equal 1",
+        "stack": "AssertionError: expected 0 to equal 1\n    at Context.<anonymous> (test/db.test.js:45:18)",
+        "expected": 1,
+        "actual": 0
+      }
+    },
+    {
+      "title": "should parse config",
+      "fullTitle": "Utils should parse config",
+      "file": "test/utils.test.js",
+      "duration": 3,
+      "err": {
+        "message": "Cannot read properties of null (reading 'key')",
+        "stack": "TypeError: Cannot read properties of null (reading 'key')\n    at Context.<anonymous> (test/utils.test.js:22:14)"
+      }
+    }
+  ],
+  "pending": [
+    {
+      "title": "should handle concurrent writes",
+      "fullTitle": "Database should handle concurrent writes",
+      "file": "test/db.test.js"
+    }
+  ]
+}

--- a/packages/server-test/__tests__/mocha-parser.test.ts
+++ b/packages/server-test/__tests__/mocha-parser.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseMochaJson, parseMochaCoverage } from "../src/lib/parsers/mocha.js";
+
+const fixture = (name: string) => readFileSync(join(__dirname, "fixtures", name), "utf-8");
+
+describe("parseMochaJson", () => {
+  it("parses JSON output with failures", () => {
+    const result = parseMochaJson(fixture("mocha-json.json"));
+
+    expect(result.framework).toBe("mocha");
+    expect(result.summary.total).toBe(8);
+    expect(result.summary.passed).toBe(5);
+    expect(result.summary.failed).toBe(2);
+    expect(result.summary.skipped).toBe(1);
+    expect(result.summary.duration).toBe(1.25);
+    expect(result.failures).toHaveLength(2);
+
+    const firstFail = result.failures[0];
+    expect(firstFail.name).toBe("Database should delete a record");
+    expect(firstFail.file).toBe("test/db.test.js");
+    expect(firstFail.message).toBe("expected 0 to equal 1");
+    expect(firstFail.expected).toBe("1");
+    expect(firstFail.actual).toBe("0");
+    expect(firstFail.stack).toContain("AssertionError");
+
+    const secondFail = result.failures[1];
+    expect(secondFail.name).toBe("Utils should parse config");
+    expect(secondFail.file).toBe("test/utils.test.js");
+    expect(secondFail.message).toContain("Cannot read properties of null");
+    expect(secondFail.expected).toBeUndefined();
+    expect(secondFail.actual).toBeUndefined();
+  });
+
+  it("parses all-passing output", () => {
+    const json = JSON.stringify({
+      stats: {
+        suites: 1,
+        tests: 3,
+        passes: 3,
+        failures: 0,
+        pending: 0,
+        duration: 500,
+      },
+      passes: [
+        { title: "test1", fullTitle: "Suite test1", file: "test/a.js", duration: 10 },
+        { title: "test2", fullTitle: "Suite test2", file: "test/a.js", duration: 15 },
+        { title: "test3", fullTitle: "Suite test3", file: "test/a.js", duration: 5 },
+      ],
+      failures: [],
+      pending: [],
+    });
+
+    const result = parseMochaJson(json);
+    expect(result.framework).toBe("mocha");
+    expect(result.summary.total).toBe(3);
+    expect(result.summary.passed).toBe(3);
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.skipped).toBe(0);
+    expect(result.summary.duration).toBe(0.5);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("parses all-failing output", () => {
+    const json = JSON.stringify({
+      stats: {
+        suites: 1,
+        tests: 2,
+        passes: 0,
+        failures: 2,
+        pending: 0,
+        duration: 200,
+      },
+      passes: [],
+      failures: [
+        {
+          title: "fail1",
+          fullTitle: "Suite fail1",
+          file: "test/b.js",
+          duration: 5,
+          err: { message: "assertion error", stack: "Error: assertion error\n    at test/b.js:10" },
+        },
+        {
+          title: "fail2",
+          fullTitle: "Suite fail2",
+          file: "test/b.js",
+          duration: 3,
+          err: {
+            message: "expected true to be false",
+            stack: "AssertionError: expected true to be false",
+            expected: false,
+            actual: true,
+          },
+        },
+      ],
+      pending: [],
+    });
+
+    const result = parseMochaJson(json);
+    expect(result.summary.total).toBe(2);
+    expect(result.summary.passed).toBe(0);
+    expect(result.summary.failed).toBe(2);
+    expect(result.failures).toHaveLength(2);
+
+    expect(result.failures[1].expected).toBe("false");
+    expect(result.failures[1].actual).toBe("true");
+  });
+
+  it("parses empty suite", () => {
+    const json = JSON.stringify({
+      stats: {
+        suites: 0,
+        tests: 0,
+        passes: 0,
+        failures: 0,
+        pending: 0,
+        duration: 10,
+      },
+      passes: [],
+      failures: [],
+      pending: [],
+    });
+
+    const result = parseMochaJson(json);
+    expect(result.summary.total).toBe(0);
+    expect(result.summary.passed).toBe(0);
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.skipped).toBe(0);
+    expect(result.summary.duration).toBe(0.01);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("handles missing file field gracefully", () => {
+    const json = JSON.stringify({
+      stats: {
+        suites: 1,
+        tests: 1,
+        passes: 0,
+        failures: 1,
+        pending: 0,
+        duration: 100,
+      },
+      passes: [],
+      failures: [
+        {
+          title: "anon test",
+          fullTitle: "anon test",
+          duration: 5,
+          err: { message: "failed" },
+        },
+      ],
+      pending: [],
+    });
+
+    const result = parseMochaJson(json);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].file).toBeUndefined();
+    expect(result.failures[0].message).toBe("failed");
+  });
+
+  it("handles zero duration", () => {
+    const json = JSON.stringify({
+      stats: {
+        suites: 1,
+        tests: 1,
+        passes: 1,
+        failures: 0,
+        pending: 0,
+        duration: 0,
+      },
+      passes: [{ title: "fast", fullTitle: "Suite fast", file: "test/c.js", duration: 0 }],
+      failures: [],
+      pending: [],
+    });
+
+    const result = parseMochaJson(json);
+    expect(result.summary.duration).toBe(0);
+  });
+});
+
+describe("parseMochaCoverage", () => {
+  it("parses nyc/Istanbul text coverage output", () => {
+    const output = `
+----------|---------|----------|---------|---------|-------------------
+File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
+----------|---------|----------|---------|---------|-------------------
+All files |   82.35 |    71.43 |   88.89 |   82.35 |
+ db.js    |     100 |      100 |     100 |     100 |
+ api.js   |   66.67 |       50 |   83.33 |   66.67 | 12-15,28
+ utils.js |      80 |    66.67 |   83.33 |      80 | 22-25
+----------|---------|----------|---------|---------|-------------------
+`;
+
+    const result = parseMochaCoverage(output);
+    expect(result.framework).toBe("mocha");
+    expect(result.summary.lines).toBe(82.35);
+    expect(result.summary.branches).toBe(71.43);
+    expect(result.summary.functions).toBe(88.89);
+    expect(result.files).toHaveLength(3);
+
+    expect(result.files[0]).toEqual({
+      file: "db.js",
+      lines: 100,
+      branches: 100,
+      functions: 100,
+    });
+    expect(result.files[1].file).toBe("api.js");
+    expect(result.files[1].lines).toBe(66.67);
+    expect(result.files[2].file).toBe("utils.js");
+    expect(result.files[2].lines).toBe(80);
+  });
+});

--- a/packages/server-test/src/index.ts
+++ b/packages/server-test/src/index.ts
@@ -8,7 +8,7 @@ const server = new McpServer(
   { name: "@paretools/test", version: "0.2.0" },
   {
     instructions:
-      "Structured test runner operations (run, coverage). Auto-detects pytest, jest, and vitest. Use instead of running test commands via bash. Returns typed JSON with structured pass/fail results and failure details.",
+      "Structured test runner operations (run, coverage). Auto-detects pytest, jest, vitest, and mocha. Use instead of running test commands via bash. Returns typed JSON with structured pass/fail results and failure details.",
   },
 );
 

--- a/packages/server-test/src/lib/parsers/mocha.ts
+++ b/packages/server-test/src/lib/parsers/mocha.ts
@@ -1,0 +1,125 @@
+import type { TestRun, Coverage } from "../../schemas/index.js";
+
+/**
+ * Mocha JSON reporter output structure (from `mocha --reporter json`).
+ */
+interface MochaJsonOutput {
+  stats: {
+    suites: number;
+    tests: number;
+    passes: number;
+    failures: number;
+    pending: number;
+    duration: number;
+  };
+  passes: Array<{
+    title: string;
+    fullTitle: string;
+    file?: string;
+    duration?: number;
+  }>;
+  failures: Array<{
+    title: string;
+    fullTitle: string;
+    file?: string;
+    duration?: number;
+    err: {
+      message: string;
+      stack?: string;
+      expected?: unknown;
+      actual?: unknown;
+    };
+  }>;
+  pending: Array<{
+    title: string;
+    fullTitle: string;
+    file?: string;
+  }>;
+}
+
+/**
+ * Parses Mocha JSON reporter output (`mocha --reporter json`) into structured data.
+ */
+export function parseMochaJson(jsonStr: string): TestRun {
+  const data = JSON.parse(jsonStr) as MochaJsonOutput;
+
+  const failures: TestRun["failures"] = [];
+
+  for (const test of data.failures) {
+    const expected =
+      test.err.expected !== undefined ? String(test.err.expected) : undefined;
+    const actual =
+      test.err.actual !== undefined ? String(test.err.actual) : undefined;
+
+    failures.push({
+      name: test.fullTitle,
+      file: test.file,
+      message: test.err.message || "Test failed",
+      expected,
+      actual,
+      stack: test.err.stack,
+    });
+  }
+
+  // Duration from mocha stats is in ms, convert to seconds
+  const durationSec = (data.stats.duration ?? 0) / 1000;
+
+  return {
+    framework: "mocha",
+    summary: {
+      total: data.stats.tests,
+      passed: data.stats.passes,
+      failed: data.stats.failures,
+      skipped: data.stats.pending,
+      duration: Math.round(durationSec * 100) / 100,
+    },
+    failures,
+  };
+}
+
+/**
+ * Parses nyc/Istanbul text coverage output for Mocha.
+ *
+ * Expected format (same as Jest/Vitest Istanbul output):
+ *   ----------|---------|----------|---------|---------|
+ *   File      | % Stmts | % Branch | % Funcs | % Lines |
+ *   ----------|---------|----------|---------|---------|
+ *   All files |   85.71 |    66.67 |     100 |   85.71 |
+ *    foo.js   |   85.71 |    66.67 |     100 |   85.71 |
+ *   ----------|---------|----------|---------|---------|
+ */
+export function parseMochaCoverage(stdout: string): Coverage {
+  const lines = stdout.split("\n");
+  const files: Coverage["files"] = [];
+  let summary = { lines: 0, branches: 0, functions: 0 };
+
+  for (const line of lines) {
+    const match = line.match(
+      /\s*(.+?)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|/,
+    );
+    if (!match) continue;
+
+    const [, name, , branch, funcs, linePct] = match;
+    const trimName = name.trim();
+
+    if (trimName === "File" || trimName.match(/^-+$/)) continue;
+
+    const entry = {
+      lines: parseFloat(linePct),
+      branches: parseFloat(branch),
+      functions: parseFloat(funcs),
+    };
+
+    if (trimName === "All files") {
+      summary = entry;
+    } else {
+      files.push({ file: trimName, ...entry });
+    }
+  }
+
+  return {
+    framework: "mocha",
+    summary,
+    files,
+  };
+}

--- a/packages/server-test/src/schemas/index.ts
+++ b/packages/server-test/src/schemas/index.ts
@@ -15,7 +15,7 @@ export type TestFailure = z.infer<typeof TestFailureSchema>;
 
 /** Zod schema for structured test run output including framework, summary counts, and failure details. */
 export const TestRunSchema = z.object({
-  framework: z.enum(["pytest", "jest", "vitest"]),
+  framework: z.enum(["pytest", "jest", "vitest", "mocha"]),
   summary: z.object({
     total: z.number(),
     passed: z.number(),
@@ -39,7 +39,7 @@ export const CoverageFileSchema = z.object({
 
 /** Zod schema for structured coverage output including framework, summary totals, and per-file details. */
 export const CoverageSchema = z.object({
-  framework: z.enum(["pytest", "jest", "vitest"]),
+  framework: z.enum(["pytest", "jest", "vitest", "mocha"]),
   summary: z.object({
     lines: z.number(),
     branches: z.number().optional(),

--- a/packages/server-test/src/tools/coverage.ts
+++ b/packages/server-test/src/tools/coverage.ts
@@ -5,6 +5,7 @@ import { detectFramework, type Framework } from "../lib/detect.js";
 import { parsePytestCoverage } from "../lib/parsers/pytest.js";
 import { parseJestCoverage } from "../lib/parsers/jest.js";
 import { parseVitestCoverage } from "../lib/parsers/vitest.js";
+import { parseMochaCoverage } from "../lib/parsers/mocha.js";
 import { formatCoverage } from "../lib/formatters.js";
 import { CoverageSchema } from "../schemas/index.js";
 
@@ -19,6 +20,8 @@ function getCoverageCommand(framework: Framework): { cmd: string; cmdArgs: strin
       return { cmd: "npx", cmdArgs: ["jest", "--coverage", "--coverageReporters=text"] };
     case "vitest":
       return { cmd: "npx", cmdArgs: ["vitest", "run", "--coverage", "--reporter=default"] };
+    case "mocha":
+      return { cmd: "npx", cmdArgs: ["nyc", "--reporter=text", "mocha"] };
   }
 }
 
@@ -32,7 +35,7 @@ export function registerCoverageTool(server: McpServer) {
       inputSchema: {
         path: z.string().optional().describe("Project root path (default: cwd)"),
         framework: z
-          .enum(["pytest", "jest", "vitest"])
+          .enum(["pytest", "jest", "vitest", "mocha"])
           .optional()
           .describe("Force a specific framework instead of auto-detecting"),
       },
@@ -56,6 +59,9 @@ export function registerCoverageTool(server: McpServer) {
           break;
         case "vitest":
           coverage = parseVitestCoverage(output);
+          break;
+        case "mocha":
+          coverage = parseMochaCoverage(output);
           break;
       }
 


### PR DESCRIPTION
## Summary
- Adds Mocha as a supported test framework with auto-detection (`.mocharc.yml`, `.mocharc.yaml`, `.mocharc.json`, `.mocharc.js`, `.mocharc.cjs`, or `mocha` in package.json) and JSON output parsing via `--reporter json`
- Adds `updateSnapshots` boolean input to the run tool, which passes `-u` flag for vitest/jest
- Adds Mocha filter support via `--grep` and Mocha coverage support via `nyc` with Istanbul text output parsing

## Changes
- **`src/schemas/index.ts`**: Added "mocha" to framework enums in `TestRunSchema` and `CoverageSchema`
- **`src/lib/detect.ts`**: Added mocha detection (config files + package.json dep), priority: vitest > jest > mocha > pytest
- **`src/lib/parsers/mocha.ts`**: New parser for Mocha JSON reporter output (`parseMochaJson`) and nyc coverage output (`parseMochaCoverage`)
- **`src/tools/run.ts`**: Added mocha to `getRunCommand`, filter (`--grep`), parser switch, `updateSnapshots` input parameter
- **`src/tools/coverage.ts`**: Added mocha coverage command (`npx nyc --reporter=text mocha`) and parser case
- **`src/index.ts`**: Updated server instructions to mention mocha

## Test plan
- [x] `parseMochaJson` — parses fixture with failures, all-passing, all-failing, empty suite, missing file field, zero duration (7 tests)
- [x] `parseMochaCoverage` — parses nyc/Istanbul text output
- [x] `detectFramework` — detects mocha from `.mocharc.yml`, `.mocharc.json`, package.json dep; jest takes priority over mocha (4 new tests)
- [x] All 54 unit tests pass; build succeeds with no TypeScript errors
- [ ] Integration test has a pre-existing failure unrelated to this PR (server-git tool list mismatch)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)