### PR TITLE
Increase default run() timeout from 30s to 60s

### DIFF
--- a/packages/shared/src/runner.ts
+++ b/packages/shared/src/runner.ts
@@ -73,7 +73,7 @@ export function run(cmd: string, args: string[], opts?: RunOptions): Promise<Run
       safeArgs,
       {
         cwd: opts?.cwd,
-        timeout: opts?.timeout ?? 30_000,
+        timeout: opts?.timeout ?? 60_000,
         env: opts?.env ? { ...process.env, ...opts.env } : undefined,
         maxBuffer: 10 * 1024 * 1024, // 10 MB
         shell: process.platform === "win32",
@@ -101,7 +101,7 @@ export function run(cmd: string, args: string[], opts?: RunOptions): Promise<Run
           if (error.killed && error.signal) {
             reject(
               new Error(
-                `Command "${cmd}" timed out after ${opts?.timeout ?? 30_000}ms and was killed (${error.signal}).`,
+                `Command "${cmd}" timed out after ${opts?.timeout ?? 60_000}ms and was killed (${error.signal}).`,
               ),
             );
             return;


### PR DESCRIPTION
## Summary

- Increase the default `execFile` timeout in `run()` from 30s to 60s
- On Windows CI, `npx eslint` routinely takes 17–29s; slow runs exceed 30s, killing the process and returning errors instead of results
- This was the root cause of the flaky `@paretools/lint` integration test on Windows Node 22 ("expected undefined to be defined")

## Test plan

- [ ] CI passes on all matrix entries, including `windows-latest, 22`
- [ ] Lint integration test passes reliably on Windows

Related to #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)