### PR TITLE
feat: new @paretools/search server (ripgrep + fd)

### DIFF
--- a/packages/server-search/__tests__/formatters.test.ts
+++ b/packages/server-search/__tests__/formatters.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatSearch,
+  formatFind,
+  formatCount,
+  compactSearchMap,
+  compactFindMap,
+  compactCountMap,
+  formatSearchCompact,
+  formatFindCompact,
+  formatCountCompact,
+} from "../src/lib/formatters.js";
+import type { SearchResult, FindResult, CountResult } from "../src/schemas/index.js";
+
+// ── Full formatters ─────────────────────────────────────────────────
+
+describe("formatSearch", () => {
+  it("formats matches with file locations", () => {
+    const data: SearchResult = {
+      matches: [
+        { file: "src/foo.ts", line: 42, column: 7, matchText: "x", lineContent: "const x = 1;" },
+        {
+          file: "src/bar.ts",
+          line: 10,
+          column: 9,
+          matchText: "x",
+          lineContent: "let y = x + 2;",
+        },
+      ],
+      totalMatches: 2,
+      filesSearched: 2,
+    };
+    const output = formatSearch(data);
+    expect(output).toContain("search: 2 matches in 2 files");
+    expect(output).toContain("src/foo.ts:42:7: const x = 1;");
+    expect(output).toContain("src/bar.ts:10:9: let y = x + 2;");
+  });
+
+  it("formats no matches", () => {
+    const data: SearchResult = { matches: [], totalMatches: 0, filesSearched: 0 };
+    expect(formatSearch(data)).toBe("search: no matches found.");
+  });
+});
+
+describe("formatFind", () => {
+  it("formats file listing", () => {
+    const data: FindResult = {
+      files: [
+        { path: "src/index.ts", name: "index.ts", ext: ".ts" },
+        { path: "README.md", name: "README.md", ext: ".md" },
+      ],
+      total: 2,
+    };
+    const output = formatFind(data);
+    expect(output).toContain("find: 2 files");
+    expect(output).toContain("src/index.ts");
+    expect(output).toContain("README.md");
+  });
+
+  it("formats no files found", () => {
+    const data: FindResult = { files: [], total: 0 };
+    expect(formatFind(data)).toBe("find: no files found.");
+  });
+});
+
+describe("formatCount", () => {
+  it("formats per-file counts", () => {
+    const data: CountResult = {
+      files: [
+        { file: "src/index.ts", count: 5 },
+        { file: "src/lib/parsers.ts", count: 12 },
+      ],
+      totalMatches: 17,
+      totalFiles: 2,
+    };
+    const output = formatCount(data);
+    expect(output).toContain("count: 17 matches in 2 files");
+    expect(output).toContain("src/index.ts: 5");
+    expect(output).toContain("src/lib/parsers.ts: 12");
+  });
+
+  it("formats no matches", () => {
+    const data: CountResult = { files: [], totalMatches: 0, totalFiles: 0 };
+    expect(formatCount(data)).toBe("count: no matches found.");
+  });
+});
+
+// ── Compact mappers ─────────────────────────────────────────────────
+
+describe("compactSearchMap", () => {
+  it("drops individual matches, keeps totals", () => {
+    const data: SearchResult = {
+      matches: [
+        { file: "src/a.ts", line: 1, column: 1, matchText: "foo", lineContent: "const foo = 1;" },
+      ],
+      totalMatches: 1,
+      filesSearched: 1,
+    };
+    const compact = compactSearchMap(data);
+    expect(compact).toEqual({ totalMatches: 1, filesSearched: 1 });
+    expect((compact as Record<string, unknown>)["matches"]).toBeUndefined();
+  });
+});
+
+describe("compactFindMap", () => {
+  it("drops individual file entries, keeps total", () => {
+    const data: FindResult = {
+      files: [{ path: "a.ts", name: "a.ts", ext: ".ts" }],
+      total: 1,
+    };
+    const compact = compactFindMap(data);
+    expect(compact).toEqual({ total: 1 });
+    expect((compact as Record<string, unknown>)["files"]).toBeUndefined();
+  });
+});
+
+describe("compactCountMap", () => {
+  it("drops per-file breakdown, keeps totals", () => {
+    const data: CountResult = {
+      files: [{ file: "a.ts", count: 5 }],
+      totalMatches: 5,
+      totalFiles: 1,
+    };
+    const compact = compactCountMap(data);
+    expect(compact).toEqual({ totalMatches: 5, totalFiles: 1 });
+    expect((compact as Record<string, unknown>)["files"]).toBeUndefined();
+  });
+});
+
+// ── Compact formatters ──────────────────────────────────────────────
+
+describe("formatSearchCompact", () => {
+  it("formats compact search summary", () => {
+    expect(formatSearchCompact({ totalMatches: 10, filesSearched: 3 })).toBe(
+      "search: 10 matches in 3 files",
+    );
+  });
+
+  it("formats no matches", () => {
+    expect(formatSearchCompact({ totalMatches: 0, filesSearched: 0 })).toBe(
+      "search: no matches found.",
+    );
+  });
+});
+
+describe("formatFindCompact", () => {
+  it("formats compact find summary", () => {
+    expect(formatFindCompact({ total: 42 })).toBe("find: 42 files");
+  });
+
+  it("formats no files", () => {
+    expect(formatFindCompact({ total: 0 })).toBe("find: no files found.");
+  });
+});
+
+describe("formatCountCompact", () => {
+  it("formats compact count summary", () => {
+    expect(formatCountCompact({ totalMatches: 100, totalFiles: 5 })).toBe(
+      "count: 100 matches in 5 files",
+    );
+  });
+
+  it("formats no matches", () => {
+    expect(formatCountCompact({ totalMatches: 0, totalFiles: 0 })).toBe("count: no matches found.");
+  });
+});

--- a/packages/server-search/__tests__/parsers.test.ts
+++ b/packages/server-search/__tests__/parsers.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from "vitest";
+import { parseRgJsonOutput, parseFdOutput, parseRgCountOutput } from "../src/lib/parsers.js";
+
+describe("parseRgJsonOutput", () => {
+  it("parses match events from rg --json output", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "match",
+        data: {
+          path: { text: "src/foo.ts" },
+          lines: { text: "const x = 1;\n" },
+          line_number: 42,
+          absolute_offset: 1234,
+          submatches: [{ match: { text: "x" }, start: 6, end: 7 }],
+        },
+      }),
+      JSON.stringify({
+        type: "match",
+        data: {
+          path: { text: "src/bar.ts" },
+          lines: { text: "let y = x + 2;\n" },
+          line_number: 10,
+          absolute_offset: 500,
+          submatches: [{ match: { text: "x" }, start: 8, end: 9 }],
+        },
+      }),
+      JSON.stringify({
+        type: "summary",
+        data: {
+          stats: {
+            searches_with_match: 2,
+            bytes_searched: 12345,
+          },
+        },
+      }),
+    ].join("\n");
+
+    const result = parseRgJsonOutput(stdout, 1000);
+
+    expect(result.totalMatches).toBe(2);
+    expect(result.filesSearched).toBe(2);
+    expect(result.matches).toHaveLength(2);
+    expect(result.matches[0]).toEqual({
+      file: "src/foo.ts",
+      line: 42,
+      column: 7, // 1-based: start(6) + 1
+      matchText: "x",
+      lineContent: "const x = 1;",
+    });
+    expect(result.matches[1]).toEqual({
+      file: "src/bar.ts",
+      line: 10,
+      column: 9, // 1-based: start(8) + 1
+      matchText: "x",
+      lineContent: "let y = x + 2;",
+    });
+  });
+
+  it("respects maxResults limit", () => {
+    const lines = [];
+    for (let i = 0; i < 5; i++) {
+      lines.push(
+        JSON.stringify({
+          type: "match",
+          data: {
+            path: { text: `file${i}.ts` },
+            lines: { text: `line ${i}\n` },
+            line_number: i + 1,
+            absolute_offset: i * 100,
+            submatches: [{ match: { text: "line" }, start: 0, end: 4 }],
+          },
+        }),
+      );
+    }
+    const stdout = lines.join("\n");
+
+    const result = parseRgJsonOutput(stdout, 3);
+
+    expect(result.totalMatches).toBe(3);
+    expect(result.matches).toHaveLength(3);
+    expect(result.matches[0].file).toBe("file0.ts");
+    expect(result.matches[2].file).toBe("file2.ts");
+  });
+
+  it("handles empty output", () => {
+    const result = parseRgJsonOutput("", 1000);
+
+    expect(result.totalMatches).toBe(0);
+    expect(result.filesSearched).toBe(0);
+    expect(result.matches).toHaveLength(0);
+  });
+
+  it("skips non-JSON lines gracefully", () => {
+    const stdout = [
+      "not valid json",
+      JSON.stringify({
+        type: "match",
+        data: {
+          path: { text: "src/valid.ts" },
+          lines: { text: "found it\n" },
+          line_number: 1,
+          absolute_offset: 0,
+          submatches: [{ match: { text: "found" }, start: 0, end: 5 }],
+        },
+      }),
+      "another invalid line",
+    ].join("\n");
+
+    const result = parseRgJsonOutput(stdout, 1000);
+
+    expect(result.totalMatches).toBe(1);
+    expect(result.matches[0].file).toBe("src/valid.ts");
+  });
+
+  it("skips non-match type events", () => {
+    const stdout = [
+      JSON.stringify({ type: "begin", data: { path: { text: "src/foo.ts" } } }),
+      JSON.stringify({
+        type: "match",
+        data: {
+          path: { text: "src/foo.ts" },
+          lines: { text: "hello world\n" },
+          line_number: 5,
+          absolute_offset: 100,
+          submatches: [{ match: { text: "hello" }, start: 0, end: 5 }],
+        },
+      }),
+      JSON.stringify({ type: "end", data: { path: { text: "src/foo.ts" }, stats: {} } }),
+    ].join("\n");
+
+    const result = parseRgJsonOutput(stdout, 1000);
+
+    expect(result.totalMatches).toBe(1);
+    expect(result.matches[0].matchText).toBe("hello");
+  });
+
+  it("counts unique files when no summary line is present", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "match",
+        data: {
+          path: { text: "src/a.ts" },
+          lines: { text: "match1\n" },
+          line_number: 1,
+          absolute_offset: 0,
+          submatches: [{ match: { text: "match1" }, start: 0, end: 6 }],
+        },
+      }),
+      JSON.stringify({
+        type: "match",
+        data: {
+          path: { text: "src/a.ts" },
+          lines: { text: "match2\n" },
+          line_number: 5,
+          absolute_offset: 50,
+          submatches: [{ match: { text: "match2" }, start: 0, end: 6 }],
+        },
+      }),
+      JSON.stringify({
+        type: "match",
+        data: {
+          path: { text: "src/b.ts" },
+          lines: { text: "match3\n" },
+          line_number: 3,
+          absolute_offset: 200,
+          submatches: [{ match: { text: "match3" }, start: 0, end: 6 }],
+        },
+      }),
+    ].join("\n");
+
+    const result = parseRgJsonOutput(stdout, 1000);
+
+    expect(result.totalMatches).toBe(3);
+    // No summary line, so filesSearched falls back to unique file count
+    expect(result.filesSearched).toBe(2);
+  });
+});
+
+describe("parseFdOutput", () => {
+  it("parses fd output with file paths", () => {
+    const stdout = ["src/index.ts", "src/lib/parsers.ts", "README.md"].join("\n");
+
+    const result = parseFdOutput(stdout, 1000);
+
+    expect(result.total).toBe(3);
+    expect(result.files).toHaveLength(3);
+    expect(result.files[0]).toEqual({
+      path: "src/index.ts",
+      name: "index.ts",
+      ext: ".ts",
+    });
+    expect(result.files[1]).toEqual({
+      path: "src/lib/parsers.ts",
+      name: "parsers.ts",
+      ext: ".ts",
+    });
+    expect(result.files[2]).toEqual({
+      path: "README.md",
+      name: "README.md",
+      ext: ".md",
+    });
+  });
+
+  it("handles files without extensions", () => {
+    const stdout = ["Makefile", "Dockerfile", ".gitignore"].join("\n");
+
+    const result = parseFdOutput(stdout, 1000);
+
+    expect(result.total).toBe(3);
+    expect(result.files[0]).toEqual({
+      path: "Makefile",
+      name: "Makefile",
+      ext: "",
+    });
+    expect(result.files[1]).toEqual({
+      path: "Dockerfile",
+      name: "Dockerfile",
+      ext: "",
+    });
+    expect(result.files[2]).toEqual({
+      path: ".gitignore",
+      name: ".gitignore",
+      ext: "",
+    });
+  });
+
+  it("respects maxResults limit", () => {
+    const stdout = ["a.ts", "b.ts", "c.ts", "d.ts", "e.ts"].join("\n");
+
+    const result = parseFdOutput(stdout, 3);
+
+    expect(result.total).toBe(3);
+    expect(result.files).toHaveLength(3);
+  });
+
+  it("handles empty output", () => {
+    const result = parseFdOutput("", 1000);
+
+    expect(result.total).toBe(0);
+    expect(result.files).toHaveLength(0);
+  });
+
+  it("handles trailing newlines and blank lines", () => {
+    const stdout = "src/index.ts\n\nsrc/lib/foo.ts\n\n";
+
+    const result = parseFdOutput(stdout, 1000);
+
+    expect(result.total).toBe(2);
+    expect(result.files[0].path).toBe("src/index.ts");
+    expect(result.files[1].path).toBe("src/lib/foo.ts");
+  });
+});
+
+describe("parseRgCountOutput", () => {
+  it("parses rg --count output with file:count format", () => {
+    const stdout = ["src/index.ts:5", "src/lib/parsers.ts:12", "README.md:1"].join("\n");
+
+    const result = parseRgCountOutput(stdout);
+
+    expect(result.totalFiles).toBe(3);
+    expect(result.totalMatches).toBe(18);
+    expect(result.files).toHaveLength(3);
+    expect(result.files[0]).toEqual({ file: "src/index.ts", count: 5 });
+    expect(result.files[1]).toEqual({ file: "src/lib/parsers.ts", count: 12 });
+    expect(result.files[2]).toEqual({ file: "README.md", count: 1 });
+  });
+
+  it("handles Windows paths with drive letter colons", () => {
+    const stdout = "C:\\Users\\code\\file.ts:3";
+
+    const result = parseRgCountOutput(stdout);
+
+    expect(result.totalFiles).toBe(1);
+    expect(result.files[0]).toEqual({ file: "C:\\Users\\code\\file.ts", count: 3 });
+  });
+
+  it("handles empty output", () => {
+    const result = parseRgCountOutput("");
+
+    expect(result.totalFiles).toBe(0);
+    expect(result.totalMatches).toBe(0);
+    expect(result.files).toHaveLength(0);
+  });
+
+  it("skips lines without colon separator", () => {
+    const stdout = ["valid.ts:5", "no-colon-here", "also_valid.ts:2"].join("\n");
+
+    const result = parseRgCountOutput(stdout);
+
+    expect(result.totalFiles).toBe(2);
+    expect(result.totalMatches).toBe(7);
+  });
+
+  it("skips lines with non-numeric count", () => {
+    const stdout = ["file.ts:abc", "other.ts:10"].join("\n");
+
+    const result = parseRgCountOutput(stdout);
+
+    expect(result.totalFiles).toBe(1);
+    expect(result.totalMatches).toBe(10);
+    expect(result.files[0]).toEqual({ file: "other.ts", count: 10 });
+  });
+});

--- a/packages/server-search/__tests__/security.test.ts
+++ b/packages/server-search/__tests__/security.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Security tests: verify that assertNoFlagInjection() prevents flag injection
+ * attacks on user-supplied parameters in search tools.
+ *
+ * These tools accept user-provided strings (patterns, paths, glob patterns,
+ * file extensions) that are passed as positional arguments to rg/fd. Without
+ * validation, a malicious input like "--exec=rm -rf /" could be interpreted
+ * as a flag.
+ */
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+
+/** Malicious inputs that must be rejected by every guarded parameter. */
+const MALICIOUS_INPUTS = [
+  "--exec=rm -rf /",
+  "-l",
+  "--replace=pwned",
+  "-o",
+  "--output",
+  "--json",
+  "--count",
+  "--files",
+  "--passthru",
+  // Whitespace bypass attempts
+  " --exec",
+  "\t-l",
+  "   --replace",
+];
+
+/** Safe inputs that must be accepted. */
+const SAFE_INPUTS = [
+  "function",
+  "TODO",
+  "import.*from",
+  "*.ts",
+  "src/lib",
+  ".",
+  "test_pattern",
+  "README.md",
+  "ts",
+  "tsx",
+];
+
+describe("security: search — pattern validation", () => {
+  it("rejects flag-like patterns", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "pattern")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe patterns", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "pattern")).not.toThrow();
+    }
+  });
+});
+
+describe("security: search — path validation", () => {
+  it("rejects flag-like paths", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "path")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe paths", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "path")).not.toThrow();
+    }
+  });
+});
+
+describe("security: search — glob validation", () => {
+  it("rejects flag-like globs", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "glob")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe globs", () => {
+    const safeGlobs = ["*.ts", "*.{js,jsx}", "src/**/*.ts", "!node_modules"];
+    for (const safe of safeGlobs) {
+      expect(() => assertNoFlagInjection(safe, "glob")).not.toThrow();
+    }
+  });
+});
+
+describe("security: find — extension validation", () => {
+  it("rejects flag-like extensions", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "extension")).toThrow(
+        /must not start with "-"/,
+      );
+    }
+  });
+
+  it("accepts safe extensions", () => {
+    const safeExtensions = ["ts", "js", "tsx", "jsx", "py", "go", "rs"];
+    for (const safe of safeExtensions) {
+      expect(() => assertNoFlagInjection(safe, "extension")).not.toThrow();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zod .max() input-limit constraints — Search tool schemas
+// ---------------------------------------------------------------------------
+
+describe("Zod .max() constraints — Search tool schemas", () => {
+  describe("pattern parameter (STRING_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.STRING_MAX);
+
+    it("accepts a pattern within the limit", () => {
+      expect(schema.safeParse("function.*export").success).toBe(true);
+    });
+
+    it("rejects a pattern exceeding STRING_MAX", () => {
+      const oversized = "x".repeat(INPUT_LIMITS.STRING_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("path parameter (PATH_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.PATH_MAX);
+
+    it("accepts a path within the limit", () => {
+      expect(schema.safeParse("/home/user/project/src").success).toBe(true);
+    });
+
+    it("rejects a path exceeding PATH_MAX", () => {
+      const oversized = "p".repeat(INPUT_LIMITS.PATH_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("glob parameter (SHORT_STRING_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.SHORT_STRING_MAX);
+
+    it("accepts a glob within the limit", () => {
+      expect(schema.safeParse("*.{ts,tsx,js,jsx}").success).toBe(true);
+    });
+
+    it("rejects a glob exceeding SHORT_STRING_MAX", () => {
+      const oversized = "g".repeat(INPUT_LIMITS.SHORT_STRING_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("extension parameter (SHORT_STRING_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.SHORT_STRING_MAX);
+
+    it("accepts an extension within the limit", () => {
+      expect(schema.safeParse("ts").success).toBe(true);
+    });
+
+    it("rejects an extension exceeding SHORT_STRING_MAX", () => {
+      const oversized = "e".repeat(INPUT_LIMITS.SHORT_STRING_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+});

--- a/packages/server-search/package.json
+++ b/packages/server-search/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@paretools/search",
+  "version": "0.7.0",
+  "mcpName": "io.github.Dave-London/search",
+  "description": "MCP server for code search (ripgrep + fd) with structured, token-efficient output",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "structured-output",
+    "ai",
+    "ai-agent",
+    "claude",
+    "cursor",
+    "copilot",
+    "token-efficient",
+    "devtools",
+    "cli",
+    "ripgrep",
+    "rg",
+    "fd",
+    "search",
+    "find",
+    "grep"
+  ],
+  "homepage": "https://github.com/Dave-London/Pare/tree/main/packages/server-search",
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "bin": {
+    "pare-search": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/Pare.git",
+    "directory": "packages/server-search"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@paretools/shared": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@paretools/tsconfig": "workspace:*",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/server-search/src/index.ts
+++ b/packages/server-search/src/index.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerAllTools } from "./tools/index.js";
+
+const server = new McpServer(
+  { name: "@paretools/search", version: "0.7.0" },
+  {
+    instructions:
+      "Structured code search operations (ripgrep + fd). Returns typed JSON with match locations, file lists, and match counts. Use instead of running rg/fd/grep/find in the terminal.",
+  },
+);
+
+registerAllTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/server-search/src/lib/formatters.ts
+++ b/packages/server-search/src/lib/formatters.ts
@@ -1,0 +1,93 @@
+import type { SearchResult, FindResult, CountResult } from "../schemas/index.js";
+
+// ── Full formatters ─────────────────────────────────────────────────
+
+/** Formats structured search results into a human-readable match listing. */
+export function formatSearch(data: SearchResult): string {
+  if (data.totalMatches === 0) return "search: no matches found.";
+
+  const lines = [`search: ${data.totalMatches} matches in ${data.filesSearched} files`];
+  for (const m of data.matches) {
+    lines.push(`  ${m.file}:${m.line}:${m.column}: ${m.lineContent}`);
+  }
+  return lines.join("\n");
+}
+
+/** Formats structured find results into a human-readable file listing. */
+export function formatFind(data: FindResult): string {
+  if (data.total === 0) return "find: no files found.";
+
+  const lines = [`find: ${data.total} files`];
+  for (const f of data.files) {
+    lines.push(`  ${f.path}`);
+  }
+  return lines.join("\n");
+}
+
+/** Formats structured count results into a human-readable per-file count listing. */
+export function formatCount(data: CountResult): string {
+  if (data.totalFiles === 0) return "count: no matches found.";
+
+  const lines = [`count: ${data.totalMatches} matches in ${data.totalFiles} files`];
+  for (const f of data.files) {
+    lines.push(`  ${f.file}: ${f.count}`);
+  }
+  return lines.join("\n");
+}
+
+// ── Compact types, mappers, and formatters ──────────────────────────
+
+/** Compact search: totals only, drop individual matches. */
+export interface SearchCompact {
+  [key: string]: unknown;
+  totalMatches: number;
+  filesSearched: number;
+}
+
+export function compactSearchMap(data: SearchResult): SearchCompact {
+  return {
+    totalMatches: data.totalMatches,
+    filesSearched: data.filesSearched,
+  };
+}
+
+export function formatSearchCompact(data: SearchCompact): string {
+  if (data.totalMatches === 0) return "search: no matches found.";
+  return `search: ${data.totalMatches} matches in ${data.filesSearched} files`;
+}
+
+/** Compact find: total count only, drop individual file entries. */
+export interface FindCompact {
+  [key: string]: unknown;
+  total: number;
+}
+
+export function compactFindMap(data: FindResult): FindCompact {
+  return {
+    total: data.total,
+  };
+}
+
+export function formatFindCompact(data: FindCompact): string {
+  if (data.total === 0) return "find: no files found.";
+  return `find: ${data.total} files`;
+}
+
+/** Compact count: totals only, drop per-file breakdown. */
+export interface CountCompact {
+  [key: string]: unknown;
+  totalMatches: number;
+  totalFiles: number;
+}
+
+export function compactCountMap(data: CountResult): CountCompact {
+  return {
+    totalMatches: data.totalMatches,
+    totalFiles: data.totalFiles,
+  };
+}
+
+export function formatCountCompact(data: CountCompact): string {
+  if (data.totalFiles === 0) return "count: no matches found.";
+  return `count: ${data.totalMatches} matches in ${data.totalFiles} files`;
+}

--- a/packages/server-search/src/lib/parsers.ts
+++ b/packages/server-search/src/lib/parsers.ts
@@ -1,0 +1,154 @@
+import type { SearchResult, FindResult, CountResult } from "../schemas/index.js";
+import * as path from "node:path";
+
+// ── rg --json parser ────────────────────────────────────────────────
+
+/**
+ * Represents a single match event from `rg --json` JSONL output.
+ * Each line has a `type` field; we only care about "match" and "summary".
+ */
+interface RgJsonMatch {
+  type: "match";
+  data: {
+    path: { text: string };
+    lines: { text: string };
+    line_number: number;
+    absolute_offset: number;
+    submatches: Array<{
+      match: { text: string };
+      start: number;
+      end: number;
+    }>;
+  };
+}
+
+interface RgJsonSummary {
+  type: "summary";
+  data: {
+    stats: {
+      searches_with_match: number;
+      bytes_searched: number;
+    };
+  };
+}
+
+type RgJsonLine = RgJsonMatch | RgJsonSummary | { type: string };
+
+/**
+ * Parses `rg --json` JSONL output into a structured SearchResult.
+ *
+ * Each line of stdout is a JSON object. We filter for type="match" events
+ * and extract the file, line number, column (from submatches[0].start),
+ * match text, and full line content (trimmed).
+ */
+export function parseRgJsonOutput(stdout: string, maxResults: number): SearchResult {
+  const lines = stdout.split("\n").filter(Boolean);
+  const matches: SearchResult["matches"] = [];
+  let filesSearched = 0;
+  const seenFiles = new Set<string>();
+
+  for (const line of lines) {
+    let parsed: RgJsonLine;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (parsed.type === "match") {
+      const data = (parsed as RgJsonMatch).data;
+      const file = data.path.text;
+      seenFiles.add(file);
+
+      if (matches.length < maxResults) {
+        const submatch = data.submatches[0];
+        matches.push({
+          file,
+          line: data.line_number,
+          column: submatch ? submatch.start + 1 : 1, // 1-based column
+          matchText: submatch ? submatch.match.text : "",
+          lineContent: data.lines.text.trimEnd(),
+        });
+      }
+    } else if (parsed.type === "summary") {
+      const stats = (parsed as RgJsonSummary).data.stats;
+      filesSearched = stats.searches_with_match;
+    }
+  }
+
+  // If no summary line was emitted, use the count of unique files with matches
+  if (filesSearched === 0) {
+    filesSearched = seenFiles.size;
+  }
+
+  return {
+    matches,
+    totalMatches: matches.length,
+    filesSearched,
+  };
+}
+
+// ── fd parser ───────────────────────────────────────────────────────
+
+/**
+ * Parses `fd` output (one file path per line) into a structured FindResult.
+ * Extracts basename and extension for each entry.
+ */
+export function parseFdOutput(stdout: string, maxResults: number): FindResult {
+  const lines = stdout.split("\n").filter(Boolean);
+  const files: FindResult["files"] = [];
+
+  for (const line of lines) {
+    if (files.length >= maxResults) break;
+
+    const filePath = line.trim();
+    if (!filePath) continue;
+
+    const name = path.basename(filePath);
+    const ext = path.extname(filePath);
+
+    files.push({
+      path: filePath,
+      name,
+      ext,
+    });
+  }
+
+  return {
+    files,
+    total: files.length,
+  };
+}
+
+// ── rg --count parser ───────────────────────────────────────────────
+
+/**
+ * Parses `rg --count` output into a structured CountResult.
+ * Each line has the format `file:count`. We split on the LAST colon
+ * to handle file paths that may contain colons (e.g., Windows drive letters).
+ */
+export function parseRgCountOutput(stdout: string): CountResult {
+  const lines = stdout.split("\n").filter(Boolean);
+  const files: CountResult["files"] = [];
+  let totalMatches = 0;
+
+  for (const line of lines) {
+    const lastColon = line.lastIndexOf(":");
+    if (lastColon === -1) continue;
+
+    const file = line.slice(0, lastColon);
+    const countStr = line.slice(lastColon + 1).trim();
+    const count = parseInt(countStr, 10);
+
+    if (isNaN(count)) continue;
+
+    files.push({ file, count });
+    totalMatches += count;
+  }
+
+  return {
+    files,
+    totalMatches,
+    totalFiles: files.length,
+  };
+}

--- a/packages/server-search/src/lib/search-runner.ts
+++ b/packages/server-search/src/lib/search-runner.ts
@@ -1,0 +1,9 @@
+import { run, type RunResult } from "@paretools/shared";
+
+export async function rgCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("rg", args, { cwd, timeout: 120_000 });
+}
+
+export async function fdCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("fd", args, { cwd, timeout: 120_000 });
+}

--- a/packages/server-search/src/schemas/index.ts
+++ b/packages/server-search/src/schemas/index.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+// ── Search (rg --json) ───────────────────────────────────────────────
+
+/** Zod schema for a single search match with file location and matched text. */
+export const SearchMatchSchema = z.object({
+  file: z.string(),
+  line: z.number(),
+  column: z.number(),
+  matchText: z.string(),
+  lineContent: z.string(),
+});
+
+/** Zod schema for structured ripgrep search output with match list and totals. */
+export const SearchResultSchema = z.object({
+  matches: z.array(SearchMatchSchema),
+  totalMatches: z.number(),
+  filesSearched: z.number(),
+});
+
+export type SearchResult = z.infer<typeof SearchResultSchema>;
+
+// ── Find (fd) ────────────────────────────────────────────────────────
+
+/** Zod schema for a single file entry with path, name, and extension. */
+export const FindFileSchema = z.object({
+  path: z.string(),
+  name: z.string(),
+  ext: z.string(),
+});
+
+/** Zod schema for structured fd output with file list and total count. */
+export const FindResultSchema = z.object({
+  files: z.array(FindFileSchema),
+  total: z.number(),
+});
+
+export type FindResult = z.infer<typeof FindResultSchema>;
+
+// ── Count (rg --count) ──────────────────────────────────────────────
+
+/** Zod schema for a single file match count entry. */
+export const CountFileSchema = z.object({
+  file: z.string(),
+  count: z.number(),
+});
+
+/** Zod schema for structured rg --count output with per-file counts and totals. */
+export const CountResultSchema = z.object({
+  files: z.array(CountFileSchema),
+  totalMatches: z.number(),
+  totalFiles: z.number(),
+});
+
+export type CountResult = z.infer<typeof CountResultSchema>;

--- a/packages/server-search/src/tools/count.ts
+++ b/packages/server-search/src/tools/count.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { rgCmd } from "../lib/search-runner.js";
+import { parseRgCountOutput } from "../lib/parsers.js";
+import { formatCount, compactCountMap, formatCountCompact } from "../lib/formatters.js";
+import { CountResultSchema } from "../schemas/index.js";
+
+export function registerCountTool(server: McpServer) {
+  server.registerTool(
+    "count",
+    {
+      title: "Match Count",
+      description:
+        "Counts pattern matches per file using ripgrep. Returns per-file match counts and totals. Use instead of running `rg --count` or `grep -c` in the terminal.",
+      inputSchema: {
+        pattern: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .describe("Regular expression pattern to count matches for"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Directory or file to search in (default: cwd)"),
+        glob: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Glob pattern to filter files (e.g., '*.ts', '*.{js,jsx}')"),
+        caseSensitive: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Case-sensitive search (default: true)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: CountResultSchema,
+    },
+    async ({ pattern, path, glob, caseSensitive, compact }) => {
+      assertNoFlagInjection(pattern, "pattern");
+      if (path) assertNoFlagInjection(path, "path");
+      if (glob) assertNoFlagInjection(glob, "glob");
+
+      const cwd = path || process.cwd();
+      const args = ["--count"];
+
+      if (!caseSensitive) {
+        args.push("--ignore-case");
+      }
+
+      if (glob) {
+        args.push("--glob", glob);
+      }
+
+      args.push(pattern);
+
+      const result = await rgCmd(args, cwd);
+
+      // rg exits with code 1 when no matches are found — that's not an error
+      const data = parseRgCountOutput(result.stdout);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatCount,
+        compactCountMap,
+        formatCountCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-search/src/tools/find.ts
+++ b/packages/server-search/src/tools/find.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { fdCmd } from "../lib/search-runner.js";
+import { parseFdOutput } from "../lib/parsers.js";
+import { formatFind, compactFindMap, formatFindCompact } from "../lib/formatters.js";
+import { FindResultSchema } from "../schemas/index.js";
+
+export function registerFindTool(server: McpServer) {
+  server.registerTool(
+    "find",
+    {
+      title: "Find Files",
+      description:
+        "Finds files and directories using fd with structured output. Returns file paths, names, and extensions. Use instead of running `fd` or `find` in the terminal.",
+      inputSchema: {
+        pattern: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Regex pattern to match file/directory names"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Directory to search in (default: cwd)"),
+        type: z
+          .enum(["file", "directory", "symlink"])
+          .optional()
+          .describe("Filter by entry type: file, directory, or symlink"),
+        extension: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Filter by file extension (e.g., 'ts', 'js')"),
+        maxResults: z
+          .number()
+          .optional()
+          .default(1000)
+          .describe("Maximum number of results to return (default: 1000)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: FindResultSchema,
+    },
+    async ({ pattern, path, type, extension, maxResults, compact }) => {
+      if (pattern) assertNoFlagInjection(pattern, "pattern");
+      if (path) assertNoFlagInjection(path, "path");
+      if (extension) assertNoFlagInjection(extension, "extension");
+
+      const cwd = path || process.cwd();
+      const args = ["--color", "never"];
+
+      if (type) {
+        const typeMap = { file: "f", directory: "d", symlink: "l" } as const;
+        args.push("--type", typeMap[type]);
+      }
+
+      if (extension) {
+        args.push("--extension", extension);
+      }
+
+      if (maxResults) {
+        args.push("--max-results", String(maxResults));
+      }
+
+      if (pattern) {
+        args.push(pattern);
+      }
+
+      const result = await fdCmd(args, cwd);
+      const data = parseFdOutput(result.stdout, maxResults ?? 1000);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatFind,
+        compactFindMap,
+        formatFindCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-search/src/tools/index.ts
+++ b/packages/server-search/src/tools/index.ts
@@ -1,0 +1,12 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
+import { registerSearchTool } from "./search.js";
+import { registerFindTool } from "./find.js";
+import { registerCountTool } from "./count.js";
+
+export function registerAllTools(server: McpServer) {
+  const s = (name: string) => shouldRegisterTool("search", name);
+  if (s("search")) registerSearchTool(server);
+  if (s("find")) registerFindTool(server);
+  if (s("count")) registerCountTool(server);
+}

--- a/packages/server-search/src/tools/search.ts
+++ b/packages/server-search/src/tools/search.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { rgCmd } from "../lib/search-runner.js";
+import { parseRgJsonOutput } from "../lib/parsers.js";
+import { formatSearch, compactSearchMap, formatSearchCompact } from "../lib/formatters.js";
+import { SearchResultSchema } from "../schemas/index.js";
+
+export function registerSearchTool(server: McpServer) {
+  server.registerTool(
+    "search",
+    {
+      title: "Code Search",
+      description:
+        "Searches file contents using ripgrep with structured JSON output. Returns match locations with file, line, column, matched text, and line content. Use instead of running `rg` or `grep` in the terminal.",
+      inputSchema: {
+        pattern: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .describe("Regular expression pattern to search for"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Directory or file to search in (default: cwd)"),
+        glob: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Glob pattern to filter files (e.g., '*.ts', '*.{js,jsx}')"),
+        caseSensitive: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Case-sensitive search (default: true)"),
+        maxResults: z
+          .number()
+          .optional()
+          .default(1000)
+          .describe("Maximum number of matches to return (default: 1000)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: SearchResultSchema,
+    },
+    async ({ pattern, path, glob, caseSensitive, maxResults, compact }) => {
+      assertNoFlagInjection(pattern, "pattern");
+      if (path) assertNoFlagInjection(path, "path");
+      if (glob) assertNoFlagInjection(glob, "glob");
+
+      const cwd = path || process.cwd();
+      const args = ["--json"];
+
+      if (!caseSensitive) {
+        args.push("--ignore-case");
+      }
+
+      if (glob) {
+        args.push("--glob", glob);
+      }
+
+      args.push(pattern);
+
+      // When path is provided, pass it as the search path argument to rg
+      // (not as cwd, since cwd is already set to it for relative paths)
+      const result = await rgCmd(args, cwd);
+
+      // rg exits with code 1 when no matches are found — that's not an error
+      const data = parseRgJsonOutput(result.stdout, maxResults ?? 1000);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatSearch,
+        compactSearchMap,
+        formatSearchCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-search/tsconfig.json
+++ b/packages/server-search/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@paretools/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/server-search/vitest.config.ts
+++ b/packages/server-search/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 60_000,
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 70,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,31 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/server-search:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.26.0(zod@4.3.6)
+      '@paretools/shared':
+        specifier: workspace:*
+        version: link:../shared
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@paretools/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/server-test:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary
- Adds new `@paretools/search` MCP server package wrapping `rg` (ripgrep) and `fd` for structured code search
- **3 tools**: `search` (rg --json content search), `find` (fd file discovery), `count` (rg --count match counting)
- Full dual output (human-readable text + typed JSON structuredContent) with compact mode support
- Security: `assertNoFlagInjection` on all user-supplied string parameters (pattern, path, glob, extension)
- Zod output schemas for all tools, INPUT_LIMITS constraints on all input parameters
- 47 tests covering parsers, formatters, compact mappers, and security validation

## Files
- `packages/server-search/package.json` — package config (`@paretools/search` v0.7.0)
- `packages/server-search/tsconfig.json` — TypeScript config
- `packages/server-search/vitest.config.ts` — Vitest config
- `packages/server-search/src/index.ts` — MCP server entry point
- `packages/server-search/src/schemas/index.ts` — Zod output schemas (SearchResult, FindResult, CountResult)
- `packages/server-search/src/lib/search-runner.ts` — rg/fd command runners
- `packages/server-search/src/lib/parsers.ts` — Output parsers (rg --json JSONL, fd paths, rg --count)
- `packages/server-search/src/lib/formatters.ts` — Human-readable + compact formatters
- `packages/server-search/src/tools/{search,find,count}.ts` — Tool registrations
- `packages/server-search/src/tools/index.ts` — registerAllTools with shouldRegisterTool
- `packages/server-search/__tests__/{parsers,formatters,security}.test.ts` — 47 tests

## Test plan
- [x] `pnpm install` — new package registered in workspace
- [x] `pnpm build` (tsc) — compiles with zero errors
- [x] `vitest run` — all 47 tests pass (parsers, formatters, security)
- [ ] Manual: verify `search` tool with real rg --json output
- [ ] Manual: verify `find` tool with real fd output
- [ ] Manual: verify `count` tool with real rg --count output

🤖 Generated with [Claude Code](https://claude.com/claude-code)