### PR TITLE
test(python): close testing gaps — fidelity, integration, error paths (#91)

### DIFF
--- a/packages/server-python/__tests__/integration.test.ts
+++ b/packages/server-python/__tests__/integration.test.ts
@@ -70,4 +70,156 @@ describe("@paretools/python integration", () => {
       }
     });
   });
+
+  describe("pip-install", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "pip-install",
+        arguments: { packages: ["nonexistent-pkg-xyz-12345"] },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/pip|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(Array.isArray(sc.installed)).toBe(true);
+        expect(typeof sc.total).toBe("number");
+        expect(typeof sc.alreadySatisfied).toBe("boolean");
+      }
+    });
+  });
+
+  describe("mypy", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "mypy",
+        arguments: { targets: ["nonexistent_dir_xyz"] },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/mypy|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(Array.isArray(sc.diagnostics)).toBe(true);
+        expect(typeof sc.total).toBe("number");
+        expect(typeof sc.errors).toBe("number");
+        expect(typeof sc.warnings).toBe("number");
+      }
+    });
+  });
+
+  describe("pip-audit", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "pip-audit",
+        arguments: {},
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/pip-audit|pip.audit|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(Array.isArray(sc.vulnerabilities)).toBe(true);
+        expect(typeof sc.total).toBe("number");
+      }
+    });
+  });
+
+  describe("pytest", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "pytest",
+        arguments: { targets: ["nonexistent_test_dir_xyz"] },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/pytest|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(typeof sc.passed).toBe("number");
+        expect(typeof sc.failed).toBe("number");
+        expect(typeof sc.errors).toBe("number");
+        expect(typeof sc.skipped).toBe("number");
+        expect(typeof sc.total).toBe("number");
+        expect(typeof sc.duration).toBe("number");
+        expect(Array.isArray(sc.failures)).toBe(true);
+      }
+    });
+  });
+
+  describe("uv-install", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "uv-install",
+        arguments: { packages: ["nonexistent-pkg-xyz-12345"] },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/uv|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(Array.isArray(sc.installed)).toBe(true);
+        expect(typeof sc.total).toBe("number");
+        expect(typeof sc.duration).toBe("number");
+      }
+    });
+  });
+
+  describe("uv-run", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "uv-run",
+        arguments: { command: ["python", "--version"] },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/uv|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(typeof sc.exitCode).toBe("number");
+        expect(typeof sc.stdout).toBe("string");
+        expect(typeof sc.stderr).toBe("string");
+        expect(typeof sc.duration).toBe("number");
+      }
+    });
+  });
+
+  describe("black", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "black",
+        arguments: { targets: ["nonexistent_dir_xyz"], check: true },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/black|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(typeof sc.filesChanged).toBe("number");
+        expect(typeof sc.filesUnchanged).toBe("number");
+        expect(typeof sc.filesChecked).toBe("number");
+        expect(Array.isArray(sc.wouldReformat)).toBe(true);
+      }
+    });
+  });
 });

--- a/packages/server-python/__tests__/parsers.test.ts
+++ b/packages/server-python/__tests__/parsers.test.ts
@@ -4,6 +4,9 @@ import {
   parseMypyOutput,
   parseRuffJson,
   parsePipAuditJson,
+  parsePytestOutput,
+  parseUvInstall,
+  parseBlackOutput,
 } from "../src/lib/parsers.js";
 
 describe("parsePipInstall", () => {
@@ -165,5 +168,226 @@ describe("parsePipAuditJson", () => {
   it("handles invalid JSON", () => {
     const result = parsePipAuditJson("not json");
     expect(result.total).toBe(0);
+  });
+});
+
+// ─── Error path tests ──────────────────────────────────────────────────────────
+
+describe("parsePipInstall — error paths", () => {
+  it("handles completely empty output", () => {
+    const result = parsePipInstall("", "", 0);
+    expect(result.success).toBe(true);
+    expect(result.installed).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("handles malformed output with no recognizable patterns", () => {
+    const result = parsePipInstall("random garbage\nno patterns here", "", 0);
+    expect(result.success).toBe(true);
+    expect(result.installed).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.alreadySatisfied).toBe(false);
+  });
+});
+
+describe("parseMypyOutput — error paths", () => {
+  it("handles empty output", () => {
+    const result = parseMypyOutput("", 0);
+    expect(result.success).toBe(true);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("handles completely malformed output", () => {
+    const result = parseMypyOutput("this is not mypy output at all\njust random text", 1);
+    expect(result.success).toBe(false);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("strips ANSI color codes from output", () => {
+    // mypy with --color-output may include ANSI codes
+    const stdout =
+      '\x1b[1m\x1b[31msrc/main.py:10:5: error: Incompatible types in assignment\x1b[0m  [assignment]';
+    const result = parseMypyOutput(stdout, 1);
+
+    // The ANSI codes may or may not be stripped by the runner before reaching the parser.
+    // Either the parser handles them gracefully or they break the regex.
+    // This test documents the current behavior.
+    expect(result.success).toBe(false);
+    // If ANSI codes are not stripped, the regex may not match
+    // The parser should still not throw
+    expect(result.total).toBeGreaterThanOrEqual(0);
+  });
+
+  it("handles output with only the summary line", () => {
+    const result = parseMypyOutput("Found 0 errors in 0 files (checked 5 source files)", 0);
+    expect(result.success).toBe(true);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});
+
+describe("parseRuffJson — error paths", () => {
+  it("handles empty string", () => {
+    const result = parseRuffJson("");
+    expect(result.total).toBe(0);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("throws on JSON that is not an array", () => {
+    // parseRuffJson expects an array from ruff --output-format json.
+    // Non-array valid JSON (object, null) causes a TypeError on .map().
+    // This documents the current behavior — ruff always produces an array.
+    expect(() => parseRuffJson('{"key": "value"}')).toThrow();
+  });
+
+  it("throws on null JSON", () => {
+    // null is valid JSON but not an array — .map() throws TypeError
+    expect(() => parseRuffJson("null")).toThrow();
+  });
+});
+
+describe("parsePipAuditJson — error paths", () => {
+  it("handles empty string", () => {
+    const result = parsePipAuditJson("");
+    expect(result.total).toBe(0);
+    expect(result.vulnerabilities).toEqual([]);
+  });
+
+  it("handles JSON with missing dependencies key", () => {
+    const result = parsePipAuditJson("{}");
+    expect(result.total).toBe(0);
+    expect(result.vulnerabilities).toEqual([]);
+  });
+
+  it("handles dependencies with missing vulns arrays", () => {
+    const json = JSON.stringify({
+      dependencies: [
+        { name: "requests", version: "2.31.0" },
+      ],
+    });
+    const result = parsePipAuditJson(json);
+    expect(result.total).toBe(0);
+    expect(result.vulnerabilities).toEqual([]);
+  });
+});
+
+describe("parsePytestOutput — error paths", () => {
+  it("handles completely empty output", () => {
+    const result = parsePytestOutput("", "", 0);
+    expect(result.success).toBe(true);
+    expect(result.passed).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.total).toBe(0);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("handles malformed output with no summary line", () => {
+    const result = parsePytestOutput("random text\nno pytest here", "", 1);
+    expect(result.success).toBe(false);
+    expect(result.total).toBe(0);
+  });
+
+  it("handles exit code 0 for passing tests", () => {
+    const stdout = "========================= 10 passed in 3.50s =========================";
+    const result = parsePytestOutput(stdout, "", 0);
+    expect(result.success).toBe(true);
+    expect(result.passed).toBe(10);
+    expect(result.total).toBe(10);
+  });
+
+  it("handles exit code 1 for failed tests", () => {
+    const stdout = "========================= 5 passed, 2 failed in 1.00s =========================";
+    const result = parsePytestOutput(stdout, "", 1);
+    expect(result.success).toBe(false);
+    expect(result.passed).toBe(5);
+    expect(result.failed).toBe(2);
+    expect(result.total).toBe(7);
+  });
+
+  it("handles exit code 2 for internal errors", () => {
+    const stdout = "========================= 3 passed, 1 errors in 0.50s =========================";
+    const result = parsePytestOutput(stdout, "", 2);
+    expect(result.success).toBe(false);
+    expect(result.errors).toBe(1);
+    expect(result.passed).toBe(3);
+  });
+
+  it("handles exit code 5 for no tests collected", () => {
+    const stdout = "========================= no tests ran in 0.01s =========================";
+    const result = parsePytestOutput(stdout, "", 5);
+    expect(result.success).toBe(true);
+    expect(result.total).toBe(0);
+  });
+});
+
+describe("parseBlackOutput — error paths", () => {
+  it("handles completely empty output", () => {
+    const result = parseBlackOutput("", "", 0);
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.filesUnchanged).toBe(0);
+    expect(result.filesChecked).toBe(0);
+    expect(result.wouldReformat).toEqual([]);
+  });
+
+  it("handles malformed summary line", () => {
+    const stderr = "some random text that is not black output";
+    const result = parseBlackOutput("", stderr, 0);
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.filesChecked).toBe(0);
+    expect(result.wouldReformat).toEqual([]);
+  });
+
+  it("handles exit code 123 (internal error)", () => {
+    const stderr = "error: cannot format src/main.py: Cannot parse: 1:0: unexpected token";
+    const result = parseBlackOutput("", stderr, 123);
+    expect(result.success).toBe(false);
+  });
+
+  it("handles summary with only reformatted count and no unchanged", () => {
+    const stderr = [
+      "reformatted app.py",
+      "All done! 1 file reformatted.",
+    ].join("\n");
+    const result = parseBlackOutput("", stderr, 0);
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(1);
+    expect(result.wouldReformat).toEqual(["app.py"]);
+  });
+});
+
+describe("parseUvInstall — error paths", () => {
+  it("handles completely empty output", () => {
+    const result = parseUvInstall("", "", 0);
+    expect(result.success).toBe(true);
+    expect(result.total).toBe(0);
+    expect(result.installed).toEqual([]);
+  });
+
+  it("handles malformed package lines", () => {
+    const stderr = [
+      "Some random output",
+      " + malformed-no-version",
+      " + valid-pkg==1.0.0",
+    ].join("\n");
+    const result = parseUvInstall("", stderr, 0);
+    // The malformed line without == should not be parsed
+    expect(result.installed).toHaveLength(1);
+    expect(result.installed[0]).toEqual({ name: "valid-pkg", version: "1.0.0" });
+  });
+
+  it("handles malformed duration strings in summary", () => {
+    const stderr = [
+      "Installed 1 package in abc",
+      " + flask==3.0.0",
+    ].join("\n");
+    const result = parseUvInstall("", stderr, 0);
+    // The summary regex expects a number, so "abc" won't match
+    expect(result.success).toBe(true);
+    expect(result.installed).toHaveLength(1);
+    expect(result.duration).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Adds fidelity tests for P3 tools (pytest, uv-install, uv-run, black) with realistic fixture-based output
- Extends integration tests to cover all 8 tools via MCP client (was only ruff-check)
- Adds error path tests for all parsers with empty, malformed, and edge-case inputs
- Adds formatter edge cases for mypy, pytest, and black

Test count: 80 → 126 (+46 new tests)

Closes #91

## Test plan
- [x] All 126 tests pass locally (`npx vitest run` in `packages/server-python/`)
- [ ] CI passes on Ubuntu
- [ ] No source code changes — only test files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)