### PR TITLE
fix: increase timeout for slow cargo operations on Windows CI

### DIFF
--- a/packages/server-cargo/__tests__/integration.test.ts
+++ b/packages/server-cargo/__tests__/integration.test.ts
@@ -54,7 +54,9 @@ describe("@paretools/cargo integration", () => {
   });
 
   describe("clippy", () => {
-    it("returns structured data or a command-not-found error", async () => {
+    // cargo clippy on a cold toolchain (especially Windows CI) can take
+    // well over 60s; give it enough room to finish or fail clearly.
+    it("returns structured data or a command-not-found error", { timeout: 120_000 }, async () => {
       const result = await client.callTool({
         name: "clippy",
         arguments: { path: resolve(__dirname, "../../..") },

--- a/packages/server-cargo/vitest.config.ts
+++ b/packages/server-cargo/vitest.config.ts
@@ -3,7 +3,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
-    testTimeout: 60_000,
+    // cargo operations (clippy, build, test) can be very slow on Windows CI
+    // with cold toolchain caches — 60s is not enough for real cargo invocations.
+    testTimeout: 120_000,
     coverage: {
       provider: "v8",
       thresholds: {

--- a/packages/shared/src/runner.ts
+++ b/packages/shared/src/runner.ts
@@ -59,6 +59,17 @@ export function run(cmd: string, args: string[], opts?: RunOptions): Promise<Run
             return;
           }
 
+          // Timeout: execFile killed the child after the configured timeout.
+          // Surface this clearly instead of silently returning exitCode 1.
+          if (error.killed && error.signal) {
+            reject(
+              new Error(
+                `Command "${cmd}" timed out after ${opts?.timeout ?? 30_000}ms and was killed (${error.signal}).`,
+              ),
+            );
+            return;
+          }
+
           // Windows: cmd.exe masks ENOENT — detect via stderr message
           const cleanStderr = stripAnsi(stderr);
           if (cleanStderr.includes("is not recognized")) {


### PR DESCRIPTION
## Summary
- Increase vitest `testTimeout` from 60s to 120s for the `@paretools/cargo` package, since cargo operations on cold Windows CI toolchains regularly exceed 60s
- Add an explicit 120s per-test timeout on the clippy integration test (the only test that runs a real `cargo clippy` invocation)
- Add timeout detection to the shared `run()` function in `@paretools/shared` so that `execFile` timeouts surface as clear `"Command timed out"` errors instead of being silently swallowed as `exitCode: 1`

Closes #117

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm --filter @paretools/cargo test` passes (139 tests)
- [x] `pnpm --filter @paretools/shared test` passes (97 tests)
- [ ] CI passes on all platforms including Windows Node 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)