### PR TITLE
feat: granular tool selection via environment variables

### DIFF
--- a/packages/server-build/src/tools/index.ts
+++ b/packages/server-build/src/tools/index.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
 import { registerTscTool } from "./tsc.js";
 import { registerBuildTool } from "./build.js";
 import { registerEsbuildTool } from "./esbuild.js";
@@ -6,9 +7,10 @@ import { registerViteBuildTool } from "./vite-build.js";
 import { registerWebpackTool } from "./webpack.js";
 
 export function registerAllTools(server: McpServer) {
-  registerTscTool(server);
-  registerBuildTool(server);
-  registerEsbuildTool(server);
-  registerViteBuildTool(server);
-  registerWebpackTool(server);
+  const s = (name: string) => shouldRegisterTool("build", name);
+  if (s("tsc")) registerTscTool(server);
+  if (s("build")) registerBuildTool(server);
+  if (s("esbuild")) registerEsbuildTool(server);
+  if (s("vite-build")) registerViteBuildTool(server);
+  if (s("webpack")) registerWebpackTool(server);
 }

--- a/packages/server-cargo/src/tools/index.ts
+++ b/packages/server-cargo/src/tools/index.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
 import { registerBuildTool } from "./build.js";
 import { registerTestTool } from "./test.js";
 import { registerClippyTool } from "./clippy.js";
@@ -10,13 +11,14 @@ import { registerDocTool } from "./doc.js";
 import { registerCheckTool } from "./check.js";
 
 export function registerAllTools(server: McpServer) {
-  registerBuildTool(server);
-  registerTestTool(server);
-  registerClippyTool(server);
-  registerRunTool(server);
-  registerAddTool(server);
-  registerRemoveTool(server);
-  registerFmtTool(server);
-  registerDocTool(server);
-  registerCheckTool(server);
+  const s = (name: string) => shouldRegisterTool("cargo", name);
+  if (s("build")) registerBuildTool(server);
+  if (s("test")) registerTestTool(server);
+  if (s("clippy")) registerClippyTool(server);
+  if (s("run")) registerRunTool(server);
+  if (s("add")) registerAddTool(server);
+  if (s("remove")) registerRemoveTool(server);
+  if (s("fmt")) registerFmtTool(server);
+  if (s("doc")) registerDocTool(server);
+  if (s("check")) registerCheckTool(server);
 }

--- a/packages/server-docker/src/tools/index.ts
+++ b/packages/server-docker/src/tools/index.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
 import { registerPsTool } from "./ps.js";
 import { registerBuildTool } from "./build.js";
 import { registerLogsTool } from "./logs.js";
@@ -10,13 +11,14 @@ import { registerComposeDownTool } from "./compose-down.js";
 import { registerPullTool } from "./pull.js";
 
 export function registerAllTools(server: McpServer) {
-  registerPsTool(server);
-  registerBuildTool(server);
-  registerLogsTool(server);
-  registerImagesTool(server);
-  registerRunTool(server);
-  registerExecTool(server);
-  registerComposeUpTool(server);
-  registerComposeDownTool(server);
-  registerPullTool(server);
+  const s = (name: string) => shouldRegisterTool("docker", name);
+  if (s("ps")) registerPsTool(server);
+  if (s("build")) registerBuildTool(server);
+  if (s("logs")) registerLogsTool(server);
+  if (s("images")) registerImagesTool(server);
+  if (s("run")) registerRunTool(server);
+  if (s("exec")) registerExecTool(server);
+  if (s("compose-up")) registerComposeUpTool(server);
+  if (s("compose-down")) registerComposeDownTool(server);
+  if (s("pull")) registerPullTool(server);
 }

--- a/packages/server-git/src/tools/index.ts
+++ b/packages/server-git/src/tools/index.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
 import { registerStatusTool } from "./status.js";
 import { registerLogTool } from "./log.js";
 import { registerDiffTool } from "./diff.js";
@@ -11,14 +12,15 @@ import { registerPullTool } from "./pull.js";
 import { registerCheckoutTool } from "./checkout.js";
 
 export function registerAllTools(server: McpServer) {
-  registerStatusTool(server);
-  registerLogTool(server);
-  registerDiffTool(server);
-  registerBranchTool(server);
-  registerShowTool(server);
-  registerAddTool(server);
-  registerCommitTool(server);
-  registerPushTool(server);
-  registerPullTool(server);
-  registerCheckoutTool(server);
+  const s = (name: string) => shouldRegisterTool("git", name);
+  if (s("status")) registerStatusTool(server);
+  if (s("log")) registerLogTool(server);
+  if (s("diff")) registerDiffTool(server);
+  if (s("branch")) registerBranchTool(server);
+  if (s("show")) registerShowTool(server);
+  if (s("add")) registerAddTool(server);
+  if (s("commit")) registerCommitTool(server);
+  if (s("push")) registerPushTool(server);
+  if (s("pull")) registerPullTool(server);
+  if (s("checkout")) registerCheckoutTool(server);
 }

--- a/packages/server-go/src/tools/index.ts
+++ b/packages/server-go/src/tools/index.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
 import { registerBuildTool } from "./build.js";
 import { registerTestTool } from "./test.js";
 import { registerVetTool } from "./vet.js";
@@ -8,11 +9,12 @@ import { registerFmtTool } from "./fmt.js";
 import { registerGenerateTool } from "./generate.js";
 
 export function registerAllTools(server: McpServer) {
-  registerBuildTool(server);
-  registerTestTool(server);
-  registerVetTool(server);
-  registerRunTool(server);
-  registerModTidyTool(server);
-  registerFmtTool(server);
-  registerGenerateTool(server);
+  const s = (name: string) => shouldRegisterTool("go", name);
+  if (s("build")) registerBuildTool(server);
+  if (s("test")) registerTestTool(server);
+  if (s("vet")) registerVetTool(server);
+  if (s("run")) registerRunTool(server);
+  if (s("mod-tidy")) registerModTidyTool(server);
+  if (s("fmt")) registerFmtTool(server);
+  if (s("generate")) registerGenerateTool(server);
 }

--- a/packages/server-lint/src/tools/index.ts
+++ b/packages/server-lint/src/tools/index.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
 import { registerLintTool } from "./lint.js";
 import { registerFormatCheckTool } from "./format-check.js";
 import { registerPrettierFormatTool } from "./prettier-format.js";
@@ -6,9 +7,10 @@ import { registerBiomeCheckTool } from "./biome-check.js";
 import { registerBiomeFormatTool } from "./biome-format.js";
 
 export function registerAllTools(server: McpServer) {
-  registerLintTool(server);
-  registerFormatCheckTool(server);
-  registerPrettierFormatTool(server);
-  registerBiomeCheckTool(server);
-  registerBiomeFormatTool(server);
+  const s = (name: string) => shouldRegisterTool("lint", name);
+  if (s("lint")) registerLintTool(server);
+  if (s("format-check")) registerFormatCheckTool(server);
+  if (s("prettier-format")) registerPrettierFormatTool(server);
+  if (s("biome-check")) registerBiomeCheckTool(server);
+  if (s("biome-format")) registerBiomeFormatTool(server);
 }

--- a/packages/server-npm/src/tools/index.ts
+++ b/packages/server-npm/src/tools/index.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
 import { registerInstallTool } from "./install.js";
 import { registerAuditTool } from "./audit.js";
 import { registerOutdatedTool } from "./outdated.js";
@@ -8,11 +9,12 @@ import { registerTestTool } from "./test.js";
 import { registerInitTool } from "./init.js";
 
 export function registerAllTools(server: McpServer) {
-  registerInstallTool(server);
-  registerAuditTool(server);
-  registerOutdatedTool(server);
-  registerListTool(server);
-  registerRunTool(server);
-  registerTestTool(server);
-  registerInitTool(server);
+  const s = (name: string) => shouldRegisterTool("npm", name);
+  if (s("install")) registerInstallTool(server);
+  if (s("audit")) registerAuditTool(server);
+  if (s("outdated")) registerOutdatedTool(server);
+  if (s("list")) registerListTool(server);
+  if (s("run")) registerRunTool(server);
+  if (s("test")) registerTestTool(server);
+  if (s("init")) registerInitTool(server);
 }

--- a/packages/server-python/src/tools/index.ts
+++ b/packages/server-python/src/tools/index.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
 import { registerPipInstallTool } from "./pip-install.js";
 import { registerMypyTool } from "./mypy.js";
 import { registerRuffTool } from "./ruff.js";
@@ -9,12 +10,13 @@ import { registerUvRunTool } from "./uv-run.js";
 import { registerBlackTool } from "./black.js";
 
 export function registerAllTools(server: McpServer) {
-  registerPipInstallTool(server);
-  registerMypyTool(server);
-  registerRuffTool(server);
-  registerPipAuditTool(server);
-  registerPytestTool(server);
-  registerUvInstallTool(server);
-  registerUvRunTool(server);
-  registerBlackTool(server);
+  const s = (name: string) => shouldRegisterTool("python", name);
+  if (s("pip-install")) registerPipInstallTool(server);
+  if (s("mypy")) registerMypyTool(server);
+  if (s("ruff-check")) registerRuffTool(server);
+  if (s("pip-audit")) registerPipAuditTool(server);
+  if (s("pytest")) registerPytestTool(server);
+  if (s("uv-install")) registerUvInstallTool(server);
+  if (s("uv-run")) registerUvRunTool(server);
+  if (s("black")) registerBlackTool(server);
 }

--- a/packages/server-test/src/tools/index.ts
+++ b/packages/server-test/src/tools/index.ts
@@ -1,8 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
 import { registerRunTool } from "./run.js";
 import { registerCoverageTool } from "./coverage.js";
 
 export function registerAllTools(server: McpServer) {
-  registerRunTool(server);
-  registerCoverageTool(server);
+  const s = (name: string) => shouldRegisterTool("test", name);
+  if (s("run")) registerRunTool(server);
+  if (s("coverage")) registerCoverageTool(server);
 }

--- a/packages/shared/__tests__/tool-filter.test.ts
+++ b/packages/shared/__tests__/tool-filter.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { shouldRegisterTool } from "../src/tool-filter.js";
+
+describe("shouldRegisterTool", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    // Save current env vars
+    savedEnv.PARE_TOOLS = process.env.PARE_TOOLS;
+    savedEnv.PARE_GIT_TOOLS = process.env.PARE_GIT_TOOLS;
+    savedEnv.PARE_NPM_TOOLS = process.env.PARE_NPM_TOOLS;
+    savedEnv.PARE_DOCKER_TOOLS = process.env.PARE_DOCKER_TOOLS;
+    // Clean slate
+    delete process.env.PARE_TOOLS;
+    delete process.env.PARE_GIT_TOOLS;
+    delete process.env.PARE_NPM_TOOLS;
+    delete process.env.PARE_DOCKER_TOOLS;
+  });
+
+  afterEach(() => {
+    // Restore env vars
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = val;
+      }
+    }
+  });
+
+  describe("default behavior (no env vars)", () => {
+    it("enables all tools when no env vars are set", () => {
+      expect(shouldRegisterTool("git", "status")).toBe(true);
+      expect(shouldRegisterTool("git", "log")).toBe(true);
+      expect(shouldRegisterTool("npm", "install")).toBe(true);
+      expect(shouldRegisterTool("docker", "ps")).toBe(true);
+    });
+  });
+
+  describe("universal filter (PARE_TOOLS)", () => {
+    it("enables only specified tools", () => {
+      process.env.PARE_TOOLS = "git:status,git:log";
+      expect(shouldRegisterTool("git", "status")).toBe(true);
+      expect(shouldRegisterTool("git", "log")).toBe(true);
+      expect(shouldRegisterTool("git", "diff")).toBe(false);
+      expect(shouldRegisterTool("npm", "install")).toBe(false);
+    });
+
+    it("handles whitespace in tool list", () => {
+      process.env.PARE_TOOLS = "git:status , npm:install , docker:ps";
+      expect(shouldRegisterTool("git", "status")).toBe(true);
+      expect(shouldRegisterTool("npm", "install")).toBe(true);
+      expect(shouldRegisterTool("docker", "ps")).toBe(true);
+      expect(shouldRegisterTool("git", "log")).toBe(false);
+    });
+
+    it("disables everything when set to empty string", () => {
+      process.env.PARE_TOOLS = "";
+      expect(shouldRegisterTool("git", "status")).toBe(false);
+      expect(shouldRegisterTool("npm", "install")).toBe(false);
+    });
+
+    it("disables everything when set to whitespace only", () => {
+      process.env.PARE_TOOLS = "   ";
+      expect(shouldRegisterTool("git", "status")).toBe(false);
+    });
+
+    it("overrides per-server filter", () => {
+      process.env.PARE_TOOLS = "git:status";
+      process.env.PARE_GIT_TOOLS = "status,log,diff";
+      // Universal takes precedence — only git:status allowed
+      expect(shouldRegisterTool("git", "status")).toBe(true);
+      expect(shouldRegisterTool("git", "log")).toBe(false);
+      expect(shouldRegisterTool("git", "diff")).toBe(false);
+    });
+  });
+
+  describe("per-server filter (PARE_{SERVER}_TOOLS)", () => {
+    it("enables only specified tools for that server", () => {
+      process.env.PARE_GIT_TOOLS = "status,log";
+      expect(shouldRegisterTool("git", "status")).toBe(true);
+      expect(shouldRegisterTool("git", "log")).toBe(true);
+      expect(shouldRegisterTool("git", "diff")).toBe(false);
+    });
+
+    it("does not affect other servers", () => {
+      process.env.PARE_GIT_TOOLS = "status";
+      // npm has no filter set → all enabled
+      expect(shouldRegisterTool("npm", "install")).toBe(true);
+      expect(shouldRegisterTool("npm", "audit")).toBe(true);
+    });
+
+    it("handles whitespace in tool list", () => {
+      process.env.PARE_GIT_TOOLS = " status , log ";
+      expect(shouldRegisterTool("git", "status")).toBe(true);
+      expect(shouldRegisterTool("git", "log")).toBe(true);
+      expect(shouldRegisterTool("git", "diff")).toBe(false);
+    });
+
+    it("disables all tools for server when set to empty string", () => {
+      process.env.PARE_GIT_TOOLS = "";
+      expect(shouldRegisterTool("git", "status")).toBe(false);
+      expect(shouldRegisterTool("git", "log")).toBe(false);
+    });
+
+    it("handles hyphenated server names", () => {
+      // e.g., server name "my-server" → PARE_MY_SERVER_TOOLS
+      process.env.PARE_MY_SERVER_TOOLS = "tool-a";
+      expect(shouldRegisterTool("my-server", "tool-a")).toBe(true);
+      expect(shouldRegisterTool("my-server", "tool-b")).toBe(false);
+    });
+
+    it("supports multiple per-server filters simultaneously", () => {
+      process.env.PARE_GIT_TOOLS = "status";
+      process.env.PARE_NPM_TOOLS = "install";
+      expect(shouldRegisterTool("git", "status")).toBe(true);
+      expect(shouldRegisterTool("git", "log")).toBe(false);
+      expect(shouldRegisterTool("npm", "install")).toBe(true);
+      expect(shouldRegisterTool("npm", "audit")).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,4 +4,5 @@ export { stripAnsi } from "./ansi.js";
 export { assertNoFlagInjection, assertAllowedCommand } from "./validation.js";
 export { INPUT_LIMITS } from "./limits.js";
 export { sanitizeErrorOutput } from "./sanitize.js";
+export { shouldRegisterTool } from "./tool-filter.js";
 export type { ToolOutput } from "./types.js";


### PR DESCRIPTION
## Summary

Implements #111 — granular tool selection via environment variables.

- **`PARE_TOOLS`** (universal): comma-separated `server:tool` pairs to control tools across all servers
- **`PARE_{SERVER}_TOOLS`** (per-server): comma-separated tool names to control a single server
- No env var = all tools enabled (default)
- Universal takes precedence over per-server

### Changes
- New `shouldRegisterTool()` in `@paretools/shared` (`packages/shared/src/tool-filter.ts`)
- All 9 server packages updated to check `shouldRegisterTool()` before registering each tool
- 12 unit tests covering default, universal, per-server, empty string, whitespace, and precedence
- README: new "Configuration > Tool Selection" section with env var docs, JSON config examples, and common patterns

### Test plan
- [x] 12 new unit tests pass (`packages/shared/__tests__/tool-filter.test.ts`)
- [x] Full `pnpm build` passes across all packages
- [x] Full `pnpm test` passes across all packages (1,334+ tests)
- [ ] Manual verification: set `PARE_GIT_TOOLS=status` and confirm only status tool is registered

Closes #111