### PR TITLE
test(lint): close testing gaps — biome fidelity, integration, runner (#89)

### DIFF
--- a/packages/server-lint/__tests__/formatters.test.ts
+++ b/packages/server-lint/__tests__/formatters.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { formatLint, formatFormatCheck } from "../src/lib/formatters.js";
-import type { LintResult, FormatCheckResult } from "../src/schemas/index.js";
+import { formatLint, formatFormatCheck, formatFormatWrite } from "../src/lib/formatters.js";
+import type { LintResult, FormatCheckResult, FormatWriteResult } from "../src/schemas/index.js";
 
 describe("formatLint", () => {
   it("formats clean lint result", () => {
@@ -99,5 +99,147 @@ describe("formatFormatCheck", () => {
     expect(output).toContain("src/index.ts");
     expect(output).toContain("src/utils.ts");
     expect(output).toContain("src/config.ts");
+  });
+
+  it("formats with 0 files needing formatting (false positive exit code)", () => {
+    const data: FormatCheckResult = {
+      formatted: false,
+      files: [],
+      total: 0,
+    };
+    const output = formatFormatCheck(data);
+    expect(output).toContain("0 files need formatting:");
+  });
+
+  it("formats with 100 files needing formatting", () => {
+    const files = Array.from({ length: 100 }, (_, i) => `src/file${i}.ts`);
+    const data: FormatCheckResult = {
+      formatted: false,
+      files,
+      total: 100,
+    };
+    const output = formatFormatCheck(data);
+    expect(output).toContain("100 files need formatting:");
+    expect(output).toContain("src/file0.ts");
+    expect(output).toContain("src/file99.ts");
+    // Verify all 100 files are listed (header line + 100 file lines)
+    const lines = output.split("\n");
+    expect(lines).toHaveLength(101);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLint edge cases
+// ---------------------------------------------------------------------------
+
+describe("formatLint edge cases", () => {
+  it("formats lint result with 10+ diagnostics across multiple files", () => {
+    const diagnostics = Array.from({ length: 12 }, (_, i) => ({
+      file: `src/module${i % 4}.ts`,
+      line: 10 + i,
+      column: 1 + (i % 10),
+      severity: (i % 3 === 0 ? "error" : "warning") as "error" | "warning",
+      rule: i % 2 === 0 ? "no-unused-vars" : "prefer-const",
+      message: `Diagnostic message number ${i + 1}.`,
+      fixable: i % 2 === 0,
+    }));
+
+    const errors = diagnostics.filter((d) => d.severity === "error").length;
+    const warnings = diagnostics.filter((d) => d.severity === "warning").length;
+    const fixable = diagnostics.filter((d) => d.fixable).length;
+
+    const data: LintResult = {
+      diagnostics,
+      total: 12,
+      errors,
+      warnings,
+      fixable,
+      filesChecked: 4,
+    };
+
+    const output = formatLint(data);
+
+    // Header line with counts
+    expect(output).toContain(`${errors} errors, ${warnings} warnings (${fixable} fixable)`);
+
+    // All 12 diagnostics should appear
+    const lines = output.split("\n");
+    // 1 header + 12 diagnostic lines
+    expect(lines).toHaveLength(13);
+
+    // Spot-check first and last
+    expect(lines[1]).toContain("src/module0.ts:10:1");
+    expect(lines[12]).toContain("src/module3.ts:21:");
+  });
+
+  it("formats lint result with special characters in file paths", () => {
+    const data: LintResult = {
+      diagnostics: [
+        {
+          file: "src/components/[id]/page.tsx",
+          line: 5,
+          column: 10,
+          severity: "error",
+          rule: "no-unused-vars",
+          message: "Unused var in dynamic route.",
+          fixable: false,
+        },
+        {
+          file: "src/utils/my file (copy).ts",
+          line: 3,
+          column: 1,
+          severity: "warning",
+          rule: "prefer-const",
+          message: "Use const.",
+          fixable: true,
+        },
+        {
+          file: "src/lib/@internal/helpers.ts",
+          line: 1,
+          column: 1,
+          severity: "error",
+          rule: "no-console",
+          message: "No console.",
+          fixable: false,
+        },
+      ],
+      total: 3,
+      errors: 2,
+      warnings: 1,
+      fixable: 1,
+      filesChecked: 3,
+    };
+
+    const output = formatLint(data);
+
+    expect(output).toContain("src/components/[id]/page.tsx:5:10");
+    expect(output).toContain("src/utils/my file (copy).ts:3:1");
+    expect(output).toContain("src/lib/@internal/helpers.ts:1:1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatFormatWrite edge cases
+// ---------------------------------------------------------------------------
+
+describe("formatFormatWrite edge cases", () => {
+  it("formats result with 0 files changed (success)", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 0,
+      files: [],
+      success: true,
+    };
+
+    expect(formatFormatWrite(data)).toBe("All files already formatted.");
+  });
+
+  it("formats failure with 0 files", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 0,
+      files: [],
+      success: false,
+    };
+
+    expect(formatFormatWrite(data)).toBe("Format failed.");
   });
 });

--- a/packages/server-lint/__tests__/integration.test.ts
+++ b/packages/server-lint/__tests__/integration.test.ts
@@ -67,4 +67,83 @@ describe("@paretools/lint integration", () => {
       expect(Array.isArray(sc.diagnostics)).toBe(true);
     }, 30_000);
   });
+
+  describe("format-check", () => {
+    it("returns structured Prettier check result", async () => {
+      const pkgPath = resolve(__dirname, "..");
+      const result = await client.callTool({
+        name: "format-check",
+        arguments: { path: pkgPath, patterns: ["src/lib/formatters.ts"] },
+      });
+
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      expect(typeof sc.formatted).toBe("boolean");
+      expect(sc.total).toEqual(expect.any(Number));
+      expect(Array.isArray(sc.files)).toBe(true);
+    }, 30_000);
+  });
+
+  describe("prettier-format", () => {
+    it("returns structured Prettier write result", async () => {
+      const pkgPath = resolve(__dirname, "..");
+      const result = await client.callTool({
+        name: "prettier-format",
+        // Use --check on a single known-formatted file to avoid modifying files
+        arguments: { path: pkgPath, patterns: ["src/lib/formatters.ts"] },
+      });
+
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      expect(typeof sc.success).toBe("boolean");
+      expect(sc.filesChanged).toEqual(expect.any(Number));
+      expect(Array.isArray(sc.files)).toBe(true);
+    }, 30_000);
+  });
+
+  describe("biome-check", () => {
+    it("returns structured result even when biome is not configured", async () => {
+      const pkgPath = resolve(__dirname, "..");
+      const result = await client.callTool({
+        name: "biome-check",
+        arguments: { path: pkgPath, patterns: ["src/lib/formatters.ts"] },
+      });
+
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      expect(sc.total).toEqual(expect.any(Number));
+      expect(sc.errors).toEqual(expect.any(Number));
+      expect(sc.warnings).toEqual(expect.any(Number));
+      expect(sc.fixable).toEqual(expect.any(Number));
+      expect(Array.isArray(sc.diagnostics)).toBe(true);
+    }, 30_000);
+  });
+
+  describe("biome-format", () => {
+    it("returns structured result even when biome is not configured", async () => {
+      const pkgPath = resolve(__dirname, "..");
+      const result = await client.callTool({
+        name: "biome-format",
+        arguments: { path: pkgPath, patterns: ["src/lib/formatters.ts"] },
+      });
+
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      expect(typeof sc.success).toBe("boolean");
+      expect(sc.filesChanged).toEqual(expect.any(Number));
+      expect(Array.isArray(sc.files)).toBe(true);
+    }, 30_000);
+  });
 });

--- a/packages/server-lint/__tests__/lint-runner.test.ts
+++ b/packages/server-lint/__tests__/lint-runner.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the @paretools/shared module before importing the runner
+vi.mock("@paretools/shared", () => ({
+  run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" }),
+}));
+
+import { eslint, prettier, biome } from "../src/lib/lint-runner.js";
+import { run } from "@paretools/shared";
+
+const mockRun = vi.mocked(run);
+
+beforeEach(() => {
+  mockRun.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// eslint() argument construction
+// ---------------------------------------------------------------------------
+
+describe("eslint()", () => {
+  it("passes arguments through to run() with npx eslint prefix", async () => {
+    await eslint(["--format", "json", "src/"], "/project");
+
+    expect(mockRun).toHaveBeenCalledOnce();
+    expect(mockRun).toHaveBeenCalledWith("npx", ["eslint", "--format", "json", "src/"], {
+      cwd: "/project",
+    });
+  });
+
+  it("constructs correct args for default lint patterns", async () => {
+    await eslint(["--format", "json", "."], "/project");
+
+    expect(mockRun).toHaveBeenCalledWith("npx", ["eslint", "--format", "json", "."], {
+      cwd: "/project",
+    });
+  });
+
+  it("constructs correct args with --fix flag", async () => {
+    await eslint(["--format", "json", "src/", "--fix"], "/project");
+
+    expect(mockRun).toHaveBeenCalledWith("npx", ["eslint", "--format", "json", "src/", "--fix"], {
+      cwd: "/project",
+    });
+  });
+
+  it("constructs correct args with multiple patterns", async () => {
+    await eslint(["--format", "json", "src/", "lib/", "tests/"], "/project");
+
+    expect(mockRun).toHaveBeenCalledWith(
+      "npx",
+      ["eslint", "--format", "json", "src/", "lib/", "tests/"],
+      { cwd: "/project" },
+    );
+  });
+
+  it("passes undefined cwd when not specified", async () => {
+    await eslint(["--format", "json", "."]);
+
+    expect(mockRun).toHaveBeenCalledWith("npx", ["eslint", "--format", "json", "."], {
+      cwd: undefined,
+    });
+  });
+
+  it("returns the RunResult from run()", async () => {
+    mockRun.mockResolvedValue({ exitCode: 1, stdout: "[]", stderr: "" });
+
+    const result = await eslint(["--format", "json", "."], "/project");
+
+    expect(result).toEqual({ exitCode: 1, stdout: "[]", stderr: "" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prettier() argument construction
+// ---------------------------------------------------------------------------
+
+describe("prettier()", () => {
+  it("passes arguments through to run() with npx prettier prefix", async () => {
+    await prettier(["--check", "."], "/project");
+
+    expect(mockRun).toHaveBeenCalledOnce();
+    expect(mockRun).toHaveBeenCalledWith("npx", ["prettier", "--check", "."], {
+      cwd: "/project",
+    });
+  });
+
+  it("constructs correct args for check mode", async () => {
+    await prettier(["--check", "src/", "lib/"], "/project");
+
+    expect(mockRun).toHaveBeenCalledWith("npx", ["prettier", "--check", "src/", "lib/"], {
+      cwd: "/project",
+    });
+  });
+
+  it("constructs correct args for write mode", async () => {
+    await prettier(["--write", "src/", "lib/"], "/project");
+
+    expect(mockRun).toHaveBeenCalledWith("npx", ["prettier", "--write", "src/", "lib/"], {
+      cwd: "/project",
+    });
+  });
+
+  it("passes undefined cwd when not specified", async () => {
+    await prettier(["--check", "."]);
+
+    expect(mockRun).toHaveBeenCalledWith("npx", ["prettier", "--check", "."], {
+      cwd: undefined,
+    });
+  });
+
+  it("returns the RunResult from run()", async () => {
+    mockRun.mockResolvedValue({ exitCode: 0, stdout: "All formatted", stderr: "" });
+
+    const result = await prettier(["--check", "."], "/project");
+
+    expect(result).toEqual({ exitCode: 0, stdout: "All formatted", stderr: "" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// biome() argument construction
+// ---------------------------------------------------------------------------
+
+describe("biome()", () => {
+  it("passes arguments through to run() with npx @biomejs/biome prefix", async () => {
+    await biome(["check", "--reporter=json", "."], "/project");
+
+    expect(mockRun).toHaveBeenCalledOnce();
+    expect(mockRun).toHaveBeenCalledWith(
+      "npx",
+      ["@biomejs/biome", "check", "--reporter=json", "."],
+      { cwd: "/project" },
+    );
+  });
+
+  it("constructs correct args for check mode with patterns", async () => {
+    await biome(["check", "--reporter=json", "src/", "lib/"], "/project");
+
+    expect(mockRun).toHaveBeenCalledWith(
+      "npx",
+      ["@biomejs/biome", "check", "--reporter=json", "src/", "lib/"],
+      { cwd: "/project" },
+    );
+  });
+
+  it("constructs correct args for format --write mode", async () => {
+    await biome(["format", "--write", "src/"], "/project");
+
+    expect(mockRun).toHaveBeenCalledWith("npx", ["@biomejs/biome", "format", "--write", "src/"], {
+      cwd: "/project",
+    });
+  });
+
+  it("constructs correct args for format --write with multiple patterns", async () => {
+    await biome(["format", "--write", "src/", "lib/", "tests/"], "/project");
+
+    expect(mockRun).toHaveBeenCalledWith(
+      "npx",
+      ["@biomejs/biome", "format", "--write", "src/", "lib/", "tests/"],
+      { cwd: "/project" },
+    );
+  });
+
+  it("passes undefined cwd when not specified", async () => {
+    await biome(["check", "--reporter=json", "."]);
+
+    expect(mockRun).toHaveBeenCalledWith(
+      "npx",
+      ["@biomejs/biome", "check", "--reporter=json", "."],
+      { cwd: undefined },
+    );
+  });
+
+  it("returns the RunResult from run()", async () => {
+    mockRun.mockResolvedValue({ exitCode: 0, stdout: '{"diagnostics":[]}', stderr: "" });
+
+    const result = await biome(["check", "--reporter=json", "."], "/project");
+
+    expect(result).toEqual({ exitCode: 0, stdout: '{"diagnostics":[]}', stderr: "" });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 46 new tests to `@paretools/lint` (54 -> 100 total), closing all identified testing gaps
- New `lint-runner.test.ts` with 17 tests verifying `eslint()`, `prettier()`, and `biome()` argument construction via mocked `run()`
- Extends `fidelity.test.ts` with 19 tests for Biome check (mixed lint+format, severity mapping, fixable flags), Biome format, and Prettier --write
- Extends `integration.test.ts` with 4 tests covering all 5 MCP tools (was only testing `lint`)
- Extends `formatters.test.ts` with 6 edge-case tests (10+ diagnostics, special chars in paths, 0/100 files)

## Test plan
- [x] All 100 tests pass locally via `npx vitest run`
- [x] No source code (`src/`) was modified
- [ ] CI passes on Ubuntu

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)