### PR TITLE
test(docker): close testing gaps — fidelity, integration, security (#90)

### DIFF
--- a/packages/server-docker/__tests__/integration.test.ts
+++ b/packages/server-docker/__tests__/integration.test.ts
@@ -26,7 +26,7 @@ describe("@paretools/docker integration", () => {
     await transport.close();
   });
 
-  it("lists all 4 tools", async () => {
+  it("lists all 9 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
@@ -69,6 +69,104 @@ describe("@paretools/docker integration", () => {
         expect(sc.total).toEqual(expect.any(Number));
         expect(sc.running).toEqual(expect.any(Number));
         expect(sc.stopped).toEqual(expect.any(Number));
+      }
+    });
+  });
+
+  describe("images", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "images",
+        arguments: {},
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/docker|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(Array.isArray(sc.images)).toBe(true);
+        expect(sc.total).toEqual(expect.any(Number));
+      }
+    });
+  });
+
+  describe("run", () => {
+    it("rejects flag injection in image param", async () => {
+      const result = await client.callTool({
+        name: "run",
+        arguments: { image: "--privileged" },
+      });
+
+      expect(result.isError).toBe(true);
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content[0].text).toMatch(/Invalid image|argument injection/i);
+    });
+  });
+
+  describe("exec", () => {
+    it("rejects flag injection in container param", async () => {
+      const result = await client.callTool({
+        name: "exec",
+        arguments: { container: "--privileged", command: ["ls"] },
+      });
+
+      expect(result.isError).toBe(true);
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content[0].text).toMatch(/Invalid container|argument injection/i);
+    });
+  });
+
+  describe("pull", () => {
+    it("rejects flag injection in image param", async () => {
+      const result = await client.callTool({
+        name: "pull",
+        arguments: { image: "--all-tags" },
+      });
+
+      expect(result.isError).toBe(true);
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content[0].text).toMatch(/Invalid image|argument injection/i);
+    });
+  });
+
+  describe("compose-up", () => {
+    it("returns error or structured data when called without docker", async () => {
+      const result = await client.callTool({
+        name: "compose-up",
+        arguments: { path: "C:\\nonexistent-path-for-testing" },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/docker|compose|not found|failed|error|no configuration/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(typeof sc.started).toBe("number");
+        expect(Array.isArray(sc.services)).toBe(true);
+      }
+    });
+  });
+
+  describe("compose-down", () => {
+    it("returns error or structured data when called without docker", async () => {
+      const result = await client.callTool({
+        name: "compose-down",
+        arguments: { path: "C:\\nonexistent-path-for-testing" },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/docker|compose|not found|failed|error|no configuration/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(typeof sc.stopped).toBe("number");
+        expect(typeof sc.removed).toBe("number");
       }
     });
   });

--- a/packages/server-docker/__tests__/security.test.ts
+++ b/packages/server-docker/__tests__/security.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Security tests: verify that assertNoFlagInjection() prevents flag injection
+ * attacks on user-supplied parameters in the run, exec, and pull tools.
+ *
+ * These tools accept user-provided strings (image names, container names) that
+ * are passed as positional arguments to the Docker CLI. Without validation,
+ * a malicious input like "--privileged" could be interpreted as a flag.
+ */
+import { describe, it, expect } from "vitest";
+import { assertNoFlagInjection } from "@paretools/shared";
+
+describe("assertNoFlagInjection — run tool (image param)", () => {
+  it("accepts a normal image name", () => {
+    expect(() => assertNoFlagInjection("nginx:latest", "image")).not.toThrow();
+  });
+
+  it("accepts an image with registry prefix", () => {
+    expect(() =>
+      assertNoFlagInjection("registry.example.com:5000/myapp:v1", "image"),
+    ).not.toThrow();
+  });
+
+  it("accepts an image with sha256 digest", () => {
+    expect(() =>
+      assertNoFlagInjection("nginx@sha256:abc123def456", "image"),
+    ).not.toThrow();
+  });
+
+  it("rejects --privileged", () => {
+    expect(() => assertNoFlagInjection("--privileged", "image")).toThrow(
+      /Invalid image.*--privileged/,
+    );
+  });
+
+  it("rejects -v /:/host", () => {
+    expect(() => assertNoFlagInjection("-v", "image")).toThrow(/Invalid image.*"-v"/);
+  });
+
+  it("rejects --rm --privileged nginx (flag-prefixed compound)", () => {
+    expect(() => assertNoFlagInjection("--rm --privileged nginx", "image")).toThrow(
+      /Invalid image/,
+    );
+  });
+
+  it("rejects --network=host", () => {
+    expect(() => assertNoFlagInjection("--network=host", "image")).toThrow(/Invalid image/);
+  });
+
+  it("rejects -it (short flags)", () => {
+    expect(() => assertNoFlagInjection("-it", "image")).toThrow(/Invalid image/);
+  });
+
+  it("rejects --cap-add=SYS_ADMIN", () => {
+    expect(() => assertNoFlagInjection("--cap-add=SYS_ADMIN", "image")).toThrow(/Invalid image/);
+  });
+
+  it("rejects --pid=host", () => {
+    expect(() => assertNoFlagInjection("--pid=host", "image")).toThrow(/Invalid image/);
+  });
+
+  it("rejects --security-opt", () => {
+    expect(() => assertNoFlagInjection("--security-opt", "image")).toThrow(/Invalid image/);
+  });
+
+  it("rejects single dash with long value", () => {
+    expect(() => assertNoFlagInjection("-d", "image")).toThrow(/Invalid image/);
+  });
+});
+
+describe("assertNoFlagInjection — exec tool (container param)", () => {
+  it("accepts a normal container name", () => {
+    expect(() => assertNoFlagInjection("my-web-app", "container")).not.toThrow();
+  });
+
+  it("accepts a container ID", () => {
+    expect(() => assertNoFlagInjection("abc123def456", "container")).not.toThrow();
+  });
+
+  it("accepts container name with underscores and dots", () => {
+    expect(() => assertNoFlagInjection("my_app.service-1", "container")).not.toThrow();
+  });
+
+  it("rejects --privileged", () => {
+    expect(() => assertNoFlagInjection("--privileged", "container")).toThrow(/Invalid container/);
+  });
+
+  it("rejects -u root", () => {
+    expect(() => assertNoFlagInjection("-u", "container")).toThrow(/Invalid container/);
+  });
+
+  it("rejects --workdir=/tmp", () => {
+    expect(() => assertNoFlagInjection("--workdir=/tmp", "container")).toThrow(
+      /Invalid container/,
+    );
+  });
+
+  it("rejects -e (env injection)", () => {
+    expect(() => assertNoFlagInjection("-e", "container")).toThrow(/Invalid container/);
+  });
+
+  it("rejects --detach", () => {
+    expect(() => assertNoFlagInjection("--detach", "container")).toThrow(/Invalid container/);
+  });
+});
+
+describe("assertNoFlagInjection — pull tool (image param)", () => {
+  it("accepts a normal image name", () => {
+    expect(() => assertNoFlagInjection("ubuntu:22.04", "image")).not.toThrow();
+  });
+
+  it("accepts a private registry image", () => {
+    expect(() =>
+      assertNoFlagInjection("ghcr.io/owner/repo:latest", "image"),
+    ).not.toThrow();
+  });
+
+  it("rejects --all-tags", () => {
+    expect(() => assertNoFlagInjection("--all-tags", "image")).toThrow(/Invalid image/);
+  });
+
+  it("rejects --platform (when passed as image)", () => {
+    expect(() => assertNoFlagInjection("--platform", "image")).toThrow(/Invalid image/);
+  });
+
+  it("rejects -a (short flag)", () => {
+    expect(() => assertNoFlagInjection("-a", "image")).toThrow(/Invalid image/);
+  });
+
+  it("rejects --quiet", () => {
+    expect(() => assertNoFlagInjection("--quiet", "image")).toThrow(/Invalid image/);
+  });
+
+  it("rejects --disable-content-trust", () => {
+    expect(() => assertNoFlagInjection("--disable-content-trust", "image")).toThrow(
+      /Invalid image/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #90 — closes all testing gaps for the `@paretools/docker` package.

- **Security tests** (`security.test.ts`, 27 tests): Verifies `assertNoFlagInjection()` blocks flag injection attacks on the `run` (image param), `exec` (container param), and `pull` (image param) tools. Tests cover `--privileged`, `-v`, `--network=host`, `--cap-add`, short flags, and more.
- **Fidelity tests** (25 new tests in `fidelity.test.ts`): Realistic fixture-based tests for all P3 parsers — `parseRunOutput` (detached/attached modes), `parseExecOutput` (various exit codes), `parseComposeUpOutput`/`parseComposeDownOutput` (full teardown, partial running), and `parsePullOutput` (fresh download, already exists, private registry, auth failure).
- **parsePorts() edge cases** (13 new tests in `parsers.test.ts`): Indirect tests via `parsePsJson` covering empty strings, bare port numbers, IPv6 bindings, non-numeric ports (NaN), port > 65535, and whitespace-only strings.
- **Integration tests** (6 new test blocks in `integration.test.ts`): Verifies P3 tools (`run`, `exec`, `pull`, `compose-up`, `compose-down`, `images`) are callable via MCP and handle Docker-not-available gracefully. Includes flag injection rejection tests at the integration level.
- **Error-path tests** (added to `run-tool.test.ts`, `exec.test.ts`, `compose.test.ts`, `pull.test.ts`): Covers error exit codes (125, 127, 137, 139), command-not-found in container, partial compose failures, missing compose file, auth failures, rate limits, and network timeouts.

**Result: 183 tests across 9 files (up from 68 tests across 8 files)**

## Test plan

- [x] All 183 tests pass: `cd packages/server-docker && npx vitest run`
- [x] No source code changes — tests only
- [x] CI should pass (Ubuntu, no Docker required — integration tests handle gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)