### PR TITLE
fix: validate docker/go array params, pin CI actions, add security model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
         node-version: [20, 22]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -35,11 +35,11 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 22
           cache: pnpm
@@ -51,11 +51,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 22
           cache: pnpm
@@ -66,11 +66,11 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 22
           cache: pnpm
@@ -30,7 +30,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@c48e67d110a68bc90ccf1098e9646092baacaa87 # v1.6.0
         with:
           publish: pnpm release
           title: "chore: version packages"

--- a/SECURITY_MODEL.md
+++ b/SECURITY_MODEL.md
@@ -1,0 +1,106 @@
+# Pare Security Model
+
+This document describes the security architecture and trust boundaries for `@paretools` MCP servers.
+
+## Overview
+
+Pare provides MCP (Model Context Protocol) servers that wrap CLI tools (Docker, Git, Go, npm, etc.), exposing them as structured tool calls for AI assistants. Because these servers execute real CLI commands, understanding the trust model is critical.
+
+## Trust Boundary: The MCP Client
+
+In the MCP architecture, the **MCP client** (e.g., Claude Desktop, VS Code, or another AI-powered IDE) is the trust boundary. The MCP client is responsible for:
+
+1. **User consent** -- presenting tool calls to the user for approval before execution
+2. **Scoping access** -- deciding which MCP servers to connect and which tools to expose
+3. **Environment isolation** -- running MCP servers in appropriate sandboxes or containers
+
+Pare MCP servers trust that the MCP client has obtained appropriate user authorization before invoking any tool. The servers themselves do not implement authentication, authorization, or user-facing consent dialogs -- this is by design, per the MCP specification.
+
+## The `path`/`cwd` Parameter
+
+Most Pare tools accept a `path` or `cwd` parameter that sets the working directory for the underlying CLI command. This parameter is **intentionally unrestricted**.
+
+### Why `path` is not validated
+
+- The MCP specification delegates filesystem access control to the client
+- Restricting paths server-side would break legitimate use cases (monorepos, multi-project workspaces, NixOS store paths, Windows `C:\Program Files\...` paths)
+- Any path restriction in the server could be trivially bypassed via symlinks or relative path traversal
+- The MCP client is the appropriate place to enforce filesystem boundaries (e.g., workspace root restrictions)
+
+### Implications
+
+- A Pare MCP server can read/write/execute in any directory the host OS user has access to
+- If the MCP client does not restrict tool invocations, a compromised or malicious prompt could instruct the AI to operate on arbitrary directories
+- Operators deploying Pare servers should ensure their MCP client enforces appropriate workspace boundaries
+
+## Input Validation: `args[]` and Flag Injection Prevention
+
+While `path`/`cwd` is unrestricted, Pare validates all positional string arguments to prevent **flag injection attacks**.
+
+### The threat
+
+CLI tools interpret arguments starting with `-` as flags. If a user-supplied value like `--privileged` is passed as a positional argument (e.g., as a Docker image name), the CLI tool may interpret it as a flag, leading to privilege escalation or unintended behavior.
+
+### The mitigation: `assertNoFlagInjection`
+
+All user-supplied string parameters that are passed as positional arguments to CLI tools are validated with `assertNoFlagInjection()`. This function rejects any value that starts with `-` (after trimming whitespace), preventing flag injection.
+
+**Protected parameters include** (non-exhaustive):
+
+- Docker: `image`, `name`, `container`, `workdir`, `volumes[]`, `env[]`
+- Docker: `ports[]` are validated with a dedicated port-mapping format regex
+- Git: `ref`, `branch`, `remote`, `message`
+- Go: `patterns[]`
+- General: any parameter passed as a CLI positional argument
+
+### Array parameter validation
+
+Array parameters (`ports[]`, `volumes[]`, `env[]`, `patterns[]`) receive element-level validation:
+
+- **`ports[]`**: Each element is validated against a port-mapping format regex (e.g., `8080`, `8080:80`, `127.0.0.1:8080:80/tcp`)
+- **`volumes[]`**, **`env[]`**, **`patterns[]`**: Each element is checked with `assertNoFlagInjection` to reject values starting with `-`
+
+### Command allowlisting
+
+For tools that accept a command name (e.g., the build tool), `assertAllowedCommand()` validates against an allowlist of known safe build tools (npm, cargo, make, etc.).
+
+## Known Limitations
+
+### 1. Path parameter is unrestricted (by design)
+
+As described above, `path`/`cwd` is not validated. This is an intentional design decision aligned with the MCP specification. See the section above for details.
+
+### 2. Command arguments after `--`
+
+Some tools pass user-supplied arrays as command arguments (e.g., `docker run <image> <command...>`). These arguments are passed directly to the container/process and are not validated beyond flag injection checks on the image/container name itself. The assumption is that the user (via the MCP client) has authorized the specific command.
+
+### 3. `go generate` executes arbitrary directives
+
+The `go generate` tool runs `//go:generate` directives embedded in Go source files. These directives can execute **any** command available on the host system. This is inherent to Go's design. The tool's description includes a warning about this behavior. Only use `go generate` on trusted, reviewed source code.
+
+### 4. `assertAllowedCommand` checks basename only
+
+The build tool's command allowlist checks only the basename of the command (e.g., `npm` from `/usr/bin/npm`). A malicious binary placed at a path like `/tmp/evil/npm` would pass the check. However, this requires prior filesystem compromise and is considered out of scope.
+
+### 5. Environment variable values are not inspected
+
+The `env[]` parameter validation only prevents flag injection (values starting with `-`). It does not validate environment variable format (e.g., `KEY=VALUE`) or inspect values for sensitive content. Environment variable values are passed as-is to the CLI tool.
+
+## Threat Model Summary
+
+| Threat                                      | Mitigation                                          | Residual Risk                                     |
+| ------------------------------------------- | --------------------------------------------------- | ------------------------------------------------- |
+| Flag injection via positional args          | `assertNoFlagInjection` on all string params        | None known                                        |
+| Flag injection via array elements           | Per-element validation (format regex or flag check) | None known                                        |
+| Arbitrary command execution via build tool  | `assertAllowedCommand` allowlist                    | Basename-only check; requires prior FS compromise |
+| Arbitrary directory access via `path`/`cwd` | Delegated to MCP client (by design)                 | MCP client must enforce boundaries                |
+| `go generate` running arbitrary commands    | Warning in tool description                         | Inherent to Go; user must trust source code       |
+| Supply chain attack via GitHub Actions      | SHA-pinned action references                        | Requires GitHub infrastructure compromise         |
+
+## Recommendations for Operators
+
+1. **Use an MCP client that supports workspace boundaries** to restrict which directories Pare servers can access
+2. **Review `go generate` directives** in source code before running the generate tool
+3. **Run Pare servers in containers or sandboxes** when operating on untrusted code
+4. **Keep Pare packages updated** to receive security patches
+5. **Monitor the `SECURITY.md` file** for vulnerability reporting procedures

--- a/packages/server-docker/src/tools/exec.ts
+++ b/packages/server-docker/src/tools/exec.ts
@@ -33,6 +33,7 @@ export function registerExecTool(server: McpServer) {
       const args = ["exec"];
       if (workdir) args.push("-w", workdir);
       for (const e of env ?? []) {
+        assertNoFlagInjection(e, "env");
         args.push("-e", e);
       }
       args.push(container, ...command);

--- a/packages/server-docker/src/tools/run.ts
+++ b/packages/server-docker/src/tools/run.ts
@@ -6,6 +6,27 @@ import { parseRunOutput } from "../lib/parsers.js";
 import { formatRun } from "../lib/formatters.js";
 import { DockerRunSchema } from "../schemas/index.js";
 
+/**
+ * Validates that a string matches a Docker port mapping format.
+ * Accepted formats:
+ *   - "8080"                  (container port only)
+ *   - "8080:80"               (host:container)
+ *   - "8080:80/tcp"           (host:container/protocol)
+ *   - "127.0.0.1:8080:80"    (ip:host:container)
+ *   - "127.0.0.1:8080:80/udp"
+ *   - "8080-8090:80-90"      (port ranges)
+ */
+const PORT_MAPPING_RE =
+  /^(?:(?:\d{1,3}\.){3}\d{1,3}:)?(?:\d{1,5}(?:-\d{1,5})?:)?\d{1,5}(?:-\d{1,5})?(?:\/(?:tcp|udp|sctp))?$/;
+
+export function assertValidPortMapping(value: string): void {
+  if (!PORT_MAPPING_RE.test(value)) {
+    throw new Error(
+      `Invalid port mapping: "${value}". Expected format like "8080", "8080:80", "127.0.0.1:8080:80/tcp", or a port range.`,
+    );
+  }
+}
+
 export function registerRunTool(server: McpServer) {
   server.registerTool(
     "run",
@@ -59,12 +80,15 @@ export function registerRunTool(server: McpServer) {
       if (rm) args.push("--rm");
       if (name) args.push("--name", name);
       for (const p of ports ?? []) {
+        assertValidPortMapping(p);
         args.push("-p", p);
       }
       for (const v of volumes ?? []) {
+        assertNoFlagInjection(v, "volumes");
         args.push("-v", v);
       }
       for (const e of env ?? []) {
+        assertNoFlagInjection(e, "env");
         args.push("-e", e);
       }
       args.push(image);

--- a/packages/server-go/src/tools/generate.ts
+++ b/packages/server-go/src/tools/generate.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoGenerateOutput } from "../lib/parsers.js";
 import { formatGoGenerate } from "../lib/formatters.js";
@@ -12,7 +12,7 @@ export function registerGenerateTool(server: McpServer) {
     {
       title: "Go Generate",
       description:
-        "Runs go generate directives in Go source files. Use instead of running `go generate` in the terminal.",
+        "Runs go generate directives in Go source files. Use instead of running `go generate` in the terminal. WARNING: `go generate` executes arbitrary commands embedded in //go:generate directives in source files. Only use this tool on trusted code that you have reviewed.",
       inputSchema: {
         path: z.string().optional().describe("Project root path (default: cwd)"),
         patterns: z
@@ -24,6 +24,9 @@ export function registerGenerateTool(server: McpServer) {
       outputSchema: GoGenerateResultSchema,
     },
     async ({ path, patterns }) => {
+      for (const p of patterns || []) {
+        assertNoFlagInjection(p, "patterns");
+      }
       const cwd = path || process.cwd();
       const result = await goCmd(["generate", ...(patterns || ["./..."])], cwd);
       const data = parseGoGenerateOutput(result.stdout, result.stderr, result.exitCode);


### PR DESCRIPTION
## Summary

Addresses four findings from the security audit:

- **SEC-003 (High)**: Docker `run` ports/volumes/env arrays and `exec` env array now have per-element validation. Ports are validated against a format regex; volumes and env vars are checked with `assertNoFlagInjection` to prevent flag injection.
- **SEC-005 (High)**: Go `generate` tool now validates each `patterns[]` element with `assertNoFlagInjection`, and the tool description includes a warning that `go generate` executes arbitrary directives from source files.
- **SEC-013 (Low)**: All GitHub Actions in `ci.yml` and `release.yml` are pinned to full SHA hashes to prevent supply chain attacks via mutable version tags.
- **SEC-004 (High)**: Added `SECURITY_MODEL.md` documenting the MCP trust boundary, the intentionally unrestricted `path`/`cwd` parameter, the `args[]` validation strategy, and known limitations.

Closes #127, #128, #129, #137

## Test plan

- [x] `pnpm build` passes (all 10 packages compile)
- [x] `pnpm test` passes (all existing tests still pass -- 20/20 tasks)
- [x] `pnpm format:check` passes for all changed files
- [ ] Verify port validation rejects malformed strings (e.g., `--privileged`, `abc`, `999999:80`)
- [ ] Verify volume/env flag injection is blocked (e.g., `--privileged` as a volume or env value)
- [ ] Verify go generate rejects flag-prefixed patterns (e.g., `--run=evil`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)