### PR TITLE
fix: harden supply chain and command execution security

### DIFF
--- a/packages/server-cargo/src/tools/add.ts
+++ b/packages/server-cargo/src/tools/add.ts
@@ -12,7 +12,10 @@ export function registerAddTool(server: McpServer) {
     {
       title: "Cargo Add",
       description:
-        "Adds dependencies to a Rust project and returns structured output. Use instead of running `cargo add` in the terminal.",
+        "Adds dependencies to a Rust project and returns structured output. " +
+        "Use instead of running `cargo add` in the terminal. " +
+        "WARNING: Adding crates downloads and compiles third-party code which may include build scripts (build.rs). " +
+        "Only add trusted crates. Use dryRun to preview changes before committing.",
       inputSchema: {
         path: z.string().optional().describe("Project root path (default: cwd)"),
         packages: z.array(z.string()).describe('Packages to add (e.g. ["serde", "tokio@1.0"])'),
@@ -21,10 +24,15 @@ export function registerAddTool(server: McpServer) {
           .array(z.string())
           .optional()
           .describe('Features to enable (e.g. ["derive", "full"])'),
+        dryRun: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Preview what would be added without modifying Cargo.toml (--dry-run)"),
       },
       outputSchema: CargoAddResultSchema,
     },
-    async ({ path, packages, dev, features }) => {
+    async ({ path, packages, dev, features, dryRun }) => {
       const cwd = path || process.cwd();
 
       for (const pkg of packages) {
@@ -39,6 +47,7 @@ export function registerAddTool(server: McpServer) {
       if (features && features.length > 0) {
         args.push("--features", features.join(","));
       }
+      if (dryRun) args.push("--dry-run");
 
       const result = await cargo(args, cwd);
       const data = parseCargoAddOutput(result.stdout, result.stderr, result.exitCode);

--- a/packages/server-docker/__tests__/security.test.ts
+++ b/packages/server-docker/__tests__/security.test.ts
@@ -99,6 +99,32 @@ describe("assertNoFlagInjection — exec tool (container param)", () => {
   });
 });
 
+describe("assertNoFlagInjection — exec tool (command[0] param)", () => {
+  it("accepts a normal command name", () => {
+    expect(() => assertNoFlagInjection("ls", "command")).not.toThrow();
+  });
+
+  it("accepts a command with path", () => {
+    expect(() => assertNoFlagInjection("/usr/bin/env", "command")).not.toThrow();
+  });
+
+  it("accepts a command like bash", () => {
+    expect(() => assertNoFlagInjection("bash", "command")).not.toThrow();
+  });
+
+  it("rejects --help as command name (flag injection)", () => {
+    expect(() => assertNoFlagInjection("--help", "command")).toThrow(/Invalid command/);
+  });
+
+  it("rejects -c as command name (flag injection)", () => {
+    expect(() => assertNoFlagInjection("-c", "command")).toThrow(/Invalid command/);
+  });
+
+  it("rejects --privileged as command name", () => {
+    expect(() => assertNoFlagInjection("--privileged", "command")).toThrow(/Invalid command/);
+  });
+});
+
 describe("assertNoFlagInjection — pull tool (image param)", () => {
   it("accepts a normal image name", () => {
     expect(() => assertNoFlagInjection("ubuntu:22.04", "image")).not.toThrow();

--- a/packages/server-docker/src/tools/exec.ts
+++ b/packages/server-docker/src/tools/exec.ts
@@ -12,7 +12,9 @@ export function registerExecTool(server: McpServer) {
     {
       title: "Docker Exec",
       description:
-        "Executes a command in a running Docker container and returns structured output. Use instead of running `docker exec` in the terminal.",
+        "Executes arbitrary commands inside a running Docker container and returns structured output. " +
+        "Use instead of running `docker exec` in the terminal. " +
+        "WARNING: This runs arbitrary commands inside the container. Only use on trusted containers.",
       inputSchema: {
         container: z.string().describe("Container name or ID"),
         command: z.array(z.string()).describe('Command to execute (e.g., ["ls", "-la"])'),
@@ -27,7 +29,11 @@ export function registerExecTool(server: McpServer) {
       outputSchema: DockerExecSchema,
     },
     async ({ container, command, workdir, env, path }) => {
+      if (!command || command.length === 0) {
+        throw new Error("command array must not be empty");
+      }
       assertNoFlagInjection(container, "container");
+      assertNoFlagInjection(command[0], "command");
       if (workdir) assertNoFlagInjection(workdir, "workdir");
       // Validate first element of command array (the binary name) to prevent flag injection.
       // Subsequent elements are intentionally unchecked as they are arguments to the command itself.

--- a/packages/server-npm/src/tools/install.ts
+++ b/packages/server-npm/src/tools/install.ts
@@ -12,7 +12,10 @@ export function registerInstallTool(server: McpServer) {
     {
       title: "npm Install",
       description:
-        "Runs npm install and returns a structured summary of added/removed packages and vulnerabilities. Use instead of running `npm install` in the terminal.",
+        "Runs npm install and returns a structured summary of added/removed packages and vulnerabilities. " +
+        "Use instead of running `npm install` in the terminal. " +
+        "WARNING: Installing npm packages may execute lifecycle scripts (preinstall/postinstall). " +
+        "Only install trusted packages. Set ignoreScripts to true to skip lifecycle scripts.",
       inputSchema: {
         path: z.string().optional().describe("Project root path (default: cwd)"),
         args: z
@@ -20,17 +23,26 @@ export function registerInstallTool(server: McpServer) {
           .optional()
           .default([])
           .describe("Additional arguments (e.g., package names to install)"),
+        ignoreScripts: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Skip lifecycle scripts (preinstall/postinstall) via --ignore-scripts. Recommended for untrusted packages.",
+          ),
       },
       outputSchema: NpmInstallSchema,
     },
-    async ({ path, args }) => {
+    async ({ path, args, ignoreScripts }) => {
       for (const a of args ?? []) {
         assertNoFlagInjection(a, "args");
       }
 
       const cwd = path || process.cwd();
+      const flags: string[] = [];
+      if (ignoreScripts) flags.push("--ignore-scripts");
       const start = Date.now();
-      const result = await npm(["install", ...(args || [])], cwd);
+      const result = await npm(["install", ...flags, ...(args || [])], cwd);
       const duration = Math.round(((Date.now() - start) / 1000) * 10) / 10;
 
       const output = result.stdout + "\n" + result.stderr;

--- a/packages/shared/__tests__/validation.test.ts
+++ b/packages/shared/__tests__/validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { assertNoFlagInjection, assertAllowedCommand } from "../src/validation.js";
 
 describe("assertNoFlagInjection", () => {
@@ -148,5 +148,36 @@ describe("assertAllowedCommand", () => {
   it("extension stripping is case-insensitive", () => {
     expect(() => assertAllowedCommand("npm.CMD")).not.toThrow();
     expect(() => assertAllowedCommand("yarn.Exe")).not.toThrow();
+  });
+
+  it("warns when a Unix full path is used", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    assertAllowedCommand("/usr/bin/npm");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[pare:security] Command uses a full path"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("/usr/bin/npm"));
+    warnSpy.mockRestore();
+  });
+
+  it("warns when a Windows full path is used", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    assertAllowedCommand("C:\\Program Files\\node\\npm");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[pare:security] Command uses a full path"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn when a bare command name is used", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    assertAllowedCommand("npm");
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("still rejects disallowed commands even with full paths", () => {
+    expect(() => assertAllowedCommand("/tmp/evil/rm")).toThrow();
+    expect(() => assertAllowedCommand("C:\\evil\\bash")).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- **SEC-002** (High): Docker exec command array now validates that the array is non-empty and applies `assertNoFlagInjection` to the first element (the binary name). Tool description warns about arbitrary command execution on trusted containers only.
- **SEC-008** (Medium): npm install now accepts an `ignoreScripts` boolean parameter that adds `--ignore-scripts` to skip lifecycle scripts. Tool description warns about supply chain risks from preinstall/postinstall scripts.
- **SEC-009** (Medium): pip-install and uv-install both gain a `dryRun` boolean parameter that adds `--dry-run` to preview installations without executing. Tool descriptions warn about arbitrary setup.py execution.
- **SEC-010** (Medium): cargo add gains a `dryRun` boolean parameter that adds `--dry-run` to preview changes before modifying Cargo.toml. Tool description warns about build script (build.rs) execution.
- **SEC-014** (Low): `assertAllowedCommand` now logs a `console.warn` when a full path is provided, creating an audit trail for the known basename-only validation limitation. Enhanced JSDoc documents the security tradeoff.

All new parameters are optional with `default: false`, ensuring full backward compatibility.

Closes #126, #132, #133, #134, #138

## Test plan

- [x] `pnpm build` compiles successfully across all packages
- [x] `pnpm test` passes all 20 tasks (build + test for each package)
- [x] New Docker security tests verify flag injection on `command[0]`
- [x] New shared validation tests verify `console.warn` on full paths and no warning on bare commands
- [ ] Manual verification: confirm `ignoreScripts: true` produces `npm install --ignore-scripts`
- [ ] Manual verification: confirm `dryRun: true` produces `--dry-run` flag for pip/uv/cargo

🤖 Generated with [Claude Code](https://claude.com/claude-code)