### PR TITLE
fix: harden Windows cmd.exe escaping and add Zod input length limits

### DIFF
--- a/packages/server-build/src/tools/build.ts
+++ b/packages/server-build/src/tools/build.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertAllowedCommand } from "@paretools/shared";
+import { dualOutput, assertAllowedCommand, INPUT_LIMITS } from "@paretools/shared";
 import { runBuildCommand } from "../lib/build-runner.js";
 import { parseBuildCommandOutput } from "../lib/parsers.js";
 import { formatBuildCommand } from "../lib/formatters.js";
@@ -14,12 +14,20 @@ export function registerBuildTool(server: McpServer) {
       description:
         "Runs a build command and returns structured success/failure with errors and warnings. Use instead of running build commands in the terminal.",
       inputSchema: {
-        command: z.string().describe("Build command to run (e.g., 'npm', 'npx', 'pnpm')"),
+        command: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .describe("Build command to run (e.g., 'npm', 'npx', 'pnpm')"),
         args: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .default([])
           .describe("Arguments for the build command (e.g., ['run', 'build'])"),
-        path: z.string().optional().describe("Working directory (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
       },
       outputSchema: BuildResultSchema,
     },

--- a/packages/server-build/src/tools/esbuild.ts
+++ b/packages/server-build/src/tools/esbuild.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { esbuildCmd } from "../lib/build-runner.js";
 import { parseEsbuildOutput } from "../lib/parsers.js";
 import { formatEsbuild } from "../lib/formatters.js";
@@ -14,12 +14,21 @@ export function registerEsbuildTool(server: McpServer) {
       description:
         "Runs the esbuild bundler and returns structured errors, warnings, and output files. Use instead of running `esbuild` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         entryPoints: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .describe("Entry point files to bundle (e.g., ['src/index.ts'])"),
-        outdir: z.string().optional().describe("Output directory"),
-        outfile: z.string().optional().describe("Output file (single entry point)"),
+        outdir: z.string().max(INPUT_LIMITS.PATH_MAX).optional().describe("Output directory"),
+        outfile: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Output file (single entry point)"),
         bundle: z
           .boolean()
           .optional()
@@ -39,7 +48,12 @@ export function registerEsbuildTool(server: McpServer) {
           .optional()
           .default(false)
           .describe("Generate source maps (default: false)"),
-        args: z.array(z.string()).optional().default([]).describe("Additional esbuild flags"),
+        args: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default([])
+          .describe("Additional esbuild flags"),
       },
       outputSchema: EsbuildResultSchema,
     },

--- a/packages/server-build/src/tools/tsc.ts
+++ b/packages/server-build/src/tools/tsc.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { tsc } from "../lib/build-runner.js";
 import { parseTscOutput } from "../lib/parsers.js";
 import { formatTsc } from "../lib/formatters.js";
@@ -14,13 +14,17 @@ export function registerTscTool(server: McpServer) {
       description:
         "Runs the TypeScript compiler and returns structured diagnostics (file, line, column, code, message). Use instead of running `tsc` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         noEmit: z
           .boolean()
           .optional()
           .default(true)
           .describe("Skip emitting output files (default: true)"),
-        project: z.string().optional().describe("Path to tsconfig.json"),
+        project: z.string().max(INPUT_LIMITS.PATH_MAX).optional().describe("Path to tsconfig.json"),
       },
       outputSchema: TscResultSchema,
     },

--- a/packages/server-build/src/tools/vite-build.ts
+++ b/packages/server-build/src/tools/vite-build.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { viteCmd } from "../lib/build-runner.js";
 import { parseViteBuildOutput } from "../lib/parsers.js";
 import { formatViteBuild } from "../lib/formatters.js";
@@ -14,13 +14,23 @@ export function registerViteBuildTool(server: McpServer) {
       description:
         "Runs Vite production build and returns structured output files with sizes. Use instead of running `vite build` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         mode: z
           .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .default("production")
           .describe("Build mode (default: production)"),
-        args: z.array(z.string()).optional().default([]).describe("Additional Vite build flags"),
+        args: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default([])
+          .describe("Additional Vite build flags"),
       },
       outputSchema: ViteBuildResultSchema,
     },

--- a/packages/server-build/src/tools/webpack.ts
+++ b/packages/server-build/src/tools/webpack.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { webpackCmd } from "../lib/build-runner.js";
 import { parseWebpackOutput } from "../lib/parsers.js";
 import { formatWebpack } from "../lib/formatters.js";
@@ -14,13 +14,26 @@ export function registerWebpackTool(server: McpServer) {
       description:
         "Runs webpack build with JSON stats output and returns structured assets, errors, and warnings. Use instead of running `webpack` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
-        config: z.string().optional().describe("Path to webpack config file"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        config: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to webpack config file"),
         mode: z
           .enum(["production", "development", "none"])
           .optional()
           .describe("Build mode (production, development, none)"),
-        args: z.array(z.string()).optional().default([]).describe("Additional webpack flags"),
+        args: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default([])
+          .describe("Additional webpack flags"),
       },
       outputSchema: WebpackResultSchema,
     },

--- a/packages/server-cargo/src/tools/add.ts
+++ b/packages/server-cargo/src/tools/add.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoAddOutput } from "../lib/parsers.js";
 import { formatCargoAdd } from "../lib/formatters.js";
@@ -17,11 +17,19 @@ export function registerAddTool(server: McpServer) {
         "WARNING: Adding crates downloads and compiles third-party code which may include build scripts (build.rs). " +
         "Only add trusted crates. Use dryRun to preview changes before committing.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
-        packages: z.array(z.string()).describe('Packages to add (e.g. ["serde", "tokio@1.0"])'),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        packages: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .describe('Packages to add (e.g. ["serde", "tokio@1.0"])'),
         dev: z.boolean().optional().default(false).describe("Add as dev dependency (--dev)"),
         features: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .describe('Features to enable (e.g. ["derive", "full"])'),
         dryRun: z

--- a/packages/server-cargo/src/tools/build.ts
+++ b/packages/server-cargo/src/tools/build.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoBuildJson } from "../lib/parsers.js";
 import { formatCargoBuild } from "../lib/formatters.js";
@@ -14,7 +14,11 @@ export function registerBuildTool(server: McpServer) {
       description:
         "Runs cargo build and returns structured diagnostics (file, line, code, severity, message). Use instead of running `cargo build` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         release: z.boolean().optional().default(false).describe("Build in release mode"),
       },
       outputSchema: CargoBuildResultSchema,

--- a/packages/server-cargo/src/tools/check.ts
+++ b/packages/server-cargo/src/tools/check.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoBuildJson } from "../lib/parsers.js";
 import { formatCargoBuild } from "../lib/formatters.js";
@@ -14,8 +14,16 @@ export function registerCheckTool(server: McpServer) {
       description:
         "Runs cargo check (type check without full build) and returns structured diagnostics. Faster than build for error checking. Use instead of running `cargo check` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
-        package: z.string().optional().describe("Package to check in a workspace"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        package: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Package to check in a workspace"),
       },
       outputSchema: CargoBuildResultSchema,
     },

--- a/packages/server-cargo/src/tools/clippy.ts
+++ b/packages/server-cargo/src/tools/clippy.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoClippyJson } from "../lib/parsers.js";
 import { formatCargoClippy } from "../lib/formatters.js";
@@ -14,7 +14,11 @@ export function registerClippyTool(server: McpServer) {
       description:
         "Runs cargo clippy and returns structured lint diagnostics. Use instead of running `cargo clippy` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
       },
       outputSchema: CargoClippyResultSchema,
     },

--- a/packages/server-cargo/src/tools/doc.ts
+++ b/packages/server-cargo/src/tools/doc.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoDocOutput } from "../lib/parsers.js";
 import { formatCargoDoc } from "../lib/formatters.js";
@@ -14,7 +14,11 @@ export function registerDocTool(server: McpServer) {
       description:
         "Generates Rust documentation and returns structured output with warning count. Use instead of running `cargo doc` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         open: z
           .boolean()
           .optional()

--- a/packages/server-cargo/src/tools/fmt.ts
+++ b/packages/server-cargo/src/tools/fmt.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoFmtOutput } from "../lib/parsers.js";
 import { formatCargoFmt } from "../lib/formatters.js";
@@ -14,7 +14,11 @@ export function registerFmtTool(server: McpServer) {
       description:
         "Checks or fixes Rust formatting and returns structured output. Use instead of running `cargo fmt` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         check: z
           .boolean()
           .optional()

--- a/packages/server-cargo/src/tools/remove.ts
+++ b/packages/server-cargo/src/tools/remove.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoRemoveOutput } from "../lib/parsers.js";
 import { formatCargoRemove } from "../lib/formatters.js";
@@ -14,8 +14,15 @@ export function registerRemoveTool(server: McpServer) {
       description:
         "Removes dependencies from a Rust project and returns structured output. Use instead of running `cargo remove` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
-        packages: z.array(z.string()).describe("Package names to remove"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        packages: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .describe("Package names to remove"),
         dev: z.boolean().optional().default(false).describe("Remove from dev dependencies (--dev)"),
       },
       outputSchema: CargoRemoveResultSchema,

--- a/packages/server-cargo/src/tools/run.ts
+++ b/packages/server-cargo/src/tools/run.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoRunOutput } from "../lib/parsers.js";
 import { formatCargoRun } from "../lib/formatters.js";
@@ -14,10 +14,22 @@ export function registerRunTool(server: McpServer) {
       description:
         "Runs a cargo binary and returns structured output (exit code, stdout, stderr). Use instead of running `cargo run` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
-        args: z.array(z.string()).optional().describe("Arguments to pass to the binary (after --)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        args: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Arguments to pass to the binary (after --)"),
         release: z.boolean().optional().default(false).describe("Run in release mode"),
-        package: z.string().optional().describe("Package to run in a workspace"),
+        package: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Package to run in a workspace"),
       },
       outputSchema: CargoRunResultSchema,
     },

--- a/packages/server-cargo/src/tools/test.ts
+++ b/packages/server-cargo/src/tools/test.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoTestOutput } from "../lib/parsers.js";
 import { formatCargoTest } from "../lib/formatters.js";
@@ -14,8 +14,16 @@ export function registerTestTool(server: McpServer) {
       description:
         "Runs cargo test and returns structured test results (name, status, pass/fail counts). Use instead of running `cargo test` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
-        filter: z.string().optional().describe("Test name filter pattern"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        filter: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Test name filter pattern"),
       },
       outputSchema: CargoTestResultSchema,
     },

--- a/packages/server-docker/src/tools/build.ts
+++ b/packages/server-docker/src/tools/build.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { docker } from "../lib/docker-runner.js";
 import { parseBuildOutput } from "../lib/parsers.js";
 import { formatBuild } from "../lib/formatters.js";
@@ -14,10 +14,27 @@ export function registerBuildTool(server: McpServer) {
       description:
         "Builds a Docker image and returns structured build results including image ID, duration, and errors. Use instead of running `docker build` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Build context path (default: cwd)"),
-        tag: z.string().optional().describe("Image tag (e.g., myapp:latest)"),
-        file: z.string().optional().describe("Dockerfile path (default: Dockerfile)"),
-        args: z.array(z.string()).optional().default([]).describe("Additional build arguments"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Build context path (default: cwd)"),
+        tag: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Image tag (e.g., myapp:latest)"),
+        file: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Dockerfile path (default: Dockerfile)"),
+        args: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default([])
+          .describe("Additional build arguments"),
       },
       outputSchema: DockerBuildSchema,
     },

--- a/packages/server-docker/src/tools/compose-down.ts
+++ b/packages/server-docker/src/tools/compose-down.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { docker } from "../lib/docker-runner.js";
 import { parseComposeDownOutput } from "../lib/parsers.js";
 import { formatComposeDown } from "../lib/formatters.js";
@@ -14,7 +14,10 @@ export function registerComposeDownTool(server: McpServer) {
       description:
         "Stops Docker Compose services and returns structured status. Use instead of running `docker compose down` in the terminal.",
       inputSchema: {
-        path: z.string().describe("Directory containing docker-compose.yml"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .describe("Directory containing docker-compose.yml"),
         volumes: z
           .boolean()
           .optional()
@@ -25,7 +28,11 @@ export function registerComposeDownTool(server: McpServer) {
           .optional()
           .default(false)
           .describe("Remove orphan containers (default: false)"),
-        file: z.string().optional().describe("Compose file path (default: docker-compose.yml)"),
+        file: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Compose file path (default: docker-compose.yml)"),
       },
       outputSchema: DockerComposeDownSchema,
     },

--- a/packages/server-docker/src/tools/compose-up.ts
+++ b/packages/server-docker/src/tools/compose-up.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { docker } from "../lib/docker-runner.js";
 import { parseComposeUpOutput } from "../lib/parsers.js";
 import { formatComposeUp } from "../lib/formatters.js";
@@ -14,9 +14,13 @@ export function registerComposeUpTool(server: McpServer) {
       description:
         "Starts Docker Compose services and returns structured status. Use instead of running `docker compose up` in the terminal.",
       inputSchema: {
-        path: z.string().describe("Directory containing docker-compose.yml"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .describe("Directory containing docker-compose.yml"),
         services: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
           .describe("Specific services to start (default: all)"),
@@ -26,7 +30,11 @@ export function registerComposeUpTool(server: McpServer) {
           .optional()
           .default(false)
           .describe("Build images before starting (default: false)"),
-        file: z.string().optional().describe("Compose file path (default: docker-compose.yml)"),
+        file: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Compose file path (default: docker-compose.yml)"),
       },
       outputSchema: DockerComposeUpSchema,
     },

--- a/packages/server-docker/src/tools/images.ts
+++ b/packages/server-docker/src/tools/images.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { docker } from "../lib/docker-runner.js";
 import { parseImagesJson } from "../lib/parsers.js";
 import { formatImages } from "../lib/formatters.js";
@@ -19,7 +19,11 @@ export function registerImagesTool(server: McpServer) {
           .optional()
           .default(false)
           .describe("Show all images including intermediates"),
-        filter: z.string().optional().describe("Filter by reference (e.g., 'myapp', 'nginx:*')"),
+        filter: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Filter by reference (e.g., 'myapp', 'nginx:*')"),
       },
       outputSchema: DockerImagesSchema,
     },

--- a/packages/server-docker/src/tools/logs.ts
+++ b/packages/server-docker/src/tools/logs.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { docker } from "../lib/docker-runner.js";
 import { parseLogsOutput } from "../lib/parsers.js";
 import { formatLogs } from "../lib/formatters.js";
@@ -14,7 +14,7 @@ export function registerLogsTool(server: McpServer) {
       description:
         "Retrieves container logs as structured line arrays. Use instead of running `docker logs` in the terminal.",
       inputSchema: {
-        container: z.string().describe("Container name or ID"),
+        container: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Container name or ID"),
         tail: z
           .number()
           .optional()
@@ -22,6 +22,7 @@ export function registerLogsTool(server: McpServer) {
           .describe("Number of lines to return (default: 100)"),
         since: z
           .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe("Show logs since timestamp (e.g., '10m', '2024-01-01')"),
       },

--- a/packages/server-docker/src/tools/pull.ts
+++ b/packages/server-docker/src/tools/pull.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { docker } from "../lib/docker-runner.js";
 import { parsePullOutput } from "../lib/parsers.js";
 import { formatPull } from "../lib/formatters.js";
@@ -14,12 +14,20 @@ export function registerPullTool(server: McpServer) {
       description:
         "Pulls a Docker image from a registry and returns structured result with digest info. Use instead of running `docker pull` in the terminal.",
       inputSchema: {
-        image: z.string().describe("Image to pull (e.g., nginx:latest, ubuntu:22.04)"),
+        image: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .describe("Image to pull (e.g., nginx:latest, ubuntu:22.04)"),
         platform: z
           .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe('Target platform (e.g., "linux/amd64", "linux/arm64")'),
-        path: z.string().optional().describe("Working directory (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
       },
       outputSchema: DockerPullSchema,
     },

--- a/packages/server-docker/src/tools/run.ts
+++ b/packages/server-docker/src/tools/run.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { docker } from "../lib/docker-runner.js";
 import { parseRunOutput } from "../lib/parsers.js";
 import { formatRun } from "../lib/formatters.js";
@@ -35,20 +35,26 @@ export function registerRunTool(server: McpServer) {
       description:
         "Runs a Docker container from an image and returns structured container ID and status. Use instead of running `docker run` in the terminal.",
       inputSchema: {
-        image: z.string().describe("Docker image to run (e.g., nginx:latest)"),
-        name: z.string().optional().describe("Container name"),
+        image: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .describe("Docker image to run (e.g., nginx:latest)"),
+        name: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Container name"),
         ports: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
           .describe('Port mappings (e.g., ["8080:80", "443:443"])'),
         volumes: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
           .describe('Volume mounts (e.g., ["/host/path:/container/path"])'),
         env: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
           .describe('Environment variables (e.g., ["KEY=VALUE"])'),
@@ -63,11 +69,16 @@ export function registerRunTool(server: McpServer) {
           .default(false)
           .describe("Remove container after exit (default: false)"),
         command: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
           .describe("Command to run in the container"),
-        path: z.string().optional().describe("Working directory (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
       },
       outputSchema: DockerRunSchema,
     },

--- a/packages/server-git/src/tools/add.ts
+++ b/packages/server-git/src/tools/add.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseAdd } from "../lib/parsers.js";
 import { formatAdd } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerAddTool(server: McpServer) {
       description:
         "Stages files for commit. Returns structured data with count and list of staged files. Use instead of running `git add` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Repository path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
         files: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .describe("File paths to stage (required unless all is true)"),
         all: z.boolean().optional().default(false).describe("Stage all changes (git add -A)"),

--- a/packages/server-git/src/tools/branch.ts
+++ b/packages/server-git/src/tools/branch.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { compactDualOutput } from "@paretools/shared";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { assertNoFlagInjection } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseBranch } from "../lib/parsers.js";
@@ -15,9 +15,21 @@ export function registerBranchTool(server: McpServer) {
       description:
         "Lists, creates, or deletes branches. Returns structured branch data. Use instead of running `git branch` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Repository path (default: cwd)"),
-        create: z.string().optional().describe("Create a new branch with this name"),
-        delete: z.string().optional().describe("Delete branch with this name"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        create: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Create a new branch with this name"),
+        delete: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Delete branch with this name"),
         all: z.boolean().optional().default(false).describe("Include remote branches"),
         compact: z
           .boolean()

--- a/packages/server-git/src/tools/checkout.ts
+++ b/packages/server-git/src/tools/checkout.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseCheckout } from "../lib/parsers.js";
 import { formatCheckout } from "../lib/formatters.js";
@@ -14,8 +14,15 @@ export function registerCheckoutTool(server: McpServer) {
       description:
         "Switches branches or restores files. Returns structured data with ref, previous ref, and whether a new branch was created. Use instead of running `git checkout` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Repository path (default: cwd)"),
-        ref: z.string().describe("Branch name, tag, or commit to checkout"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        ref: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .describe("Branch name, tag, or commit to checkout"),
         create: z.boolean().optional().default(false).describe("Create a new branch (-b)"),
       },
       outputSchema: GitCheckoutSchema,

--- a/packages/server-git/src/tools/commit.ts
+++ b/packages/server-git/src/tools/commit.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseCommit } from "../lib/parsers.js";
 import { formatCommit } from "../lib/formatters.js";
@@ -14,8 +14,12 @@ export function registerCommitTool(server: McpServer) {
       description:
         "Creates a commit with the given message. Returns structured data with hash, message, and change statistics. Use instead of running `git commit` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Repository path (default: cwd)"),
-        message: z.string().describe("Commit message"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        message: z.string().max(INPUT_LIMITS.MESSAGE_MAX).describe("Commit message"),
         amend: z.boolean().optional().default(false).describe("Amend the previous commit"),
       },
       outputSchema: GitCommitSchema,

--- a/packages/server-git/src/tools/diff.ts
+++ b/packages/server-git/src/tools/diff.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { compactDualOutput } from "@paretools/shared";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { assertNoFlagInjection } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseDiffStat } from "../lib/parsers.js";
@@ -15,10 +15,22 @@ export function registerDiffTool(server: McpServer) {
       description:
         "Returns file-level diff statistics as structured data. Use full=true for patch content. Use instead of running `git diff` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Repository path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
         staged: z.boolean().optional().default(false).describe("Show staged changes (--cached)"),
-        ref: z.string().optional().describe("Compare against a specific ref (branch, tag, commit)"),
-        file: z.string().optional().describe("Limit diff to a specific file"),
+        ref: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Compare against a specific ref (branch, tag, commit)"),
+        file: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Limit diff to a specific file"),
         full: z
           .boolean()
           .optional()

--- a/packages/server-git/src/tools/log.ts
+++ b/packages/server-git/src/tools/log.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { compactDualOutput } from "@paretools/shared";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { assertNoFlagInjection } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseLog } from "../lib/parsers.js";
@@ -18,14 +18,26 @@ export function registerLogTool(server: McpServer) {
       description:
         "Returns commit history as structured data. Use instead of running `git log` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Repository path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
         maxCount: z
           .number()
           .optional()
           .default(10)
           .describe("Number of commits to return (default: 10)"),
-        ref: z.string().optional().describe("Branch, tag, or commit to start from"),
-        author: z.string().optional().describe("Filter by author name or email"),
+        ref: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Branch, tag, or commit to start from"),
+        author: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Filter by author name or email"),
         compact: z
           .boolean()
           .optional()

--- a/packages/server-git/src/tools/pull.ts
+++ b/packages/server-git/src/tools/pull.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parsePull } from "../lib/parsers.js";
 import { formatPull } from "../lib/formatters.js";
@@ -14,9 +14,22 @@ export function registerPullTool(server: McpServer) {
       description:
         "Pulls changes from a remote repository. Returns structured data with success status, summary, change statistics, and any conflicts. Use instead of running `git pull` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Repository path (default: cwd)"),
-        remote: z.string().optional().default("origin").describe('Remote name (default: "origin")'),
-        branch: z.string().optional().describe("Branch to pull (default: current tracking branch)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        remote: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .default("origin")
+          .describe('Remote name (default: "origin")'),
+        branch: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Branch to pull (default: current tracking branch)"),
         rebase: z
           .boolean()
           .optional()

--- a/packages/server-git/src/tools/push.ts
+++ b/packages/server-git/src/tools/push.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parsePush } from "../lib/parsers.js";
 import { formatPush } from "../lib/formatters.js";
@@ -14,9 +14,22 @@ export function registerPushTool(server: McpServer) {
       description:
         "Pushes commits to a remote repository. Returns structured data with success status, remote, branch, and summary. Use instead of running `git push` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Repository path (default: cwd)"),
-        remote: z.string().optional().default("origin").describe('Remote name (default: "origin")'),
-        branch: z.string().optional().describe("Branch to push (default: current branch)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        remote: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .default("origin")
+          .describe('Remote name (default: "origin")'),
+        branch: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Branch to push (default: current branch)"),
         force: z.boolean().optional().default(false).describe("Force push (--force)"),
         setUpstream: z.boolean().optional().default(false).describe("Set upstream tracking (-u)"),
       },

--- a/packages/server-git/src/tools/show.ts
+++ b/packages/server-git/src/tools/show.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { compactDualOutput } from "@paretools/shared";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { assertNoFlagInjection } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseShow } from "../lib/parsers.js";
@@ -18,9 +18,14 @@ export function registerShowTool(server: McpServer) {
       description:
         "Shows commit details and diff statistics for a given ref. Use instead of running `git show` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Repository path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
         ref: z
           .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .default("HEAD")
           .describe("Commit hash, branch, or tag (default: HEAD)"),

--- a/packages/server-git/src/tools/status.ts
+++ b/packages/server-git/src/tools/status.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseStatus } from "../lib/parsers.js";
 import { formatStatus } from "../lib/formatters.js";
@@ -14,7 +14,11 @@ export function registerStatusTool(server: McpServer) {
       description:
         "Returns the working tree status as structured data (branch, staged, modified, untracked, conflicts). Use instead of running `git status` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Repository path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
       },
       outputSchema: GitStatusSchema,
     },

--- a/packages/server-go/src/tools/build.ts
+++ b/packages/server-go/src/tools/build.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoBuildOutput } from "../lib/parsers.js";
 import { formatGoBuild } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerBuildTool(server: McpServer) {
       description:
         "Runs go build and returns structured error list (file, line, column, message). Use instead of running `go build` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         packages: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["./..."])
           .describe("Packages to build (default: ./...)"),

--- a/packages/server-go/src/tools/fmt.ts
+++ b/packages/server-go/src/tools/fmt.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { gofmtCmd } from "../lib/go-runner.js";
 import { parseGoFmtOutput } from "../lib/parsers.js";
 import { formatGoFmt } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerFmtTool(server: McpServer) {
       description:
         "Checks or fixes Go source formatting using gofmt. In check mode (-l), lists unformatted files. In fix mode (-w), rewrites files. Use instead of running `gofmt` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         patterns: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["."])
           .describe("File patterns to format (default: ['.'])"),

--- a/packages/server-go/src/tools/generate.ts
+++ b/packages/server-go/src/tools/generate.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoGenerateOutput } from "../lib/parsers.js";
 import { formatGoGenerate } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerGenerateTool(server: McpServer) {
       description:
         "Runs go generate directives in Go source files. Use instead of running `go generate` in the terminal. WARNING: `go generate` executes arbitrary commands embedded in //go:generate directives in source files. Only use this tool on trusted code that you have reviewed.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         patterns: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["./..."])
           .describe("Packages to generate (default: ./...)"),

--- a/packages/server-go/src/tools/mod-tidy.ts
+++ b/packages/server-go/src/tools/mod-tidy.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoModTidyOutput } from "../lib/parsers.js";
 import { formatGoModTidy } from "../lib/formatters.js";
@@ -14,7 +14,11 @@ export function registerModTidyTool(server: McpServer) {
       description:
         "Runs go mod tidy to add missing and remove unused module dependencies. Use instead of running `go mod tidy` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
       },
       outputSchema: GoModTidyResultSchema,
     },

--- a/packages/server-go/src/tools/run.ts
+++ b/packages/server-go/src/tools/run.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoRunOutput } from "../lib/parsers.js";
 import { formatGoRun } from "../lib/formatters.js";
@@ -14,15 +14,26 @@ export function registerRunTool(server: McpServer) {
       description:
         "Runs a Go program and returns structured output (stdout, stderr, exit code). Use instead of running `go run` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
-        file: z.string().optional().default(".").describe("Go file or package to run (default: .)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        file: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .default(".")
+          .describe("Go file or package to run (default: .)"),
         args: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
           .describe("Arguments to pass to the program"),
         buildArgs: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
           .describe("Build flags to pass to go run (e.g., -race, -tags)"),

--- a/packages/server-go/src/tools/test.ts
+++ b/packages/server-go/src/tools/test.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoTestJson } from "../lib/parsers.js";
 import { formatGoTest } from "../lib/formatters.js";
@@ -14,13 +14,22 @@ export function registerTestTool(server: McpServer) {
       description:
         "Runs go test and returns structured test results (name, status, package, elapsed). Use instead of running `go test` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         packages: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["./..."])
           .describe("Packages to test (default: ./...)"),
-        run: z.string().optional().describe("Test name filter regex"),
+        run: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Test name filter regex"),
       },
       outputSchema: GoTestResultSchema,
     },

--- a/packages/server-go/src/tools/vet.ts
+++ b/packages/server-go/src/tools/vet.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoVetOutput } from "../lib/parsers.js";
 import { formatGoVet } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerVetTool(server: McpServer) {
       description:
         "Runs go vet and returns structured static analysis diagnostics. Use instead of running `go vet` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         packages: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["./..."])
           .describe("Packages to vet (default: ./...)"),

--- a/packages/server-lint/src/tools/biome-check.ts
+++ b/packages/server-lint/src/tools/biome-check.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { biome } from "../lib/lint-runner.js";
 import { parseBiomeJson } from "../lib/parsers.js";
 import { formatLint } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerBiomeCheckTool(server: McpServer) {
       description:
         "Runs Biome check (lint + format) and returns structured diagnostics (file, line, rule, severity, message). Use instead of running `biome check` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         patterns: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["."])
           .describe("File patterns to check (default: ['.'])"),

--- a/packages/server-lint/src/tools/biome-format.ts
+++ b/packages/server-lint/src/tools/biome-format.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { biome } from "../lib/lint-runner.js";
 import { parseBiomeFormat } from "../lib/parsers.js";
 import { formatFormatWrite } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerBiomeFormatTool(server: McpServer) {
       description:
         "Formats files with Biome (format --write) and returns a structured list of changed files. Use instead of running `biome format --write` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         patterns: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["."])
           .describe("File patterns to format (default: ['.'])"),

--- a/packages/server-lint/src/tools/format-check.ts
+++ b/packages/server-lint/src/tools/format-check.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { prettier } from "../lib/lint-runner.js";
 import { parsePrettierCheck } from "../lib/parsers.js";
 import { formatFormatCheck } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerFormatCheckTool(server: McpServer) {
       description:
         "Checks if files are formatted and returns a structured list of files needing formatting. Use instead of running `prettier --check` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         patterns: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["."])
           .describe("File patterns to check (default: ['.'])"),

--- a/packages/server-lint/src/tools/lint.ts
+++ b/packages/server-lint/src/tools/lint.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { eslint } from "../lib/lint-runner.js";
 import { parseEslintJson } from "../lib/parsers.js";
 import { formatLint } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerLintTool(server: McpServer) {
       description:
         "Runs ESLint and returns structured diagnostics (file, line, rule, severity, message). Use instead of running `eslint` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         patterns: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["."])
           .describe("File patterns to lint (default: ['.'])"),

--- a/packages/server-lint/src/tools/prettier-format.ts
+++ b/packages/server-lint/src/tools/prettier-format.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { prettier } from "../lib/lint-runner.js";
 import { parsePrettierWrite } from "../lib/parsers.js";
 import { formatFormatWrite } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerPrettierFormatTool(server: McpServer) {
       description:
         "Formats files with Prettier (--write) and returns a structured list of changed files. Use instead of running `prettier --write` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         patterns: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["."])
           .describe("File patterns to format (default: ['.'])"),

--- a/packages/server-npm/src/tools/audit.ts
+++ b/packages/server-npm/src/tools/audit.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { npm } from "../lib/npm-runner.js";
 import { parseAuditJson } from "../lib/parsers.js";
 import { formatAudit } from "../lib/formatters.js";
@@ -14,7 +14,11 @@ export function registerAuditTool(server: McpServer) {
       description:
         "Runs npm audit and returns structured vulnerability data. Use instead of running `npm audit` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
       },
       outputSchema: NpmAuditSchema,
     },

--- a/packages/server-npm/src/tools/init.ts
+++ b/packages/server-npm/src/tools/init.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { npm } from "../lib/npm-runner.js";
 import { parseInitOutput } from "../lib/parsers.js";
 import { formatInit } from "../lib/formatters.js";
@@ -16,13 +16,21 @@ export function registerInitTool(server: McpServer) {
       description:
         "Initializes a new package.json in the target directory. Returns structured output with the package name, version, and path.",
       inputSchema: {
-        path: z.string().optional().describe("Directory to initialize (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Directory to initialize (default: cwd)"),
         yes: z
           .boolean()
           .optional()
           .default(true)
           .describe("Use -y flag for non-interactive init with defaults (default: true)"),
-        scope: z.string().optional().describe("npm scope for the package (e.g., '@myorg')"),
+        scope: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("npm scope for the package (e.g., '@myorg')"),
       },
       outputSchema: NpmInitSchema,
     },

--- a/packages/server-npm/src/tools/install.ts
+++ b/packages/server-npm/src/tools/install.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { npm } from "../lib/npm-runner.js";
 import { parseInstallOutput } from "../lib/parsers.js";
 import { formatInstall } from "../lib/formatters.js";
@@ -17,9 +17,14 @@ export function registerInstallTool(server: McpServer) {
         "WARNING: Installing npm packages may execute lifecycle scripts (preinstall/postinstall). " +
         "Only install trusted packages. Set ignoreScripts to true to skip lifecycle scripts.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         args: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
           .describe("Additional arguments (e.g., package names to install)"),

--- a/packages/server-npm/src/tools/list.ts
+++ b/packages/server-npm/src/tools/list.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { compactDualOutput } from "@paretools/shared";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { npm } from "../lib/npm-runner.js";
 import { parseListJson } from "../lib/parsers.js";
 import { formatList, compactListMap, formatListCompact } from "../lib/formatters.js";
@@ -14,7 +14,11 @@ export function registerListTool(server: McpServer) {
       description:
         "Lists installed packages as structured dependency data. Use instead of running `npm list` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         depth: z
           .number()
           .optional()

--- a/packages/server-npm/src/tools/outdated.ts
+++ b/packages/server-npm/src/tools/outdated.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput } from "@paretools/shared";
+import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { npm } from "../lib/npm-runner.js";
 import { parseOutdatedJson } from "../lib/parsers.js";
 import { formatOutdated } from "../lib/formatters.js";
@@ -14,7 +14,11 @@ export function registerOutdatedTool(server: McpServer) {
       description:
         "Checks for outdated packages and returns structured update information. Use instead of running `npm outdated` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
       },
       outputSchema: NpmOutdatedSchema,
     },

--- a/packages/server-npm/src/tools/run.ts
+++ b/packages/server-npm/src/tools/run.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { npm } from "../lib/npm-runner.js";
 import { parseRunOutput } from "../lib/parsers.js";
 import { formatRun } from "../lib/formatters.js";
@@ -14,10 +14,18 @@ export function registerRunTool(server: McpServer) {
       description:
         "Runs a package.json script via `npm run <script>` and returns structured output with exit code, stdout, stderr, and duration. Use instead of running `npm run` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
-        script: z.string().describe("The package.json script name to run"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        script: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .describe("The package.json script name to run"),
         args: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
           .describe("Additional arguments passed after -- to the script"),

--- a/packages/server-npm/src/tools/test.ts
+++ b/packages/server-npm/src/tools/test.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { npm } from "../lib/npm-runner.js";
 import { parseTestOutput } from "../lib/parsers.js";
 import { formatTest } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerTestTool(server: McpServer) {
       description:
         "Runs `npm test` and returns structured output with exit code, stdout, stderr, and duration. Shorthand for running the test script defined in package.json.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         args: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
           .describe("Additional arguments passed after -- to the test script"),

--- a/packages/server-python/src/tools/black.ts
+++ b/packages/server-python/src/tools/black.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { black } from "../lib/python-runner.js";
 import { parseBlackOutput } from "../lib/parsers.js";
 import { formatBlack } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerBlackTool(server: McpServer) {
       description:
         "Runs Black code formatter and returns structured results (files changed, unchanged, would reformat). Use instead of running `black` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         targets: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["."])
           .describe('Files or directories to format (default: ["."])'),

--- a/packages/server-python/src/tools/mypy.ts
+++ b/packages/server-python/src/tools/mypy.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { mypy } from "../lib/python-runner.js";
 import { parseMypyOutput } from "../lib/parsers.js";
 import { formatMypy } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerMypyTool(server: McpServer) {
       description:
         "Runs mypy and returns structured type-check diagnostics (file, line, severity, message, code). Use instead of running `mypy` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         targets: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["."])
           .describe("Files or directories to check (default: ['.'])"),

--- a/packages/server-python/src/tools/pip-audit.ts
+++ b/packages/server-python/src/tools/pip-audit.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { parsePipAuditJson } from "../lib/parsers.js";
 import { formatPipAudit } from "../lib/formatters.js";
 import { PipAuditResultSchema } from "../schemas/index.js";
@@ -13,8 +13,16 @@ export function registerPipAuditTool(server: McpServer) {
       description:
         "Runs pip-audit and returns a structured vulnerability report. Use instead of running `pip-audit` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
-        requirements: z.string().optional().describe("Path to requirements file"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        requirements: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to requirements file"),
       },
       outputSchema: PipAuditResultSchema,
     },

--- a/packages/server-python/src/tools/pip-install.ts
+++ b/packages/server-python/src/tools/pip-install.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { pip } from "../lib/python-runner.js";
 import { parsePipInstall } from "../lib/parsers.js";
 import { formatPipInstall } from "../lib/formatters.js";
@@ -18,12 +18,21 @@ export function registerPipInstallTool(server: McpServer) {
         "Only install trusted packages. Use dryRun to preview what would be installed before committing.",
       inputSchema: {
         packages: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
           .describe("Packages to install (empty for requirements.txt)"),
-        requirements: z.string().optional().describe("Path to requirements file"),
-        path: z.string().optional().describe("Working directory (default: cwd)"),
+        requirements: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to requirements file"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
         dryRun: z
           .boolean()
           .optional()

--- a/packages/server-python/src/tools/pytest.ts
+++ b/packages/server-python/src/tools/pytest.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { pytest } from "../lib/python-runner.js";
 import { parsePytestOutput } from "../lib/parsers.js";
 import { formatPytest } from "../lib/formatters.js";
@@ -14,12 +14,21 @@ export function registerPytestTool(server: McpServer) {
       description:
         "Runs pytest and returns structured test results (passed, failed, errors, skipped, failures). Use instead of running `pytest` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         targets: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .describe("Test files or directories to run (default: auto-discover)"),
-        markers: z.string().optional().describe('Pytest marker expression (e.g. "not slow")'),
+        markers: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe('Pytest marker expression (e.g. "not slow")'),
         verbose: z.boolean().optional().default(false).describe("Enable verbose output"),
         exitFirst: z.boolean().optional().default(false).describe("Stop on first failure (-x)"),
       },

--- a/packages/server-python/src/tools/ruff.ts
+++ b/packages/server-python/src/tools/ruff.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { ruff } from "../lib/python-runner.js";
 import { parseRuffJson } from "../lib/parsers.js";
 import { formatRuff } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerRuffTool(server: McpServer) {
       description:
         "Runs ruff check and returns structured lint diagnostics (file, line, code, message). Use instead of running `ruff check` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         targets: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default(["."])
           .describe("Files or directories to check (default: ['.'])"),

--- a/packages/server-python/src/tools/uv-install.ts
+++ b/packages/server-python/src/tools/uv-install.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { uv } from "../lib/python-runner.js";
 import { parseUvInstall } from "../lib/parsers.js";
 import { formatUvInstall } from "../lib/formatters.js";
@@ -17,9 +17,21 @@ export function registerUvInstallTool(server: McpServer) {
         "WARNING: Installing packages may execute arbitrary setup.py code during build. " +
         "Only install trusted packages. Use dryRun to preview what would be installed before committing.",
       inputSchema: {
-        path: z.string().optional().describe("Working directory (default: cwd)"),
-        packages: z.array(z.string()).optional().describe("Packages to install"),
-        requirements: z.string().optional().describe("Path to requirements file"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+        packages: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Packages to install"),
+        requirements: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to requirements file"),
         dryRun: z
           .boolean()
           .optional()

--- a/packages/server-python/src/tools/uv-run.ts
+++ b/packages/server-python/src/tools/uv-run.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { uv } from "../lib/python-runner.js";
 import { parseUvRun } from "../lib/parsers.js";
 import { formatUvRun } from "../lib/formatters.js";
@@ -14,9 +14,14 @@ export function registerUvRunTool(server: McpServer) {
       description:
         "Runs a command in a uv-managed environment and returns structured output. Use instead of running `uv run` in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Working directory (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
         command: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .min(1)
           .describe("Command and arguments to run (e.g. ['python', 'script.py'])"),
       },

--- a/packages/server-test/src/tools/coverage.ts
+++ b/packages/server-test/src/tools/coverage.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, run } from "@paretools/shared";
+import { dualOutput, run, INPUT_LIMITS } from "@paretools/shared";
 import { detectFramework, type Framework } from "../lib/detect.js";
 import { parsePytestCoverage } from "../lib/parsers/pytest.js";
 import { parseJestCoverage } from "../lib/parsers/jest.js";
@@ -33,7 +33,11 @@ export function registerCoverageTool(server: McpServer) {
       description:
         "Runs tests with coverage and returns structured coverage summary per file. Use instead of running test coverage commands in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         framework: z
           .enum(["pytest", "jest", "vitest", "mocha"])
           .optional()

--- a/packages/server-test/src/tools/run.ts
+++ b/packages/server-test/src/tools/run.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, run, assertNoFlagInjection } from "@paretools/shared";
+import { dualOutput, run, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { detectFramework, type Framework } from "../lib/detect.js";
 import { parsePytestOutput } from "../lib/parsers/pytest.js";
 import { parseJestJson } from "../lib/parsers/jest.js";
@@ -34,13 +34,18 @@ export function registerRunTool(server: McpServer) {
       description:
         "Auto-detects test framework (pytest/jest/vitest/mocha), runs tests, returns structured results with failures. Use instead of running pytest/jest/vitest/mocha in the terminal.",
       inputSchema: {
-        path: z.string().optional().describe("Project root path (default: cwd)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
         framework: z
           .enum(["pytest", "jest", "vitest", "mocha"])
           .optional()
           .describe("Force a specific framework instead of auto-detecting"),
         filter: z
           .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe("Test filter pattern (file path or test name pattern)"),
         updateSnapshots: z
@@ -49,7 +54,8 @@ export function registerRunTool(server: McpServer) {
           .default(false)
           .describe("Update snapshots (vitest/jest only, adds -u flag)"),
         args: z
-          .array(z.string())
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
           .describe("Additional arguments to pass to the test runner"),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export { dualOutput, estimateTokens, compactDualOutput } from "./output.js";
-export { run, type RunResult, type RunOptions } from "./runner.js";
+export { run, escapeCmdArg, type RunResult, type RunOptions } from "./runner.js";
 export { stripAnsi } from "./ansi.js";
 export { assertNoFlagInjection, assertAllowedCommand } from "./validation.js";
+export { INPUT_LIMITS } from "./limits.js";
 export type { ToolOutput } from "./types.js";

--- a/packages/shared/src/limits.ts
+++ b/packages/shared/src/limits.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared input-validation limits for all Pare MCP servers.
+ *
+ * These provide defense-in-depth against DoS via extremely long inputs.
+ * Applied to Zod input schemas with `.max()` — output schemas are NOT
+ * constrained because their size is determined by tool output, not user input.
+ */
+export const INPUT_LIMITS = {
+  /** Maximum length for any general string parameter (64 KB). */
+  STRING_MAX: 65_536,
+
+  /** Maximum items in any array parameter. */
+  ARRAY_MAX: 1_000,
+
+  /** Maximum length for file system paths. */
+  PATH_MAX: 4_096,
+
+  /** Maximum length for commit messages (generous to allow long messages). */
+  MESSAGE_MAX: 72_000,
+
+  /** Maximum length for short identifiers (branch names, package names, etc.). */
+  SHORT_STRING_MAX: 255,
+} as const;


### PR DESCRIPTION
## Summary

Addresses two findings from the security audit:

- **SEC-007 (Medium)**: Expand Windows `shell: true` cmd.exe argument escaping beyond just `%` → `%%` to also caret-escape `&`, `|`, `^`, `<`, `>`. Extracted a dedicated `escapeCmdArg()` function in `packages/shared/src/runner.ts` with comprehensive tests.
- **SEC-012 (Low)**: Add `.max()` constraints to all string and array parameters in Zod input schemas across all 9 MCP servers. Created shared `INPUT_LIMITS` constants in `packages/shared/src/limits.ts` (exported from `@paretools/shared`) and applied them systematically to every tool input schema.

### Changes

- **`packages/shared/src/runner.ts`**: Extracted `escapeCmdArg()` that escapes `%`, `^`, `&`, `|`, `<`, `>` for Windows cmd.exe. Updated `run()` to use it.
- **`packages/shared/src/limits.ts`** (new): Shared constants — `STRING_MAX` (64K), `ARRAY_MAX` (1000), `PATH_MAX` (4096), `MESSAGE_MAX` (72K), `SHORT_STRING_MAX` (255).
- **`packages/shared/src/index.ts`**: Exports `escapeCmdArg` and `INPUT_LIMITS`.
- **`packages/shared/__tests__/runner.test.ts`**: 9 new tests for `escapeCmdArg`.
- **62 tool files across 9 servers**: Added `.max(INPUT_LIMITS.*)` to all string/array input params using appropriate limit categories.

### Limit categories applied

| Limit | Value | Used for |
|-------|-------|----------|
| `PATH_MAX` | 4,096 | File paths, working directories |
| `SHORT_STRING_MAX` | 255 | Branch names, package names, container names, filters |
| `STRING_MAX` | 65,536 | General strings, command arguments |
| `MESSAGE_MAX` | 72,000 | Commit messages |
| `ARRAY_MAX` | 1,000 | All array parameters (with inner string `.max()` too) |

Closes #131
Closes #136

## Test plan

- [x] `pnpm build` — all 10 packages compile successfully
- [x] `pnpm test` — all 10 test suites pass (hundreds of tests)
- [x] New `escapeCmdArg` tests cover all metacharacters, combinations, plain strings, and empty strings
- [ ] Verify on Windows that cmd.exe escaping works correctly with shell metacharacters in arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)