### PR TITLE
test(test): close testing gaps — coverage fidelity, formatters, mocha (#86)

### DIFF
--- a/packages/server-test/__tests__/detect.test.ts
+++ b/packages/server-test/__tests__/detect.test.ts
@@ -137,4 +137,24 @@ describe("detectFramework", () => {
     expect(result).toBe("jest");
     await cleanup();
   });
+
+  it("handles corrupted package.json (invalid JSON) gracefully", async () => {
+    const dir = await createTempDir();
+    await writeFile(join(dir, "package.json"), "{ this is not valid json !!!");
+
+    // No config files, corrupted package.json => should throw "No supported test framework"
+    await expect(detectFramework(dir)).rejects.toThrow("No supported test framework detected");
+    await cleanup();
+  });
+
+  it("detects framework from config file even with corrupted package.json", async () => {
+    const dir = await createTempDir();
+    await writeFile(join(dir, "package.json"), "not json at all");
+    await writeFile(join(dir, "vitest.config.ts"), "export default {}");
+
+    // Config file should be detected even though package.json is corrupted
+    const result = await detectFramework(dir);
+    expect(result).toBe("vitest");
+    await cleanup();
+  });
 });

--- a/packages/server-test/__tests__/extract-json.test.ts
+++ b/packages/server-test/__tests__/extract-json.test.ts
@@ -54,4 +54,22 @@ describe("extractJson", () => {
     const result = extractJson(output);
     expect(JSON.parse(result)).toEqual({ a: { b: 1 } });
   });
+
+  it("returns a string for truncated JSON (missing closing brace) that may not parse", () => {
+    // extractJson just extracts between first { and last }, so incomplete
+    // JSON with only an opening brace should throw
+    expect(() => extractJson('prefix { "key": "value"')).toThrow(/No JSON output found/);
+  });
+
+  it("handles truncated JSON where last } is from a nested object", () => {
+    // This tests that extractJson returns a substring even when JSON is incomplete
+    // The extracted string may not be valid JSON but extractJson doesn't validate
+    const output = 'prefix {"a": {"b": 1}, "c": "truncated... suffix';
+    // There is no } after the opening {, except inside the nested object
+    // First { is at "prefix " position, last } is after "1"
+    const result = extractJson(output);
+    // extractJson should return something (first { to last })
+    expect(result).toContain('"a"');
+    expect(result).toContain('"b"');
+  });
 });

--- a/packages/server-test/__tests__/tool-params.test.ts
+++ b/packages/server-test/__tests__/tool-params.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tool parameter tests: verify that run/coverage tools handle parameters
+ * correctly (filter, args, nonexistent paths).
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const SERVER_PATH = resolve(__dirname, "../dist/index.js");
+
+describe("tool parameter handling", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [SERVER_PATH],
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "test-client", version: "1.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await transport.close();
+  });
+
+  describe("run tool", () => {
+    it("accepts filter parameter and passes it to the framework", async () => {
+      const gitPkgPath = resolve(__dirname, "../../server-git");
+      // Use a filter that matches a specific test file pattern
+      const result = await client.callTool({
+        name: "run",
+        arguments: { path: gitPkgPath, framework: "vitest", filter: "parsers" },
+      });
+
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      expect(sc.framework).toBe("vitest");
+
+      const summary = sc.summary as Record<string, unknown>;
+      expect(summary).toBeDefined();
+      expect(summary.total).toEqual(expect.any(Number));
+      // With a filter, we should get some tests (fewer than the full suite)
+      expect(summary.total as number).toBeGreaterThan(0);
+    }, 30_000);
+
+    it("accepts custom args parameter and passes them through", async () => {
+      const gitPkgPath = resolve(__dirname, "../../server-git");
+      // Pass --bail as a custom arg (stop on first failure)
+      const result = await client.callTool({
+        name: "run",
+        arguments: { path: gitPkgPath, framework: "vitest", args: ["--bail", "1"] },
+      });
+
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      expect(sc.framework).toBe("vitest");
+
+      const summary = sc.summary as Record<string, unknown>;
+      expect(summary.total).toEqual(expect.any(Number));
+    }, 30_000);
+
+    it("returns error for nonexistent path", async () => {
+      const result = await client.callTool({
+        name: "run",
+        arguments: { path: resolve(__dirname, "../../nonexistent-package-xyz") },
+      });
+
+      // MCP returns errors in the content with isError flag
+      expect(result.isError).toBe(true);
+    }, 15_000);
+  });
+
+  describe("coverage tool", () => {
+    it("returns error for nonexistent path", async () => {
+      const result = await client.callTool({
+        name: "coverage",
+        arguments: { path: resolve(__dirname, "../../nonexistent-package-xyz") },
+      });
+
+      expect(result.isError).toBe(true);
+    }, 15_000);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds **33 new tests** (84 -> 117) to close all testing gaps in `@paretools/test`
- Coverage parser fidelity tests for **jest**, **pytest** (expanded), and **mocha/nyc** — verifying all file percentages and decimal precision are preserved through parsing
- Expanded mocha coverage parser tests: many files, decimal percentages, empty/no-table output, 0%/100% edge cases, single file
- Expanded formatter tests for `formatTestRun()` and `formatCoverage()`: large failure arrays (10+), zero duration, missing optional fields, long test names, all-skip results, 0%/100% coverage, undefined branches/functions, empty file lists, single file
- Tool parameter tests: filter passthrough, custom args passthrough, nonexistent path error handling for both `run` and `coverage` tools
- Edge case tests: truncated/incomplete JSON in `extractJson`, corrupted `package.json` in framework detection

## Test plan
- [x] All 117 tests pass (`npx vitest run` in `packages/server-test/`)
- [x] No source code changes — test-only PR
- [x] New tests cover all gaps identified in issue #86

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)