### PR TITLE
feat: new @paretools/github server (gh CLI)

### DIFF
--- a/packages/server-github/__tests__/formatters.test.ts
+++ b/packages/server-github/__tests__/formatters.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatPrView,
+  formatPrList,
+  formatPrCreate,
+  formatIssueView,
+  formatIssueList,
+  formatIssueCreate,
+  formatRunView,
+  formatRunList,
+  compactPrViewMap,
+  formatPrViewCompact,
+  compactPrListMap,
+  formatPrListCompact,
+  compactIssueViewMap,
+  formatIssueViewCompact,
+  compactIssueListMap,
+  formatIssueListCompact,
+  compactRunViewMap,
+  formatRunViewCompact,
+  compactRunListMap,
+  formatRunListCompact,
+} from "../src/lib/formatters.js";
+import type {
+  PrViewResult,
+  PrListResult,
+  PrCreateResult,
+  IssueViewResult,
+  IssueListResult,
+  IssueCreateResult,
+  RunViewResult,
+  RunListResult,
+} from "../src/schemas/index.js";
+
+// ── PR View ──────────────────────────────────────────────────────────
+
+describe("formatPrView", () => {
+  const data: PrViewResult = {
+    number: 42,
+    state: "OPEN",
+    title: "Add feature",
+    body: "Description here",
+    mergeable: "MERGEABLE",
+    reviewDecision: "APPROVED",
+    checks: [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS" }],
+    url: "https://github.com/owner/repo/pull/42",
+    headBranch: "feat/add",
+    baseBranch: "main",
+    additions: 50,
+    deletions: 10,
+    changedFiles: 3,
+  };
+
+  it("formats PR view with all fields", () => {
+    const output = formatPrView(data);
+    expect(output).toContain("PR #42: Add feature (OPEN)");
+    expect(output).toContain("feat/add → main");
+    expect(output).toContain("mergeable: MERGEABLE");
+    expect(output).toContain("+50 -10 (3 files)");
+    expect(output).toContain("CI: COMPLETED (SUCCESS)");
+  });
+
+  it("includes body preview", () => {
+    const output = formatPrView(data);
+    expect(output).toContain("body: Description here");
+  });
+
+  it("truncates long body", () => {
+    const longBody: PrViewResult = {
+      ...data,
+      body: "x".repeat(300),
+    };
+    const output = formatPrView(longBody);
+    expect(output).toContain("...");
+  });
+});
+
+describe("compactPrView", () => {
+  it("maps to compact format", () => {
+    const data: PrViewResult = {
+      number: 1,
+      state: "OPEN",
+      title: "Test",
+      body: "long body",
+      mergeable: "MERGEABLE",
+      reviewDecision: "APPROVED",
+      checks: [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS" }],
+      url: "https://github.com/owner/repo/pull/1",
+      headBranch: "feat/test",
+      baseBranch: "main",
+      additions: 10,
+      deletions: 5,
+      changedFiles: 2,
+    };
+    const compact = compactPrViewMap(data);
+    expect(compact.checksTotal).toBe(1);
+    expect(compact).not.toHaveProperty("body");
+    expect(compact).not.toHaveProperty("checks");
+
+    const text = formatPrViewCompact(compact);
+    expect(text).toContain("PR #1");
+    expect(text).toContain("1 checks");
+  });
+});
+
+// ── PR List ──────────────────────────────────────────────────────────
+
+describe("formatPrList", () => {
+  it("formats PR list", () => {
+    const data: PrListResult = {
+      prs: [
+        {
+          number: 1,
+          state: "OPEN",
+          title: "First",
+          url: "https://url",
+          headBranch: "feat/1",
+          author: "alice",
+        },
+      ],
+      total: 1,
+    };
+    const output = formatPrList(data);
+    expect(output).toContain("1 pull requests:");
+    expect(output).toContain("#1 First (OPEN)");
+    expect(output).toContain("@alice");
+  });
+
+  it("formats empty list", () => {
+    const data: PrListResult = { prs: [], total: 0 };
+    expect(formatPrList(data)).toBe("No pull requests found.");
+  });
+});
+
+describe("compactPrList", () => {
+  it("maps to compact format", () => {
+    const data: PrListResult = {
+      prs: [
+        { number: 1, state: "OPEN", title: "PR", url: "https://url", headBranch: "b", author: "a" },
+      ],
+      total: 1,
+    };
+    const compact = compactPrListMap(data);
+    expect(compact.prs[0]).not.toHaveProperty("url");
+    expect(compact.prs[0]).not.toHaveProperty("headBranch");
+
+    const text = formatPrListCompact(compact);
+    expect(text).toContain("1 PRs:");
+  });
+});
+
+// ── PR Create ────────────────────────────────────────────────────────
+
+describe("formatPrCreate", () => {
+  it("formats PR create result", () => {
+    const data: PrCreateResult = { number: 99, url: "https://github.com/owner/repo/pull/99" };
+    expect(formatPrCreate(data)).toBe("Created PR #99: https://github.com/owner/repo/pull/99");
+  });
+});
+
+// ── Issue View ───────────────────────────────────────────────────────
+
+describe("formatIssueView", () => {
+  it("formats issue view with all fields", () => {
+    const data: IssueViewResult = {
+      number: 15,
+      state: "OPEN",
+      title: "Bug report",
+      body: "Steps to reproduce",
+      labels: ["bug", "priority:high"],
+      assignees: ["alice"],
+      url: "https://github.com/owner/repo/issues/15",
+      createdAt: "2024-01-15T10:00:00Z",
+    };
+    const output = formatIssueView(data);
+    expect(output).toContain("Issue #15: Bug report (OPEN)");
+    expect(output).toContain("labels: bug, priority:high");
+    expect(output).toContain("assignees: alice");
+  });
+
+  it("omits empty labels and assignees", () => {
+    const data: IssueViewResult = {
+      number: 1,
+      state: "CLOSED",
+      title: "Done",
+      body: null,
+      labels: [],
+      assignees: [],
+      url: "https://url",
+      createdAt: "2024-01-01T00:00:00Z",
+    };
+    const output = formatIssueView(data);
+    expect(output).not.toContain("labels:");
+    expect(output).not.toContain("assignees:");
+    expect(output).not.toContain("body:");
+  });
+});
+
+describe("compactIssueView", () => {
+  it("maps to compact format", () => {
+    const data: IssueViewResult = {
+      number: 1,
+      state: "OPEN",
+      title: "Test",
+      body: "long body text",
+      labels: ["bug"],
+      assignees: ["alice"],
+      url: "https://url",
+      createdAt: "2024-01-01T00:00:00Z",
+    };
+    const compact = compactIssueViewMap(data);
+    expect(compact).not.toHaveProperty("body");
+
+    const text = formatIssueViewCompact(compact);
+    expect(text).toContain("Issue #1");
+    expect(text).toContain("[bug]");
+  });
+});
+
+// ── Issue List ───────────────────────────────────────────────────────
+
+describe("formatIssueList", () => {
+  it("formats issue list", () => {
+    const data: IssueListResult = {
+      issues: [
+        {
+          number: 1,
+          state: "OPEN",
+          title: "Bug",
+          url: "https://url",
+          labels: ["bug"],
+          assignees: [],
+        },
+      ],
+      total: 1,
+    };
+    const output = formatIssueList(data);
+    expect(output).toContain("1 issues:");
+    expect(output).toContain("#1 Bug (OPEN) [bug]");
+  });
+
+  it("formats empty list", () => {
+    const data: IssueListResult = { issues: [], total: 0 };
+    expect(formatIssueList(data)).toBe("No issues found.");
+  });
+});
+
+describe("compactIssueList", () => {
+  it("maps to compact format", () => {
+    const data: IssueListResult = {
+      issues: [
+        {
+          number: 1,
+          state: "OPEN",
+          title: "Bug",
+          url: "https://url",
+          labels: ["bug"],
+          assignees: ["a"],
+        },
+      ],
+      total: 1,
+    };
+    const compact = compactIssueListMap(data);
+    expect(compact.issues[0]).not.toHaveProperty("url");
+    expect(compact.issues[0]).not.toHaveProperty("labels");
+
+    const text = formatIssueListCompact(compact);
+    expect(text).toContain("1 issues:");
+  });
+});
+
+// ── Issue Create ─────────────────────────────────────────────────────
+
+describe("formatIssueCreate", () => {
+  it("formats issue create result", () => {
+    const data: IssueCreateResult = { number: 50, url: "https://github.com/owner/repo/issues/50" };
+    expect(formatIssueCreate(data)).toBe(
+      "Created issue #50: https://github.com/owner/repo/issues/50",
+    );
+  });
+});
+
+// ── Run View ─────────────────────────────────────────────────────────
+
+describe("formatRunView", () => {
+  it("formats run view with all fields", () => {
+    const data: RunViewResult = {
+      id: 12345,
+      status: "completed",
+      conclusion: "success",
+      name: "CI",
+      workflowName: "Build and Test",
+      headBranch: "main",
+      jobs: [
+        { name: "build", status: "completed", conclusion: "success" },
+        { name: "test", status: "completed", conclusion: "failure" },
+      ],
+      url: "https://github.com/owner/repo/actions/runs/12345",
+      createdAt: "2024-01-15T10:00:00Z",
+    };
+    const output = formatRunView(data);
+    expect(output).toContain("Run #12345: Build and Test / CI (completed)");
+    expect(output).toContain("conclusion: success");
+    expect(output).toContain("branch: main");
+    expect(output).toContain("build: completed (success)");
+    expect(output).toContain("test: completed (failure)");
+  });
+
+  it("formats run with pending conclusion", () => {
+    const data: RunViewResult = {
+      id: 1,
+      status: "in_progress",
+      conclusion: null,
+      name: "CI",
+      workflowName: "Build",
+      headBranch: "feat/test",
+      jobs: [],
+      url: "https://url",
+      createdAt: "2024-01-01T00:00:00Z",
+    };
+    const output = formatRunView(data);
+    expect(output).toContain("conclusion: pending");
+  });
+});
+
+describe("compactRunView", () => {
+  it("maps to compact format", () => {
+    const data: RunViewResult = {
+      id: 1,
+      status: "completed",
+      conclusion: "success",
+      name: "CI",
+      workflowName: "Build",
+      headBranch: "main",
+      jobs: [{ name: "build", status: "completed", conclusion: "success" }],
+      url: "https://url",
+      createdAt: "2024-01-01T00:00:00Z",
+    };
+    const compact = compactRunViewMap(data);
+    expect(compact.jobsTotal).toBe(1);
+    expect(compact).not.toHaveProperty("jobs");
+    expect(compact).not.toHaveProperty("name");
+
+    const text = formatRunViewCompact(compact);
+    expect(text).toContain("Run #1");
+    expect(text).toContain("1 jobs");
+  });
+});
+
+// ── Run List ─────────────────────────────────────────────────────────
+
+describe("formatRunList", () => {
+  it("formats run list", () => {
+    const data: RunListResult = {
+      runs: [
+        {
+          id: 100,
+          status: "completed",
+          conclusion: "success",
+          name: "CI",
+          workflowName: "Build",
+          headBranch: "main",
+          url: "https://url",
+          createdAt: "2024-01-01T00:00:00Z",
+        },
+      ],
+      total: 1,
+    };
+    const output = formatRunList(data);
+    expect(output).toContain("1 workflow runs:");
+    expect(output).toContain("#100 Build / CI (completed → success) [main]");
+  });
+
+  it("formats empty list", () => {
+    const data: RunListResult = { runs: [], total: 0 };
+    expect(formatRunList(data)).toBe("No workflow runs found.");
+  });
+});
+
+describe("compactRunList", () => {
+  it("maps to compact format", () => {
+    const data: RunListResult = {
+      runs: [
+        {
+          id: 1,
+          status: "completed",
+          conclusion: "success",
+          name: "CI",
+          workflowName: "Build",
+          headBranch: "main",
+          url: "https://url",
+          createdAt: "2024-01-01T00:00:00Z",
+        },
+      ],
+      total: 1,
+    };
+    const compact = compactRunListMap(data);
+    expect(compact.runs[0]).not.toHaveProperty("headBranch");
+    expect(compact.runs[0]).not.toHaveProperty("url");
+
+    const text = formatRunListCompact(compact);
+    expect(text).toContain("1 runs:");
+  });
+});

--- a/packages/server-github/__tests__/parsers.test.ts
+++ b/packages/server-github/__tests__/parsers.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect } from "vitest";
+import {
+  parsePrView,
+  parsePrList,
+  parsePrCreate,
+  parseIssueView,
+  parseIssueList,
+  parseIssueCreate,
+  parseRunView,
+  parseRunList,
+} from "../src/lib/parsers.js";
+
+describe("parsePrView", () => {
+  it("parses full PR view JSON", () => {
+    const json = JSON.stringify({
+      number: 42,
+      state: "OPEN",
+      title: "Add new feature",
+      body: "This PR adds a new feature.",
+      mergeable: "MERGEABLE",
+      reviewDecision: "APPROVED",
+      statusCheckRollup: [
+        { name: "CI", status: "COMPLETED", conclusion: "SUCCESS" },
+        { name: "Lint", status: "COMPLETED", conclusion: "FAILURE" },
+      ],
+      url: "https://github.com/owner/repo/pull/42",
+      headRefName: "feat/new-feature",
+      baseRefName: "main",
+      additions: 100,
+      deletions: 20,
+      changedFiles: 5,
+    });
+
+    const result = parsePrView(json);
+
+    expect(result.number).toBe(42);
+    expect(result.state).toBe("OPEN");
+    expect(result.title).toBe("Add new feature");
+    expect(result.body).toBe("This PR adds a new feature.");
+    expect(result.mergeable).toBe("MERGEABLE");
+    expect(result.reviewDecision).toBe("APPROVED");
+    expect(result.checks).toHaveLength(2);
+    expect(result.checks[0]).toEqual({
+      name: "CI",
+      status: "COMPLETED",
+      conclusion: "SUCCESS",
+    });
+    expect(result.checks[1]).toEqual({
+      name: "Lint",
+      status: "COMPLETED",
+      conclusion: "FAILURE",
+    });
+    expect(result.url).toBe("https://github.com/owner/repo/pull/42");
+    expect(result.headBranch).toBe("feat/new-feature");
+    expect(result.baseBranch).toBe("main");
+    expect(result.additions).toBe(100);
+    expect(result.deletions).toBe(20);
+    expect(result.changedFiles).toBe(5);
+  });
+
+  it("handles missing optional fields", () => {
+    const json = JSON.stringify({
+      number: 1,
+      state: "OPEN",
+      title: "Minimal PR",
+      headRefName: "fix/bug",
+      baseRefName: "main",
+      url: "https://github.com/owner/repo/pull/1",
+    });
+
+    const result = parsePrView(json);
+
+    expect(result.body).toBeNull();
+    expect(result.mergeable).toBe("UNKNOWN");
+    expect(result.reviewDecision).toBe("");
+    expect(result.checks).toEqual([]);
+    expect(result.additions).toBe(0);
+    expect(result.deletions).toBe(0);
+    expect(result.changedFiles).toBe(0);
+  });
+
+  it("handles checks with context field instead of name", () => {
+    const json = JSON.stringify({
+      number: 5,
+      state: "OPEN",
+      title: "Test PR",
+      headRefName: "test",
+      baseRefName: "main",
+      url: "https://github.com/owner/repo/pull/5",
+      statusCheckRollup: [{ context: "ci/circleci", state: "SUCCESS", conclusion: null }],
+    });
+
+    const result = parsePrView(json);
+
+    expect(result.checks[0]).toEqual({
+      name: "ci/circleci",
+      status: "SUCCESS",
+      conclusion: null,
+    });
+  });
+});
+
+describe("parsePrList", () => {
+  it("parses PR list JSON", () => {
+    const json = JSON.stringify([
+      {
+        number: 10,
+        state: "OPEN",
+        title: "First PR",
+        url: "https://github.com/owner/repo/pull/10",
+        headRefName: "feat/first",
+        author: { login: "alice" },
+      },
+      {
+        number: 11,
+        state: "MERGED",
+        title: "Second PR",
+        url: "https://github.com/owner/repo/pull/11",
+        headRefName: "feat/second",
+        author: { login: "bob" },
+      },
+    ]);
+
+    const result = parsePrList(json);
+
+    expect(result.total).toBe(2);
+    expect(result.prs[0]).toEqual({
+      number: 10,
+      state: "OPEN",
+      title: "First PR",
+      url: "https://github.com/owner/repo/pull/10",
+      headBranch: "feat/first",
+      author: "alice",
+    });
+    expect(result.prs[1].author).toBe("bob");
+  });
+
+  it("handles empty list", () => {
+    const result = parsePrList("[]");
+    expect(result.total).toBe(0);
+    expect(result.prs).toEqual([]);
+  });
+
+  it("handles missing author", () => {
+    const json = JSON.stringify([
+      {
+        number: 1,
+        state: "OPEN",
+        title: "No author",
+        url: "https://github.com/owner/repo/pull/1",
+        headRefName: "fix/bug",
+      },
+    ]);
+
+    const result = parsePrList(json);
+    expect(result.prs[0].author).toBe("");
+  });
+});
+
+describe("parsePrCreate", () => {
+  it("parses PR create URL output", () => {
+    const result = parsePrCreate("https://github.com/owner/repo/pull/99\n");
+
+    expect(result.number).toBe(99);
+    expect(result.url).toBe("https://github.com/owner/repo/pull/99");
+  });
+
+  it("handles URL without trailing newline", () => {
+    const result = parsePrCreate("https://github.com/owner/repo/pull/1");
+    expect(result.number).toBe(1);
+  });
+
+  it("returns 0 for unrecognized URL format", () => {
+    const result = parsePrCreate("https://github.com/unknown-format");
+    expect(result.number).toBe(0);
+    expect(result.url).toBe("https://github.com/unknown-format");
+  });
+});
+
+describe("parseIssueView", () => {
+  it("parses full issue view JSON", () => {
+    const json = JSON.stringify({
+      number: 15,
+      state: "OPEN",
+      title: "Bug report",
+      body: "Steps to reproduce...",
+      labels: [{ name: "bug" }, { name: "priority:high" }],
+      assignees: [{ login: "alice" }, { login: "bob" }],
+      url: "https://github.com/owner/repo/issues/15",
+      createdAt: "2024-01-15T10:00:00Z",
+    });
+
+    const result = parseIssueView(json);
+
+    expect(result.number).toBe(15);
+    expect(result.state).toBe("OPEN");
+    expect(result.title).toBe("Bug report");
+    expect(result.body).toBe("Steps to reproduce...");
+    expect(result.labels).toEqual(["bug", "priority:high"]);
+    expect(result.assignees).toEqual(["alice", "bob"]);
+    expect(result.url).toBe("https://github.com/owner/repo/issues/15");
+    expect(result.createdAt).toBe("2024-01-15T10:00:00Z");
+  });
+
+  it("handles missing optional fields", () => {
+    const json = JSON.stringify({
+      number: 1,
+      state: "CLOSED",
+      title: "Minimal issue",
+      url: "https://github.com/owner/repo/issues/1",
+    });
+
+    const result = parseIssueView(json);
+
+    expect(result.body).toBeNull();
+    expect(result.labels).toEqual([]);
+    expect(result.assignees).toEqual([]);
+    expect(result.createdAt).toBe("");
+  });
+});
+
+describe("parseIssueList", () => {
+  it("parses issue list JSON", () => {
+    const json = JSON.stringify([
+      {
+        number: 1,
+        state: "OPEN",
+        title: "First issue",
+        url: "https://github.com/owner/repo/issues/1",
+        labels: [{ name: "bug" }],
+        assignees: [{ login: "alice" }],
+      },
+      {
+        number: 2,
+        state: "CLOSED",
+        title: "Second issue",
+        url: "https://github.com/owner/repo/issues/2",
+        labels: [],
+        assignees: [],
+      },
+    ]);
+
+    const result = parseIssueList(json);
+
+    expect(result.total).toBe(2);
+    expect(result.issues[0].labels).toEqual(["bug"]);
+    expect(result.issues[0].assignees).toEqual(["alice"]);
+    expect(result.issues[1].labels).toEqual([]);
+    expect(result.issues[1].assignees).toEqual([]);
+  });
+
+  it("handles empty list", () => {
+    const result = parseIssueList("[]");
+    expect(result.total).toBe(0);
+    expect(result.issues).toEqual([]);
+  });
+});
+
+describe("parseIssueCreate", () => {
+  it("parses issue create URL output", () => {
+    const result = parseIssueCreate("https://github.com/owner/repo/issues/50\n");
+
+    expect(result.number).toBe(50);
+    expect(result.url).toBe("https://github.com/owner/repo/issues/50");
+  });
+
+  it("returns 0 for unrecognized URL format", () => {
+    const result = parseIssueCreate("https://github.com/unknown");
+    expect(result.number).toBe(0);
+  });
+});
+
+describe("parseRunView", () => {
+  it("parses full run view JSON", () => {
+    const json = JSON.stringify({
+      databaseId: 12345,
+      status: "completed",
+      conclusion: "success",
+      name: "CI",
+      workflowName: "Build and Test",
+      headBranch: "main",
+      jobs: [
+        { name: "build", status: "completed", conclusion: "success" },
+        { name: "test", status: "completed", conclusion: "success" },
+      ],
+      url: "https://github.com/owner/repo/actions/runs/12345",
+      createdAt: "2024-01-15T10:00:00Z",
+    });
+
+    const result = parseRunView(json);
+
+    expect(result.id).toBe(12345);
+    expect(result.status).toBe("completed");
+    expect(result.conclusion).toBe("success");
+    expect(result.name).toBe("CI");
+    expect(result.workflowName).toBe("Build and Test");
+    expect(result.headBranch).toBe("main");
+    expect(result.jobs).toHaveLength(2);
+    expect(result.jobs[0]).toEqual({
+      name: "build",
+      status: "completed",
+      conclusion: "success",
+    });
+    expect(result.url).toBe("https://github.com/owner/repo/actions/runs/12345");
+    expect(result.createdAt).toBe("2024-01-15T10:00:00Z");
+  });
+
+  it("handles missing optional fields", () => {
+    const json = JSON.stringify({
+      databaseId: 1,
+      status: "in_progress",
+      headBranch: "feat/test",
+      url: "https://github.com/owner/repo/actions/runs/1",
+    });
+
+    const result = parseRunView(json);
+
+    expect(result.conclusion).toBeNull();
+    expect(result.name).toBe("");
+    expect(result.workflowName).toBe("");
+    expect(result.jobs).toEqual([]);
+    expect(result.createdAt).toBe("");
+  });
+
+  it("handles jobs with null conclusion", () => {
+    const json = JSON.stringify({
+      databaseId: 100,
+      status: "in_progress",
+      headBranch: "main",
+      url: "https://github.com/owner/repo/actions/runs/100",
+      jobs: [{ name: "build", status: "in_progress", conclusion: null }],
+    });
+
+    const result = parseRunView(json);
+    expect(result.jobs[0].conclusion).toBeNull();
+  });
+});
+
+describe("parseRunList", () => {
+  it("parses run list JSON", () => {
+    const json = JSON.stringify([
+      {
+        databaseId: 100,
+        status: "completed",
+        conclusion: "success",
+        name: "Build",
+        workflowName: "CI",
+        headBranch: "main",
+        url: "https://github.com/owner/repo/actions/runs/100",
+        createdAt: "2024-01-15T10:00:00Z",
+      },
+      {
+        databaseId: 101,
+        status: "in_progress",
+        conclusion: null,
+        name: "Test",
+        workflowName: "CI",
+        headBranch: "feat/test",
+        url: "https://github.com/owner/repo/actions/runs/101",
+        createdAt: "2024-01-15T11:00:00Z",
+      },
+    ]);
+
+    const result = parseRunList(json);
+
+    expect(result.total).toBe(2);
+    expect(result.runs[0].id).toBe(100);
+    expect(result.runs[0].conclusion).toBe("success");
+    expect(result.runs[1].id).toBe(101);
+    expect(result.runs[1].conclusion).toBeNull();
+  });
+
+  it("handles empty list", () => {
+    const result = parseRunList("[]");
+    expect(result.total).toBe(0);
+    expect(result.runs).toEqual([]);
+  });
+});

--- a/packages/server-github/__tests__/security.test.ts
+++ b/packages/server-github/__tests__/security.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Security tests: verify that assertNoFlagInjection() prevents flag injection
+ * attacks on user-supplied parameters in GitHub tools.
+ *
+ * These tools accept user-provided strings (titles, branch names, authors,
+ * labels, assignees) that are passed as arguments to the gh CLI. Without
+ * validation, a malicious input like "--exec=rm -rf /" could be interpreted
+ * as a flag.
+ */
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+
+/** Malicious inputs that must be rejected by every guarded parameter. */
+const MALICIOUS_INPUTS = [
+  "--exec=rm -rf /",
+  "-v",
+  "--json",
+  "--jq",
+  "--template",
+  "--web",
+  "-w",
+  "--repo",
+  "-R",
+  // Whitespace bypass attempts
+  " --exec",
+  "\t-v",
+  "   --json",
+];
+
+/** Safe inputs that must be accepted. */
+const SAFE_INPUTS = [
+  "fix bug in auth",
+  "alice",
+  "feat/new-feature",
+  "main",
+  "bug",
+  "priority:high",
+  "v1.0.0",
+  "good first issue",
+];
+
+describe("security: pr-create — title validation", () => {
+  it("rejects flag-like titles", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "title")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe titles", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "title")).not.toThrow();
+    }
+  });
+});
+
+describe("security: pr-create — base branch validation", () => {
+  it("rejects flag-like base branches", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "base")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe branch names", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "base")).not.toThrow();
+    }
+  });
+});
+
+describe("security: pr-create — head branch validation", () => {
+  it("rejects flag-like head branches", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "head")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: pr-list — author validation", () => {
+  it("rejects flag-like authors", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "author")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe author names", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "author")).not.toThrow();
+    }
+  });
+});
+
+describe("security: pr-list / issue-list — label validation", () => {
+  it("rejects flag-like labels", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "label")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe labels", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "label")).not.toThrow();
+    }
+  });
+});
+
+describe("security: issue-list — assignee validation", () => {
+  it("rejects flag-like assignees", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "assignee")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe assignee names", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "assignee")).not.toThrow();
+    }
+  });
+});
+
+describe("security: issue-create — labels array validation", () => {
+  it("rejects flag-like labels in array", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "labels")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: issue-create — title validation", () => {
+  it("rejects flag-like titles", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "title")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: run-list — branch validation", () => {
+  it("rejects flag-like branch names", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "branch")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe branch names", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "branch")).not.toThrow();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zod .max() input-limit constraints — GitHub tool schemas
+// ---------------------------------------------------------------------------
+
+describe("Zod .max() constraints — GitHub tool schemas", () => {
+  describe("title (SHORT_STRING_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.SHORT_STRING_MAX);
+
+    it("accepts a title within the limit", () => {
+      expect(schema.safeParse("Fix auth bug").success).toBe(true);
+    });
+
+    it("rejects a title exceeding SHORT_STRING_MAX", () => {
+      const oversized = "T".repeat(INPUT_LIMITS.SHORT_STRING_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("body (STRING_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.STRING_MAX);
+
+    it("accepts a body within the limit", () => {
+      expect(schema.safeParse("Description of the issue.").success).toBe(true);
+    });
+
+    it("rejects a body exceeding STRING_MAX", () => {
+      const oversized = "B".repeat(INPUT_LIMITS.STRING_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("path parameter (PATH_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.PATH_MAX);
+
+    it("accepts a path within the limit", () => {
+      expect(schema.safeParse("/home/user/project").success).toBe(true);
+    });
+
+    it("rejects a path exceeding PATH_MAX", () => {
+      const oversized = "p".repeat(INPUT_LIMITS.PATH_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("labels array (ARRAY_MAX + SHORT_STRING_MAX)", () => {
+    const schema = z
+      .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+      .max(INPUT_LIMITS.ARRAY_MAX);
+
+    it("rejects array exceeding ARRAY_MAX", () => {
+      const oversized = Array.from({ length: INPUT_LIMITS.ARRAY_MAX + 1 }, (_, i) => `label${i}`);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+
+    it("rejects label exceeding SHORT_STRING_MAX", () => {
+      const oversized = ["x".repeat(INPUT_LIMITS.SHORT_STRING_MAX + 1)];
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+
+    it("accepts normal labels", () => {
+      expect(schema.safeParse(["bug", "enhancement", "good first issue"]).success).toBe(true);
+    });
+  });
+});

--- a/packages/server-github/package.json
+++ b/packages/server-github/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@paretools/github",
+  "version": "0.7.0",
+  "mcpName": "io.github.Dave-London/github",
+  "description": "MCP server for GitHub operations (PRs, issues, actions) with structured, token-efficient output",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "structured-output",
+    "ai",
+    "ai-agent",
+    "claude",
+    "cursor",
+    "copilot",
+    "token-efficient",
+    "devtools",
+    "cli",
+    "github",
+    "gh",
+    "pull-request",
+    "issues",
+    "actions"
+  ],
+  "homepage": "https://github.com/Dave-London/Pare/tree/main/packages/server-github",
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "bin": {
+    "pare-github": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/Pare.git",
+    "directory": "packages/server-github"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@paretools/shared": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@paretools/tsconfig": "workspace:*",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/server-github/src/index.ts
+++ b/packages/server-github/src/index.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerAllTools } from "./tools/index.js";
+
+const server = new McpServer(
+  { name: "@paretools/github", version: "0.7.0" },
+  {
+    instructions:
+      "Structured GitHub operations (PRs, issues, actions runs) via gh CLI. Returns typed JSON. Use instead of running gh commands via bash.",
+  },
+);
+
+registerAllTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -1,0 +1,298 @@
+import type {
+  PrViewResult,
+  PrListResult,
+  PrCreateResult,
+  IssueViewResult,
+  IssueListResult,
+  IssueCreateResult,
+  RunViewResult,
+  RunListResult,
+} from "../schemas/index.js";
+
+// ── Full formatters ──────────────────────────────────────────────────
+
+/** Formats structured PR view data into human-readable text. */
+export function formatPrView(data: PrViewResult): string {
+  const lines = [
+    `PR #${data.number}: ${data.title} (${data.state})`,
+    `  ${data.headBranch} → ${data.baseBranch}`,
+    `  mergeable: ${data.mergeable}, review: ${data.reviewDecision || "none"}`,
+    `  +${data.additions} -${data.deletions} (${data.changedFiles} files)`,
+    `  ${data.url}`,
+  ];
+  if (data.checks.length > 0) {
+    lines.push(`  checks:`);
+    for (const c of data.checks) {
+      lines.push(`    ${c.name}: ${c.status} (${c.conclusion ?? "pending"})`);
+    }
+  }
+  if (data.body) {
+    lines.push(`  body: ${data.body.slice(0, 200)}${data.body.length > 200 ? "..." : ""}`);
+  }
+  return lines.join("\n");
+}
+
+/** Formats structured PR list data into human-readable text. */
+export function formatPrList(data: PrListResult): string {
+  if (data.total === 0) return "No pull requests found.";
+
+  const lines = [`${data.total} pull requests:`];
+  for (const pr of data.prs) {
+    lines.push(`  #${pr.number} ${pr.title} (${pr.state}) [${pr.headBranch}] @${pr.author}`);
+  }
+  return lines.join("\n");
+}
+
+/** Formats structured PR create data into human-readable text. */
+export function formatPrCreate(data: PrCreateResult): string {
+  return `Created PR #${data.number}: ${data.url}`;
+}
+
+/** Formats structured issue view data into human-readable text. */
+export function formatIssueView(data: IssueViewResult): string {
+  const lines = [
+    `Issue #${data.number}: ${data.title} (${data.state})`,
+    `  created: ${data.createdAt}`,
+    `  ${data.url}`,
+  ];
+  if (data.labels.length > 0) {
+    lines.push(`  labels: ${data.labels.join(", ")}`);
+  }
+  if (data.assignees.length > 0) {
+    lines.push(`  assignees: ${data.assignees.join(", ")}`);
+  }
+  if (data.body) {
+    lines.push(`  body: ${data.body.slice(0, 200)}${data.body.length > 200 ? "..." : ""}`);
+  }
+  return lines.join("\n");
+}
+
+/** Formats structured issue list data into human-readable text. */
+export function formatIssueList(data: IssueListResult): string {
+  if (data.total === 0) return "No issues found.";
+
+  const lines = [`${data.total} issues:`];
+  for (const issue of data.issues) {
+    const labels = issue.labels.length > 0 ? ` [${issue.labels.join(", ")}]` : "";
+    lines.push(`  #${issue.number} ${issue.title} (${issue.state})${labels}`);
+  }
+  return lines.join("\n");
+}
+
+/** Formats structured issue create data into human-readable text. */
+export function formatIssueCreate(data: IssueCreateResult): string {
+  return `Created issue #${data.number}: ${data.url}`;
+}
+
+/** Formats structured run view data into human-readable text. */
+export function formatRunView(data: RunViewResult): string {
+  const lines = [
+    `Run #${data.id}: ${data.workflowName} / ${data.name} (${data.status})`,
+    `  conclusion: ${data.conclusion ?? "pending"}`,
+    `  branch: ${data.headBranch}`,
+    `  created: ${data.createdAt}`,
+    `  ${data.url}`,
+  ];
+  if (data.jobs.length > 0) {
+    lines.push(`  jobs:`);
+    for (const j of data.jobs) {
+      lines.push(`    ${j.name}: ${j.status} (${j.conclusion ?? "pending"})`);
+    }
+  }
+  return lines.join("\n");
+}
+
+/** Formats structured run list data into human-readable text. */
+export function formatRunList(data: RunListResult): string {
+  if (data.total === 0) return "No workflow runs found.";
+
+  const lines = [`${data.total} workflow runs:`];
+  for (const r of data.runs) {
+    const conclusion = r.conclusion ? ` → ${r.conclusion}` : "";
+    lines.push(
+      `  #${r.id} ${r.workflowName} / ${r.name} (${r.status}${conclusion}) [${r.headBranch}]`,
+    );
+  }
+  return lines.join("\n");
+}
+
+// ── Compact types, mappers, and formatters ───────────────────────────
+
+/** Compact PR view: key fields, no body or checks details. */
+export interface PrViewCompact {
+  [key: string]: unknown;
+  number: number;
+  state: string;
+  title: string;
+  mergeable: string;
+  reviewDecision: string;
+  url: string;
+  headBranch: string;
+  baseBranch: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  checksTotal: number;
+}
+
+export function compactPrViewMap(data: PrViewResult): PrViewCompact {
+  return {
+    number: data.number,
+    state: data.state,
+    title: data.title,
+    mergeable: data.mergeable,
+    reviewDecision: data.reviewDecision,
+    url: data.url,
+    headBranch: data.headBranch,
+    baseBranch: data.baseBranch,
+    additions: data.additions,
+    deletions: data.deletions,
+    changedFiles: data.changedFiles,
+    checksTotal: data.checks.length,
+  };
+}
+
+export function formatPrViewCompact(data: PrViewCompact): string {
+  return `PR #${data.number}: ${data.title} (${data.state}) +${data.additions} -${data.deletions} (${data.changedFiles} files), ${data.checksTotal} checks`;
+}
+
+/** Compact PR list: number, title, state only. */
+export interface PrListCompact {
+  [key: string]: unknown;
+  prs: { number: number; title: string; state: string }[];
+  total: number;
+}
+
+export function compactPrListMap(data: PrListResult): PrListCompact {
+  return {
+    prs: data.prs.map((pr) => ({
+      number: pr.number,
+      title: pr.title,
+      state: pr.state,
+    })),
+    total: data.total,
+  };
+}
+
+export function formatPrListCompact(data: PrListCompact): string {
+  if (data.total === 0) return "No pull requests found.";
+  const lines = [`${data.total} PRs:`];
+  for (const pr of data.prs) {
+    lines.push(`  #${pr.number} ${pr.title} (${pr.state})`);
+  }
+  return lines.join("\n");
+}
+
+/** Compact issue view: key fields, no body. */
+export interface IssueViewCompact {
+  [key: string]: unknown;
+  number: number;
+  state: string;
+  title: string;
+  url: string;
+  labels: string[];
+  assignees: string[];
+  createdAt: string;
+}
+
+export function compactIssueViewMap(data: IssueViewResult): IssueViewCompact {
+  return {
+    number: data.number,
+    state: data.state,
+    title: data.title,
+    url: data.url,
+    labels: data.labels,
+    assignees: data.assignees,
+    createdAt: data.createdAt,
+  };
+}
+
+export function formatIssueViewCompact(data: IssueViewCompact): string {
+  const labels = data.labels.length > 0 ? ` [${data.labels.join(", ")}]` : "";
+  return `Issue #${data.number}: ${data.title} (${data.state})${labels}`;
+}
+
+/** Compact issue list: number, title, state only. */
+export interface IssueListCompact {
+  [key: string]: unknown;
+  issues: { number: number; title: string; state: string }[];
+  total: number;
+}
+
+export function compactIssueListMap(data: IssueListResult): IssueListCompact {
+  return {
+    issues: data.issues.map((i) => ({
+      number: i.number,
+      title: i.title,
+      state: i.state,
+    })),
+    total: data.total,
+  };
+}
+
+export function formatIssueListCompact(data: IssueListCompact): string {
+  if (data.total === 0) return "No issues found.";
+  const lines = [`${data.total} issues:`];
+  for (const i of data.issues) {
+    lines.push(`  #${i.number} ${i.title} (${i.state})`);
+  }
+  return lines.join("\n");
+}
+
+/** Compact run view: key fields, no jobs. */
+export interface RunViewCompact {
+  [key: string]: unknown;
+  id: number;
+  status: string;
+  conclusion: string | null;
+  workflowName: string;
+  headBranch: string;
+  jobsTotal: number;
+  url: string;
+}
+
+export function compactRunViewMap(data: RunViewResult): RunViewCompact {
+  return {
+    id: data.id,
+    status: data.status,
+    conclusion: data.conclusion,
+    workflowName: data.workflowName,
+    headBranch: data.headBranch,
+    jobsTotal: data.jobs.length,
+    url: data.url,
+  };
+}
+
+export function formatRunViewCompact(data: RunViewCompact): string {
+  const conclusion = data.conclusion ? ` → ${data.conclusion}` : "";
+  return `Run #${data.id}: ${data.workflowName} (${data.status}${conclusion}) [${data.headBranch}], ${data.jobsTotal} jobs`;
+}
+
+/** Compact run list: id, workflow, status only. */
+export interface RunListCompact {
+  [key: string]: unknown;
+  runs: { id: number; workflowName: string; status: string; conclusion: string | null }[];
+  total: number;
+}
+
+export function compactRunListMap(data: RunListResult): RunListCompact {
+  return {
+    runs: data.runs.map((r) => ({
+      id: r.id,
+      workflowName: r.workflowName,
+      status: r.status,
+      conclusion: r.conclusion,
+    })),
+    total: data.total,
+  };
+}
+
+export function formatRunListCompact(data: RunListCompact): string {
+  if (data.total === 0) return "No workflow runs found.";
+  const lines = [`${data.total} runs:`];
+  for (const r of data.runs) {
+    const conclusion = r.conclusion ? ` → ${r.conclusion}` : "";
+    lines.push(`  #${r.id} ${r.workflowName} (${r.status}${conclusion})`);
+  }
+  return lines.join("\n");
+}

--- a/packages/server-github/src/lib/gh-runner.ts
+++ b/packages/server-github/src/lib/gh-runner.ts
@@ -1,0 +1,5 @@
+import { run, type RunResult } from "@paretools/shared";
+
+export async function ghCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("gh", args, { cwd, timeout: 30_000 });
+}

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -1,0 +1,205 @@
+import type {
+  PrViewResult,
+  PrListResult,
+  PrCreateResult,
+  IssueViewResult,
+  IssueListResult,
+  IssueCreateResult,
+  RunViewResult,
+  RunListResult,
+} from "../schemas/index.js";
+
+/**
+ * Parses `gh pr view --json ...` output into structured PR view data.
+ * Renames gh field names to our schema names (e.g., headRefName → headBranch).
+ */
+export function parsePrView(json: string): PrViewResult {
+  const raw = JSON.parse(json);
+
+  const checks = (raw.statusCheckRollup ?? []).map(
+    (c: {
+      name?: string;
+      context?: string;
+      status?: string;
+      state?: string;
+      conclusion?: string | null;
+    }) => ({
+      name: c.name || c.context || "unknown",
+      status: c.status || c.state || "unknown",
+      conclusion: c.conclusion ?? null,
+    }),
+  );
+
+  return {
+    number: raw.number,
+    state: raw.state,
+    title: raw.title,
+    body: raw.body ?? null,
+    mergeable: raw.mergeable ?? "UNKNOWN",
+    reviewDecision: raw.reviewDecision ?? "",
+    checks,
+    url: raw.url,
+    headBranch: raw.headRefName,
+    baseBranch: raw.baseRefName,
+    additions: raw.additions ?? 0,
+    deletions: raw.deletions ?? 0,
+    changedFiles: raw.changedFiles ?? 0,
+  };
+}
+
+/**
+ * Parses `gh pr list --json ...` output into structured PR list data.
+ */
+export function parsePrList(json: string): PrListResult {
+  const raw = JSON.parse(json);
+  const items = Array.isArray(raw) ? raw : [];
+
+  const prs = items.map(
+    (pr: {
+      number: number;
+      state: string;
+      title: string;
+      url: string;
+      headRefName: string;
+      author: { login: string };
+    }) => ({
+      number: pr.number,
+      state: pr.state,
+      title: pr.title,
+      url: pr.url,
+      headBranch: pr.headRefName,
+      author: pr.author?.login ?? "",
+    }),
+  );
+
+  return { prs, total: prs.length };
+}
+
+/**
+ * Parses `gh pr create` output (URL on stdout) into structured data.
+ * The gh CLI prints the new PR URL to stdout. We extract the number from it.
+ */
+export function parsePrCreate(stdout: string): PrCreateResult {
+  const url = stdout.trim();
+  const match = url.match(/\/pull\/(\d+)$/);
+  const number = match ? parseInt(match[1], 10) : 0;
+  return { number, url };
+}
+
+/**
+ * Parses `gh issue view --json ...` output into structured issue view data.
+ */
+export function parseIssueView(json: string): IssueViewResult {
+  const raw = JSON.parse(json);
+
+  return {
+    number: raw.number,
+    state: raw.state,
+    title: raw.title,
+    body: raw.body ?? null,
+    labels: (raw.labels ?? []).map((l: { name: string }) => l.name),
+    assignees: (raw.assignees ?? []).map((a: { login: string }) => a.login),
+    url: raw.url,
+    createdAt: raw.createdAt ?? "",
+  };
+}
+
+/**
+ * Parses `gh issue list --json ...` output into structured issue list data.
+ */
+export function parseIssueList(json: string): IssueListResult {
+  const raw = JSON.parse(json);
+  const items = Array.isArray(raw) ? raw : [];
+
+  const issues = items.map(
+    (issue: {
+      number: number;
+      state: string;
+      title: string;
+      url: string;
+      labels: { name: string }[];
+      assignees: { login: string }[];
+    }) => ({
+      number: issue.number,
+      state: issue.state,
+      title: issue.title,
+      url: issue.url,
+      labels: (issue.labels ?? []).map((l) => l.name),
+      assignees: (issue.assignees ?? []).map((a) => a.login),
+    }),
+  );
+
+  return { issues, total: issues.length };
+}
+
+/**
+ * Parses `gh issue create` output (URL on stdout) into structured data.
+ * The gh CLI prints the new issue URL to stdout. We extract the number from it.
+ */
+export function parseIssueCreate(stdout: string): IssueCreateResult {
+  const url = stdout.trim();
+  const match = url.match(/\/issues\/(\d+)$/);
+  const number = match ? parseInt(match[1], 10) : 0;
+  return { number, url };
+}
+
+/**
+ * Parses `gh run view --json ...` output into structured run view data.
+ * Renames gh field names (e.g., databaseId → id).
+ */
+export function parseRunView(json: string): RunViewResult {
+  const raw = JSON.parse(json);
+
+  const jobs = (raw.jobs ?? []).map(
+    (j: { name: string; status: string; conclusion: string | null }) => ({
+      name: j.name,
+      status: j.status,
+      conclusion: j.conclusion ?? null,
+    }),
+  );
+
+  return {
+    id: raw.databaseId,
+    status: raw.status,
+    conclusion: raw.conclusion ?? null,
+    name: raw.name ?? raw.displayTitle ?? "",
+    workflowName: raw.workflowName ?? "",
+    headBranch: raw.headBranch,
+    jobs,
+    url: raw.url,
+    createdAt: raw.createdAt ?? "",
+  };
+}
+
+/**
+ * Parses `gh run list --json ...` output into structured run list data.
+ */
+export function parseRunList(json: string): RunListResult {
+  const raw = JSON.parse(json);
+  const items = Array.isArray(raw) ? raw : [];
+
+  const runs = items.map(
+    (r: {
+      databaseId: number;
+      status: string;
+      conclusion: string | null;
+      name: string;
+      displayTitle?: string;
+      workflowName: string;
+      headBranch: string;
+      url: string;
+      createdAt: string;
+    }) => ({
+      id: r.databaseId,
+      status: r.status,
+      conclusion: r.conclusion ?? null,
+      name: r.name ?? r.displayTitle ?? "",
+      workflowName: r.workflowName ?? "",
+      headBranch: r.headBranch,
+      url: r.url,
+      createdAt: r.createdAt ?? "",
+    }),
+  );
+
+  return { runs, total: runs.length };
+}

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+
+// ── PR schemas ───────────────────────────────────────────────────────
+
+/** Zod schema for a single status check on a PR. */
+export const PrCheckSchema = z.object({
+  name: z.string(),
+  status: z.string(),
+  conclusion: z.string().nullable(),
+});
+
+/** Zod schema for structured pr-view output. */
+export const PrViewResultSchema = z.object({
+  number: z.number(),
+  state: z.string(),
+  title: z.string(),
+  body: z.string().nullable(),
+  mergeable: z.string(),
+  reviewDecision: z.string(),
+  checks: z.array(PrCheckSchema),
+  url: z.string(),
+  headBranch: z.string(),
+  baseBranch: z.string(),
+  additions: z.number(),
+  deletions: z.number(),
+  changedFiles: z.number(),
+});
+
+export type PrViewResult = z.infer<typeof PrViewResultSchema>;
+
+/** Zod schema for a single PR in list output. */
+export const PrListItemSchema = z.object({
+  number: z.number(),
+  state: z.string(),
+  title: z.string(),
+  url: z.string(),
+  headBranch: z.string(),
+  author: z.string(),
+});
+
+/** Zod schema for structured pr-list output. */
+export const PrListResultSchema = z.object({
+  prs: z.array(PrListItemSchema),
+  total: z.number(),
+});
+
+export type PrListResult = z.infer<typeof PrListResultSchema>;
+
+/** Zod schema for structured pr-create output. */
+export const PrCreateResultSchema = z.object({
+  number: z.number(),
+  url: z.string(),
+});
+
+export type PrCreateResult = z.infer<typeof PrCreateResultSchema>;
+
+// ── Issue schemas ────────────────────────────────────────────────────
+
+/** Zod schema for structured issue-view output. */
+export const IssueViewResultSchema = z.object({
+  number: z.number(),
+  state: z.string(),
+  title: z.string(),
+  body: z.string().nullable(),
+  labels: z.array(z.string()),
+  assignees: z.array(z.string()),
+  url: z.string(),
+  createdAt: z.string(),
+});
+
+export type IssueViewResult = z.infer<typeof IssueViewResultSchema>;
+
+/** Zod schema for a single issue in list output. */
+export const IssueListItemSchema = z.object({
+  number: z.number(),
+  state: z.string(),
+  title: z.string(),
+  url: z.string(),
+  labels: z.array(z.string()),
+  assignees: z.array(z.string()),
+});
+
+/** Zod schema for structured issue-list output. */
+export const IssueListResultSchema = z.object({
+  issues: z.array(IssueListItemSchema),
+  total: z.number(),
+});
+
+export type IssueListResult = z.infer<typeof IssueListResultSchema>;
+
+/** Zod schema for structured issue-create output. */
+export const IssueCreateResultSchema = z.object({
+  number: z.number(),
+  url: z.string(),
+});
+
+export type IssueCreateResult = z.infer<typeof IssueCreateResultSchema>;
+
+// ── Run schemas ──────────────────────────────────────────────────────
+
+/** Zod schema for a single job in a workflow run. */
+export const RunJobSchema = z.object({
+  name: z.string(),
+  status: z.string(),
+  conclusion: z.string().nullable(),
+});
+
+/** Zod schema for structured run-view output. */
+export const RunViewResultSchema = z.object({
+  id: z.number(),
+  status: z.string(),
+  conclusion: z.string().nullable(),
+  name: z.string(),
+  workflowName: z.string(),
+  headBranch: z.string(),
+  jobs: z.array(RunJobSchema),
+  url: z.string(),
+  createdAt: z.string(),
+});
+
+export type RunViewResult = z.infer<typeof RunViewResultSchema>;
+
+/** Zod schema for a single run in list output. */
+export const RunListItemSchema = z.object({
+  id: z.number(),
+  status: z.string(),
+  conclusion: z.string().nullable(),
+  name: z.string(),
+  workflowName: z.string(),
+  headBranch: z.string(),
+  url: z.string(),
+  createdAt: z.string(),
+});
+
+/** Zod schema for structured run-list output. */
+export const RunListResultSchema = z.object({
+  runs: z.array(RunListItemSchema),
+  total: z.number(),
+});
+
+export type RunListResult = z.infer<typeof RunListResultSchema>;

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -1,0 +1,22 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
+import { registerPrViewTool } from "./pr-view.js";
+import { registerPrListTool } from "./pr-list.js";
+import { registerPrCreateTool } from "./pr-create.js";
+import { registerIssueViewTool } from "./issue-view.js";
+import { registerIssueListTool } from "./issue-list.js";
+import { registerIssueCreateTool } from "./issue-create.js";
+import { registerRunViewTool } from "./run-view.js";
+import { registerRunListTool } from "./run-list.js";
+
+export function registerAllTools(server: McpServer) {
+  const s = (name: string) => shouldRegisterTool("github", name);
+  if (s("pr-view")) registerPrViewTool(server);
+  if (s("pr-list")) registerPrListTool(server);
+  if (s("pr-create")) registerPrCreateTool(server);
+  if (s("issue-view")) registerIssueViewTool(server);
+  if (s("issue-list")) registerIssueListTool(server);
+  if (s("issue-create")) registerIssueCreateTool(server);
+  if (s("run-view")) registerRunViewTool(server);
+  if (s("run-list")) registerRunListTool(server);
+}

--- a/packages/server-github/src/tools/issue-create.ts
+++ b/packages/server-github/src/tools/issue-create.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseIssueCreate } from "../lib/parsers.js";
+import { formatIssueCreate } from "../lib/formatters.js";
+import { IssueCreateResultSchema } from "../schemas/index.js";
+
+export function registerIssueCreateTool(server: McpServer) {
+  server.registerTool(
+    "issue-create",
+    {
+      title: "Issue Create",
+      description:
+        "Creates a new issue. Returns structured data with issue number and URL. Use instead of running `gh issue create` in the terminal.",
+      inputSchema: {
+        title: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Issue title"),
+        body: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Issue body/description"),
+        labels: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Labels to apply"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+      },
+      outputSchema: IssueCreateResultSchema,
+    },
+    async ({ title, body, labels, path }) => {
+      const cwd = path || process.cwd();
+
+      assertNoFlagInjection(title, "title");
+      if (labels) {
+        for (const label of labels) {
+          assertNoFlagInjection(label, "labels");
+        }
+      }
+
+      const args = ["issue", "create", "--title", title, "--body", body];
+      if (labels && labels.length > 0) {
+        for (const label of labels) {
+          args.push("--label", label);
+        }
+      }
+
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh issue create failed: ${result.stderr}`);
+      }
+
+      const data = parseIssueCreate(result.stdout);
+      return dualOutput(data, formatIssueCreate);
+    },
+  );
+}

--- a/packages/server-github/src/tools/issue-list.ts
+++ b/packages/server-github/src/tools/issue-list.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseIssueList } from "../lib/parsers.js";
+import { formatIssueList, compactIssueListMap, formatIssueListCompact } from "../lib/formatters.js";
+import { IssueListResultSchema } from "../schemas/index.js";
+
+const ISSUE_LIST_FIELDS = "number,state,title,url,labels,assignees";
+
+export function registerIssueListTool(server: McpServer) {
+  server.registerTool(
+    "issue-list",
+    {
+      title: "Issue List",
+      description:
+        "Lists issues with optional filters. Returns structured list with issue number, state, title, labels, and assignees. Use instead of running `gh issue list` in the terminal.",
+      inputSchema: {
+        state: z
+          .enum(["open", "closed", "all"])
+          .optional()
+          .default("open")
+          .describe("Filter by issue state (default: open)"),
+        limit: z
+          .number()
+          .optional()
+          .default(30)
+          .describe("Maximum number of issues to return (default: 30)"),
+        label: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Filter by label"),
+        assignee: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Filter by assignee username"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: IssueListResultSchema,
+    },
+    async ({ state, limit, label, assignee, path, compact }) => {
+      const cwd = path || process.cwd();
+
+      if (label) assertNoFlagInjection(label, "label");
+      if (assignee) assertNoFlagInjection(assignee, "assignee");
+
+      const args = ["issue", "list", "--json", ISSUE_LIST_FIELDS, "--limit", String(limit)];
+      if (state) args.push("--state", state);
+      if (label) args.push("--label", label);
+      if (assignee) args.push("--assignee", assignee);
+
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh issue list failed: ${result.stderr}`);
+      }
+
+      const data = parseIssueList(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatIssueList,
+        compactIssueListMap,
+        formatIssueListCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-github/src/tools/issue-view.ts
+++ b/packages/server-github/src/tools/issue-view.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseIssueView } from "../lib/parsers.js";
+import { formatIssueView, compactIssueViewMap, formatIssueViewCompact } from "../lib/formatters.js";
+import { IssueViewResultSchema } from "../schemas/index.js";
+
+const ISSUE_VIEW_FIELDS = "number,state,title,body,labels,assignees,url,createdAt";
+
+export function registerIssueViewTool(server: McpServer) {
+  server.registerTool(
+    "issue-view",
+    {
+      title: "Issue View",
+      description:
+        "Views an issue by number. Returns structured data with state, labels, assignees, and body. Use instead of running `gh issue view` in the terminal.",
+      inputSchema: {
+        number: z.number().describe("Issue number"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: IssueViewResultSchema,
+    },
+    async ({ number, path, compact }) => {
+      const cwd = path || process.cwd();
+
+      const args = ["issue", "view", String(number), "--json", ISSUE_VIEW_FIELDS];
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh issue view failed: ${result.stderr}`);
+      }
+
+      const data = parseIssueView(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatIssueView,
+        compactIssueViewMap,
+        formatIssueViewCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-github/src/tools/pr-create.ts
+++ b/packages/server-github/src/tools/pr-create.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parsePrCreate } from "../lib/parsers.js";
+import { formatPrCreate } from "../lib/formatters.js";
+import { PrCreateResultSchema } from "../schemas/index.js";
+
+export function registerPrCreateTool(server: McpServer) {
+  server.registerTool(
+    "pr-create",
+    {
+      title: "PR Create",
+      description:
+        "Creates a new pull request. Returns structured data with PR number and URL. Use instead of running `gh pr create` in the terminal.",
+      inputSchema: {
+        title: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Pull request title"),
+        body: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Pull request body/description"),
+        base: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Base branch (default: repo default branch)"),
+        head: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Head branch (default: current branch)"),
+        draft: z.boolean().optional().default(false).describe("Create as draft PR"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+      },
+      outputSchema: PrCreateResultSchema,
+    },
+    async ({ title, body, base, head, draft, path }) => {
+      const cwd = path || process.cwd();
+
+      assertNoFlagInjection(title, "title");
+      if (base) assertNoFlagInjection(base, "base");
+      if (head) assertNoFlagInjection(head, "head");
+
+      const args = ["pr", "create", "--title", title, "--body", body];
+      if (base) args.push("--base", base);
+      if (head) args.push("--head", head);
+      if (draft) args.push("--draft");
+
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh pr create failed: ${result.stderr}`);
+      }
+
+      const data = parsePrCreate(result.stdout);
+      return dualOutput(data, formatPrCreate);
+    },
+  );
+}

--- a/packages/server-github/src/tools/pr-list.ts
+++ b/packages/server-github/src/tools/pr-list.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parsePrList } from "../lib/parsers.js";
+import { formatPrList, compactPrListMap, formatPrListCompact } from "../lib/formatters.js";
+import { PrListResultSchema } from "../schemas/index.js";
+
+const PR_LIST_FIELDS = "number,state,title,url,headRefName,author";
+
+export function registerPrListTool(server: McpServer) {
+  server.registerTool(
+    "pr-list",
+    {
+      title: "PR List",
+      description:
+        "Lists pull requests with optional filters. Returns structured list with PR number, state, title, author, and branch. Use instead of running `gh pr list` in the terminal.",
+      inputSchema: {
+        state: z
+          .enum(["open", "closed", "merged", "all"])
+          .optional()
+          .default("open")
+          .describe("Filter by PR state (default: open)"),
+        limit: z
+          .number()
+          .optional()
+          .default(30)
+          .describe("Maximum number of PRs to return (default: 30)"),
+        author: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Filter by author username"),
+        label: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Filter by label"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: PrListResultSchema,
+    },
+    async ({ state, limit, author, label, path, compact }) => {
+      const cwd = path || process.cwd();
+
+      if (author) assertNoFlagInjection(author, "author");
+      if (label) assertNoFlagInjection(label, "label");
+
+      const args = ["pr", "list", "--json", PR_LIST_FIELDS, "--limit", String(limit)];
+      if (state) args.push("--state", state);
+      if (author) args.push("--author", author);
+      if (label) args.push("--label", label);
+
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh pr list failed: ${result.stderr}`);
+      }
+
+      const data = parsePrList(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatPrList,
+        compactPrListMap,
+        formatPrListCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-github/src/tools/pr-view.ts
+++ b/packages/server-github/src/tools/pr-view.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parsePrView } from "../lib/parsers.js";
+import { formatPrView, compactPrViewMap, formatPrViewCompact } from "../lib/formatters.js";
+import { PrViewResultSchema } from "../schemas/index.js";
+
+const PR_VIEW_FIELDS =
+  "number,state,title,body,mergeable,reviewDecision,statusCheckRollup,url,headRefName,baseRefName,additions,deletions,changedFiles";
+
+export function registerPrViewTool(server: McpServer) {
+  server.registerTool(
+    "pr-view",
+    {
+      title: "PR View",
+      description:
+        "Views a pull request by number. Returns structured data with state, checks, review decision, and diff stats. Use instead of running `gh pr view` in the terminal.",
+      inputSchema: {
+        number: z.number().describe("Pull request number"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: PrViewResultSchema,
+    },
+    async ({ number, path, compact }) => {
+      const cwd = path || process.cwd();
+
+      const args = ["pr", "view", String(number), "--json", PR_VIEW_FIELDS];
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh pr view failed: ${result.stderr}`);
+      }
+
+      const data = parsePrView(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatPrView,
+        compactPrViewMap,
+        formatPrViewCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-github/src/tools/run-list.ts
+++ b/packages/server-github/src/tools/run-list.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseRunList } from "../lib/parsers.js";
+import { formatRunList, compactRunListMap, formatRunListCompact } from "../lib/formatters.js";
+import { RunListResultSchema } from "../schemas/index.js";
+
+const RUN_LIST_FIELDS = "databaseId,status,conclusion,name,workflowName,headBranch,url,createdAt";
+
+export function registerRunListTool(server: McpServer) {
+  server.registerTool(
+    "run-list",
+    {
+      title: "Run List",
+      description:
+        "Lists workflow runs with optional filters. Returns structured list with run ID, status, conclusion, and workflow details. Use instead of running `gh run list` in the terminal.",
+      inputSchema: {
+        limit: z
+          .number()
+          .optional()
+          .default(20)
+          .describe("Maximum number of runs to return (default: 20)"),
+        branch: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Filter by branch name"),
+        status: z
+          .enum(["queued", "in_progress", "completed", "failure", "success"])
+          .optional()
+          .describe("Filter by run status"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: RunListResultSchema,
+    },
+    async ({ limit, branch, status, path, compact }) => {
+      const cwd = path || process.cwd();
+
+      if (branch) assertNoFlagInjection(branch, "branch");
+
+      const args = ["run", "list", "--json", RUN_LIST_FIELDS, "--limit", String(limit)];
+      if (branch) args.push("--branch", branch);
+      if (status) args.push("--status", status);
+
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh run list failed: ${result.stderr}`);
+      }
+
+      const data = parseRunList(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatRunList,
+        compactRunListMap,
+        formatRunListCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-github/src/tools/run-view.ts
+++ b/packages/server-github/src/tools/run-view.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseRunView } from "../lib/parsers.js";
+import { formatRunView, compactRunViewMap, formatRunViewCompact } from "../lib/formatters.js";
+import { RunViewResultSchema } from "../schemas/index.js";
+
+const RUN_VIEW_FIELDS =
+  "databaseId,status,conclusion,name,workflowName,headBranch,jobs,url,createdAt";
+
+export function registerRunViewTool(server: McpServer) {
+  server.registerTool(
+    "run-view",
+    {
+      title: "Run View",
+      description:
+        "Views a workflow run by ID. Returns structured data with status, conclusion, jobs, and workflow details. Use instead of running `gh run view` in the terminal.",
+      inputSchema: {
+        id: z.number().describe("Workflow run ID"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: RunViewResultSchema,
+    },
+    async ({ id, path, compact }) => {
+      const cwd = path || process.cwd();
+
+      const args = ["run", "view", String(id), "--json", RUN_VIEW_FIELDS];
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh run view failed: ${result.stderr}`);
+      }
+
+      const data = parseRunView(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatRunView,
+        compactRunViewMap,
+        formatRunViewCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-github/tsconfig.json
+++ b/packages/server-github/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@paretools/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/server-github/vitest.config.ts
+++ b/packages/server-github/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 60_000,
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 70,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,31 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/server-github:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.26.0(zod@4.3.6)
+      '@paretools/shared':
+        specifier: workspace:*
+        version: link:../shared
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@paretools/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/server-go:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary
- New `@paretools/github` package (v0.7.0) wrapping the `gh` CLI for structured GitHub operations
- Implements 8 tools: `pr-view`, `pr-list`, `pr-create`, `issue-view`, `issue-list`, `issue-create`, `run-view`, `run-list`
- All tools return typed JSON via dual output with automatic compact mode support
- Full security validation with `assertNoFlagInjection` on all user-supplied string parameters
- 65 tests covering parsers, formatters, and security (flag injection prevention)

## Tools
| Tool | Wraps | Description |
|---|---|---|
| `pr-view` | `gh pr view N --json ...` | View PR with state, checks, review decision, diff stats |
| `pr-list` | `gh pr list --json ...` | List PRs with state/author/label filters |
| `pr-create` | `gh pr create` | Create PR, returns number + URL |
| `issue-view` | `gh issue view N --json ...` | View issue with labels, assignees, body |
| `issue-list` | `gh issue list --json ...` | List issues with state/label/assignee filters |
| `issue-create` | `gh issue create` | Create issue, returns number + URL |
| `run-view` | `gh run view ID --json ...` | View workflow run with jobs, status, conclusion |
| `run-list` | `gh run list --json ...` | List runs with branch/status filters |

## Test plan
- [x] TypeScript compiles with zero errors (`tsc --noEmit`)
- [x] All 65 tests pass (`vitest run`)
- [x] ESLint: 0 diagnostics across 14 files
- [x] Prettier: all files formatted correctly
- [ ] Manual verification: run `pr-list` and `issue-list` against a real repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)