### PR TITLE
feat(test): add compact mode support for all tools

### DIFF
--- a/packages/server-test/src/schemas/index.ts
+++ b/packages/server-test/src/schemas/index.ts
@@ -5,7 +5,7 @@ export const TestFailureSchema = z.object({
   name: z.string(),
   file: z.string().optional(),
   line: z.number().optional(),
-  message: z.string(),
+  message: z.string().optional(),
   expected: z.string().optional(),
   actual: z.string().optional(),
   stack: z.string().optional(),
@@ -45,7 +45,8 @@ export const CoverageSchema = z.object({
     branches: z.number().optional(),
     functions: z.number().optional(),
   }),
-  files: z.array(CoverageFileSchema),
+  files: z.array(CoverageFileSchema).optional(),
+  totalFiles: z.number().optional(),
 });
 
 export type Coverage = z.infer<typeof CoverageSchema>;


### PR DESCRIPTION
## Summary
- Adds automatic compact mode to both test server tools (run, coverage)
- Test failures compact to names only (drops stack traces, messages, expected/actual)
- Coverage compacts to summary totals (drops per-file breakdown)

## Changes
- 2 compact interfaces, mappers, and formatters in `formatters.ts`
- Schema fields made optional for compact compatibility
- Both tool files updated to use `compactDualOutput`
- 10 new unit tests for compact mappers/formatters

Closes #124 (test portion)

## Test plan
- [x] `pnpm build` compiles all packages
- [x] `pnpm --filter @paretools/test test` — 137 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)