### PR TITLE
feat: new @paretools/make server (make + just)

### DIFF
--- a/packages/server-make/__tests__/formatters.test.ts
+++ b/packages/server-make/__tests__/formatters.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatRun,
+  formatList,
+  compactRunMap,
+  formatRunCompact,
+  compactListMap,
+  formatListCompact,
+} from "../src/lib/formatters.js";
+import type { MakeRunResult, MakeListResult } from "../src/schemas/index.js";
+
+// ── Full formatters ──────────────────────────────────────────────────
+
+describe("formatRun", () => {
+  it("formats successful run", () => {
+    const data: MakeRunResult = {
+      target: "build",
+      success: true,
+      exitCode: 0,
+      stdout: "Build complete",
+      duration: 1234,
+      tool: "make",
+    };
+    const output = formatRun(data);
+    expect(output).toContain("make build: success (1234ms).");
+    expect(output).toContain("Build complete");
+  });
+
+  it("formats failed run", () => {
+    const data: MakeRunResult = {
+      target: "test",
+      success: false,
+      exitCode: 2,
+      stderr: "make: *** [test] Error 2",
+      duration: 567,
+      tool: "make",
+    };
+    const output = formatRun(data);
+    expect(output).toContain("make test: exit code 2 (567ms).");
+    expect(output).toContain("make: *** [test] Error 2");
+  });
+
+  it("formats just run", () => {
+    const data: MakeRunResult = {
+      target: "deploy",
+      success: true,
+      exitCode: 0,
+      stdout: "Deployed!",
+      duration: 5000,
+      tool: "just",
+    };
+    const output = formatRun(data);
+    expect(output).toContain("just deploy: success (5000ms).");
+    expect(output).toContain("Deployed!");
+  });
+
+  it("formats run with no output", () => {
+    const data: MakeRunResult = {
+      target: "clean",
+      success: true,
+      exitCode: 0,
+      duration: 50,
+      tool: "make",
+    };
+    const output = formatRun(data);
+    expect(output).toBe("make clean: success (50ms).");
+  });
+});
+
+describe("formatList", () => {
+  it("formats empty target list", () => {
+    const data: MakeListResult = {
+      targets: [],
+      total: 0,
+      tool: "make",
+    };
+    expect(formatList(data)).toBe("make: no targets found.");
+  });
+
+  it("formats just target list with descriptions", () => {
+    const data: MakeListResult = {
+      targets: [
+        { name: "build", description: "Build the project" },
+        { name: "test", description: "Run tests" },
+        { name: "clean" },
+      ],
+      total: 3,
+      tool: "just",
+    };
+    const output = formatList(data);
+    expect(output).toContain("just: 3 targets");
+    expect(output).toContain("  build # Build the project");
+    expect(output).toContain("  test # Run tests");
+    expect(output).toContain("  clean");
+    // clean should NOT have a # suffix
+    expect(output).not.toContain("clean #");
+  });
+
+  it("formats make target list", () => {
+    const data: MakeListResult = {
+      targets: [{ name: "all" }, { name: "build" }, { name: "test" }],
+      total: 3,
+      tool: "make",
+    };
+    const output = formatList(data);
+    expect(output).toContain("make: 3 targets");
+    expect(output).toContain("  all");
+    expect(output).toContain("  build");
+    expect(output).toContain("  test");
+  });
+});
+
+// ── Compact mappers and formatters ───────────────────────────────────
+
+describe("compactRunMap", () => {
+  it("keeps target, exitCode, success, duration, tool — drops stdout/stderr", () => {
+    const data: MakeRunResult = {
+      target: "build",
+      success: true,
+      exitCode: 0,
+      stdout: "lots of build output...",
+      stderr: "some warnings",
+      duration: 1234,
+      tool: "make",
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.target).toBe("build");
+    expect(compact.success).toBe(true);
+    expect(compact.exitCode).toBe(0);
+    expect(compact.duration).toBe(1234);
+    expect(compact.tool).toBe("make");
+    expect(compact).not.toHaveProperty("stdout");
+    expect(compact).not.toHaveProperty("stderr");
+  });
+
+  it("preserves non-zero exit code", () => {
+    const data: MakeRunResult = {
+      target: "test",
+      success: false,
+      exitCode: 2,
+      stderr: "error details",
+      duration: 567,
+      tool: "just",
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.exitCode).toBe(2);
+    expect(compact.success).toBe(false);
+    expect(compact.tool).toBe("just");
+  });
+});
+
+describe("formatRunCompact", () => {
+  it("formats successful run", () => {
+    expect(
+      formatRunCompact({
+        target: "build",
+        exitCode: 0,
+        success: true,
+        duration: 100,
+        tool: "make",
+      }),
+    ).toBe("make build: success (100ms).");
+  });
+
+  it("formats failed run with exit code", () => {
+    expect(
+      formatRunCompact({
+        target: "test",
+        exitCode: 2,
+        success: false,
+        duration: 500,
+        tool: "just",
+      }),
+    ).toBe("just test: exit code 2 (500ms).");
+  });
+});
+
+describe("compactListMap", () => {
+  it("keeps total and tool, drops target details", () => {
+    const data: MakeListResult = {
+      targets: [
+        { name: "build", description: "Build it" },
+        { name: "test", description: "Test it" },
+        { name: "clean" },
+      ],
+      total: 3,
+      tool: "just",
+    };
+
+    const compact = compactListMap(data);
+
+    expect(compact.total).toBe(3);
+    expect(compact.tool).toBe("just");
+    expect(compact).not.toHaveProperty("targets");
+  });
+
+  it("preserves zero total for empty list", () => {
+    const data: MakeListResult = {
+      targets: [],
+      total: 0,
+      tool: "make",
+    };
+
+    const compact = compactListMap(data);
+
+    expect(compact.total).toBe(0);
+    expect(compact.tool).toBe("make");
+  });
+});
+
+describe("formatListCompact", () => {
+  it("formats no targets found", () => {
+    expect(formatListCompact({ total: 0, tool: "make" })).toBe("make: no targets found.");
+  });
+
+  it("formats target count", () => {
+    expect(formatListCompact({ total: 5, tool: "just" })).toBe("just: 5 targets");
+  });
+});

--- a/packages/server-make/__tests__/parsers.test.ts
+++ b/packages/server-make/__tests__/parsers.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseRunOutput,
+  parseJustList,
+  parseMakeTargets,
+  buildListResult,
+} from "../src/lib/parsers.js";
+
+describe("parseRunOutput", () => {
+  it("parses successful run", () => {
+    const result = parseRunOutput("build", "Build complete\n", "", 0, 1234, "make");
+
+    expect(result.target).toBe("build");
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("Build complete");
+    expect(result.stderr).toBeUndefined();
+    expect(result.duration).toBe(1234);
+    expect(result.tool).toBe("make");
+  });
+
+  it("parses failed run", () => {
+    const result = parseRunOutput("test", "", "make: *** [test] Error 2\n", 2, 567, "make");
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBeUndefined();
+    expect(result.stderr).toBe("make: *** [test] Error 2");
+    expect(result.tool).toBe("make");
+  });
+
+  it("parses run with both stdout and stderr", () => {
+    const result = parseRunOutput(
+      "deploy",
+      "Deploying...\nDone.",
+      "Warning: slow connection",
+      0,
+      5000,
+      "just",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.stdout).toBe("Deploying...\nDone.");
+    expect(result.stderr).toBe("Warning: slow connection");
+    expect(result.tool).toBe("just");
+  });
+
+  it("handles empty stdout and stderr", () => {
+    const result = parseRunOutput("clean", "", "", 0, 100, "make");
+
+    expect(result.success).toBe(true);
+    expect(result.stdout).toBeUndefined();
+    expect(result.stderr).toBeUndefined();
+  });
+});
+
+describe("parseJustList", () => {
+  it("parses just --list output with descriptions", () => {
+    const stdout = [
+      "Available recipes:",
+      "    build  # Build the project",
+      "    test   # Run tests",
+      "    clean",
+      "",
+    ].join("\n");
+
+    const result = parseJustList(stdout);
+
+    expect(result.total).toBe(3);
+    expect(result.targets).toEqual([
+      { name: "build", description: "Build the project" },
+      { name: "test", description: "Run tests" },
+      { name: "clean", description: undefined },
+    ]);
+  });
+
+  it("parses just --list output without descriptions", () => {
+    const stdout = ["Available recipes:", "    build", "    test", "    deploy", ""].join("\n");
+
+    const result = parseJustList(stdout);
+
+    expect(result.total).toBe(3);
+    expect(result.targets[0]).toEqual({ name: "build", description: undefined });
+    expect(result.targets[1]).toEqual({ name: "test", description: undefined });
+    expect(result.targets[2]).toEqual({ name: "deploy", description: undefined });
+  });
+
+  it("handles empty output", () => {
+    const result = parseJustList("");
+
+    expect(result.total).toBe(0);
+    expect(result.targets).toEqual([]);
+  });
+
+  it("handles output with only header", () => {
+    const result = parseJustList("Available recipes:\n");
+
+    expect(result.total).toBe(0);
+    expect(result.targets).toEqual([]);
+  });
+
+  it("handles mixed targets with and without descriptions", () => {
+    const stdout = [
+      "Available recipes:",
+      "    build   # Compile everything",
+      "    clean",
+      "    lint    # Check code style",
+      "",
+    ].join("\n");
+
+    const result = parseJustList(stdout);
+
+    expect(result.total).toBe(3);
+    expect(result.targets[0].description).toBe("Compile everything");
+    expect(result.targets[1].description).toBeUndefined();
+    expect(result.targets[2].description).toBe("Check code style");
+  });
+});
+
+describe("parseMakeTargets", () => {
+  it("parses make database output for targets", () => {
+    const stdout = [
+      "# GNU Make 4.3",
+      "# Built for x86_64-pc-linux-gnu",
+      "",
+      "# Files",
+      "",
+      "build:",
+      "\tgcc -o main main.c",
+      "",
+      "test: build",
+      "\t./run-tests.sh",
+      "",
+      "clean:",
+      "\trm -rf *.o",
+      "",
+    ].join("\n");
+
+    const result = parseMakeTargets(stdout);
+
+    expect(result.total).toBe(3);
+    expect(result.targets.map((t) => t.name)).toEqual(["build", "test", "clean"]);
+  });
+
+  it("skips built-in targets starting with dot", () => {
+    const stdout = [
+      ".PHONY: build test",
+      ".DEFAULT_GOAL := build",
+      ".SUFFIXES:",
+      "build:",
+      "\techo building",
+      "",
+    ].join("\n");
+
+    const result = parseMakeTargets(stdout);
+
+    expect(result.total).toBe(1);
+    expect(result.targets[0].name).toBe("build");
+  });
+
+  it("skips Makefile as target", () => {
+    const stdout = ["Makefile:", "build:", "\techo building", ""].join("\n");
+
+    const result = parseMakeTargets(stdout);
+
+    expect(result.total).toBe(1);
+    expect(result.targets[0].name).toBe("build");
+  });
+
+  it("handles empty output", () => {
+    const result = parseMakeTargets("");
+
+    expect(result.total).toBe(0);
+    expect(result.targets).toEqual([]);
+  });
+
+  it("deduplicates targets", () => {
+    const stdout = ["build: dep1", "build: dep2", "test:", ""].join("\n");
+
+    const result = parseMakeTargets(stdout);
+
+    expect(result.total).toBe(2);
+    expect(result.targets.map((t) => t.name)).toEqual(["build", "test"]);
+  });
+
+  it("handles targets with hyphens and numbers", () => {
+    const stdout = ["build-all:", "test-unit:", "deploy-v2:", "step3:", ""].join("\n");
+
+    const result = parseMakeTargets(stdout);
+
+    expect(result.total).toBe(4);
+    expect(result.targets.map((t) => t.name)).toEqual([
+      "build-all",
+      "test-unit",
+      "deploy-v2",
+      "step3",
+    ]);
+  });
+
+  it("skips comment lines", () => {
+    const stdout = ["# This is a comment", "# Another comment: with colon", "build:", ""].join(
+      "\n",
+    );
+
+    const result = parseMakeTargets(stdout);
+
+    expect(result.total).toBe(1);
+    expect(result.targets[0].name).toBe("build");
+  });
+});
+
+describe("buildListResult", () => {
+  it("builds full result for just", () => {
+    const parsed = {
+      targets: [{ name: "build", description: "Build it" }, { name: "test" }],
+      total: 2,
+    };
+
+    const result = buildListResult(parsed, "just");
+
+    expect(result.tool).toBe("just");
+    expect(result.total).toBe(2);
+    expect(result.targets).toEqual(parsed.targets);
+  });
+
+  it("builds full result for make", () => {
+    const parsed = {
+      targets: [{ name: "all" }, { name: "clean" }],
+      total: 2,
+    };
+
+    const result = buildListResult(parsed, "make");
+
+    expect(result.tool).toBe("make");
+    expect(result.total).toBe(2);
+  });
+});

--- a/packages/server-make/__tests__/security.test.ts
+++ b/packages/server-make/__tests__/security.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Security tests: verify that assertNoFlagInjection() prevents flag injection
+ * attacks on user-supplied parameters in Make/Just tools.
+ *
+ * These tools accept user-provided strings (target names, arguments) that are
+ * passed as positional arguments to make/just. Without validation, a malicious
+ * input like "--eval=..." could be interpreted as a flag.
+ */
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+
+/** Malicious inputs that must be rejected by every guarded parameter. */
+const MALICIOUS_INPUTS = [
+  "--eval=rm -rf /",
+  "-f",
+  "--file=/etc/passwd",
+  "-n",
+  "--just-flag",
+  "-B",
+  "--always-make",
+  "--directory",
+  // Whitespace bypass attempts
+  " --eval",
+  "\t-f",
+  "   --file",
+];
+
+/** Safe inputs that must be accepted. */
+const SAFE_INPUTS = [
+  "build",
+  "test",
+  "clean",
+  "deploy-staging",
+  "build_all",
+  "test-unit",
+  "my-project/build",
+  "v1.0.0",
+  "step3",
+];
+
+describe("security: make/just run — target validation", () => {
+  it("rejects flag-like targets", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "target")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe target names", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "target")).not.toThrow();
+    }
+  });
+});
+
+describe("security: make/just run — args validation", () => {
+  it("rejects flag-like args", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "args")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe args values", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "args")).not.toThrow();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zod .max() input-limit constraints — Make tool schemas
+// ---------------------------------------------------------------------------
+
+describe("Zod .max() constraints — Make tool schemas", () => {
+  describe("target parameter (SHORT_STRING_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.SHORT_STRING_MAX);
+
+    it("accepts a target within the limit", () => {
+      expect(schema.safeParse("build").success).toBe(true);
+    });
+
+    it("rejects a target exceeding SHORT_STRING_MAX", () => {
+      const oversized = "t".repeat(INPUT_LIMITS.SHORT_STRING_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("args array (ARRAY_MAX + STRING_MAX)", () => {
+    const schema = z.array(z.string().max(INPUT_LIMITS.STRING_MAX)).max(INPUT_LIMITS.ARRAY_MAX);
+
+    it("rejects array exceeding ARRAY_MAX", () => {
+      const oversized = Array.from({ length: INPUT_LIMITS.ARRAY_MAX + 1 }, (_, i) => `arg${i}`);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+
+    it("rejects arg exceeding STRING_MAX", () => {
+      const oversized = ["x".repeat(INPUT_LIMITS.STRING_MAX + 1)];
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+
+    it("accepts normal args", () => {
+      expect(schema.safeParse(["VAR=value", "VERBOSE=1"]).success).toBe(true);
+    });
+  });
+
+  describe("path parameter (PATH_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.PATH_MAX);
+
+    it("accepts a path within the limit", () => {
+      expect(schema.safeParse("/home/user/project").success).toBe(true);
+    });
+
+    it("rejects a path exceeding PATH_MAX", () => {
+      const oversized = "p".repeat(INPUT_LIMITS.PATH_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+});

--- a/packages/server-make/package.json
+++ b/packages/server-make/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@paretools/make",
+  "version": "0.7.0",
+  "mcpName": "io.github.Dave-London/make",
+  "description": "MCP server for Make/Just task runners with structured, token-efficient output",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "structured-output",
+    "ai",
+    "ai-agent",
+    "claude",
+    "cursor",
+    "copilot",
+    "token-efficient",
+    "devtools",
+    "cli",
+    "make",
+    "makefile",
+    "just",
+    "justfile",
+    "task-runner"
+  ],
+  "homepage": "https://github.com/Dave-London/Pare/tree/main/packages/server-make",
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "bin": {
+    "pare-make": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/Pare.git",
+    "directory": "packages/server-make"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@paretools/shared": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@paretools/tsconfig": "workspace:*",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/server-make/src/index.ts
+++ b/packages/server-make/src/index.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerAllTools } from "./tools/index.js";
+
+const server = new McpServer(
+  { name: "@paretools/make", version: "0.7.0" },
+  {
+    instructions:
+      "Structured Make/Just task runner operations (run, list). Auto-detects make vs just. Returns typed JSON. Use instead of running make/just in the terminal.",
+  },
+);
+
+registerAllTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/server-make/src/lib/formatters.ts
+++ b/packages/server-make/src/lib/formatters.ts
@@ -1,0 +1,74 @@
+import type { MakeRunResult, MakeListResult } from "../schemas/index.js";
+
+// ── Full formatters ──────────────────────────────────────────────────
+
+/** Formats structured run results into a human-readable output summary. */
+export function formatRun(data: MakeRunResult): string {
+  const lines: string[] = [];
+  if (data.success) {
+    lines.push(`${data.tool} ${data.target}: success (${data.duration}ms).`);
+  } else {
+    lines.push(`${data.tool} ${data.target}: exit code ${data.exitCode} (${data.duration}ms).`);
+  }
+  if (data.stdout) lines.push(data.stdout);
+  if (data.stderr) lines.push(data.stderr);
+  return lines.join("\n");
+}
+
+/** Formats structured list results into a human-readable target listing. */
+export function formatList(data: MakeListResult): string {
+  if (data.total === 0) return `${data.tool}: no targets found.`;
+
+  const lines = [`${data.tool}: ${data.total} targets`];
+  for (const t of data.targets) {
+    const desc = t.description ? ` # ${t.description}` : "";
+    lines.push(`  ${t.name}${desc}`);
+  }
+  return lines.join("\n");
+}
+
+// ── Compact types, mappers, and formatters ───────────────────────────
+
+/** Compact run: target, exitCode, success, duration. Drop stdout/stderr. */
+export interface MakeRunCompact {
+  [key: string]: unknown;
+  target: string;
+  success: boolean;
+  exitCode: number;
+  duration: number;
+  tool: "make" | "just";
+}
+
+export function compactRunMap(data: MakeRunResult): MakeRunCompact {
+  return {
+    target: data.target,
+    success: data.success,
+    exitCode: data.exitCode,
+    duration: data.duration,
+    tool: data.tool,
+  };
+}
+
+export function formatRunCompact(data: MakeRunCompact): string {
+  if (data.success) return `${data.tool} ${data.target}: success (${data.duration}ms).`;
+  return `${data.tool} ${data.target}: exit code ${data.exitCode} (${data.duration}ms).`;
+}
+
+/** Compact list: total and tool. Drop individual target details. */
+export interface MakeListCompact {
+  [key: string]: unknown;
+  total: number;
+  tool: "make" | "just";
+}
+
+export function compactListMap(data: MakeListResult): MakeListCompact {
+  return {
+    total: data.total,
+    tool: data.tool,
+  };
+}
+
+export function formatListCompact(data: MakeListCompact): string {
+  if (data.total === 0) return `${data.tool}: no targets found.`;
+  return `${data.tool}: ${data.total} targets`;
+}

--- a/packages/server-make/src/lib/make-runner.ts
+++ b/packages/server-make/src/lib/make-runner.ts
@@ -1,0 +1,34 @@
+import { run, type RunResult } from "@paretools/shared";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export type MakeTool = "make" | "just";
+
+/**
+ * Auto-detects the task runner to use based on the presence of task files.
+ * Checks for Justfile/justfile first (use `just`), then falls back to `make`.
+ */
+export function detectTool(cwd: string): MakeTool {
+  if (existsSync(join(cwd, "Justfile")) || existsSync(join(cwd, "justfile"))) {
+    return "just";
+  }
+  return "make";
+}
+
+/**
+ * Resolves the tool to use: if "auto", detect from the filesystem; otherwise use the specified tool.
+ */
+export function resolveTool(tool: "auto" | "make" | "just", cwd: string): MakeTool {
+  if (tool === "auto") return detectTool(cwd);
+  return tool;
+}
+
+/** Runs a `make` command with the given arguments. */
+export async function makeCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("make", args, { cwd, timeout: 300_000 });
+}
+
+/** Runs a `just` command with the given arguments. */
+export async function justCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("just", args, { cwd, timeout: 300_000 });
+}

--- a/packages/server-make/src/lib/parsers.ts
+++ b/packages/server-make/src/lib/parsers.ts
@@ -1,0 +1,111 @@
+import type { MakeRunResult, MakeListResult } from "../schemas/index.js";
+import type { MakeTool } from "./make-runner.js";
+
+/**
+ * Parses the output of a `make` or `just` run into structured result data.
+ */
+export function parseRunOutput(
+  target: string,
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  duration: number,
+  tool: MakeTool,
+): MakeRunResult {
+  return {
+    target,
+    success: exitCode === 0,
+    exitCode,
+    stdout: stdout.trimEnd() || undefined,
+    stderr: stderr.trimEnd() || undefined,
+    duration,
+    tool,
+  };
+}
+
+/**
+ * Parses `just --list` output into structured target data.
+ *
+ * Expected format:
+ * ```
+ * Available recipes:
+ *     build  # Build the project
+ *     test   # Run tests
+ *     clean
+ * ```
+ */
+export function parseJustList(stdout: string): {
+  targets: { name: string; description?: string }[];
+  total: number;
+} {
+  const targets: { name: string; description?: string }[] = [];
+
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("Available")) continue;
+
+    const match = trimmed.match(/^(\S+)\s*(?:#\s*(.+))?$/);
+    if (match) {
+      targets.push({
+        name: match[1],
+        description: match[2]?.trim() || undefined,
+      });
+    }
+  }
+
+  return { targets, total: targets.length };
+}
+
+/**
+ * Parses `make -pRrq` database output to extract user-defined target names.
+ *
+ * The make database output contains lines like:
+ * ```
+ * target-name: dependency1 dependency2
+ * # Not a target
+ * .PHONY: ...
+ * ```
+ *
+ * We extract lines matching `^[a-zA-Z0-9_-]+:` that are not built-in targets
+ * (starting with `.`) and not comments.
+ */
+export function parseMakeTargets(stdout: string): { targets: { name: string }[]; total: number } {
+  const targets: { name: string }[] = [];
+  const seen = new Set<string>();
+
+  // The make -pRrq output includes a "# Files" section followed by rules.
+  // Target lines appear as: "targetname: deps" or "targetname:"
+  const targetRe = /^([a-zA-Z0-9_][a-zA-Z0-9_.\-/]*):/;
+
+  for (const line of stdout.split("\n")) {
+    // Skip comments and empty lines
+    if (line.startsWith("#") || line.startsWith("\t") || !line.trim()) continue;
+
+    const match = line.match(targetRe);
+    if (match) {
+      const name = match[1];
+      // Skip built-in/special targets (start with .) and Makefile itself
+      if (name.startsWith(".") || name === "Makefile" || name === "makefile") continue;
+      if (!seen.has(name)) {
+        seen.add(name);
+        targets.push({ name });
+      }
+    }
+  }
+
+  return { targets, total: targets.length };
+}
+
+/**
+ * Builds a full MakeListResult from parsed target data and the detected tool.
+ */
+export function buildListResult(
+  parsed: { targets: { name: string; description?: string }[]; total: number },
+  tool: MakeTool,
+): MakeListResult {
+  return {
+    targets: parsed.targets,
+    total: parsed.total,
+    tool,
+  };
+}

--- a/packages/server-make/src/schemas/index.ts
+++ b/packages/server-make/src/schemas/index.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+/** Zod schema for structured make/just run output with stdout, stderr, exit code, and duration. */
+export const MakeRunResultSchema = z.object({
+  target: z.string(),
+  success: z.boolean(),
+  exitCode: z.number(),
+  stdout: z.string().optional(),
+  stderr: z.string().optional(),
+  duration: z.number(),
+  tool: z.enum(["make", "just"]),
+});
+
+export type MakeRunResult = z.infer<typeof MakeRunResultSchema>;
+
+/** Zod schema for a single target entry with name and optional description. */
+export const MakeTargetSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+});
+
+/** Zod schema for structured make/just list output with targets and total count. */
+export const MakeListResultSchema = z.object({
+  targets: z.array(MakeTargetSchema),
+  total: z.number(),
+  tool: z.enum(["make", "just"]),
+});
+
+export type MakeListResult = z.infer<typeof MakeListResultSchema>;

--- a/packages/server-make/src/tools/index.ts
+++ b/packages/server-make/src/tools/index.ts
@@ -1,0 +1,10 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
+import { registerRunTool } from "./run.js";
+import { registerListTool } from "./list.js";
+
+export function registerAllTools(server: McpServer) {
+  const s = (name: string) => shouldRegisterTool("make", name);
+  if (s("run")) registerRunTool(server);
+  if (s("list")) registerListTool(server);
+}

--- a/packages/server-make/src/tools/list.ts
+++ b/packages/server-make/src/tools/list.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { makeCmd, justCmd, resolveTool } from "../lib/make-runner.js";
+import { parseJustList, parseMakeTargets, buildListResult } from "../lib/parsers.js";
+import { formatList, compactListMap, formatListCompact } from "../lib/formatters.js";
+import { MakeListResultSchema } from "../schemas/index.js";
+
+export function registerListTool(server: McpServer) {
+  server.registerTool(
+    "list",
+    {
+      title: "Make/Just List Targets",
+      description:
+        "Lists available make or just targets with optional descriptions. Auto-detects make vs just. Use instead of running `make` or `just --list` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        tool: z
+          .enum(["auto", "make", "just"])
+          .optional()
+          .default("auto")
+          .describe('Task runner to use: "auto" detects from files, or force "make"/"just"'),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: MakeListResultSchema,
+    },
+    async ({ path, tool, compact }) => {
+      const cwd = path || process.cwd();
+      const resolved = resolveTool(tool || "auto", cwd);
+
+      let parsed: { targets: { name: string; description?: string }[]; total: number };
+      let rawOutput: string;
+
+      if (resolved === "just") {
+        const result = await justCmd(["--list"], cwd);
+        rawOutput = result.stdout.trim();
+        parsed = parseJustList(result.stdout);
+      } else {
+        const result = await makeCmd(["-pRrq", ":"], cwd);
+        // make -pRrq exits non-zero when the dummy target ":" fails, but still
+        // prints the database to stdout. We only care about stdout.
+        rawOutput = result.stdout.trim();
+        parsed = parseMakeTargets(result.stdout);
+      }
+
+      const data = buildListResult(parsed, resolved);
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatList,
+        compactListMap,
+        formatListCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-make/src/tools/run.ts
+++ b/packages/server-make/src/tools/run.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { makeCmd, justCmd, resolveTool } from "../lib/make-runner.js";
+import { parseRunOutput } from "../lib/parsers.js";
+import { formatRun, compactRunMap, formatRunCompact } from "../lib/formatters.js";
+import { MakeRunResultSchema } from "../schemas/index.js";
+
+export function registerRunTool(server: McpServer) {
+  server.registerTool(
+    "run",
+    {
+      title: "Make/Just Run",
+      description:
+        "Runs a make or just target and returns structured output (stdout, stderr, exit code, duration). Auto-detects make vs just. Use instead of running `make` or `just` in the terminal.",
+      inputSchema: {
+        target: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Target to run"),
+        args: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default([])
+          .describe("Additional arguments to pass to the target"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        tool: z
+          .enum(["auto", "make", "just"])
+          .optional()
+          .default("auto")
+          .describe('Task runner to use: "auto" detects from files, or force "make"/"just"'),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: MakeRunResultSchema,
+    },
+    async ({ target, args, path, tool, compact }) => {
+      const cwd = path || process.cwd();
+      assertNoFlagInjection(target, "target");
+      for (const a of args ?? []) {
+        assertNoFlagInjection(a, "args");
+      }
+
+      const resolved = resolveTool(tool || "auto", cwd);
+      const cmdArgs = [target, ...(args || [])];
+
+      const start = Date.now();
+      const result =
+        resolved === "just" ? await justCmd(cmdArgs, cwd) : await makeCmd(cmdArgs, cwd);
+      const duration = Date.now() - start;
+
+      const data = parseRunOutput(
+        target,
+        result.stdout,
+        result.stderr,
+        result.exitCode,
+        duration,
+        resolved,
+      );
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatRun,
+        compactRunMap,
+        formatRunCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-make/tsconfig.json
+++ b/packages/server-make/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@paretools/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/server-make/vitest.config.ts
+++ b/packages/server-make/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 60_000,
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 70,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,31 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/server-make:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.26.0(zod@4.3.6)
+      '@paretools/shared':
+        specifier: workspace:*
+        version: link:../shared
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@paretools/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/server-npm:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary
- Adds a new `@paretools/make` MCP server package that wraps `make` and `just` task runners with structured, token-efficient JSON output
- Implements 2 tools: `run` (execute targets) and `list` (enumerate available targets with descriptions)
- Auto-detects whether to use `make` or `just` based on the presence of `Justfile`/`justfile` vs `Makefile`/`makefile`
- Follows all existing Pare patterns: dual output, compact mode, Zod schemas, security validation, `assertNoFlagInjection`

## Tools

### `run`
Executes a make/just target and returns structured output with `target`, `success`, `exitCode`, `stdout`, `stderr`, `duration`, and `tool`.

### `list`
Lists available targets by parsing `just --list` output (with descriptions) or `make -pRrq` database output. Returns `targets[]`, `total`, and `tool`.

## Test plan
- [x] 44 unit tests pass covering parsers, formatters, compact mappers, and security
- [x] Parser tests: `parseRunOutput`, `parseJustList`, `parseMakeTargets`, `buildListResult`
- [x] Formatter tests: `formatRun`, `formatList`, compact variants
- [x] Security tests: `assertNoFlagInjection` on target and args, Zod `.max()` input limits
- [x] Full repo `pnpm build` succeeds
- [ ] Manual integration test with actual make/just projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)