### PR TITLE
feat(lint): add compact mode support for all tools

### DIFF
--- a/packages/server-lint/__tests__/compact.test.ts
+++ b/packages/server-lint/__tests__/compact.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from "vitest";
+import {
+  compactLintMap,
+  formatLintCompact,
+  compactFormatCheckMap,
+  formatFormatCheckCompact,
+  compactFormatWriteMap,
+  formatFormatWriteCompact,
+} from "../src/lib/formatters.js";
+import type { LintResult, FormatCheckResult, FormatWriteResult } from "../src/schemas/index.js";
+
+// ---------------------------------------------------------------------------
+// compactLintMap
+// ---------------------------------------------------------------------------
+
+describe("compactLintMap", () => {
+  it("keeps only counts, drops diagnostics", () => {
+    const data: LintResult = {
+      diagnostics: [
+        {
+          file: "src/index.ts",
+          line: 5,
+          column: 10,
+          severity: "error",
+          rule: "no-unused-vars",
+          message: "'foo' is defined but never used.",
+          fixable: false,
+        },
+        {
+          file: "src/utils.ts",
+          line: 12,
+          column: 1,
+          severity: "warning",
+          rule: "prefer-const",
+          message: "'x' is never reassigned. Use 'const' instead.",
+          fixable: true,
+        },
+      ],
+      total: 2,
+      errors: 1,
+      warnings: 1,
+      fixable: 1,
+      filesChecked: 10,
+    };
+
+    const compact = compactLintMap(data);
+
+    expect(compact.total).toBe(2);
+    expect(compact.errors).toBe(1);
+    expect(compact.warnings).toBe(1);
+    expect(compact.fixable).toBe(1);
+    expect(compact.filesChecked).toBe(10);
+    // Verify diagnostics are dropped
+    expect(compact).not.toHaveProperty("diagnostics");
+  });
+
+  it("handles clean lint result", () => {
+    const data: LintResult = {
+      diagnostics: [],
+      total: 0,
+      errors: 0,
+      warnings: 0,
+      fixable: 0,
+      filesChecked: 25,
+    };
+
+    const compact = compactLintMap(data);
+
+    expect(compact.total).toBe(0);
+    expect(compact.filesChecked).toBe(25);
+    expect(compact).not.toHaveProperty("diagnostics");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLintCompact
+// ---------------------------------------------------------------------------
+
+describe("formatLintCompact", () => {
+  it("formats clean lint result", () => {
+    const compact = { total: 0, errors: 0, warnings: 0, fixable: 0, filesChecked: 25 };
+    expect(formatLintCompact(compact)).toBe("Lint: no issues found (25 files checked).");
+  });
+
+  it("formats lint result with counts", () => {
+    const compact = { total: 5, errors: 2, warnings: 3, fixable: 1, filesChecked: 10 };
+    expect(formatLintCompact(compact)).toBe(
+      "Lint: 2 errors, 3 warnings (1 fixable) across 10 files.",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compactFormatCheckMap
+// ---------------------------------------------------------------------------
+
+describe("compactFormatCheckMap", () => {
+  it("keeps only formatted and total, drops file list", () => {
+    const data: FormatCheckResult = {
+      formatted: false,
+      files: ["src/index.ts", "src/utils.ts", "src/config.ts"],
+      total: 3,
+    };
+
+    const compact = compactFormatCheckMap(data);
+
+    expect(compact.formatted).toBe(false);
+    expect(compact.total).toBe(3);
+    // Verify files are dropped
+    expect(compact).not.toHaveProperty("files");
+  });
+
+  it("handles all-formatted result", () => {
+    const data: FormatCheckResult = {
+      formatted: true,
+      files: [],
+      total: 0,
+    };
+
+    const compact = compactFormatCheckMap(data);
+
+    expect(compact.formatted).toBe(true);
+    expect(compact.total).toBe(0);
+    expect(compact).not.toHaveProperty("files");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatFormatCheckCompact
+// ---------------------------------------------------------------------------
+
+describe("formatFormatCheckCompact", () => {
+  it("formats when all files are formatted", () => {
+    const compact = { formatted: true, total: 0 };
+    expect(formatFormatCheckCompact(compact)).toBe("All files are formatted.");
+  });
+
+  it("formats when files need formatting", () => {
+    const compact = { formatted: false, total: 5 };
+    expect(formatFormatCheckCompact(compact)).toBe("5 files need formatting.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compactFormatWriteMap
+// ---------------------------------------------------------------------------
+
+describe("compactFormatWriteMap", () => {
+  it("keeps only success and filesChanged, drops file list", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 3,
+      files: ["src/index.ts", "src/utils.ts", "src/config.ts"],
+      success: true,
+    };
+
+    const compact = compactFormatWriteMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact.filesChanged).toBe(3);
+    // Verify files are dropped
+    expect(compact).not.toHaveProperty("files");
+  });
+
+  it("handles failed format result", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 0,
+      files: [],
+      success: false,
+    };
+
+    const compact = compactFormatWriteMap(data);
+
+    expect(compact.success).toBe(false);
+    expect(compact.filesChanged).toBe(0);
+    expect(compact).not.toHaveProperty("files");
+  });
+
+  it("handles zero files changed (already formatted)", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 0,
+      files: [],
+      success: true,
+    };
+
+    const compact = compactFormatWriteMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact.filesChanged).toBe(0);
+    expect(compact).not.toHaveProperty("files");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatFormatWriteCompact
+// ---------------------------------------------------------------------------
+
+describe("formatFormatWriteCompact", () => {
+  it("formats failure", () => {
+    const compact = { success: false, filesChanged: 0 };
+    expect(formatFormatWriteCompact(compact)).toBe("Format failed.");
+  });
+
+  it("formats zero files changed", () => {
+    const compact = { success: true, filesChanged: 0 };
+    expect(formatFormatWriteCompact(compact)).toBe("All files already formatted.");
+  });
+
+  it("formats files changed", () => {
+    const compact = { success: true, filesChanged: 7 };
+    expect(formatFormatWriteCompact(compact)).toBe("Formatted 7 files.");
+  });
+});

--- a/packages/server-lint/__tests__/integration.test.ts
+++ b/packages/server-lint/__tests__/integration.test.ts
@@ -64,7 +64,8 @@ describe("@paretools/lint integration", () => {
       expect(sc.warnings).toEqual(expect.any(Number));
       expect(sc.fixable).toEqual(expect.any(Number));
       expect(sc.filesChecked).toEqual(expect.any(Number));
-      expect(Array.isArray(sc.diagnostics)).toBe(true);
+      // diagnostics may be omitted in compact mode
+      expect(sc.diagnostics === undefined || Array.isArray(sc.diagnostics)).toBe(true);
     }, 60_000);
   });
 
@@ -83,7 +84,8 @@ describe("@paretools/lint integration", () => {
       expect(sc).toBeDefined();
       expect(typeof sc.formatted).toBe("boolean");
       expect(sc.total).toEqual(expect.any(Number));
-      expect(Array.isArray(sc.files)).toBe(true);
+      // files may be omitted in compact mode
+      expect(sc.files === undefined || Array.isArray(sc.files)).toBe(true);
     }, 60_000);
   });
 
@@ -103,7 +105,8 @@ describe("@paretools/lint integration", () => {
       expect(sc).toBeDefined();
       expect(typeof sc.success).toBe("boolean");
       expect(sc.filesChanged).toEqual(expect.any(Number));
-      expect(Array.isArray(sc.files)).toBe(true);
+      // files may be omitted in compact mode
+      expect(sc.files === undefined || Array.isArray(sc.files)).toBe(true);
     }, 60_000);
   });
 
@@ -124,7 +127,8 @@ describe("@paretools/lint integration", () => {
       expect(sc.errors).toEqual(expect.any(Number));
       expect(sc.warnings).toEqual(expect.any(Number));
       expect(sc.fixable).toEqual(expect.any(Number));
-      expect(Array.isArray(sc.diagnostics)).toBe(true);
+      // diagnostics may be omitted in compact mode
+      expect(sc.diagnostics === undefined || Array.isArray(sc.diagnostics)).toBe(true);
     }, 60_000);
   });
 
@@ -143,7 +147,8 @@ describe("@paretools/lint integration", () => {
       expect(sc).toBeDefined();
       expect(typeof sc.success).toBe("boolean");
       expect(sc.filesChanged).toEqual(expect.any(Number));
-      expect(Array.isArray(sc.files)).toBe(true);
+      // files may be omitted in compact mode
+      expect(sc.files === undefined || Array.isArray(sc.files)).toBe(true);
     }, 60_000);
   });
 });

--- a/packages/server-lint/src/lib/formatters.ts
+++ b/packages/server-lint/src/lib/formatters.ts
@@ -7,7 +7,7 @@ export function formatLint(data: LintResult): string {
   const lines = [
     `Lint: ${data.errors} errors, ${data.warnings} warnings (${data.fixable} fixable)`,
   ];
-  for (const d of data.diagnostics) {
+  for (const d of data.diagnostics ?? []) {
     lines.push(`  ${d.file}:${d.line}:${d.column} ${d.severity} ${d.rule}: ${d.message}`);
   }
   return lines.join("\n");
@@ -18,7 +18,7 @@ export function formatFormatCheck(data: FormatCheckResult): string {
   if (data.formatted) return "All files are formatted.";
 
   const lines = [`${data.total} files need formatting:`];
-  for (const f of data.files) {
+  for (const f of data.files ?? []) {
     lines.push(`  ${f}`);
   }
   return lines.join("\n");
@@ -30,8 +30,74 @@ export function formatFormatWrite(data: FormatWriteResult): string {
   if (data.filesChanged === 0) return "All files already formatted.";
 
   const lines = [`Formatted ${data.filesChanged} files:`];
-  for (const f of data.files) {
+  for (const f of data.files ?? []) {
     lines.push(`  ${f}`);
   }
   return lines.join("\n");
+}
+
+// ── Compact types, mappers, and formatters ───────────────────────────
+
+/** Compact lint: counts only, no individual diagnostics. */
+export interface LintResultCompact {
+  [key: string]: unknown;
+  total: number;
+  errors: number;
+  warnings: number;
+  fixable: number;
+  filesChecked: number;
+}
+
+export function compactLintMap(data: LintResult): LintResultCompact {
+  return {
+    total: data.total,
+    errors: data.errors,
+    warnings: data.warnings,
+    fixable: data.fixable,
+    filesChecked: data.filesChecked,
+  };
+}
+
+export function formatLintCompact(data: LintResultCompact): string {
+  if (data.total === 0) return `Lint: no issues found (${data.filesChecked} files checked).`;
+  return `Lint: ${data.errors} errors, ${data.warnings} warnings (${data.fixable} fixable) across ${data.filesChecked} files.`;
+}
+
+/** Compact format check: counts only, no individual file paths. */
+export interface FormatCheckResultCompact {
+  [key: string]: unknown;
+  formatted: boolean;
+  total: number;
+}
+
+export function compactFormatCheckMap(data: FormatCheckResult): FormatCheckResultCompact {
+  return {
+    formatted: data.formatted,
+    total: data.total,
+  };
+}
+
+export function formatFormatCheckCompact(data: FormatCheckResultCompact): string {
+  if (data.formatted) return "All files are formatted.";
+  return `${data.total} files need formatting.`;
+}
+
+/** Compact format write: counts only, no individual file paths. */
+export interface FormatWriteResultCompact {
+  [key: string]: unknown;
+  success: boolean;
+  filesChanged: number;
+}
+
+export function compactFormatWriteMap(data: FormatWriteResult): FormatWriteResultCompact {
+  return {
+    success: data.success,
+    filesChanged: data.filesChanged,
+  };
+}
+
+export function formatFormatWriteCompact(data: FormatWriteResultCompact): string {
+  if (!data.success) return "Format failed.";
+  if (data.filesChanged === 0) return "All files already formatted.";
+  return `Formatted ${data.filesChanged} files.`;
 }

--- a/packages/server-lint/src/schemas/index.ts
+++ b/packages/server-lint/src/schemas/index.ts
@@ -15,7 +15,7 @@ export const LintDiagnosticSchema = z.object({
 
 /** Zod schema for structured ESLint output including diagnostics, counts, and files checked. */
 export const LintResultSchema = z.object({
-  diagnostics: z.array(LintDiagnosticSchema),
+  diagnostics: z.array(LintDiagnosticSchema).optional(),
   total: z.number(),
   errors: z.number(),
   warnings: z.number(),
@@ -29,7 +29,7 @@ export type LintDiagnostic = z.infer<typeof LintDiagnosticSchema>;
 /** Zod schema for structured Prettier format check output with formatted status and unformatted file list. */
 export const FormatCheckResultSchema = z.object({
   formatted: z.boolean(),
-  files: z.array(z.string()),
+  files: z.array(z.string()).optional(),
   total: z.number(),
 });
 
@@ -38,7 +38,7 @@ export type FormatCheckResult = z.infer<typeof FormatCheckResultSchema>;
 /** Zod schema for structured format-write output (Prettier --write, Biome format --write). */
 export const FormatWriteResultSchema = z.object({
   filesChanged: z.number(),
-  files: z.array(z.string()),
+  files: z.array(z.string()).optional(),
   success: z.boolean(),
 });
 

--- a/packages/server-lint/src/tools/biome-format.ts
+++ b/packages/server-lint/src/tools/biome-format.ts
@@ -1,9 +1,13 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { biome } from "../lib/lint-runner.js";
 import { parseBiomeFormat } from "../lib/parsers.js";
-import { formatFormatWrite } from "../lib/formatters.js";
+import {
+  formatFormatWrite,
+  compactFormatWriteMap,
+  formatFormatWriteCompact,
+} from "../lib/formatters.js";
 import { FormatWriteResultSchema } from "../schemas/index.js";
 
 export function registerBiomeFormatTool(server: McpServer) {
@@ -25,10 +29,17 @@ export function registerBiomeFormatTool(server: McpServer) {
           .optional()
           .default(["."])
           .describe("File patterns to format (default: ['.'])"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
       },
       outputSchema: FormatWriteResultSchema,
     },
-    async ({ path, patterns }) => {
+    async ({ path, patterns, compact }) => {
       const cwd = path || process.cwd();
       for (const p of patterns ?? []) {
         assertNoFlagInjection(p, "patterns");
@@ -37,7 +48,14 @@ export function registerBiomeFormatTool(server: McpServer) {
 
       const result = await biome(args, cwd);
       const data = parseBiomeFormat(result.stdout, result.stderr, result.exitCode);
-      return dualOutput(data, formatFormatWrite);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatFormatWrite,
+        compactFormatWriteMap,
+        formatFormatWriteCompact,
+        compact === false,
+      );
     },
   );
 }


### PR DESCRIPTION
## Summary
- Adds automatic compact mode to all 5 lint tools (lint/ESLint, biome-check, biome-format, format-check, prettier-format)
- Diagnostics compact to error/warning counts (drops individual entries)
- Format results compact to file counts (drops file paths)

## Changes
- 3 compact interfaces, mappers, and formatters in `formatters.ts`
- Schema fields made optional for compact compatibility
- All 5 tool files updated to use `compactDualOutput`
- 14 new unit tests for compact mappers/formatters

Closes #124 (lint portion)

## Test plan
- [x] `pnpm build` compiles all packages
- [x] `pnpm --filter @paretools/lint test` — 126 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)