### PR TITLE
style: fix prettier formatting on compact mode files

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -8,7 +8,7 @@ The tool definitions do have an upfront context cost — that's true of any MCP 
 
 ### "JSON is verbose compared to plain text though?"
 
-Raw CLI output isn't minimal either — it's full of whitespace padding, box-drawing characters, ANSI formatting, repeated column headers, and progress indicators. Pare strips all that and returns only the fields an agent actually needs. The savings come from *structured minimal JSON* vs *decorated terminal output*, not raw JSON vs raw text.
+Raw CLI output isn't minimal either — it's full of whitespace padding, box-drawing characters, ANSI formatting, repeated column headers, and progress indicators. Pare strips all that and returns only the fields an agent actually needs. The savings come from _structured minimal JSON_ vs _decorated terminal output_, not raw JSON vs raw text.
 
 ### "If I use frequent intentional compaction, I only make a few tool calls per session. Is it still worth it?"
 
@@ -32,7 +32,7 @@ Pare is a set of standalone MCP servers. Each one (git, npm, cargo, etc.) calls 
 
 ### "Does structured output actually improve agent reasoning, or just save tokens?"
 
-No formal benchmark yet, but from daily usage with Claude Code we've seen no degradation in response quality — if anything it's better. When an agent gets a structured diff with `file`, `additions`, `deletions` fields it doesn't hallucinate line counts from eyeballing patch text. A `success: false` boolean is unambiguous vs the agent trying to grep "FAILED" out of a wall of stdout. Fewer tokens *and* less room for misinterpretation.
+No formal benchmark yet, but from daily usage with Claude Code we've seen no degradation in response quality — if anything it's better. When an agent gets a structured diff with `file`, `additions`, `deletions` fields it doesn't hallucinate line counts from eyeballing patch text. A `success: false` boolean is unambiguous vs the agent trying to grep "FAILED" out of a wall of stdout. Fewer tokens _and_ less room for misinterpretation.
 
 A proper eval comparing agent accuracy on raw CLI vs Pare structured output is planned — see [#110](https://github.com/Dave-London/Pare/issues/110).
 

--- a/packages/server-git/__tests__/compact.test.ts
+++ b/packages/server-git/__tests__/compact.test.ts
@@ -41,7 +41,11 @@ describe("compactLogMap", () => {
 
     expect(compact.total).toBe(2);
     expect(compact.commits).toHaveLength(2);
-    expect(compact.commits[0]).toEqual({ hashShort: "abc1234", message: "Fix bug", refs: "HEAD -> main" });
+    expect(compact.commits[0]).toEqual({
+      hashShort: "abc1234",
+      message: "Fix bug",
+      refs: "HEAD -> main",
+    });
     expect(compact.commits[1]).toEqual({ hashShort: "def5678", message: "Add feature" });
     // Verify dropped fields are not present
     expect(compact.commits[0]).not.toHaveProperty("hash");

--- a/packages/server-npm/__tests__/compact.test.ts
+++ b/packages/server-npm/__tests__/compact.test.ts
@@ -8,8 +8,14 @@ describe("compactListMap", () => {
       name: "my-app",
       version: "1.0.0",
       dependencies: {
-        express: { version: "4.18.2", resolved: "https://registry.npmjs.org/express/-/express-4.18.2.tgz" },
-        lodash: { version: "4.17.21", resolved: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz" },
+        express: {
+          version: "4.18.2",
+          resolved: "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+        },
+        lodash: {
+          version: "4.17.21",
+          resolved: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+        },
       },
       total: 2,
     };

--- a/packages/shared/__tests__/compact.test.ts
+++ b/packages/shared/__tests__/compact.test.ts
@@ -30,7 +30,14 @@ describe("compactDualOutput", () => {
   const formatCompact = (d: ReturnType<typeof compactMap>) => `Compact: ${d.total} items`;
 
   it("returns full data when forceFullSchema is true", () => {
-    const result = compactDualOutput(fullData, "short", formatFull, compactMap, formatCompact, true);
+    const result = compactDualOutput(
+      fullData,
+      "short",
+      formatFull,
+      compactMap,
+      formatCompact,
+      true,
+    );
     expect(result.structuredContent).toBe(fullData);
     expect(result.content[0].text).toBe("Full: 1 items");
   });


### PR DESCRIPTION
## Summary
- Ran prettier on 4 files that failed CI format check after the compact mode feature commit

## Test plan
- [ ] CI format:check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)