### PR TITLE
Fix flaky Windows Node 22 test timeout in shared package

### DIFF
--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    testTimeout: 15_000,
     coverage: {
       provider: "v8",
       thresholds: {


### PR DESCRIPTION
## Summary

- Add `testTimeout: 15_000` to `packages/shared/vitest.config.ts` — the only package that was missing it
- All other packages already set 60,000ms or 120,000ms; shared was relying on vitest's default 5,000ms
- On Windows + Node 22, `run("node", ["-e", ...])` cold-start takes 3,000–5,400ms through `cmd.exe`, causing intermittent timeouts

## Test plan

- [ ] CI passes on all matrix entries, including `windows-latest, 22`
- [ ] Existing tests unaffected (no behavioral change, only timeout threshold)

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)