### PR TITLE
fix: escape ! in cmd.exe args and sanitize error paths

### DIFF
--- a/packages/shared/__tests__/runner.test.ts
+++ b/packages/shared/__tests__/runner.test.ts
@@ -109,6 +109,15 @@ describe("escapeCmdArg", () => {
     expect(escapeCmdArg("^^^")).toBe("^^^^^^");
   });
 
+  it("escapes exclamation mark to prevent delayed expansion", () => {
+    expect(escapeCmdArg("hello!world")).toBe("hello^!world");
+    expect(escapeCmdArg("!PATH!")).toBe("^!PATH^!");
+  });
+
+  it("escapes exclamation mark combined with other metacharacters", () => {
+    expect(escapeCmdArg("!foo&bar!")).toBe("^!foo^&bar^!");
+  });
+
   it("handles newlines and tabs (not metacharacters, passed through)", () => {
     expect(escapeCmdArg("line1\nline2")).toBe("line1\nline2");
     expect(escapeCmdArg("col1\tcol2")).toBe("col1\tcol2");

--- a/packages/shared/__tests__/sanitize.test.ts
+++ b/packages/shared/__tests__/sanitize.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeErrorOutput } from "../src/sanitize.js";
+
+describe("sanitizeErrorOutput", () => {
+  it("replaces /home/<user>/ paths with ~/", () => {
+    expect(sanitizeErrorOutput("/home/dave/.gitconfig: Permission denied")).toBe(
+      "~/.gitconfig: Permission denied",
+    );
+  });
+
+  it("replaces /Users/<user>/ paths with ~/", () => {
+    expect(sanitizeErrorOutput("/Users/dave/projects/app/src/index.ts")).toBe(
+      "~/projects/app/src/index.ts",
+    );
+  });
+
+  it("replaces /root/ paths with ~/", () => {
+    expect(sanitizeErrorOutput("/root/.bashrc: No such file")).toBe("~/.bashrc: No such file");
+  });
+
+  it("replaces Windows C:\\Users\\<user>\\ paths with ~\\", () => {
+    expect(sanitizeErrorOutput("C:\\Users\\dave\\Documents\\file.txt")).toBe(
+      "~\\Documents\\file.txt",
+    );
+  });
+
+  it("leaves relative paths unchanged", () => {
+    expect(sanitizeErrorOutput("./src/index.ts")).toBe("./src/index.ts");
+  });
+
+  it("leaves normal error text unchanged", () => {
+    expect(sanitizeErrorOutput("Error: command failed")).toBe("Error: command failed");
+  });
+
+  it("handles multiple paths in a single message", () => {
+    const input = "error in /home/alice/project/a.ts and /Users/bob/project/b.ts";
+    expect(sanitizeErrorOutput(input)).toBe("error in ~/project/a.ts and ~/project/b.ts");
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeErrorOutput("")).toBe("");
+  });
+
+  it("handles path with no trailing content after username directory", () => {
+    // The path must have content after the username directory for the regex to match
+    expect(sanitizeErrorOutput("/home/dave/file.txt")).toBe("~/file.txt");
+  });
+
+  it("is case-insensitive for Windows drive letters", () => {
+    expect(sanitizeErrorOutput("c:\\Users\\dave\\file.txt")).toBe("~\\file.txt");
+    expect(sanitizeErrorOutput("D:\\Users\\dave\\file.txt")).toBe("~\\file.txt");
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,4 +3,5 @@ export { run, escapeCmdArg, type RunResult, type RunOptions } from "./runner.js"
 export { stripAnsi } from "./ansi.js";
 export { assertNoFlagInjection, assertAllowedCommand } from "./validation.js";
 export { INPUT_LIMITS } from "./limits.js";
+export { sanitizeErrorOutput } from "./sanitize.js";
 export type { ToolOutput } from "./types.js";

--- a/packages/shared/src/sanitize.ts
+++ b/packages/shared/src/sanitize.ts
@@ -1,0 +1,26 @@
+/**
+ * Sanitizes error output by replacing sensitive filesystem paths with
+ * home-relative equivalents. This prevents leaking usernames and absolute
+ * home directory paths in error messages returned to MCP clients.
+ *
+ * Replacements:
+ *   /home/<user>/...  → ~/...
+ *   /Users/<user>/... → ~/...
+ *   /root/...         → ~/...
+ *   C:\Users\<user>\... → ~\...
+ */
+export function sanitizeErrorOutput(text: string): string {
+  // Unix: /home/<username>/rest → ~/rest
+  let result = text.replace(/\/home\/[^/\s]+\//g, "~/");
+
+  // macOS: /Users/<username>/rest → ~/rest
+  result = result.replace(/\/Users\/[^/\s]+\//g, "~/");
+
+  // Unix: /root/rest → ~/rest
+  result = result.replace(/\/root\//g, "~/");
+
+  // Windows: C:\Users\<username>\rest → ~\rest (with escaped or literal backslashes)
+  result = result.replace(/[A-Z]:\\Users\\[^\\:\s]+\\/gi, "~\\");
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- **Fixes #148**: Add `!` escaping to `escapeCmdArg()` to prevent cmd.exe delayed expansion of `!VAR!` when `shell: true` is used on Windows. The `!` is escaped to `^!` after the existing `^` escaping step.
- **Fixes #149**: Add `sanitizeErrorOutput()` function that replaces sensitive filesystem paths (`/home/<user>/`, `/Users/<user>/`, `/root/`, `C:\Users\<user>\`) with `~/` in stderr output, preventing username and home directory leakage in MCP error responses. Applied automatically in `run()`.

## Changes

- `packages/shared/src/runner.ts` — Added `!` → `^!` escaping step; imported and applied `sanitizeErrorOutput` to stderr
- `packages/shared/src/sanitize.ts` — New module with `sanitizeErrorOutput()` function
- `packages/shared/src/index.ts` — Export `sanitizeErrorOutput` from `@paretools/shared`
- `packages/shared/__tests__/runner.test.ts` — Added 2 tests for `!` escaping (basic + combined metacharacters)
- `packages/shared/__tests__/sanitize.test.ts` — Added 10 tests covering Unix, macOS, Windows, and edge cases

## Test plan

- [x] All 155 shared package tests pass (8 test files)
- [x] Full monorepo build and test suite passes (20/20 tasks)
- [ ] Verify `!` escaping works on actual Windows cmd.exe with delayed expansion enabled
- [ ] Verify error messages from real tool invocations have paths sanitized

🤖 Generated with [Claude Code](https://claude.com/claude-code)