### PR TITLE
test(npm): close testing gaps — fidelity, integration, runner, branches (#87)

### DIFF
--- a/packages/server-npm/__tests__/init.test.ts
+++ b/packages/server-npm/__tests__/init.test.ts
@@ -78,3 +78,46 @@ describe("formatInit", () => {
     expect(output).toBe("Created @myorg/utils@1.0.0 at /tmp/utils/package.json");
   });
 });
+
+// ─── Error path tests ────────────────────────────────────────────────────────
+
+describe("parseInitOutput error paths", () => {
+  it("handles permission denied (read-only directory)", () => {
+    const result = parseInitOutput(false, "unknown", "0.0.0", "/readonly/package.json");
+
+    expect(result.success).toBe(false);
+    expect(result.packageName).toBe("unknown");
+    expect(result.version).toBe("0.0.0");
+    expect(result.path).toBe("/readonly/package.json");
+  });
+
+  it("handles non-existent directory", () => {
+    const result = parseInitOutput(false, "unknown", "0.0.0", "/nonexistent/path/package.json");
+
+    expect(result.success).toBe(false);
+    expect(result.path).toBe("/nonexistent/path/package.json");
+  });
+
+  it("handles existing package.json overwrite", () => {
+    const result = parseInitOutput(true, "existing-project", "2.0.0", "/project/package.json");
+
+    expect(result.success).toBe(true);
+    expect(result.packageName).toBe("existing-project");
+    expect(result.version).toBe("2.0.0");
+  });
+});
+
+describe("formatInit error paths", () => {
+  it("formats failure with long path", () => {
+    const data: NpmInit = {
+      success: false,
+      packageName: "unknown",
+      version: "0.0.0",
+      path: "/very/deeply/nested/directory/structure/package.json",
+    };
+    const output = formatInit(data);
+    expect(output).toBe(
+      "Failed to initialize package.json at /very/deeply/nested/directory/structure/package.json",
+    );
+  });
+});

--- a/packages/server-npm/__tests__/npm-runner.test.ts
+++ b/packages/server-npm/__tests__/npm-runner.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the shared runner before importing the module under test
+vi.mock("@paretools/shared", () => ({
+  run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" }),
+}));
+
+import { npm } from "../src/lib/npm-runner.js";
+import { run } from "@paretools/shared";
+
+const mockRun = vi.mocked(run);
+
+beforeEach(() => {
+  mockRun.mockClear();
+});
+
+describe("npm runner", () => {
+  describe("argument construction", () => {
+    it("passes args array directly to run()", async () => {
+      await npm(["install", "--save-dev", "vitest"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["install", "--save-dev", "vitest"],
+        expect.objectContaining({}),
+      );
+    });
+
+    it("passes cwd option to run()", async () => {
+      await npm(["audit", "--json"], "/home/user/project");
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["audit", "--json"],
+        expect.objectContaining({ cwd: "/home/user/project" }),
+      );
+    });
+
+    it("passes undefined cwd when not provided", async () => {
+      await npm(["outdated", "--json"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["outdated", "--json"],
+        expect.objectContaining({ cwd: undefined }),
+      );
+    });
+  });
+
+  describe("timeout logic", () => {
+    it("uses 300s timeout for install", async () => {
+      await npm(["install"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["install"],
+        expect.objectContaining({ timeout: 300_000 }),
+      );
+    });
+
+    it("uses 300s timeout for i (install shorthand)", async () => {
+      await npm(["i"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["i"],
+        expect.objectContaining({ timeout: 300_000 }),
+      );
+    });
+
+    it("uses 300s timeout for ci", async () => {
+      await npm(["ci"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["ci"],
+        expect.objectContaining({ timeout: 300_000 }),
+      );
+    });
+
+    it("uses 300s timeout for run", async () => {
+      await npm(["run", "build"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["run", "build"],
+        expect.objectContaining({ timeout: 300_000 }),
+      );
+    });
+
+    it("uses 300s timeout for run-script", async () => {
+      await npm(["run-script", "lint"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["run-script", "lint"],
+        expect.objectContaining({ timeout: 300_000 }),
+      );
+    });
+
+    it("uses 300s timeout for test", async () => {
+      await npm(["test"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["test"],
+        expect.objectContaining({ timeout: 300_000 }),
+      );
+    });
+
+    it("uses 300s timeout for t (test shorthand)", async () => {
+      await npm(["t"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["t"],
+        expect.objectContaining({ timeout: 300_000 }),
+      );
+    });
+
+    it("uses 60s timeout for audit", async () => {
+      await npm(["audit", "--json"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["audit", "--json"],
+        expect.objectContaining({ timeout: 60_000 }),
+      );
+    });
+
+    it("uses 60s timeout for outdated", async () => {
+      await npm(["outdated", "--json"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["outdated", "--json"],
+        expect.objectContaining({ timeout: 60_000 }),
+      );
+    });
+
+    it("uses 60s timeout for ls (list)", async () => {
+      await npm(["ls", "--json", "--depth=0"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["ls", "--json", "--depth=0"],
+        expect.objectContaining({ timeout: 60_000 }),
+      );
+    });
+
+    it("uses 60s timeout for init", async () => {
+      await npm(["init", "-y"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "npm",
+        ["init", "-y"],
+        expect.objectContaining({ timeout: 60_000 }),
+      );
+    });
+  });
+
+  describe("return value", () => {
+    it("returns the RunResult from the shared runner", async () => {
+      mockRun.mockResolvedValueOnce({ exitCode: 1, stdout: "some output", stderr: "some error" });
+
+      const result = await npm(["test"]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe("some output");
+      expect(result.stderr).toBe("some error");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes #87

- Add **61 new tests** (72 → 133) across 8 test files for `@paretools/npm`
- **Fidelity tests** for P3 tools (`run`, `test`, `init`) using realistic npm CLI fixture data
- **Branch coverage** improvements for all parsers: `parseInstallOutput` with 0 vulnerabilities and absent funding; `parseAuditJson` with missing metadata, missing via array, and invalid JSON; `parseOutdatedJson` with missing optional fields and invalid JSON; `parseListJson` with missing name/version/dependencies and invalid JSON
- **Integration tests** for `audit`, `run`, `test`, and `init` tools called through the MCP client
- **Runner unit tests** (`npm-runner.test.ts`) verifying argument construction and timeout logic (300s for install/run/test vs 60s for audit/outdated/list/init) with mocked `@paretools/shared` runner
- **Error-path tests** for `run`, `test`, and `init` parsers covering permission errors, timeouts, signal termination, and OOM scenarios

No source code changes — test-only PR.

## Test plan
- [x] `cd packages/server-npm && npx vitest run` — 133 tests pass across 8 files
- [ ] CI passes on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)