### PR TITLE
test(build): fix esbuild regex + close testing gaps (#88)

### DIFF
--- a/packages/server-build/__tests__/esbuild.test.ts
+++ b/packages/server-build/__tests__/esbuild.test.ts
@@ -95,15 +95,27 @@ describe("parseEsbuildOutput", () => {
     expect(result.errors[1].line).toBe(10);
   });
 
-  it("parses header-style warning", () => {
-    // Use the X marker variant for warnings too
+  it("parses header-style warning with ▲ marker", () => {
     const result = parseEsbuildOutput("", ESBUILD_HEADER_WARNING, 0, 0.1);
 
-    // The warning uses "▲" which doesn't match the [✘✗X] pattern, so let's
-    // check if the regex handles it. If not, the test will reveal the gap.
-    // The fixture uses ▲ which is NOT in our regex [✘✗X], so it won't match.
-    // Let's test with a proper warning header format.
     expect(result.success).toBe(true);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].file).toBe("src/utils.ts");
+    expect(result.warnings[0].line).toBe(1);
+    expect(result.warnings[0].message).toBe("This import is never used");
+  });
+
+  it("parses header-style mixed errors and ▲ warnings", () => {
+    const result = parseEsbuildOutput("", ESBUILD_HEADER_MIXED, 1, 0.5);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.errors[0].message).toContain("Cannot assign");
+    expect(result.errors[0].file).toBe("src/index.ts");
+    expect(result.errors[0].line).toBe(15);
+    expect(result.warnings[0].message).toContain("never used");
+    expect(result.warnings[0].file).toBe("src/utils.ts");
   });
 
   it("parses header-style warning with X marker", () => {

--- a/packages/server-build/__tests__/integration.test.ts
+++ b/packages/server-build/__tests__/integration.test.ts
@@ -60,4 +60,131 @@ describe("@paretools/build integration", () => {
       expect(sc.warnings).toEqual(expect.any(Number));
     }, 60_000);
   });
+
+  describe("build", () => {
+    it("returns structured build result", async () => {
+      // Use a known-safe command that will fail fast (no actual build needed)
+      const result = await client.callTool({
+        name: "build",
+        arguments: { command: "npm", args: ["--version"] },
+      });
+
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      expect(typeof sc.success).toBe("boolean");
+      expect(typeof sc.duration).toBe("number");
+      expect(Array.isArray(sc.errors)).toBe(true);
+      expect(Array.isArray(sc.warnings)).toBe(true);
+    }, 30_000);
+
+    it("rejects disallowed commands", async () => {
+      const result = await client.callTool({
+        name: "build",
+        arguments: { command: "rm", args: ["-rf", "/"] },
+      });
+
+      // The tool should return an error (isError flag or error in content)
+      expect(result.isError).toBe(true);
+    }, 10_000);
+  });
+
+  describe("esbuild", () => {
+    it("accepts input and returns content without crashing", async () => {
+      // Call with a non-existent entry point; esbuild will fail but the tool
+      // should return either structured output or an error — not crash
+      const result = await client.callTool({
+        name: "esbuild",
+        arguments: {
+          entryPoints: ["__nonexistent_entry__.ts"],
+          outdir: "dist",
+        },
+      });
+
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+
+      // The tool may return structured output or an error depending on
+      // whether esbuild is installed. Either is acceptable.
+      if (result.structuredContent) {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(typeof sc.success).toBe("boolean");
+        expect(typeof sc.duration).toBe("number");
+        expect(Array.isArray(sc.errors)).toBe(true);
+        expect(Array.isArray(sc.warnings)).toBe(true);
+      } else {
+        // If no structured content, it should be marked as an error
+        expect(result.isError).toBe(true);
+      }
+    }, 60_000);
+
+    it("rejects flag injection in entryPoints", async () => {
+      const result = await client.callTool({
+        name: "esbuild",
+        arguments: {
+          entryPoints: ["--outfile=/etc/passwd"],
+          outdir: "dist",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+    }, 10_000);
+  });
+
+  describe("vite-build", () => {
+    it("accepts input and returns content without crashing", async () => {
+      // vite build will fail without a proper project, but should not crash
+      const result = await client.callTool({
+        name: "vite-build",
+        arguments: { path: resolve(__dirname, "..") },
+      });
+
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+
+      if (result.structuredContent) {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(typeof sc.success).toBe("boolean");
+        expect(typeof sc.duration).toBe("number");
+        expect(Array.isArray(sc.outputs)).toBe(true);
+        expect(Array.isArray(sc.errors)).toBe(true);
+        expect(Array.isArray(sc.warnings)).toBe(true);
+      } else {
+        expect(result.isError).toBe(true);
+      }
+    }, 60_000);
+  });
+
+  describe("webpack", () => {
+    it("accepts input and returns content or times out gracefully", async () => {
+      // webpack may not be installed and npx install can take a long time,
+      // so we accept both a result and a timeout as valid outcomes
+      try {
+        const result = await client.callTool({
+          name: "webpack",
+          arguments: { path: resolve(__dirname, "..") },
+        });
+
+        expect(result.content).toBeDefined();
+        expect(Array.isArray(result.content)).toBe(true);
+
+        if (result.structuredContent) {
+          const sc = result.structuredContent as Record<string, unknown>;
+          expect(typeof sc.success).toBe("boolean");
+          expect(typeof sc.duration).toBe("number");
+          expect(Array.isArray(sc.assets)).toBe(true);
+          expect(Array.isArray(sc.errors)).toBe(true);
+          expect(Array.isArray(sc.warnings)).toBe(true);
+        } else {
+          expect(result.isError).toBe(true);
+        }
+      } catch (err: unknown) {
+        // MCP SDK may throw a timeout error — that's acceptable
+        const message = err instanceof Error ? err.message : String(err);
+        expect(message).toMatch(/timed out/i);
+      }
+    }, 120_000);
+  });
 });

--- a/packages/server-build/__tests__/security.test.ts
+++ b/packages/server-build/__tests__/security.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { assertAllowedCommand, assertNoFlagInjection } from "@paretools/shared";
+
+// ---------------------------------------------------------------------------
+// assertAllowedCommand — used by the build tool
+// ---------------------------------------------------------------------------
+
+describe("assertAllowedCommand", () => {
+  it("allows known safe commands", () => {
+    const safe = ["npm", "npx", "pnpm", "yarn", "bun", "make", "cargo", "go", "tsc", "esbuild"];
+    for (const cmd of safe) {
+      expect(() => assertAllowedCommand(cmd)).not.toThrow();
+    }
+  });
+
+  it("rejects arbitrary commands", () => {
+    expect(() => assertAllowedCommand("rm")).toThrow(/not in the allowed/);
+    expect(() => assertAllowedCommand("curl")).toThrow(/not in the allowed/);
+    expect(() => assertAllowedCommand("bash")).toThrow(/not in the allowed/);
+    expect(() => assertAllowedCommand("sh")).toThrow(/not in the allowed/);
+    expect(() => assertAllowedCommand("powershell")).toThrow(/not in the allowed/);
+    expect(() => assertAllowedCommand("cmd")).toThrow(/not in the allowed/);
+  });
+
+  it("rejects empty string", () => {
+    expect(() => assertAllowedCommand("")).toThrow(/not in the allowed/);
+  });
+
+  it("extracts base name from full path (Unix)", () => {
+    expect(() => assertAllowedCommand("/usr/bin/npm")).not.toThrow();
+    expect(() => assertAllowedCommand("/usr/local/bin/pnpm")).not.toThrow();
+  });
+
+  it("extracts base name from full path (Windows)", () => {
+    expect(() => assertAllowedCommand("C:\\Program Files\\nodejs\\npm.cmd")).not.toThrow();
+    expect(() => assertAllowedCommand("C:\\tools\\yarn.exe")).not.toThrow();
+  });
+
+  it("strips .cmd, .exe, .bat, .sh extensions", () => {
+    expect(() => assertAllowedCommand("npm.cmd")).not.toThrow();
+    expect(() => assertAllowedCommand("pnpm.exe")).not.toThrow();
+    expect(() => assertAllowedCommand("make.bat")).not.toThrow();
+    expect(() => assertAllowedCommand("cargo.sh")).not.toThrow();
+  });
+
+  it("rejects dangerous commands even with full path", () => {
+    expect(() => assertAllowedCommand("/usr/bin/rm")).toThrow(/not in the allowed/);
+    expect(() => assertAllowedCommand("C:\\Windows\\System32\\cmd.exe")).toThrow(
+      /not in the allowed/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertNoFlagInjection — used by the esbuild tool for entryPoints
+// ---------------------------------------------------------------------------
+
+describe("assertNoFlagInjection", () => {
+  it("allows normal file paths", () => {
+    expect(() => assertNoFlagInjection("src/index.ts", "entryPoints")).not.toThrow();
+    expect(() => assertNoFlagInjection("./app.tsx", "entryPoints")).not.toThrow();
+    expect(() => assertNoFlagInjection("lib/utils.js", "entryPoints")).not.toThrow();
+  });
+
+  it("rejects values starting with single dash", () => {
+    expect(() => assertNoFlagInjection("-o", "entryPoints")).toThrow(/must not start with/);
+    expect(() => assertNoFlagInjection("-exec", "entryPoints")).toThrow(/must not start with/);
+  });
+
+  it("rejects values starting with double dash", () => {
+    expect(() => assertNoFlagInjection("--outfile=/etc/passwd", "entryPoints")).toThrow(
+      /must not start with/,
+    );
+    expect(() => assertNoFlagInjection("--loader:.ts=tsx", "entryPoints")).toThrow(
+      /must not start with/,
+    );
+  });
+
+  it("includes parameter name in error message", () => {
+    expect(() => assertNoFlagInjection("--evil", "entryPoints")).toThrow(/entryPoints/);
+    expect(() => assertNoFlagInjection("--evil", "ref")).toThrow(/ref/);
+  });
+
+  it("allows paths that contain dashes but don't start with one", () => {
+    expect(() => assertNoFlagInjection("src/my-component.ts", "entryPoints")).not.toThrow();
+    expect(() => assertNoFlagInjection("pages/about-us.tsx", "entryPoints")).not.toThrow();
+  });
+});

--- a/packages/server-build/src/lib/parsers.ts
+++ b/packages/server-build/src/lib/parsers.ts
@@ -83,7 +83,7 @@ export function parseBuildCommandOutput(
 //   file:line:col:
 // or: > file.ts:10:5: error: message
 // Simplified: capture "X [ERROR] msg" and "file:line:col:" lines
-const ESBUILD_DIAG_HEADER_RE = /^[✘✗X]\s+\[(ERROR|WARNING)]\s+(.+)$/;
+const ESBUILD_DIAG_HEADER_RE = /^[✘✗X▲]\s+\[(ERROR|WARNING)]\s+(.+)$/;
 const ESBUILD_LOCATION_RE = /^\s+(.+?):(\d+):(\d+):$/;
 // Alternate format from older esbuild / --log-level output
 const ESBUILD_INLINE_RE = /^>\s*(.+?):(\d+):(\d+):\s+(error|warning):\s+(.+)$/;


### PR DESCRIPTION
## Summary
- **Bug fix**: esbuild warning regex (`ESBUILD_DIAG_HEADER_RE`) was missing `▲` character that real esbuild uses for warning markers. Added `▲` to the `[✘✗X▲]` character class in `parsers.ts`.
- **Fidelity tests**: Added realistic fixture-based tests for esbuild (errors with locations, warnings with `▲` marker, output files), vite-build (multi-file output with sizes, header line filtering), and webpack (JSON stats with assets, modules, errors, warnings).
- **Vite filter test**: Verifies the output filter correctly skips `vite`/`building` header lines while keeping user-relevant files like `dist/vite-plugin-output.js` or `dist/building-blocks.js`.
- **Integration tests**: Extended to cover all 5 tools (tsc, build, esbuild, vite-build, webpack) via MCP client — verifies tools accept input and return structured output or graceful errors.
- **Security tests**: New `security.test.ts` covering `assertAllowedCommand()` (rejects arbitrary commands, handles full paths, strips extensions) and `assertNoFlagInjection()` (rejects flag-like entry points).

Closes #88

## Test plan
- [x] All 110 tests pass across 8 test files
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] esbuild `▲ [WARNING]` lines are now correctly parsed (was a real bug)
- [x] Security functions reject dangerous inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)