### PR TITLE
feat(go): add compact mode support for all tools

### DIFF
--- a/packages/server-go/__tests__/compact.test.ts
+++ b/packages/server-go/__tests__/compact.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from "vitest";
+import {
+  compactBuildMap,
+  formatBuildCompact,
+  compactTestMap,
+  formatTestCompact,
+  compactVetMap,
+  formatVetCompact,
+  compactFmtMap,
+  formatFmtCompact,
+  compactRunMap,
+  formatRunCompact,
+  compactGenerateMap,
+  formatGenerateCompact,
+  compactModTidyMap,
+  formatModTidyCompact,
+} from "../src/lib/formatters.js";
+import type {
+  GoBuildResult,
+  GoTestResult,
+  GoVetResult,
+  GoFmtResult,
+  GoRunResult,
+  GoGenerateResult,
+  GoModTidyResult,
+} from "../src/schemas/index.js";
+
+// ---------------------------------------------------------------------------
+// build
+// ---------------------------------------------------------------------------
+describe("compactBuildMap", () => {
+  it("keeps only success and total, drops error details", () => {
+    const data: GoBuildResult = {
+      success: false,
+      errors: [
+        { file: "main.go", line: 10, column: 5, message: "undefined: foo" },
+        { file: "util.go", line: 22, message: "syntax error" },
+      ],
+      total: 2,
+    };
+
+    const compact = compactBuildMap(data);
+
+    expect(compact.success).toBe(false);
+    expect(compact.total).toBe(2);
+    expect(compact).not.toHaveProperty("errors");
+  });
+
+  it("preserves success state for clean build", () => {
+    const data: GoBuildResult = { success: true, errors: [], total: 0 };
+
+    const compact = compactBuildMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact.total).toBe(0);
+  });
+});
+
+describe("formatBuildCompact", () => {
+  it("formats successful build", () => {
+    expect(formatBuildCompact({ success: true, total: 0 })).toBe("go build: success.");
+  });
+
+  it("formats failed build with error count", () => {
+    expect(formatBuildCompact({ success: false, total: 3 })).toBe("go build: 3 errors");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// test
+// ---------------------------------------------------------------------------
+describe("compactTestMap", () => {
+  it("keeps counts, drops individual test details", () => {
+    const data: GoTestResult = {
+      success: false,
+      tests: [
+        { package: "myapp/auth", name: "TestLogin", status: "pass", elapsed: 0.05 },
+        { package: "myapp/auth", name: "TestLogout", status: "fail", elapsed: 0.02 },
+        { package: "myapp/util", name: "TestSkipped", status: "skip" },
+      ],
+      total: 3,
+      passed: 1,
+      failed: 1,
+      skipped: 1,
+    };
+
+    const compact = compactTestMap(data);
+
+    expect(compact.success).toBe(false);
+    expect(compact.total).toBe(3);
+    expect(compact.passed).toBe(1);
+    expect(compact.failed).toBe(1);
+    expect(compact.skipped).toBe(1);
+    expect(compact).not.toHaveProperty("tests");
+  });
+
+  it("preserves zero counts for empty suite", () => {
+    const data: GoTestResult = {
+      success: true,
+      tests: [],
+      total: 0,
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+    };
+
+    const compact = compactTestMap(data);
+
+    expect(compact.total).toBe(0);
+    expect(compact.passed).toBe(0);
+    expect(compact.failed).toBe(0);
+    expect(compact.skipped).toBe(0);
+  });
+});
+
+describe("formatTestCompact", () => {
+  it("formats passing test summary", () => {
+    expect(formatTestCompact({ success: true, total: 5, passed: 5, failed: 0, skipped: 0 })).toBe(
+      "ok: 5 passed, 0 failed, 0 skipped",
+    );
+  });
+
+  it("formats failing test summary", () => {
+    expect(formatTestCompact({ success: false, total: 3, passed: 1, failed: 1, skipped: 1 })).toBe(
+      "FAIL: 1 passed, 1 failed, 1 skipped",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// vet
+// ---------------------------------------------------------------------------
+describe("compactVetMap", () => {
+  it("keeps only total count, drops diagnostic details", () => {
+    const data: GoVetResult = {
+      diagnostics: [
+        { file: "main.go", line: 15, column: 2, message: "unreachable code" },
+        { file: "handler.go", line: 30, message: "possible misuse of unsafe.Pointer" },
+      ],
+      total: 2,
+    };
+
+    const compact = compactVetMap(data);
+
+    expect(compact.total).toBe(2);
+    expect(compact).not.toHaveProperty("diagnostics");
+  });
+
+  it("preserves zero total for clean vet", () => {
+    const data: GoVetResult = { diagnostics: [], total: 0 };
+
+    const compact = compactVetMap(data);
+
+    expect(compact.total).toBe(0);
+  });
+});
+
+describe("formatVetCompact", () => {
+  it("formats clean vet", () => {
+    expect(formatVetCompact({ total: 0 })).toBe("go vet: no issues found.");
+  });
+
+  it("formats vet with issues", () => {
+    expect(formatVetCompact({ total: 3 })).toBe("go vet: 3 issues");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fmt
+// ---------------------------------------------------------------------------
+describe("compactFmtMap", () => {
+  it("keeps success and file count, drops file list", () => {
+    const data: GoFmtResult = {
+      success: false,
+      filesChanged: 3,
+      files: ["main.go", "cmd/server/handler.go", "internal/util/helpers.go"],
+    };
+
+    const compact = compactFmtMap(data);
+
+    expect(compact.success).toBe(false);
+    expect(compact.filesChanged).toBe(3);
+    expect(compact).not.toHaveProperty("files");
+  });
+
+  it("preserves clean format state", () => {
+    const data: GoFmtResult = { success: true, filesChanged: 0, files: [] };
+
+    const compact = compactFmtMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact.filesChanged).toBe(0);
+  });
+});
+
+describe("formatFmtCompact", () => {
+  it("formats all formatted", () => {
+    expect(formatFmtCompact({ success: true, filesChanged: 0 })).toBe(
+      "gofmt: all files formatted.",
+    );
+  });
+
+  it("formats with file count", () => {
+    expect(formatFmtCompact({ success: false, filesChanged: 5 })).toBe("gofmt: 5 files");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run
+// ---------------------------------------------------------------------------
+describe("compactRunMap", () => {
+  it("keeps exitCode and success, drops stdout/stderr", () => {
+    const data: GoRunResult = {
+      exitCode: 0,
+      stdout: "Hello, World!\nLine 2",
+      stderr: "",
+      success: true,
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.exitCode).toBe(0);
+    expect(compact.success).toBe(true);
+    expect(compact).not.toHaveProperty("stdout");
+    expect(compact).not.toHaveProperty("stderr");
+  });
+
+  it("preserves non-zero exit code", () => {
+    const data: GoRunResult = {
+      exitCode: 2,
+      stdout: "",
+      stderr: "panic: runtime error",
+      success: false,
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.exitCode).toBe(2);
+    expect(compact.success).toBe(false);
+  });
+});
+
+describe("formatRunCompact", () => {
+  it("formats successful run", () => {
+    expect(formatRunCompact({ exitCode: 0, success: true })).toBe("go run: success.");
+  });
+
+  it("formats failed run with exit code", () => {
+    expect(formatRunCompact({ exitCode: 2, success: false })).toBe("go run: exit code 2.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generate
+// ---------------------------------------------------------------------------
+describe("compactGenerateMap", () => {
+  it("keeps only success, drops output", () => {
+    const data: GoGenerateResult = {
+      success: true,
+      output: "mockgen -source=service.go -destination=mock_service.go",
+    };
+
+    const compact = compactGenerateMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact).not.toHaveProperty("output");
+  });
+
+  it("preserves failure state", () => {
+    const data: GoGenerateResult = {
+      success: false,
+      output: 'main.go:3: running "mockgen": exec: "mockgen": executable file not found',
+    };
+
+    const compact = compactGenerateMap(data);
+
+    expect(compact.success).toBe(false);
+  });
+});
+
+describe("formatGenerateCompact", () => {
+  it("formats successful generate", () => {
+    expect(formatGenerateCompact({ success: true })).toBe("go generate: success.");
+  });
+
+  it("formats failed generate", () => {
+    expect(formatGenerateCompact({ success: false })).toBe("go generate: FAIL");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mod-tidy
+// ---------------------------------------------------------------------------
+describe("compactModTidyMap", () => {
+  it("keeps only success, drops summary text", () => {
+    const data: GoModTidyResult = {
+      success: true,
+      summary: "go.mod and go.sum are already tidy.",
+    };
+
+    const compact = compactModTidyMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact).not.toHaveProperty("summary");
+  });
+
+  it("preserves failure state", () => {
+    const data: GoModTidyResult = {
+      success: false,
+      summary: "go.mod file not found in current directory or any parent directory",
+    };
+
+    const compact = compactModTidyMap(data);
+
+    expect(compact.success).toBe(false);
+  });
+});
+
+describe("formatModTidyCompact", () => {
+  it("formats successful mod tidy", () => {
+    expect(formatModTidyCompact({ success: true })).toBe("go mod tidy: success.");
+  });
+
+  it("formats failed mod tidy", () => {
+    expect(formatModTidyCompact({ success: false })).toBe("go mod tidy: FAIL");
+  });
+});

--- a/packages/server-go/__tests__/integration.test.ts
+++ b/packages/server-go/__tests__/integration.test.ts
@@ -108,7 +108,7 @@ describe("@paretools/go integration", () => {
     it("returns structured data or a command-not-found error", async () => {
       const result = await client.callTool({
         name: "run",
-        arguments: { path: resolve(__dirname, "../../.."), file: "." },
+        arguments: { path: resolve(__dirname, "../../.."), file: ".", compact: false },
       });
 
       if (result.isError) {
@@ -129,7 +129,7 @@ describe("@paretools/go integration", () => {
     it("returns structured data or a command-not-found error", async () => {
       const result = await client.callTool({
         name: "mod-tidy",
-        arguments: { path: resolve(__dirname, "../../..") },
+        arguments: { path: resolve(__dirname, "../../.."), compact: false },
       });
 
       if (result.isError) {
@@ -148,7 +148,7 @@ describe("@paretools/go integration", () => {
     it("returns structured data or a command-not-found error", async () => {
       const result = await client.callTool({
         name: "fmt",
-        arguments: { path: resolve(__dirname, "../../.."), check: true },
+        arguments: { path: resolve(__dirname, "../../.."), check: true, compact: false },
       });
 
       if (result.isError) {
@@ -168,7 +168,7 @@ describe("@paretools/go integration", () => {
     it("returns structured data or a command-not-found error", async () => {
       const result = await client.callTool({
         name: "generate",
-        arguments: { path: resolve(__dirname, "../../..") },
+        arguments: { path: resolve(__dirname, "../../.."), compact: false },
       });
 
       if (result.isError) {

--- a/packages/server-go/src/lib/formatters.ts
+++ b/packages/server-go/src/lib/formatters.ts
@@ -13,7 +13,7 @@ export function formatGoBuild(data: GoBuildResult): string {
   if (data.success) return "go build: success.";
 
   const lines = [`go build: ${data.total} errors`];
-  for (const e of data.errors) {
+  for (const e of data.errors ?? []) {
     const col = e.column ? `:${e.column}` : "";
     lines.push(`  ${e.file}:${e.line}${col}: ${e.message}`);
   }
@@ -26,7 +26,7 @@ export function formatGoTest(data: GoTestResult): string {
   const lines = [
     `${status}: ${data.passed} passed, ${data.failed} failed, ${data.skipped} skipped`,
   ];
-  for (const t of data.tests) {
+  for (const t of data.tests ?? []) {
     const elapsed = t.elapsed !== undefined ? ` (${t.elapsed}s)` : "";
     lines.push(`  ${t.status.padEnd(4)} ${t.package}/${t.name}${elapsed}`);
   }
@@ -38,7 +38,7 @@ export function formatGoVet(data: GoVetResult): string {
   if (data.total === 0) return "go vet: no issues found.";
 
   const lines = [`go vet: ${data.total} issues`];
-  for (const d of data.diagnostics) {
+  for (const d of data.diagnostics ?? []) {
     const col = d.column ? `:${d.column}` : "";
     lines.push(`  ${d.file}:${d.line}${col}: ${d.message}`);
   }
@@ -69,7 +69,7 @@ export function formatGoFmt(data: GoFmtResult): string {
   if (data.success && data.filesChanged === 0) return "gofmt: all files formatted.";
 
   const lines = [`gofmt: ${data.filesChanged} files`];
-  for (const f of data.files) {
+  for (const f of data.files ?? []) {
     lines.push(`  ${f}`);
   }
   return lines.join("\n");
@@ -81,4 +81,139 @@ export function formatGoGenerate(data: GoGenerateResult): string {
     return data.output ? `go generate: success.\n${data.output}` : "go generate: success.";
   }
   return `go generate: FAIL\n${data.output}`;
+}
+
+// ── Compact types, mappers, and formatters ───────────────────────────
+
+/** Compact build: success, error/warning count. Drop full error details. */
+export interface GoBuildCompact {
+  [key: string]: unknown;
+  success: boolean;
+  total: number;
+}
+
+export function compactBuildMap(data: GoBuildResult): GoBuildCompact {
+  return {
+    success: data.success,
+    total: data.total,
+  };
+}
+
+export function formatBuildCompact(data: GoBuildCompact): string {
+  if (data.success) return "go build: success.";
+  return `go build: ${data.total} errors`;
+}
+
+/** Compact test: total, passed, failed, skipped. Drop individual test details. */
+export interface GoTestCompact {
+  [key: string]: unknown;
+  success: boolean;
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+}
+
+export function compactTestMap(data: GoTestResult): GoTestCompact {
+  return {
+    success: data.success,
+    total: data.total,
+    passed: data.passed,
+    failed: data.failed,
+    skipped: data.skipped,
+  };
+}
+
+export function formatTestCompact(data: GoTestCompact): string {
+  const status = data.success ? "ok" : "FAIL";
+  return `${status}: ${data.passed} passed, ${data.failed} failed, ${data.skipped} skipped`;
+}
+
+/** Compact vet: diagnostic count only. Drop individual file/line/message entries. */
+export interface GoVetCompact {
+  [key: string]: unknown;
+  total: number;
+}
+
+export function compactVetMap(data: GoVetResult): GoVetCompact {
+  return {
+    total: data.total,
+  };
+}
+
+export function formatVetCompact(data: GoVetCompact): string {
+  if (data.total === 0) return "go vet: no issues found.";
+  return `go vet: ${data.total} issues`;
+}
+
+/** Compact fmt: success, file count. Drop individual file list. */
+export interface GoFmtCompact {
+  [key: string]: unknown;
+  success: boolean;
+  filesChanged: number;
+}
+
+export function compactFmtMap(data: GoFmtResult): GoFmtCompact {
+  return {
+    success: data.success,
+    filesChanged: data.filesChanged,
+  };
+}
+
+export function formatFmtCompact(data: GoFmtCompact): string {
+  if (data.success && data.filesChanged === 0) return "gofmt: all files formatted.";
+  return `gofmt: ${data.filesChanged} files`;
+}
+
+/** Compact run: exitCode, success. Drop stdout/stderr. */
+export interface GoRunCompact {
+  [key: string]: unknown;
+  exitCode: number;
+  success: boolean;
+}
+
+export function compactRunMap(data: GoRunResult): GoRunCompact {
+  return {
+    exitCode: data.exitCode,
+    success: data.success,
+  };
+}
+
+export function formatRunCompact(data: GoRunCompact): string {
+  if (data.success) return "go run: success.";
+  return `go run: exit code ${data.exitCode}.`;
+}
+
+/** Compact generate: success only. Drop full output. */
+export interface GoGenerateCompact {
+  [key: string]: unknown;
+  success: boolean;
+}
+
+export function compactGenerateMap(data: GoGenerateResult): GoGenerateCompact {
+  return {
+    success: data.success,
+  };
+}
+
+export function formatGenerateCompact(data: GoGenerateCompact): string {
+  if (data.success) return "go generate: success.";
+  return "go generate: FAIL";
+}
+
+/** Compact mod-tidy: success only. Drop summary text. */
+export interface GoModTidyCompact {
+  [key: string]: unknown;
+  success: boolean;
+}
+
+export function compactModTidyMap(data: GoModTidyResult): GoModTidyCompact {
+  return {
+    success: data.success,
+  };
+}
+
+export function formatModTidyCompact(data: GoModTidyCompact): string {
+  if (data.success) return "go mod tidy: success.";
+  return "go mod tidy: FAIL";
 }

--- a/packages/server-go/src/schemas/index.ts
+++ b/packages/server-go/src/schemas/index.ts
@@ -11,7 +11,7 @@ export const GoBuildErrorSchema = z.object({
 /** Zod schema for structured go build output with success status and error list. */
 export const GoBuildResultSchema = z.object({
   success: z.boolean(),
-  errors: z.array(GoBuildErrorSchema),
+  errors: z.array(GoBuildErrorSchema).optional(),
   total: z.number(),
 });
 
@@ -29,7 +29,7 @@ export const GoTestCaseSchema = z.object({
 /** Zod schema for structured go test output with test list and pass/fail/skip counts. */
 export const GoTestResultSchema = z.object({
   success: z.boolean(),
-  tests: z.array(GoTestCaseSchema),
+  tests: z.array(GoTestCaseSchema).optional(),
   total: z.number(),
   passed: z.number(),
   failed: z.number(),
@@ -48,7 +48,7 @@ export const GoVetDiagnosticSchema = z.object({
 
 /** Zod schema for structured go vet output with diagnostic list and total count. */
 export const GoVetResultSchema = z.object({
-  diagnostics: z.array(GoVetDiagnosticSchema),
+  diagnostics: z.array(GoVetDiagnosticSchema).optional(),
   total: z.number(),
 });
 
@@ -57,8 +57,8 @@ export type GoVetResult = z.infer<typeof GoVetResultSchema>;
 /** Zod schema for structured go run output with stdout, stderr, and exit code. */
 export const GoRunResultSchema = z.object({
   exitCode: z.number(),
-  stdout: z.string(),
-  stderr: z.string(),
+  stdout: z.string().optional(),
+  stderr: z.string().optional(),
   success: z.boolean(),
 });
 
@@ -67,7 +67,7 @@ export type GoRunResult = z.infer<typeof GoRunResultSchema>;
 /** Zod schema for structured go mod tidy output with success status and summary. */
 export const GoModTidyResultSchema = z.object({
   success: z.boolean(),
-  summary: z.string(),
+  summary: z.string().optional(),
 });
 
 export type GoModTidyResult = z.infer<typeof GoModTidyResultSchema>;
@@ -76,7 +76,7 @@ export type GoModTidyResult = z.infer<typeof GoModTidyResultSchema>;
 export const GoFmtResultSchema = z.object({
   success: z.boolean(),
   filesChanged: z.number(),
-  files: z.array(z.string()),
+  files: z.array(z.string()).optional(),
 });
 
 export type GoFmtResult = z.infer<typeof GoFmtResultSchema>;
@@ -84,7 +84,7 @@ export type GoFmtResult = z.infer<typeof GoFmtResultSchema>;
 /** Zod schema for structured go generate output with success status and output text. */
 export const GoGenerateResultSchema = z.object({
   success: z.boolean(),
-  output: z.string(),
+  output: z.string().optional(),
 });
 
 export type GoGenerateResult = z.infer<typeof GoGenerateResultSchema>;

--- a/packages/server-go/src/tools/mod-tidy.ts
+++ b/packages/server-go/src/tools/mod-tidy.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoModTidyOutput } from "../lib/parsers.js";
-import { formatGoModTidy } from "../lib/formatters.js";
+import { formatGoModTidy, compactModTidyMap, formatModTidyCompact } from "../lib/formatters.js";
 import { GoModTidyResultSchema } from "../schemas/index.js";
 
 export function registerModTidyTool(server: McpServer) {
@@ -19,14 +19,29 @@ export function registerModTidyTool(server: McpServer) {
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe("Project root path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
       },
       outputSchema: GoModTidyResultSchema,
     },
-    async ({ path }) => {
+    async ({ path, compact }) => {
       const cwd = path || process.cwd();
       const result = await goCmd(["mod", "tidy"], cwd);
       const data = parseGoModTidyOutput(result.stdout, result.stderr, result.exitCode);
-      return dualOutput(data, formatGoModTidy);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatGoModTidy,
+        compactModTidyMap,
+        formatModTidyCompact,
+        compact === false,
+      );
     },
   );
 }

--- a/packages/server-go/src/tools/vet.ts
+++ b/packages/server-go/src/tools/vet.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { goCmd } from "../lib/go-runner.js";
 import { parseGoVetOutput } from "../lib/parsers.js";
-import { formatGoVet } from "../lib/formatters.js";
+import { formatGoVet, compactVetMap, formatVetCompact } from "../lib/formatters.js";
 import { GoVetResultSchema } from "../schemas/index.js";
 
 export function registerVetTool(server: McpServer) {
@@ -25,17 +25,32 @@ export function registerVetTool(server: McpServer) {
           .optional()
           .default(["./..."])
           .describe("Packages to vet (default: ./...)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
       },
       outputSchema: GoVetResultSchema,
     },
-    async ({ path, packages }) => {
+    async ({ path, packages, compact }) => {
       const cwd = path || process.cwd();
       for (const p of packages ?? []) {
         assertNoFlagInjection(p, "packages");
       }
       const result = await goCmd(["vet", ...(packages || ["./..."])], cwd);
       const data = parseGoVetOutput(result.stdout, result.stderr);
-      return dualOutput(data, formatGoVet);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatGoVet,
+        compactVetMap,
+        formatVetCompact,
+        compact === false,
+      );
     },
   );
 }


### PR DESCRIPTION
## Summary
- Adds automatic compact mode to all 7 Go tools (build, test, vet, fmt, run, generate, mod-tidy)
- Build/test/vet results compact to counts (drops individual error/test/diagnostic entries)
- Run/generate compact to exit code and success flag (drops stdout/stderr)

## Changes
- 7 compact interfaces, mappers, and formatters in `formatters.ts`
- Schema fields made optional for compact compatibility
- All 7 tool files updated to use `compactDualOutput`
- 28 new unit tests for compact mappers/formatters

Closes #124 (go portion)

## Test plan
- [x] `pnpm build` compiles all packages
- [x] `pnpm --filter @paretools/go test` — 175 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)