### PR TITLE
feat(build): add compact mode support for all tools

### DIFF
--- a/packages/server-build/__tests__/compact.test.ts
+++ b/packages/server-build/__tests__/compact.test.ts
@@ -1,0 +1,517 @@
+import { describe, it, expect } from "vitest";
+import {
+  compactTscMap,
+  formatTscCompact,
+  compactEsbuildMap,
+  formatEsbuildCompact,
+  compactViteBuildMap,
+  formatViteBuildCompact,
+  compactWebpackMap,
+  formatWebpackCompact,
+  compactBuildMap,
+  formatBuildCompact,
+} from "../src/lib/formatters.js";
+import type {
+  TscResult,
+  EsbuildResult,
+  ViteBuildResult,
+  WebpackResult,
+  BuildResult,
+} from "../src/schemas/index.js";
+
+// ---------------------------------------------------------------------------
+// tsc compact
+// ---------------------------------------------------------------------------
+
+describe("compactTscMap", () => {
+  it("keeps success, counts, and truncated diagnostics (file:line only)", () => {
+    const data: TscResult = {
+      success: false,
+      diagnostics: [
+        {
+          file: "src/index.ts",
+          line: 10,
+          column: 5,
+          code: 2322,
+          severity: "error",
+          message: "Type 'string' is not assignable to type 'number'.",
+        },
+        {
+          file: "src/utils.ts",
+          line: 3,
+          column: 1,
+          code: 6133,
+          severity: "warning",
+          message: "'x' is declared but its value is never read.",
+        },
+      ],
+      total: 2,
+      errors: 1,
+      warnings: 1,
+    };
+
+    const compact = compactTscMap(data);
+
+    expect(compact.success).toBe(false);
+    expect(compact.errors).toBe(1);
+    expect(compact.warnings).toBe(1);
+    expect(compact.diagnostics).toHaveLength(2);
+    expect(compact.diagnostics[0]).toEqual({
+      file: "src/index.ts",
+      line: 10,
+      severity: "error",
+    });
+    expect(compact.diagnostics[1]).toEqual({
+      file: "src/utils.ts",
+      line: 3,
+      severity: "warning",
+    });
+    // Verify dropped fields
+    expect(compact.diagnostics[0]).not.toHaveProperty("column");
+    expect(compact.diagnostics[0]).not.toHaveProperty("code");
+    expect(compact.diagnostics[0]).not.toHaveProperty("message");
+    expect(compact).not.toHaveProperty("total");
+  });
+
+  it("limits diagnostics to 10 entries", () => {
+    const diagnostics = Array.from({ length: 20 }, (_, i) => ({
+      file: `src/file${i}.ts`,
+      line: i + 1,
+      column: 1,
+      code: 2322,
+      severity: "error" as const,
+      message: "Some error",
+    }));
+
+    const data: TscResult = {
+      success: false,
+      diagnostics,
+      total: 20,
+      errors: 20,
+      warnings: 0,
+    };
+
+    const compact = compactTscMap(data);
+    expect(compact.diagnostics).toHaveLength(10);
+    expect(compact.diagnostics[9].file).toBe("src/file9.ts");
+  });
+
+  it("handles clean build with no diagnostics", () => {
+    const data: TscResult = {
+      success: true,
+      diagnostics: [],
+      total: 0,
+      errors: 0,
+      warnings: 0,
+    };
+
+    const compact = compactTscMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact.errors).toBe(0);
+    expect(compact.warnings).toBe(0);
+    expect(compact.diagnostics).toEqual([]);
+  });
+});
+
+describe("formatTscCompact", () => {
+  it("formats clean result", () => {
+    const compact = { success: true, errors: 0, warnings: 0, diagnostics: [] };
+    expect(formatTscCompact(compact)).toBe("TypeScript: no errors found.");
+  });
+
+  it("formats compact diagnostics with file:line only", () => {
+    const compact = {
+      success: false,
+      errors: 1,
+      warnings: 1,
+      diagnostics: [
+        { file: "src/index.ts", line: 10, severity: "error" },
+        { file: "src/utils.ts", line: 3, severity: "warning" },
+      ],
+    };
+    const output = formatTscCompact(compact);
+    expect(output).toContain("TypeScript: 1 errors, 1 warnings");
+    expect(output).toContain("src/index.ts:10 error");
+    expect(output).toContain("src/utils.ts:3 warning");
+    // Should NOT contain message text or codes
+    expect(output).not.toContain("TS2322");
+    expect(output).not.toContain("assignable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// esbuild compact
+// ---------------------------------------------------------------------------
+
+describe("compactEsbuildMap", () => {
+  it("keeps success, counts, and duration; drops individual entries", () => {
+    const data: EsbuildResult = {
+      success: false,
+      errors: [
+        { file: "src/index.ts", line: 10, column: 5, message: 'Could not resolve "./missing"' },
+        { message: "Another error" },
+      ],
+      warnings: [{ file: "src/utils.ts", line: 1, message: "Unused import" }],
+      outputFiles: ["dist/index.js", "dist/index.css"],
+      duration: 1.5,
+    };
+
+    const compact = compactEsbuildMap(data);
+
+    expect(compact.success).toBe(false);
+    expect(compact.errorCount).toBe(2);
+    expect(compact.warningCount).toBe(1);
+    expect(compact.outputFileCount).toBe(2);
+    expect(compact.duration).toBe(1.5);
+    // Verify dropped fields
+    expect(compact).not.toHaveProperty("errors");
+    expect(compact).not.toHaveProperty("warnings");
+    expect(compact).not.toHaveProperty("outputFiles");
+  });
+
+  it("handles successful build with no output files", () => {
+    const data: EsbuildResult = {
+      success: true,
+      errors: [],
+      warnings: [],
+      duration: 0.3,
+    };
+
+    const compact = compactEsbuildMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact.errorCount).toBe(0);
+    expect(compact.warningCount).toBe(0);
+    expect(compact.outputFileCount).toBe(0);
+  });
+});
+
+describe("formatEsbuildCompact", () => {
+  it("formats successful build", () => {
+    const compact = {
+      success: true,
+      errorCount: 0,
+      warningCount: 0,
+      outputFileCount: 3,
+      duration: 0.5,
+    };
+    const output = formatEsbuildCompact(compact);
+    expect(output).toContain("build succeeded in 0.5s");
+    expect(output).toContain("3 output files");
+  });
+
+  it("formats failed build", () => {
+    const compact = {
+      success: false,
+      errorCount: 2,
+      warningCount: 1,
+      outputFileCount: 0,
+      duration: 0.1,
+    };
+    const output = formatEsbuildCompact(compact);
+    expect(output).toContain("build failed");
+    expect(output).toContain("2 errors");
+    expect(output).toContain("1 warnings");
+  });
+
+  it("formats build with warnings only", () => {
+    const compact = {
+      success: true,
+      errorCount: 0,
+      warningCount: 3,
+      outputFileCount: 1,
+      duration: 0.8,
+    };
+    const output = formatEsbuildCompact(compact);
+    expect(output).toContain("build succeeded");
+    expect(output).toContain("3 warnings");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// vite-build compact
+// ---------------------------------------------------------------------------
+
+describe("compactViteBuildMap", () => {
+  it("keeps success, file count, and duration; drops per-file entries", () => {
+    const data: ViteBuildResult = {
+      success: true,
+      duration: 1.5,
+      outputs: [
+        { file: "dist/index.html", size: "0.45 kB" },
+        { file: "dist/assets/index.js", size: "52.31 kB" },
+        { file: "dist/assets/vendor.js", size: "142.05 kB" },
+      ],
+      errors: [],
+      warnings: ["Chunk size warning"],
+    };
+
+    const compact = compactViteBuildMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact.fileCount).toBe(3);
+    expect(compact.errorCount).toBe(0);
+    expect(compact.warningCount).toBe(1);
+    expect(compact.duration).toBe(1.5);
+    // Verify dropped fields
+    expect(compact).not.toHaveProperty("outputs");
+    expect(compact).not.toHaveProperty("errors");
+    expect(compact).not.toHaveProperty("warnings");
+  });
+
+  it("handles failed build", () => {
+    const data: ViteBuildResult = {
+      success: false,
+      duration: 0.5,
+      outputs: [],
+      errors: ["Build error 1", "Build error 2"],
+      warnings: [],
+    };
+
+    const compact = compactViteBuildMap(data);
+
+    expect(compact.success).toBe(false);
+    expect(compact.fileCount).toBe(0);
+    expect(compact.errorCount).toBe(2);
+  });
+});
+
+describe("formatViteBuildCompact", () => {
+  it("formats successful build with files", () => {
+    const compact = {
+      success: true,
+      fileCount: 4,
+      errorCount: 0,
+      warningCount: 0,
+      duration: 1.2,
+    };
+    const output = formatViteBuildCompact(compact);
+    expect(output).toContain("Vite build succeeded in 1.2s");
+    expect(output).toContain("4 output files");
+  });
+
+  it("formats failed build", () => {
+    const compact = {
+      success: false,
+      fileCount: 0,
+      errorCount: 3,
+      warningCount: 0,
+      duration: 0.5,
+    };
+    const output = formatViteBuildCompact(compact);
+    expect(output).toContain("Vite build failed (0.5s)");
+    expect(output).toContain("3 errors");
+  });
+
+  it("formats build with warnings", () => {
+    const compact = {
+      success: true,
+      fileCount: 2,
+      errorCount: 0,
+      warningCount: 1,
+      duration: 3.0,
+    };
+    const output = formatViteBuildCompact(compact);
+    expect(output).toContain("1 warnings");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// webpack compact
+// ---------------------------------------------------------------------------
+
+describe("compactWebpackMap", () => {
+  it("keeps success, asset count, total size, and duration; drops per-asset details", () => {
+    const data: WebpackResult = {
+      success: true,
+      duration: 2.5,
+      assets: [
+        { name: "main.js", size: 52480 },
+        { name: "vendor.js", size: 143360 },
+        { name: "styles.css", size: 8192 },
+      ],
+      errors: [],
+      warnings: [],
+      modules: 42,
+    };
+
+    const compact = compactWebpackMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact.assetCount).toBe(3);
+    expect(compact.totalSize).toBe(52480 + 143360 + 8192);
+    expect(compact.errorCount).toBe(0);
+    expect(compact.warningCount).toBe(0);
+    expect(compact.duration).toBe(2.5);
+    // Verify dropped fields
+    expect(compact).not.toHaveProperty("assets");
+    expect(compact).not.toHaveProperty("modules");
+    expect(compact).not.toHaveProperty("errors");
+    expect(compact).not.toHaveProperty("warnings");
+  });
+
+  it("handles empty build", () => {
+    const data: WebpackResult = {
+      success: true,
+      duration: 0.1,
+      assets: [],
+      errors: [],
+      warnings: [],
+    };
+
+    const compact = compactWebpackMap(data);
+
+    expect(compact.assetCount).toBe(0);
+    expect(compact.totalSize).toBe(0);
+  });
+
+  it("handles failed build with errors", () => {
+    const data: WebpackResult = {
+      success: false,
+      duration: 1.0,
+      assets: [],
+      errors: ["Module not found", "Compilation failed"],
+      warnings: ["Deprecation warning"],
+    };
+
+    const compact = compactWebpackMap(data);
+
+    expect(compact.success).toBe(false);
+    expect(compact.errorCount).toBe(2);
+    expect(compact.warningCount).toBe(1);
+  });
+});
+
+describe("formatWebpackCompact", () => {
+  it("formats successful build with assets", () => {
+    const compact = {
+      success: true,
+      assetCount: 3,
+      totalSize: 204032,
+      errorCount: 0,
+      warningCount: 0,
+      duration: 2.5,
+    };
+    const output = formatWebpackCompact(compact);
+    expect(output).toContain("webpack: build succeeded in 2.5s");
+    expect(output).toContain("3 assets");
+    expect(output).toContain("kB");
+  });
+
+  it("formats failed build", () => {
+    const compact = {
+      success: false,
+      assetCount: 0,
+      totalSize: 0,
+      errorCount: 2,
+      warningCount: 0,
+      duration: 1.0,
+    };
+    const output = formatWebpackCompact(compact);
+    expect(output).toContain("webpack: build failed (1s)");
+    expect(output).toContain("2 errors");
+  });
+
+  it("formats build with warnings", () => {
+    const compact = {
+      success: true,
+      assetCount: 1,
+      totalSize: 524288,
+      errorCount: 0,
+      warningCount: 2,
+      duration: 3.0,
+    };
+    const output = formatWebpackCompact(compact);
+    expect(output).toContain("2 warnings");
+  });
+
+  it("formats build with no assets", () => {
+    const compact = {
+      success: true,
+      assetCount: 0,
+      totalSize: 0,
+      errorCount: 0,
+      warningCount: 0,
+      duration: 0.1,
+    };
+    const output = formatWebpackCompact(compact);
+    expect(output).toBe("webpack: build succeeded in 0.1s");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// build (generic) compact
+// ---------------------------------------------------------------------------
+
+describe("compactBuildMap", () => {
+  it("keeps success, counts, and duration; drops error/warning strings", () => {
+    const data: BuildResult = {
+      success: false,
+      duration: 2.5,
+      errors: ["Module not found: ./missing", "Syntax error in src/app.ts:15"],
+      warnings: ["Unused variable"],
+    };
+
+    const compact = compactBuildMap(data);
+
+    expect(compact.success).toBe(false);
+    expect(compact.errorCount).toBe(2);
+    expect(compact.warningCount).toBe(1);
+    expect(compact.duration).toBe(2.5);
+    // Verify dropped fields
+    expect(compact).not.toHaveProperty("errors");
+    expect(compact).not.toHaveProperty("warnings");
+  });
+
+  it("handles successful build with no issues", () => {
+    const data: BuildResult = {
+      success: true,
+      duration: 8.3,
+      errors: [],
+      warnings: [],
+    };
+
+    const compact = compactBuildMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact.errorCount).toBe(0);
+    expect(compact.warningCount).toBe(0);
+  });
+});
+
+describe("formatBuildCompact", () => {
+  it("formats successful build", () => {
+    const compact = {
+      success: true,
+      errorCount: 0,
+      warningCount: 0,
+      duration: 8.3,
+    };
+    expect(formatBuildCompact(compact)).toBe("Build succeeded in 8.3s");
+  });
+
+  it("formats successful build with warnings", () => {
+    const compact = {
+      success: true,
+      errorCount: 0,
+      warningCount: 2,
+      duration: 12.0,
+    };
+    const output = formatBuildCompact(compact);
+    expect(output).toContain("Build succeeded in 12s");
+    expect(output).toContain("2 warnings");
+  });
+
+  it("formats failed build", () => {
+    const compact = {
+      success: false,
+      errorCount: 3,
+      warningCount: 0,
+      duration: 2.5,
+    };
+    const output = formatBuildCompact(compact);
+    expect(output).toContain("Build failed (2.5s)");
+    expect(output).toContain("3 errors");
+  });
+});

--- a/packages/server-build/__tests__/integration.test.ts
+++ b/packages/server-build/__tests__/integration.test.ts
@@ -55,7 +55,10 @@ describe("@paretools/build integration", () => {
       expect(sc).toBeDefined();
       expect(typeof sc.success).toBe("boolean");
       expect(Array.isArray(sc.diagnostics)).toBe(true);
-      expect(sc.total).toEqual(expect.any(Number));
+      // total may be omitted in compact mode
+      if (sc.total !== undefined) {
+        expect(sc.total).toEqual(expect.any(Number));
+      }
       expect(sc.errors).toEqual(expect.any(Number));
       expect(sc.warnings).toEqual(expect.any(Number));
     }, 60_000);
@@ -76,8 +79,13 @@ describe("@paretools/build integration", () => {
       expect(sc).toBeDefined();
       expect(typeof sc.success).toBe("boolean");
       expect(typeof sc.duration).toBe("number");
-      expect(Array.isArray(sc.errors)).toBe(true);
-      expect(Array.isArray(sc.warnings)).toBe(true);
+      // In compact mode, arrays are replaced by counts
+      if (Array.isArray(sc.errors)) {
+        expect(Array.isArray(sc.warnings)).toBe(true);
+      } else {
+        expect(typeof sc.errorCount).toBe("number");
+        expect(typeof sc.warningCount).toBe("number");
+      }
     }, 60_000);
 
     it("rejects disallowed commands", async () => {
@@ -112,8 +120,13 @@ describe("@paretools/build integration", () => {
         const sc = result.structuredContent as Record<string, unknown>;
         expect(typeof sc.success).toBe("boolean");
         expect(typeof sc.duration).toBe("number");
-        expect(Array.isArray(sc.errors)).toBe(true);
-        expect(Array.isArray(sc.warnings)).toBe(true);
+        // In compact mode, arrays are replaced by counts
+        if (Array.isArray(sc.errors)) {
+          expect(Array.isArray(sc.warnings)).toBe(true);
+        } else {
+          expect(typeof sc.errorCount).toBe("number");
+          expect(typeof sc.warningCount).toBe("number");
+        }
       } else {
         // If no structured content, it should be marked as an error
         expect(result.isError).toBe(true);
@@ -148,9 +161,15 @@ describe("@paretools/build integration", () => {
         const sc = result.structuredContent as Record<string, unknown>;
         expect(typeof sc.success).toBe("boolean");
         expect(typeof sc.duration).toBe("number");
-        expect(Array.isArray(sc.outputs)).toBe(true);
-        expect(Array.isArray(sc.errors)).toBe(true);
-        expect(Array.isArray(sc.warnings)).toBe(true);
+        // In compact mode, per-file outputs and error/warning arrays are replaced by counts
+        if (Array.isArray(sc.outputs)) {
+          expect(Array.isArray(sc.errors)).toBe(true);
+          expect(Array.isArray(sc.warnings)).toBe(true);
+        } else {
+          expect(typeof sc.fileCount).toBe("number");
+          expect(typeof sc.errorCount).toBe("number");
+          expect(typeof sc.warningCount).toBe("number");
+        }
       } else {
         expect(result.isError).toBe(true);
       }
@@ -174,9 +193,15 @@ describe("@paretools/build integration", () => {
           const sc = result.structuredContent as Record<string, unknown>;
           expect(typeof sc.success).toBe("boolean");
           expect(typeof sc.duration).toBe("number");
-          expect(Array.isArray(sc.assets)).toBe(true);
-          expect(Array.isArray(sc.errors)).toBe(true);
-          expect(Array.isArray(sc.warnings)).toBe(true);
+          // In compact mode, per-asset and error/warning arrays are replaced by counts
+          if (Array.isArray(sc.assets)) {
+            expect(Array.isArray(sc.errors)).toBe(true);
+            expect(Array.isArray(sc.warnings)).toBe(true);
+          } else {
+            expect(typeof sc.assetCount).toBe("number");
+            expect(typeof sc.errorCount).toBe("number");
+            expect(typeof sc.warningCount).toBe("number");
+          }
         } else {
           expect(result.isError).toBe(true);
         }

--- a/packages/server-build/src/tools/webpack.ts
+++ b/packages/server-build/src/tools/webpack.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { webpackCmd } from "../lib/build-runner.js";
 import { parseWebpackOutput } from "../lib/parsers.js";
-import { formatWebpack } from "../lib/formatters.js";
+import { formatWebpack, compactWebpackMap, formatWebpackCompact } from "../lib/formatters.js";
 import { WebpackResultSchema } from "../schemas/index.js";
 
 export function registerWebpackTool(server: McpServer) {
@@ -34,10 +34,17 @@ export function registerWebpackTool(server: McpServer) {
           .optional()
           .default([])
           .describe("Additional webpack flags"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
       },
       outputSchema: WebpackResultSchema,
     },
-    async ({ path, config, mode, args }) => {
+    async ({ path, config, mode, args, compact }) => {
       const cwd = path || process.cwd();
       if (config) assertNoFlagInjection(config, "config");
       for (const a of args ?? []) {
@@ -57,9 +64,17 @@ export function registerWebpackTool(server: McpServer) {
       const start = Date.now();
       const result = await webpackCmd(cliArgs, cwd);
       const duration = Math.round((Date.now() - start) / 100) / 10;
+      const rawOutput = result.stdout + "\n" + result.stderr;
 
       const data = parseWebpackOutput(result.stdout, result.stderr, result.exitCode, duration);
-      return dualOutput(data, formatWebpack);
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatWebpack,
+        compactWebpackMap,
+        formatWebpackCompact,
+        compact === false,
+      );
     },
   );
 }


### PR DESCRIPTION
## Summary
- Adds automatic compact mode to all 5 build tools (tsc, esbuild, vite-build, webpack, build)
- Diagnostics compact to error/warning counts (drops individual entries)
- Asset lists compact to counts and total sizes (drops per-file details)

## Changes
- 5 compact interfaces, mappers, and formatters in `formatters.ts`
- Schema fields made optional for compact compatibility
- All 5 tool files updated to use `compactDualOutput`
- 27 new unit tests for compact mappers/formatters

Closes #124 (build portion)

## Test plan
- [x] `pnpm build` compiles all packages
- [x] `pnpm --filter @paretools/build test` — all tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)