### PR TITLE
test(go): close testing gaps — fidelity, integration, runner (#93)

### DIFF
--- a/packages/server-go/__tests__/error-paths.test.ts
+++ b/packages/server-go/__tests__/error-paths.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Error path tests: exercise edge cases and unusual inputs for the Go parsers
+ * that are not covered by the main parser/fidelity tests.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  parseGoTestJson,
+  parseGoFmtOutput,
+  parseGoBuildOutput,
+  parseGoVetOutput,
+} from "../src/lib/parsers.js";
+
+// ---------------------------------------------------------------------------
+// parseGoTestJson — subtests (e.g., TestMain/SubTest)
+// ---------------------------------------------------------------------------
+describe("error paths: parseGoTestJson subtests", () => {
+  it("parses subtests with parent/child naming", () => {
+    const stdout = [
+      JSON.stringify({ Action: "run", Package: "myapp", Test: "TestMain" }),
+      JSON.stringify({ Action: "run", Package: "myapp", Test: "TestMain/SubAdd" }),
+      JSON.stringify({ Action: "run", Package: "myapp", Test: "TestMain/SubSub" }),
+      JSON.stringify({
+        Action: "pass",
+        Package: "myapp",
+        Test: "TestMain/SubAdd",
+        Elapsed: 0.001,
+      }),
+      JSON.stringify({
+        Action: "fail",
+        Package: "myapp",
+        Test: "TestMain/SubSub",
+        Elapsed: 0.002,
+      }),
+      JSON.stringify({ Action: "fail", Package: "myapp", Test: "TestMain", Elapsed: 0.003 }),
+    ].join("\n");
+
+    const result = parseGoTestJson(stdout, 1);
+
+    // Parent and subtests are all tracked separately by key (Package/Test)
+    expect(result.total).toBe(3);
+    expect(result.passed).toBe(1);
+    expect(result.failed).toBe(2);
+
+    const subAdd = result.tests.find((t) => t.name === "TestMain/SubAdd");
+    const subSub = result.tests.find((t) => t.name === "TestMain/SubSub");
+    const parent = result.tests.find((t) => t.name === "TestMain");
+    expect(subAdd?.status).toBe("pass");
+    expect(subSub?.status).toBe("fail");
+    expect(parent?.status).toBe("fail");
+  });
+
+  it("parses deeply nested subtests", () => {
+    const stdout = [
+      JSON.stringify({ Action: "run", Package: "myapp", Test: "TestAPI/GET/users/200" }),
+      JSON.stringify({
+        Action: "pass",
+        Package: "myapp",
+        Test: "TestAPI/GET/users/200",
+        Elapsed: 0.01,
+      }),
+      JSON.stringify({ Action: "run", Package: "myapp", Test: "TestAPI/POST/users/400" }),
+      JSON.stringify({
+        Action: "fail",
+        Package: "myapp",
+        Test: "TestAPI/POST/users/400",
+        Elapsed: 0.02,
+      }),
+    ].join("\n");
+
+    const result = parseGoTestJson(stdout, 1);
+
+    expect(result.total).toBe(2);
+    const getTest = result.tests.find((t) => t.name === "TestAPI/GET/users/200");
+    const postTest = result.tests.find((t) => t.name === "TestAPI/POST/users/400");
+    expect(getTest?.status).toBe("pass");
+    expect(postTest?.status).toBe("fail");
+  });
+
+  it("handles subtests with spaces (URL-encoded in test name)", () => {
+    const stdout = [
+      JSON.stringify({
+        Action: "run",
+        Package: "myapp",
+        Test: "TestTable/case_with_spaces",
+      }),
+      JSON.stringify({
+        Action: "pass",
+        Package: "myapp",
+        Test: "TestTable/case_with_spaces",
+        Elapsed: 0.001,
+      }),
+    ].join("\n");
+
+    const result = parseGoTestJson(stdout, 0);
+
+    expect(result.total).toBe(1);
+    expect(result.tests[0].name).toBe("TestTable/case_with_spaces");
+    expect(result.tests[0].status).toBe("pass");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseGoFmtOutput — non-.go files in output
+// ---------------------------------------------------------------------------
+describe("error paths: parseGoFmtOutput with non-.go files", () => {
+  it("includes non-.go filenames if present in output", () => {
+    // gofmt normally only outputs .go files, but the parser should not filter
+    const stdout = "main.go\nREADME.md\nMakefile\n";
+    const result = parseGoFmtOutput(stdout, "", 0, true);
+
+    expect(result.filesChanged).toBe(3);
+    expect(result.files).toContain("main.go");
+    expect(result.files).toContain("README.md");
+    expect(result.files).toContain("Makefile");
+  });
+
+  it("handles files with unusual extensions", () => {
+    const stdout = "main.go\ngenerated.pb.go\nvendor/lib.go\n";
+    const result = parseGoFmtOutput(stdout, "", 0, true);
+
+    expect(result.filesChanged).toBe(3);
+    expect(result.files).toContain("generated.pb.go");
+    expect(result.files).toContain("vendor/lib.go");
+  });
+
+  it("handles blank lines in output", () => {
+    const stdout = "main.go\n\nutil.go\n\n";
+    const result = parseGoFmtOutput(stdout, "", 0, true);
+
+    // Blank lines should be filtered out
+    expect(result.filesChanged).toBe(2);
+    expect(result.files).toEqual(["main.go", "util.go"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parsers with non-ASCII characters in error paths
+// ---------------------------------------------------------------------------
+describe("error paths: non-ASCII characters", () => {
+  it("parseGoBuildOutput handles non-ASCII file paths", () => {
+    const stderr = "\u00fcbung.go:5:3: undefined: greet";
+    const result = parseGoBuildOutput("", stderr, 2);
+
+    expect(result.success).toBe(false);
+    expect(result.total).toBe(1);
+    expect(result.errors[0].file).toBe("\u00fcbung.go");
+    expect(result.errors[0].line).toBe(5);
+    expect(result.errors[0].column).toBe(3);
+    expect(result.errors[0].message).toBe("undefined: greet");
+  });
+
+  it("parseGoBuildOutput handles CJK characters in error messages", () => {
+    const stderr = 'main.go:12:7: \u672a\u5b9a\u7fa9\u306e\u5909\u6570: x';
+    const result = parseGoBuildOutput("", stderr, 2);
+
+    expect(result.success).toBe(false);
+    expect(result.total).toBe(1);
+    expect(result.errors[0].message).toContain("\u672a\u5b9a\u7fa9");
+  });
+
+  it("parseGoVetOutput handles non-ASCII file paths", () => {
+    const stderr = "caf\u00e9.go:10:2: printf: extra arg";
+    const result = parseGoVetOutput("", stderr);
+
+    expect(result.total).toBe(1);
+    expect(result.diagnostics[0].file).toBe("caf\u00e9.go");
+    expect(result.diagnostics[0].line).toBe(10);
+    expect(result.diagnostics[0].column).toBe(2);
+    expect(result.diagnostics[0].message).toBe("printf: extra arg");
+  });
+
+  it("parseGoTestJson handles non-ASCII test names", () => {
+    const stdout = [
+      JSON.stringify({
+        Action: "run",
+        Package: "myapp",
+        Test: "Test\u65e5\u672c\u8a9e",
+      }),
+      JSON.stringify({
+        Action: "pass",
+        Package: "myapp",
+        Test: "Test\u65e5\u672c\u8a9e",
+        Elapsed: 0.001,
+      }),
+    ].join("\n");
+
+    const result = parseGoTestJson(stdout, 0);
+
+    expect(result.total).toBe(1);
+    expect(result.tests[0].name).toBe("Test\u65e5\u672c\u8a9e");
+    expect(result.tests[0].status).toBe("pass");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseGoBuildOutput — multi-line error messages
+// ---------------------------------------------------------------------------
+describe("error paths: parseGoBuildOutput multi-line errors", () => {
+  it("parses each line as a separate error (Go compiler format)", () => {
+    // Go compiler outputs each error on its own line, even if logically related.
+    // Multi-line context lines (like "have ..." / "want ...") are indented and
+    // won't match the error regex — only the main error line is captured.
+    const stderr = [
+      "main.go:10:5: cannot use x (variable of type string) as int value in argument to process",
+      "\thave (string)",
+      "\twant (int)",
+      "main.go:20:3: undefined: bar",
+    ].join("\n");
+
+    const result = parseGoBuildOutput("", stderr, 2);
+
+    // The indented "have/want" lines don't match the regex, so only 2 errors
+    expect(result.success).toBe(false);
+    expect(result.total).toBe(2);
+    expect(result.errors[0].file).toBe("main.go");
+    expect(result.errors[0].line).toBe(10);
+    expect(result.errors[0].message).toBe(
+      "cannot use x (variable of type string) as int value in argument to process",
+    );
+    expect(result.errors[1].file).toBe("main.go");
+    expect(result.errors[1].line).toBe(20);
+    expect(result.errors[1].message).toBe("undefined: bar");
+  });
+
+  it("handles linker errors mixed with compiler errors", () => {
+    const stderr = [
+      "# myapp",
+      "main.go:5:2: undefined: missingFunc",
+      "# myapp",
+      "./main.go:8:3: too many arguments in call to fmt.Println",
+    ].join("\n");
+
+    const result = parseGoBuildOutput("", stderr, 2);
+
+    expect(result.success).toBe(false);
+    expect(result.total).toBe(2);
+    expect(result.errors[0].message).toBe("undefined: missingFunc");
+    expect(result.errors[1].message).toBe("too many arguments in call to fmt.Println");
+  });
+
+  it("handles errors with colons in the message", () => {
+    const stderr = 'main.go:1:1: expected \'package\', found \'EOF\'';
+    const result = parseGoBuildOutput("", stderr, 2);
+
+    expect(result.success).toBe(false);
+    expect(result.total).toBe(1);
+    expect(result.errors[0].file).toBe("main.go");
+    expect(result.errors[0].line).toBe(1);
+    expect(result.errors[0].column).toBe(1);
+    expect(result.errors[0].message).toBe("expected 'package', found 'EOF'");
+  });
+
+  it("handles errors from files in subdirectories", () => {
+    const stderr = [
+      "cmd/server/main.go:15:4: undefined: config.Load",
+      "internal/auth/jwt.go:22:8: cannot convert x (type int) to string",
+      "pkg/util/helper.go:3:1: expected declaration, got '}'",
+    ].join("\n");
+
+    const result = parseGoBuildOutput("", stderr, 2);
+
+    expect(result.success).toBe(false);
+    expect(result.total).toBe(3);
+    expect(result.errors[0].file).toBe("cmd/server/main.go");
+    expect(result.errors[1].file).toBe("internal/auth/jwt.go");
+    expect(result.errors[2].file).toBe("pkg/util/helper.go");
+  });
+});

--- a/packages/server-go/__tests__/fidelity.test.ts
+++ b/packages/server-go/__tests__/fidelity.test.ts
@@ -7,7 +7,15 @@
  * result contains every piece of information present in the input.
  */
 import { describe, it, expect } from "vitest";
-import { parseGoBuildOutput, parseGoTestJson, parseGoVetOutput } from "../src/lib/parsers.js";
+import {
+  parseGoBuildOutput,
+  parseGoTestJson,
+  parseGoVetOutput,
+  parseGoRunOutput,
+  parseGoModTidyOutput,
+  parseGoFmtOutput,
+  parseGoGenerateOutput,
+} from "../src/lib/parsers.js";
 
 // ---------------------------------------------------------------------------
 // go build
@@ -350,5 +358,238 @@ describe("fidelity: go vet", () => {
       column: 1,
       message: "missing return at end of function",
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// go run
+// ---------------------------------------------------------------------------
+describe("fidelity: go run", () => {
+  it("parses successful run with multi-line stdout", () => {
+    const stdout = "Hello, World!\nLine 2\nLine 3\n";
+    const result = parseGoRunOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("Hello, World!\nLine 2\nLine 3");
+    expect(result.stderr).toBe("");
+  });
+
+  it("parses failed run with compile error", () => {
+    const stderr = [
+      "# command-line-arguments",
+      "./main.go:5:2: undefined: fmt.Prinln",
+    ].join("\n");
+    const result = parseGoRunOutput("", stderr, 2);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("undefined: fmt.Prinln");
+    expect(result.stderr).toContain("command-line-arguments");
+  });
+
+  it("parses runtime panic with goroutine stack trace", () => {
+    const stderr = [
+      "goroutine 1 [running]:",
+      "main.main()",
+      "\t/home/user/project/main.go:12 +0x68",
+      "",
+      "goroutine 2 [running]:",
+      "runtime.goexit()",
+      "\t/usr/local/go/src/runtime/asm_amd64.s:1650 +0x1",
+    ].join("\n");
+    const result = parseGoRunOutput("", stderr, 2);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("goroutine 1 [running]:");
+    expect(result.stderr).toContain("/home/user/project/main.go:12");
+    expect(result.stderr).toContain("goroutine 2 [running]:");
+  });
+
+  it("preserves stdout and stderr independently", () => {
+    const stdout = "output: 42\nresult: ok\n";
+    const stderr = "warning: deprecation notice\n";
+    const result = parseGoRunOutput(stdout, stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.stdout).toBe("output: 42\nresult: ok");
+    expect(result.stderr).toBe("warning: deprecation notice");
+  });
+
+  it("trims trailing whitespace from both streams", () => {
+    // trimEnd() removes all trailing whitespace (spaces, newlines)
+    const result = parseGoRunOutput("hello  \n\n", "  \n", 0);
+
+    expect(result.stdout).toBe("hello");
+    expect(result.stderr).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// go mod tidy
+// ---------------------------------------------------------------------------
+describe("fidelity: go mod tidy", () => {
+  it("returns clean message when already tidy (no output)", () => {
+    const result = parseGoModTidyOutput("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("go.mod and go.sum are already tidy.");
+  });
+
+  it("preserves download messages for added modules", () => {
+    const stderr = [
+      "go: downloading github.com/stretchr/testify v1.9.0",
+      "go: downloading github.com/davecgh/go-spew v1.1.2",
+      "go: downloading github.com/pmezard/go-difflib v1.0.1",
+    ].join("\n");
+    const result = parseGoModTidyOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain("github.com/stretchr/testify v1.9.0");
+    expect(result.summary).toContain("github.com/davecgh/go-spew v1.1.2");
+    expect(result.summary).toContain("github.com/pmezard/go-difflib v1.0.1");
+  });
+
+  it("reports failure when go.mod is missing", () => {
+    const stderr =
+      "go: go.mod file not found in current directory or any parent directory; see 'go help modules'\n";
+    const result = parseGoModTidyOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.summary).toContain("go.mod file not found");
+  });
+
+  it("reports failure with dependency resolution conflict", () => {
+    const stderr = [
+      "go: example.com/foo@v1.2.3 requires",
+      "\texample.com/bar@v2.0.0: version \"v2.0.0\" invalid: unknown revision v2.0.0",
+    ].join("\n");
+    const result = parseGoModTidyOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.summary).toContain("example.com/foo@v1.2.3");
+    expect(result.summary).toContain("unknown revision v2.0.0");
+  });
+
+  it("preserves output from stdout when present", () => {
+    const stdout = "go: finding module for package github.com/pkg/errors\n";
+    const result = parseGoModTidyOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain("github.com/pkg/errors");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gofmt
+// ---------------------------------------------------------------------------
+describe("fidelity: gofmt", () => {
+  it("lists unformatted files in check mode (-l)", () => {
+    const stdout = [
+      "main.go",
+      "cmd/server/handler.go",
+      "internal/util/helpers.go",
+    ].join("\n") + "\n";
+
+    const result = parseGoFmtOutput(stdout, "", 0, true);
+
+    expect(result.success).toBe(false);
+    expect(result.filesChanged).toBe(3);
+    expect(result.files).toEqual([
+      "main.go",
+      "cmd/server/handler.go",
+      "internal/util/helpers.go",
+    ]);
+  });
+
+  it("returns success when no files need formatting (check mode)", () => {
+    const result = parseGoFmtOutput("", "", 0, true);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.files).toEqual([]);
+  });
+
+  it("returns success with empty output in fix mode (-w)", () => {
+    // gofmt -w rewrites files in place, producing no stdout
+    const result = parseGoFmtOutput("", "", 0, false);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.files).toEqual([]);
+  });
+
+  it("reports failure on syntax error in check mode", () => {
+    const stderr = "main.go:10:1: expected declaration, got '}'";
+    const result = parseGoFmtOutput("", stderr, 2, true);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("handles deeply nested paths", () => {
+    const stdout = "pkg/internal/middleware/auth/jwt/token_validator.go\n";
+    const result = parseGoFmtOutput(stdout, "", 0, true);
+
+    expect(result.success).toBe(false);
+    expect(result.filesChanged).toBe(1);
+    expect(result.files[0]).toBe("pkg/internal/middleware/auth/jwt/token_validator.go");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// go generate
+// ---------------------------------------------------------------------------
+describe("fidelity: go generate", () => {
+  it("parses successful generate with no output", () => {
+    const result = parseGoGenerateOutput("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("");
+  });
+
+  it("preserves generator stdout output", () => {
+    const stdout = [
+      "mockgen -source=service.go -destination=mock_service.go",
+      "stringer -type=Color",
+    ].join("\n") + "\n";
+    const result = parseGoGenerateOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("mockgen -source=service.go");
+    expect(result.output).toContain("stringer -type=Color");
+  });
+
+  it("preserves failure output with missing generator", () => {
+    const stderr =
+      'main.go:3: running "mockgen": exec: "mockgen": executable file not found in $PATH\n';
+    const result = parseGoGenerateOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("mockgen");
+    expect(result.output).toContain("executable file not found");
+  });
+
+  it("combines stdout and stderr in output", () => {
+    const stdout = "generating code for service.go\n";
+    const stderr = "warning: deprecated directive format\n";
+    const result = parseGoGenerateOutput(stdout, stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("generating code for service.go");
+    expect(result.output).toContain("warning: deprecated directive format");
+  });
+
+  it("parses generate failure with bad directive syntax", () => {
+    const stderr = [
+      "main.go:3: bad flag syntax in //go:generate directive",
+      "types.go:7: invalid go:generate directive",
+    ].join("\n") + "\n";
+    const result = parseGoGenerateOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("bad flag syntax");
+    expect(result.output).toContain("invalid go:generate directive");
   });
 });

--- a/packages/server-go/__tests__/go-runner.test.ts
+++ b/packages/server-go/__tests__/go-runner.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { RunResult } from "@paretools/shared";
+
+// Mock @paretools/shared before importing the module under test
+vi.mock("@paretools/shared", () => ({
+  run: vi.fn(),
+}));
+
+// Import after mock is registered
+import { run } from "@paretools/shared";
+import { goCmd, gofmtCmd } from "../src/lib/go-runner.js";
+
+const mockRun = vi.mocked(run);
+
+describe("goCmd", () => {
+  beforeEach(() => {
+    mockRun.mockReset();
+    mockRun.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+  });
+
+  it("calls run with 'go' as the command", async () => {
+    await goCmd(["build", "./..."], "/project");
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    expect(mockRun.mock.calls[0][0]).toBe("go");
+  });
+
+  it("passes arguments array through to run", async () => {
+    await goCmd(["test", "-json", "./..."], "/project");
+
+    expect(mockRun.mock.calls[0][1]).toEqual(["test", "-json", "./..."]);
+  });
+
+  it("passes cwd option to run", async () => {
+    await goCmd(["build", "./..."], "/my/project");
+
+    expect(mockRun.mock.calls[0][2]).toMatchObject({ cwd: "/my/project" });
+  });
+
+  it("sets timeout to 300 seconds (300_000ms)", async () => {
+    await goCmd(["build", "./..."], "/project");
+
+    expect(mockRun.mock.calls[0][2]).toMatchObject({ timeout: 300_000 });
+  });
+
+  it("passes undefined cwd when not provided", async () => {
+    await goCmd(["vet", "./..."]);
+
+    expect(mockRun.mock.calls[0][2]).toMatchObject({ cwd: undefined });
+  });
+
+  it("returns the RunResult from run()", async () => {
+    const expected: RunResult = { exitCode: 2, stdout: "", stderr: "error" };
+    mockRun.mockResolvedValue(expected);
+
+    const result = await goCmd(["build", "."]);
+
+    expect(result).toBe(expected);
+  });
+
+  it("propagates errors from run()", async () => {
+    mockRun.mockRejectedValue(new Error('Command not found: "go"'));
+
+    await expect(goCmd(["build"])).rejects.toThrow('Command not found: "go"');
+  });
+
+  it("handles empty args array", async () => {
+    await goCmd([], "/project");
+
+    expect(mockRun.mock.calls[0][1]).toEqual([]);
+  });
+});
+
+describe("gofmtCmd", () => {
+  beforeEach(() => {
+    mockRun.mockReset();
+    mockRun.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+  });
+
+  it("calls run with 'gofmt' as the command", async () => {
+    await gofmtCmd(["-l", "."], "/project");
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    expect(mockRun.mock.calls[0][0]).toBe("gofmt");
+  });
+
+  it("passes arguments array through to run", async () => {
+    await gofmtCmd(["-w", "main.go"], "/project");
+
+    expect(mockRun.mock.calls[0][1]).toEqual(["-w", "main.go"]);
+  });
+
+  it("passes cwd option to run", async () => {
+    await gofmtCmd(["-l", "."], "/my/project");
+
+    expect(mockRun.mock.calls[0][2]).toMatchObject({ cwd: "/my/project" });
+  });
+
+  it("sets timeout to 120 seconds (120_000ms)", async () => {
+    await gofmtCmd(["-l", "."], "/project");
+
+    expect(mockRun.mock.calls[0][2]).toMatchObject({ timeout: 120_000 });
+  });
+
+  it("passes undefined cwd when not provided", async () => {
+    await gofmtCmd(["-l", "."]);
+
+    expect(mockRun.mock.calls[0][2]).toMatchObject({ cwd: undefined });
+  });
+
+  it("returns the RunResult from run()", async () => {
+    const expected: RunResult = { exitCode: 0, stdout: "main.go\n", stderr: "" };
+    mockRun.mockResolvedValue(expected);
+
+    const result = await gofmtCmd(["-l", "."]);
+
+    expect(result).toBe(expected);
+  });
+
+  it("propagates errors from run()", async () => {
+    mockRun.mockRejectedValue(new Error('Command not found: "gofmt"'));
+
+    await expect(gofmtCmd(["-l", "."])).rejects.toThrow('Command not found: "gofmt"');
+  });
+});

--- a/packages/server-go/__tests__/integration.test.ts
+++ b/packages/server-go/__tests__/integration.test.ts
@@ -60,4 +60,126 @@ describe("@paretools/go integration", () => {
       }
     });
   });
+
+  describe("build", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "build",
+        arguments: { path: resolve(__dirname, "../../..") },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/go|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(sc.total).toEqual(expect.any(Number));
+        expect(Array.isArray(sc.errors)).toBe(true);
+      }
+    });
+  });
+
+  describe("test", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "test",
+        arguments: { path: resolve(__dirname, "../../..") },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/go|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(sc.total).toEqual(expect.any(Number));
+        expect(sc.passed).toEqual(expect.any(Number));
+        expect(sc.failed).toEqual(expect.any(Number));
+        expect(sc.skipped).toEqual(expect.any(Number));
+        expect(Array.isArray(sc.tests)).toBe(true);
+      }
+    });
+  });
+
+  describe("run", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "run",
+        arguments: { path: resolve(__dirname, "../../.."), file: "." },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/go|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(typeof sc.exitCode).toBe("number");
+        expect(typeof sc.stdout).toBe("string");
+        expect(typeof sc.stderr).toBe("string");
+      }
+    });
+  });
+
+  describe("mod-tidy", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "mod-tidy",
+        arguments: { path: resolve(__dirname, "../../..") },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/go|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(typeof sc.summary).toBe("string");
+      }
+    });
+  });
+
+  describe("fmt", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "fmt",
+        arguments: { path: resolve(__dirname, "../../.."), check: true },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/gofmt|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(typeof sc.filesChanged).toBe("number");
+        expect(Array.isArray(sc.files)).toBe(true);
+      }
+    });
+  });
+
+  describe("generate", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool({
+        name: "generate",
+        arguments: { path: resolve(__dirname, "../../..") },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/go|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.success).toBe("boolean");
+        expect(typeof sc.output).toBe("string");
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds **55 new tests** (75 -> 130) for `@paretools/go`, closing all testing gaps identified in #93
- **Fidelity tests** for P3 tools (run, mod-tidy, fmt, generate) with realistic fixture-based input
- **Integration tests** for all 7 tools via MCP client (previously only vet was covered)
- **Runner tests** for `goCmd` and `gofmtCmd` — argument construction, timeout values (300s/120s), cwd passthrough, error propagation
- **Error path tests** — subtests, non-.go files in fmt output, non-ASCII characters in paths/messages, multi-line build errors

## Test plan
- [x] All 130 tests pass locally (`npx vitest run` in `packages/server-go`)
- [ ] CI passes on Ubuntu

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)