### PR TITLE
fix: validate all args arrays and string params against flag injection

### DIFF
--- a/packages/server-build/src/tools/esbuild.ts
+++ b/packages/server-build/src/tools/esbuild.ts
@@ -72,6 +72,9 @@ export function registerEsbuildTool(server: McpServer) {
       if (platform) cliArgs.push(`--platform=${platform}`);
       if (sourcemap) cliArgs.push("--sourcemap");
 
+      for (const a of args ?? []) {
+        assertNoFlagInjection(a, "args");
+      }
       if (args) {
         cliArgs.push(...args);
       }

--- a/packages/server-build/src/tools/tsc.ts
+++ b/packages/server-build/src/tools/tsc.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { tsc } from "../lib/build-runner.js";
 import { parseTscOutput } from "../lib/parsers.js";
 import { formatTsc } from "../lib/formatters.js";
@@ -26,6 +26,8 @@ export function registerTscTool(server: McpServer) {
     },
     async ({ path, noEmit, project }) => {
       const cwd = path || process.cwd();
+      if (project) assertNoFlagInjection(project, "project");
+
       const args: string[] = [];
       if (noEmit !== false) args.push("--noEmit");
       if (project) args.push("--project", project);

--- a/packages/server-build/src/tools/vite-build.ts
+++ b/packages/server-build/src/tools/vite-build.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { viteCmd } from "../lib/build-runner.js";
 import { parseViteBuildOutput } from "../lib/parsers.js";
 import { formatViteBuild } from "../lib/formatters.js";
@@ -26,6 +26,11 @@ export function registerViteBuildTool(server: McpServer) {
     },
     async ({ path, mode, args }) => {
       const cwd = path || process.cwd();
+      if (mode) assertNoFlagInjection(mode, "mode");
+      for (const a of args ?? []) {
+        assertNoFlagInjection(a, "args");
+      }
+
       const cliArgs: string[] = [];
 
       if (mode && mode !== "production") {

--- a/packages/server-build/src/tools/webpack.ts
+++ b/packages/server-build/src/tools/webpack.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { webpackCmd } from "../lib/build-runner.js";
 import { parseWebpackOutput } from "../lib/parsers.js";
 import { formatWebpack } from "../lib/formatters.js";
@@ -26,6 +26,11 @@ export function registerWebpackTool(server: McpServer) {
     },
     async ({ path, config, mode, args }) => {
       const cwd = path || process.cwd();
+      if (config) assertNoFlagInjection(config, "config");
+      for (const a of args ?? []) {
+        assertNoFlagInjection(a, "args");
+      }
+
       const cliArgs: string[] = [];
 
       if (config) cliArgs.push("--config", config);

--- a/packages/server-cargo/__tests__/security.test.ts
+++ b/packages/server-cargo/__tests__/security.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Security tests: verify that assertNoFlagInjection() prevents flag injection
+ * attacks on user-supplied parameters in cargo tools.
+ *
+ * These tools accept user-provided strings (package names, test filters,
+ * feature names, args arrays) that are passed as positional arguments to the
+ * Cargo CLI. Without validation, a malicious input like "--release" or
+ * "--manifest-path=/evil" could be interpreted as a flag.
+ */
+import { describe, it, expect } from "vitest";
+import { assertNoFlagInjection } from "@paretools/shared";
+
+/** Malicious inputs that must be rejected by every guarded parameter. */
+const MALICIOUS_INPUTS = [
+  "--release",
+  "--manifest-path=/evil",
+  "-p",
+  "--features",
+  "--all-features",
+  "--no-default-features",
+  "-j",
+  "--jobs",
+  "--target",
+  // Whitespace bypass attempts
+  " --release",
+  "\t--features",
+  "   -p",
+];
+
+/** Safe inputs that must be accepted. */
+const SAFE_INPUTS = [
+  "my-crate",
+  "serde",
+  "tokio",
+  "my_project",
+  "tests/integration",
+  "test_name_filter",
+  "derive",
+  "full",
+  "v1.0.0",
+];
+
+describe("security: cargo check — package validation", () => {
+  it("rejects flag-like package names", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "package")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe package names", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "package")).not.toThrow();
+    }
+  });
+});
+
+describe("security: cargo test — filter validation", () => {
+  it("rejects flag-like filter values", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "filter")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe filter values", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "filter")).not.toThrow();
+    }
+  });
+});
+
+describe("security: cargo add — features validation", () => {
+  it("rejects flag-like feature names", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "features")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe feature names", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "features")).not.toThrow();
+    }
+  });
+});
+
+describe("security: cargo run — args validation", () => {
+  it("rejects flag-like args values", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "args")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe args values", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "args")).not.toThrow();
+    }
+  });
+});

--- a/packages/server-cargo/src/tools/add.ts
+++ b/packages/server-cargo/src/tools/add.ts
@@ -30,6 +30,9 @@ export function registerAddTool(server: McpServer) {
       for (const pkg of packages) {
         assertNoFlagInjection(pkg, "packages");
       }
+      for (const f of features ?? []) {
+        assertNoFlagInjection(f, "features");
+      }
 
       const args = ["add", ...packages];
       if (dev) args.push("--dev");

--- a/packages/server-cargo/src/tools/check.ts
+++ b/packages/server-cargo/src/tools/check.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoBuildJson } from "../lib/parsers.js";
 import { formatCargoBuild } from "../lib/formatters.js";
@@ -21,6 +21,8 @@ export function registerCheckTool(server: McpServer) {
     },
     async ({ path, package: pkg }) => {
       const cwd = path || process.cwd();
+      if (pkg) assertNoFlagInjection(pkg, "package");
+
       const args = ["check", "--message-format=json"];
       if (pkg) args.push("-p", pkg);
 

--- a/packages/server-cargo/src/tools/run.ts
+++ b/packages/server-cargo/src/tools/run.ts
@@ -24,6 +24,10 @@ export function registerRunTool(server: McpServer) {
     async ({ path, args, release, package: pkg }) => {
       const cwd = path || process.cwd();
       if (pkg) assertNoFlagInjection(pkg, "package");
+      // Defense-in-depth: validate args even though they come after "--" separator
+      for (const a of args ?? []) {
+        assertNoFlagInjection(a, "args");
+      }
 
       const cargoArgs = ["run"];
       if (release) cargoArgs.push("--release");

--- a/packages/server-cargo/src/tools/test.ts
+++ b/packages/server-cargo/src/tools/test.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoTestOutput } from "../lib/parsers.js";
 import { formatCargoTest } from "../lib/formatters.js";
@@ -21,6 +21,8 @@ export function registerTestTool(server: McpServer) {
     },
     async ({ path, filter }) => {
       const cwd = path || process.cwd();
+      if (filter) assertNoFlagInjection(filter, "filter");
+
       const args = ["test"];
       if (filter) args.push(filter);
 

--- a/packages/server-docker/src/tools/build.ts
+++ b/packages/server-docker/src/tools/build.ts
@@ -24,6 +24,9 @@ export function registerBuildTool(server: McpServer) {
     async ({ path, tag, file, args }) => {
       if (tag) assertNoFlagInjection(tag, "tag");
       if (file) assertNoFlagInjection(file, "file");
+      for (const a of args ?? []) {
+        assertNoFlagInjection(a, "args");
+      }
 
       const cwd = path || process.cwd();
       const dockerArgs = ["build", "."];

--- a/packages/server-docker/src/tools/exec.ts
+++ b/packages/server-docker/src/tools/exec.ts
@@ -29,6 +29,11 @@ export function registerExecTool(server: McpServer) {
     async ({ container, command, workdir, env, path }) => {
       assertNoFlagInjection(container, "container");
       if (workdir) assertNoFlagInjection(workdir, "workdir");
+      // Validate first element of command array (the binary name) to prevent flag injection.
+      // Subsequent elements are intentionally unchecked as they are arguments to the command itself.
+      if (command.length > 0) {
+        assertNoFlagInjection(command[0], "command");
+      }
 
       const args = ["exec"];
       if (workdir) args.push("-w", workdir);

--- a/packages/server-docker/src/tools/run.ts
+++ b/packages/server-docker/src/tools/run.ts
@@ -53,6 +53,11 @@ export function registerRunTool(server: McpServer) {
     async ({ image, name, ports, volumes, env, detach, rm, command, path }) => {
       assertNoFlagInjection(image, "image");
       if (name) assertNoFlagInjection(name, "name");
+      // Validate first element of command array (the binary name) to prevent flag injection.
+      // Subsequent elements are intentionally unchecked as they are arguments to the command itself.
+      if (command && command.length > 0) {
+        assertNoFlagInjection(command[0], "command");
+      }
 
       const args = ["run"];
       if (detach) args.push("-d");

--- a/packages/server-go/__tests__/security.test.ts
+++ b/packages/server-go/__tests__/security.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Security tests: verify that assertNoFlagInjection() prevents flag injection
+ * attacks on user-supplied parameters in Go tools.
+ *
+ * These tools accept user-provided strings (package paths, test filters,
+ * file patterns, build args) that are passed as positional arguments to the
+ * Go CLI. Without validation, a malicious input like "--exec=rm -rf /" could
+ * be interpreted as a flag.
+ */
+import { describe, it, expect } from "vitest";
+import { assertNoFlagInjection } from "@paretools/shared";
+
+/** Malicious inputs that must be rejected by every guarded parameter. */
+const MALICIOUS_INPUTS = [
+  "--exec=rm -rf /",
+  "-race",
+  "--tags",
+  "-v",
+  "--count",
+  "--run",
+  "-o",
+  "--output",
+  "--ldflags",
+  // Whitespace bypass attempts
+  " --exec",
+  "\t-race",
+  "   --tags",
+];
+
+/** Safe inputs that must be accepted. */
+const SAFE_INPUTS = [
+  "./...",
+  "./cmd/myapp",
+  "mypackage",
+  "TestMyFunction",
+  "src/main.go",
+  ".",
+  "internal/utils",
+  "v1.0.0",
+];
+
+describe("security: go build — packages validation", () => {
+  it("rejects flag-like package paths", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "packages")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe package paths", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "packages")).not.toThrow();
+    }
+  });
+});
+
+describe("security: go test — packages and run validation", () => {
+  it("rejects flag-like package paths", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "packages")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("rejects flag-like run filter", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "run")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe run filter values", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "run")).not.toThrow();
+    }
+  });
+});
+
+describe("security: go vet — packages validation", () => {
+  it("rejects flag-like package paths", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "packages")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: go generate — patterns validation", () => {
+  it("rejects flag-like patterns", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "patterns")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: go fmt — patterns validation", () => {
+  it("rejects flag-like patterns", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "patterns")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe patterns", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "patterns")).not.toThrow();
+    }
+  });
+});
+
+describe("security: go run — buildArgs validation", () => {
+  it("rejects flag-like buildArgs", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "buildArgs")).toThrow(
+        /must not start with "-"/,
+      );
+    }
+  });
+});

--- a/packages/server-go/src/tools/build.ts
+++ b/packages/server-go/src/tools/build.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoBuildOutput } from "../lib/parsers.js";
 import { formatGoBuild } from "../lib/formatters.js";
@@ -25,6 +25,9 @@ export function registerBuildTool(server: McpServer) {
     },
     async ({ path, packages }) => {
       const cwd = path || process.cwd();
+      for (const p of packages ?? []) {
+        assertNoFlagInjection(p, "packages");
+      }
       const result = await goCmd(["build", ...(packages || ["./..."])], cwd);
       const data = parseGoBuildOutput(result.stdout, result.stderr, result.exitCode);
       return dualOutput(data, formatGoBuild);

--- a/packages/server-go/src/tools/fmt.ts
+++ b/packages/server-go/src/tools/fmt.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { gofmtCmd } from "../lib/go-runner.js";
 import { parseGoFmtOutput } from "../lib/parsers.js";
 import { formatGoFmt } from "../lib/formatters.js";
@@ -30,6 +30,9 @@ export function registerFmtTool(server: McpServer) {
     },
     async ({ path, patterns, check }) => {
       const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
       const flag = check ? "-l" : "-w";
       const args = [flag, ...(patterns || ["."])];
       const result = await gofmtCmd(args, cwd);

--- a/packages/server-go/src/tools/generate.ts
+++ b/packages/server-go/src/tools/generate.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoGenerateOutput } from "../lib/parsers.js";
 import { formatGoGenerate } from "../lib/formatters.js";
@@ -25,6 +25,9 @@ export function registerGenerateTool(server: McpServer) {
     },
     async ({ path, patterns }) => {
       const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
       const result = await goCmd(["generate", ...(patterns || ["./..."])], cwd);
       const data = parseGoGenerateOutput(result.stdout, result.stderr, result.exitCode);
       return dualOutput(data, formatGoGenerate);

--- a/packages/server-go/src/tools/run.ts
+++ b/packages/server-go/src/tools/run.ts
@@ -33,6 +33,9 @@ export function registerRunTool(server: McpServer) {
       const cwd = path || process.cwd();
       const target = file || ".";
       assertNoFlagInjection(target, "file");
+      for (const a of buildArgs ?? []) {
+        assertNoFlagInjection(a, "buildArgs");
+      }
       const cmdArgs = ["run", ...(buildArgs || []), target];
       const programArgs = args || [];
       if (programArgs.length > 0) {

--- a/packages/server-go/src/tools/test.ts
+++ b/packages/server-go/src/tools/test.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoTestJson } from "../lib/parsers.js";
 import { formatGoTest } from "../lib/formatters.js";
@@ -26,6 +26,11 @@ export function registerTestTool(server: McpServer) {
     },
     async ({ path, packages, run: runFilter }) => {
       const cwd = path || process.cwd();
+      for (const p of packages ?? []) {
+        assertNoFlagInjection(p, "packages");
+      }
+      if (runFilter) assertNoFlagInjection(runFilter, "run");
+
       const args = ["test", "-json", ...(packages || ["./..."])];
       if (runFilter) args.push("-run", runFilter);
 

--- a/packages/server-go/src/tools/vet.ts
+++ b/packages/server-go/src/tools/vet.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoVetOutput } from "../lib/parsers.js";
 import { formatGoVet } from "../lib/formatters.js";
@@ -25,6 +25,9 @@ export function registerVetTool(server: McpServer) {
     },
     async ({ path, packages }) => {
       const cwd = path || process.cwd();
+      for (const p of packages ?? []) {
+        assertNoFlagInjection(p, "packages");
+      }
       const result = await goCmd(["vet", ...(packages || ["./..."])], cwd);
       const data = parseGoVetOutput(result.stdout, result.stderr);
       return dualOutput(data, formatGoVet);

--- a/packages/server-lint/__tests__/security.test.ts
+++ b/packages/server-lint/__tests__/security.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Security tests: verify that assertNoFlagInjection() prevents flag injection
+ * attacks on user-supplied parameters in lint tools.
+ *
+ * These tools accept user-provided strings (file patterns) that are passed
+ * as positional arguments to lint CLIs (ESLint, Biome, Prettier). Without
+ * validation, a malicious input like "--fix-dry-run" could be interpreted
+ * as a flag.
+ */
+import { describe, it, expect } from "vitest";
+import { assertNoFlagInjection } from "@paretools/shared";
+
+/** Malicious inputs that must be rejected by every guarded parameter. */
+const MALICIOUS_INPUTS = [
+  "--fix",
+  "--fix-dry-run",
+  "--config",
+  "-c",
+  "--format",
+  "--output-file",
+  "--write",
+  "--check",
+  "--reporter",
+  // Whitespace bypass attempts
+  " --fix",
+  "\t--config",
+  "   -c",
+];
+
+/** Safe inputs that must be accepted. */
+const SAFE_INPUTS = [
+  ".",
+  "src/",
+  "src/**/*.ts",
+  "lib/",
+  "index.js",
+  "components/",
+  "*.tsx",
+  "app/",
+];
+
+describe("security: lint (ESLint) — patterns validation", () => {
+  it("rejects flag-like patterns", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "patterns")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe patterns", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "patterns")).not.toThrow();
+    }
+  });
+});
+
+describe("security: biome-check — patterns validation", () => {
+  it("rejects flag-like patterns", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "patterns")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe patterns", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "patterns")).not.toThrow();
+    }
+  });
+});
+
+describe("security: biome-format — patterns validation", () => {
+  it("rejects flag-like patterns", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "patterns")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: prettier-format — patterns validation", () => {
+  it("rejects flag-like patterns", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "patterns")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: format-check (Prettier) — patterns validation", () => {
+  it("rejects flag-like patterns", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "patterns")).toThrow(/must not start with "-"/);
+    }
+  });
+});

--- a/packages/server-lint/src/tools/biome-check.ts
+++ b/packages/server-lint/src/tools/biome-check.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { biome } from "../lib/lint-runner.js";
 import { parseBiomeJson } from "../lib/parsers.js";
 import { formatLint } from "../lib/formatters.js";
@@ -25,6 +25,9 @@ export function registerBiomeCheckTool(server: McpServer) {
     },
     async ({ path, patterns }) => {
       const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
       const args = ["check", "--reporter=json", ...(patterns || ["."])];
 
       const result = await biome(args, cwd);

--- a/packages/server-lint/src/tools/biome-format.ts
+++ b/packages/server-lint/src/tools/biome-format.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { biome } from "../lib/lint-runner.js";
 import { parseBiomeFormat } from "../lib/parsers.js";
 import { formatFormatWrite } from "../lib/formatters.js";
@@ -25,6 +25,9 @@ export function registerBiomeFormatTool(server: McpServer) {
     },
     async ({ path, patterns }) => {
       const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
       const args = ["format", "--write", ...(patterns || ["."])];
 
       const result = await biome(args, cwd);

--- a/packages/server-lint/src/tools/format-check.ts
+++ b/packages/server-lint/src/tools/format-check.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { prettier } from "../lib/lint-runner.js";
 import { parsePrettierCheck } from "../lib/parsers.js";
 import { formatFormatCheck } from "../lib/formatters.js";
@@ -25,6 +25,9 @@ export function registerFormatCheckTool(server: McpServer) {
     },
     async ({ path, patterns }) => {
       const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
       const args = ["--check", ...(patterns || ["."])];
 
       const result = await prettier(args, cwd);

--- a/packages/server-lint/src/tools/lint.ts
+++ b/packages/server-lint/src/tools/lint.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { eslint } from "../lib/lint-runner.js";
 import { parseEslintJson } from "../lib/parsers.js";
 import { formatLint } from "../lib/formatters.js";
@@ -26,6 +26,9 @@ export function registerLintTool(server: McpServer) {
     },
     async ({ path, patterns, fix }) => {
       const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
       const args = ["--format", "json", ...(patterns || ["."])];
       if (fix) args.push("--fix");
 

--- a/packages/server-lint/src/tools/prettier-format.ts
+++ b/packages/server-lint/src/tools/prettier-format.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { prettier } from "../lib/lint-runner.js";
 import { parsePrettierWrite } from "../lib/parsers.js";
 import { formatFormatWrite } from "../lib/formatters.js";
@@ -25,6 +25,9 @@ export function registerPrettierFormatTool(server: McpServer) {
     },
     async ({ path, patterns }) => {
       const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
       const args = ["--write", ...(patterns || ["."])];
 
       const result = await prettier(args, cwd);

--- a/packages/server-npm/__tests__/security.test.ts
+++ b/packages/server-npm/__tests__/security.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Security tests: verify that assertNoFlagInjection() prevents flag injection
+ * attacks on user-supplied parameters in npm tools.
+ *
+ * These tools accept user-provided strings (script names, args arrays) that
+ * are passed as positional arguments to the npm CLI. Without validation,
+ * a malicious input like "--scripts-prepend-node-path" could be interpreted
+ * as a flag.
+ */
+import { describe, it, expect } from "vitest";
+import { assertNoFlagInjection } from "@paretools/shared";
+
+/** Malicious inputs that must be rejected by every guarded parameter. */
+const MALICIOUS_INPUTS = [
+  "--force",
+  "--scripts-prepend-node-path",
+  "-g",
+  "--global",
+  "--unsafe-perm",
+  "--ignore-scripts",
+  "-D",
+  "--save-dev",
+  "--registry",
+  // Whitespace bypass attempts
+  " --force",
+  "\t--global",
+  "   -g",
+];
+
+/** Safe inputs that must be accepted. */
+const SAFE_INPUTS = [
+  "express",
+  "lodash",
+  "react",
+  "@types/node",
+  "my-package",
+  "build",
+  "test",
+  "start",
+  "lint",
+  "src/index.ts",
+];
+
+describe("security: npm install — args validation", () => {
+  it("rejects flag-like args", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "args")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe args values", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "args")).not.toThrow();
+    }
+  });
+});
+
+describe("security: npm test — args validation", () => {
+  it("rejects flag-like args", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "args")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: npm run — script and args validation", () => {
+  it("rejects flag-like script names", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "script")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe script names", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "script")).not.toThrow();
+    }
+  });
+
+  it("rejects flag-like args", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "args")).toThrow(/must not start with "-"/);
+    }
+  });
+});

--- a/packages/server-npm/src/tools/install.ts
+++ b/packages/server-npm/src/tools/install.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { npm } from "../lib/npm-runner.js";
 import { parseInstallOutput } from "../lib/parsers.js";
 import { formatInstall } from "../lib/formatters.js";
@@ -24,6 +24,10 @@ export function registerInstallTool(server: McpServer) {
       outputSchema: NpmInstallSchema,
     },
     async ({ path, args }) => {
+      for (const a of args ?? []) {
+        assertNoFlagInjection(a, "args");
+      }
+
       const cwd = path || process.cwd();
       const start = Date.now();
       const result = await npm(["install", ...(args || [])], cwd);

--- a/packages/server-npm/src/tools/run.ts
+++ b/packages/server-npm/src/tools/run.ts
@@ -27,6 +27,10 @@ export function registerRunTool(server: McpServer) {
     async ({ path, script, args }) => {
       const cwd = path || process.cwd();
       assertNoFlagInjection(script, "script");
+      // Defense-in-depth: validate args even though they come after "--" separator
+      for (const a of args ?? []) {
+        assertNoFlagInjection(a, "args");
+      }
 
       const npmArgs = ["run", script];
       if (args && args.length > 0) {

--- a/packages/server-npm/src/tools/test.ts
+++ b/packages/server-npm/src/tools/test.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { npm } from "../lib/npm-runner.js";
 import { parseTestOutput } from "../lib/parsers.js";
 import { formatTest } from "../lib/formatters.js";
@@ -24,6 +24,11 @@ export function registerTestTool(server: McpServer) {
       outputSchema: NpmTestSchema,
     },
     async ({ path, args }) => {
+      // Defense-in-depth: validate args even though they come after "--" separator
+      for (const a of args ?? []) {
+        assertNoFlagInjection(a, "args");
+      }
+
       const cwd = path || process.cwd();
 
       const npmArgs = ["test"];

--- a/packages/server-python/__tests__/security.test.ts
+++ b/packages/server-python/__tests__/security.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Security tests: verify that assertNoFlagInjection() prevents flag injection
+ * attacks on user-supplied parameters in Python tools.
+ *
+ * These tools accept user-provided strings (file targets, marker expressions,
+ * package names, requirements paths) that are passed as positional arguments
+ * to Python CLI tools. Without validation, a malicious input like
+ * "--output=/etc/passwd" could be interpreted as a flag.
+ */
+import { describe, it, expect } from "vitest";
+import { assertNoFlagInjection } from "@paretools/shared";
+
+/** Malicious inputs that must be rejected by every guarded parameter. */
+const MALICIOUS_INPUTS = [
+  "--output=/etc/passwd",
+  "-c",
+  "--config",
+  "--install-option",
+  "--global-option",
+  "-e",
+  "--editable",
+  "--pre",
+  "--force-reinstall",
+  // Whitespace bypass attempts
+  " --output",
+  "\t-c",
+  "   --config",
+];
+
+/** Safe inputs that must be accepted. */
+const SAFE_INPUTS = [
+  "tests/",
+  "src/mymodule",
+  "test_file.py",
+  ".",
+  "requests",
+  "flask",
+  "numpy>=1.0",
+  "requirements.txt",
+  "not slow",
+  "src/",
+];
+
+describe("security: pytest — targets and markers validation", () => {
+  it("rejects flag-like targets", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "targets")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe targets", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "targets")).not.toThrow();
+    }
+  });
+
+  it("rejects flag-like markers", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "markers")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: black — targets validation", () => {
+  it("rejects flag-like targets", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "targets")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe targets", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "targets")).not.toThrow();
+    }
+  });
+});
+
+describe("security: mypy — targets validation", () => {
+  it("rejects flag-like targets", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "targets")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: ruff — targets validation", () => {
+  it("rejects flag-like targets", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "targets")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: pip-install — packages and requirements validation", () => {
+  it("rejects flag-like packages", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "packages")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe packages", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "packages")).not.toThrow();
+    }
+  });
+
+  it("rejects flag-like requirements path", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "requirements")).toThrow(
+        /must not start with "-"/,
+      );
+    }
+  });
+
+  it("accepts safe requirements paths", () => {
+    expect(() => assertNoFlagInjection("requirements.txt", "requirements")).not.toThrow();
+    expect(() => assertNoFlagInjection("reqs/dev.txt", "requirements")).not.toThrow();
+  });
+});
+
+describe("security: pip-audit — requirements validation", () => {
+  it("rejects flag-like requirements path", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "requirements")).toThrow(
+        /must not start with "-"/,
+      );
+    }
+  });
+});
+
+describe("security: uv-install — packages and requirements validation", () => {
+  it("rejects flag-like packages", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "packages")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("rejects flag-like requirements path", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "requirements")).toThrow(
+        /must not start with "-"/,
+      );
+    }
+  });
+});

--- a/packages/server-python/src/tools/black.ts
+++ b/packages/server-python/src/tools/black.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { black } from "../lib/python-runner.js";
 import { parseBlackOutput } from "../lib/parsers.js";
 import { formatBlack } from "../lib/formatters.js";
@@ -30,6 +30,9 @@ export function registerBlackTool(server: McpServer) {
     },
     async ({ path, targets, check }) => {
       const cwd = path || process.cwd();
+      for (const t of targets ?? []) {
+        assertNoFlagInjection(t, "targets");
+      }
       const args = [...(targets || ["."])];
       if (check) args.push("--check");
 

--- a/packages/server-python/src/tools/mypy.ts
+++ b/packages/server-python/src/tools/mypy.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { mypy } from "../lib/python-runner.js";
 import { parseMypyOutput } from "../lib/parsers.js";
 import { formatMypy } from "../lib/formatters.js";
@@ -25,6 +25,9 @@ export function registerMypyTool(server: McpServer) {
     },
     async ({ path, targets }) => {
       const cwd = path || process.cwd();
+      for (const t of targets ?? []) {
+        assertNoFlagInjection(t, "targets");
+      }
       const args = [...(targets || ["."])];
 
       const result = await mypy(args, cwd);

--- a/packages/server-python/src/tools/pip-audit.ts
+++ b/packages/server-python/src/tools/pip-audit.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { parsePipAuditJson } from "../lib/parsers.js";
 import { formatPipAudit } from "../lib/formatters.js";
 import { PipAuditResultSchema } from "../schemas/index.js";
@@ -20,6 +20,8 @@ export function registerPipAuditTool(server: McpServer) {
     },
     async ({ path, requirements }) => {
       const cwd = path || process.cwd();
+      if (requirements) assertNoFlagInjection(requirements, "requirements");
+
       const args = ["audit", "--format", "json"];
       if (requirements) args.push("-r", requirements);
 

--- a/packages/server-python/src/tools/pip-install.ts
+++ b/packages/server-python/src/tools/pip-install.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { pip } from "../lib/python-runner.js";
 import { parsePipInstall } from "../lib/parsers.js";
 import { formatPipInstall } from "../lib/formatters.js";
@@ -26,6 +26,11 @@ export function registerPipInstallTool(server: McpServer) {
     },
     async ({ packages, requirements, path }) => {
       const cwd = path || process.cwd();
+      for (const p of packages ?? []) {
+        assertNoFlagInjection(p, "packages");
+      }
+      if (requirements) assertNoFlagInjection(requirements, "requirements");
+
       const args = ["install"];
       if (requirements) {
         args.push("-r", requirements);

--- a/packages/server-python/src/tools/pytest.ts
+++ b/packages/server-python/src/tools/pytest.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { pytest } from "../lib/python-runner.js";
 import { parsePytestOutput } from "../lib/parsers.js";
 import { formatPytest } from "../lib/formatters.js";
@@ -27,6 +27,11 @@ export function registerPytestTool(server: McpServer) {
     },
     async ({ path, targets, markers, verbose, exitFirst }) => {
       const cwd = path || process.cwd();
+      for (const t of targets ?? []) {
+        assertNoFlagInjection(t, "targets");
+      }
+      if (markers) assertNoFlagInjection(markers, "markers");
+
       const args = ["--tb=short", "-q"];
 
       if (verbose) args.splice(args.indexOf("-q"), 1, "-v");

--- a/packages/server-python/src/tools/ruff.ts
+++ b/packages/server-python/src/tools/ruff.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { ruff } from "../lib/python-runner.js";
 import { parseRuffJson } from "../lib/parsers.js";
 import { formatRuff } from "../lib/formatters.js";
@@ -26,6 +26,9 @@ export function registerRuffTool(server: McpServer) {
     },
     async ({ path, targets, fix }) => {
       const cwd = path || process.cwd();
+      for (const t of targets ?? []) {
+        assertNoFlagInjection(t, "targets");
+      }
       const args = ["check", "--output-format", "json", ...(targets || ["."])];
       if (fix) args.push("--fix");
 

--- a/packages/server-python/src/tools/uv-install.ts
+++ b/packages/server-python/src/tools/uv-install.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
 import { uv } from "../lib/python-runner.js";
 import { parseUvInstall } from "../lib/parsers.js";
 import { formatUvInstall } from "../lib/formatters.js";
@@ -22,6 +22,11 @@ export function registerUvInstallTool(server: McpServer) {
     },
     async ({ path, packages, requirements }) => {
       const cwd = path || process.cwd();
+      for (const p of packages ?? []) {
+        assertNoFlagInjection(p, "packages");
+      }
+      if (requirements) assertNoFlagInjection(requirements, "requirements");
+
       const args = ["pip", "install"];
 
       if (requirements) {

--- a/packages/server-test/__tests__/security.test.ts
+++ b/packages/server-test/__tests__/security.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Security tests: verify that assertNoFlagInjection() prevents flag injection
+ * attacks on user-supplied parameters in the test runner tool.
+ *
+ * The run tool accepts an args array that gets spread into CLI arguments for
+ * the detected test framework (pytest, jest, vitest, mocha). Without
+ * validation, a malicious input like "--bail" or "--exec" could be
+ * interpreted as a flag.
+ */
+import { describe, it, expect } from "vitest";
+import { assertNoFlagInjection } from "@paretools/shared";
+
+/** Malicious inputs that must be rejected by every guarded parameter. */
+const MALICIOUS_INPUTS = [
+  "--bail",
+  "--exec",
+  "-u",
+  "--updateSnapshot",
+  "--coverage",
+  "--config",
+  "--reporter",
+  "--outputFile",
+  "-x",
+  // Whitespace bypass attempts
+  " --bail",
+  "\t--exec",
+  "   -u",
+];
+
+/** Safe inputs that must be accepted. */
+const SAFE_INPUTS = [
+  "tests/",
+  "src/",
+  "test_file.py",
+  "MyTest",
+  "integration",
+  "unit",
+  "*.test.ts",
+  "login.spec.js",
+];
+
+describe("security: test run — args validation", () => {
+  it("rejects flag-like args", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "args")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe args values", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "args")).not.toThrow();
+    }
+  });
+
+  it("includes the parameter name in the error message", () => {
+    expect(() => assertNoFlagInjection("--bail", "args")).toThrow(/args/);
+  });
+
+  it("includes the invalid value in the error message", () => {
+    expect(() => assertNoFlagInjection("--bail", "args")).toThrow(/--bail/);
+    expect(() => assertNoFlagInjection("-x", "args")).toThrow(/-x/);
+  });
+});

--- a/packages/server-test/src/tools/run.ts
+++ b/packages/server-test/src/tools/run.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, run } from "@paretools/shared";
+import { dualOutput, run, assertNoFlagInjection } from "@paretools/shared";
 import { detectFramework, type Framework } from "../lib/detect.js";
 import { parsePytestOutput } from "../lib/parsers/pytest.js";
 import { parseJestJson } from "../lib/parsers/jest.js";
@@ -57,6 +57,10 @@ export function registerRunTool(server: McpServer) {
       outputSchema: TestRunSchema,
     },
     async ({ path, framework, filter, updateSnapshots, args }) => {
+      for (const a of args ?? []) {
+        assertNoFlagInjection(a, "args");
+      }
+
       const cwd = path || process.cwd();
       const detected = framework || (await detectFramework(cwd));
       const extraArgs = [...(args || [])];


### PR DESCRIPTION
## Summary

- **SEC-001 (Critical)**: Adds `assertNoFlagInjection` validation to every element of `args[]`/`command[]`/`buildArgs[]` arrays in 13+ tools across 6 servers (server-docker, server-npm, server-cargo, server-go, server-build, server-test) before they are spread into CLI arguments
- **SEC-006 (Medium)**: Adds `assertNoFlagInjection` to ~40 individual string parameters (package names, test filters, file patterns, requirements paths, etc.) that were missing validation across server-cargo, server-go, server-python, server-lint, and server-build
- **SEC-011 (Related)**: Creates `security.test.ts` for 6 servers that were missing them (server-cargo, server-go, server-npm, server-python, server-lint, server-test), modeled after existing tests in server-git, server-docker, and server-build

### Affected servers and parameters

| Server | Tool | Parameter(s) validated |
|--------|------|----------------------|
| server-docker | build | `args[]` |
| server-docker | exec | `command[0]` (binary name) |
| server-docker | run | `command[0]` (binary name) |
| server-npm | install | `args[]` |
| server-npm | test | `args[]` |
| server-npm | run | `args[]` |
| server-cargo | run | `args[]` |
| server-cargo | check | `package` |
| server-cargo | test | `filter` |
| server-cargo | add | `features[]` |
| server-go | run | `buildArgs[]` |
| server-go | build | `packages[]` |
| server-go | test | `packages[]`, `run` |
| server-go | vet | `packages[]` |
| server-go | generate | `patterns[]` |
| server-go | fmt | `patterns[]` |
| server-build | esbuild | `args[]` |
| server-build | vite-build | `args[]`, `mode` |
| server-build | webpack | `args[]`, `config` |
| server-build | tsc | `project` |
| server-test | run | `args[]` |
| server-python | pytest | `targets[]`, `markers` |
| server-python | black | `targets[]` |
| server-python | mypy | `targets[]` |
| server-python | ruff | `targets[]` |
| server-python | pip-install | `packages[]`, `requirements` |
| server-python | pip-audit | `requirements` |
| server-python | uv-install | `packages[]`, `requirements` |
| server-lint | lint | `patterns[]` |
| server-lint | biome-check | `patterns[]` |
| server-lint | biome-format | `patterns[]` |
| server-lint | prettier-format | `patterns[]` |
| server-lint | format-check | `patterns[]` |

### Design decisions

- **Docker exec/run `command[]`**: Only the first element (binary name) is validated. Subsequent elements are intentionally unchecked as they are arguments to the command itself.
- **Args after `--` separator** (npm test/run, cargo run): Validated as defense-in-depth even though `--` tells the CLI to treat everything after as positional.

Closes #125, closes #130, closes #135

## Test plan

- [x] `pnpm build` passes (all 10 packages compile)
- [x] `pnpm test` passes (all 20 test tasks, including 6 new security test files)
- [x] Updated `tool-params.test.ts` in server-test to use non-flag args and added test verifying flag-like args are rejected
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)