### PR TITLE
feat: new @paretools/http server (curl)

### DIFF
--- a/packages/server-http/__tests__/formatters.test.ts
+++ b/packages/server-http/__tests__/formatters.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatHttpResponse,
+  formatHttpHeadResponse,
+  compactResponseMap,
+  formatResponseCompact,
+  compactHeadResponseMap,
+  formatHeadResponseCompact,
+} from "../src/lib/formatters.js";
+import type { HttpResponse, HttpHeadResponse } from "../src/schemas/index.js";
+
+describe("formatHttpResponse", () => {
+  it("formats a successful JSON response", () => {
+    const data: HttpResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "13",
+      },
+      body: '{"ok":true}',
+      timing: { total: 0.25 },
+      size: 13,
+      contentType: "application/json",
+    };
+
+    const output = formatHttpResponse(data);
+
+    expect(output).toContain("HTTP 200 OK");
+    expect(output).toContain("Content-Type: application/json");
+    expect(output).toContain("Size: 13 bytes");
+    expect(output).toContain("Time: 0.250s");
+    expect(output).toContain("Headers: 2");
+    expect(output).toContain('{"ok":true}');
+  });
+
+  it("formats a response without body", () => {
+    const data: HttpResponse = {
+      status: 204,
+      statusText: "No Content",
+      headers: {},
+      timing: { total: 0.1 },
+      size: 0,
+    };
+
+    const output = formatHttpResponse(data);
+
+    expect(output).toContain("HTTP 204 No Content");
+    expect(output).toContain("Size: 0 bytes");
+    expect(output).not.toContain("Content-Type:");
+  });
+
+  it("truncates long body in human-readable output", () => {
+    const longBody = "x".repeat(600);
+    const data: HttpResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      body: longBody,
+      timing: { total: 0.5 },
+      size: 600,
+    };
+
+    const output = formatHttpResponse(data);
+
+    expect(output).toContain("...");
+    // Body preview should be truncated to ~500 chars
+    expect(output.length).toBeLessThan(longBody.length + 200);
+  });
+});
+
+describe("formatHttpHeadResponse", () => {
+  it("formats a HEAD response", () => {
+    const data: HttpHeadResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {
+        "content-type": "text/html",
+        "content-length": "5000",
+      },
+      timing: { total: 0.15 },
+      contentType: "text/html",
+    };
+
+    const output = formatHttpHeadResponse(data);
+
+    expect(output).toContain("HTTP 200 OK");
+    expect(output).toContain("Content-Type: text/html");
+    expect(output).toContain("Time: 0.150s");
+    expect(output).toContain("Headers: 2");
+    // Should NOT contain body-related content
+    expect(output).not.toContain("Size:");
+  });
+});
+
+describe("compactResponseMap", () => {
+  it("maps full response to compact form (no headers, no body)", () => {
+    const full: HttpResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {
+        "content-type": "application/json",
+        "x-custom": "value",
+      },
+      body: '{"data":"large payload"}',
+      timing: { total: 0.3 },
+      size: 24,
+      contentType: "application/json",
+    };
+
+    const compact = compactResponseMap(full);
+
+    expect(compact.status).toBe(200);
+    expect(compact.statusText).toBe("OK");
+    expect(compact.contentType).toBe("application/json");
+    expect(compact.size).toBe(24);
+    expect(compact.timing.total).toBe(0.3);
+    // Should NOT have headers or body
+    expect("headers" in compact).toBe(false);
+    expect("body" in compact).toBe(false);
+  });
+});
+
+describe("formatResponseCompact", () => {
+  it("formats compact response as single line", () => {
+    const compact = {
+      status: 200,
+      statusText: "OK",
+      contentType: "application/json",
+      size: 42,
+      timing: { total: 0.123 },
+    };
+
+    const output = formatResponseCompact(compact);
+
+    expect(output).toBe("HTTP 200 OK (application/json) | 42 bytes | 0.123s");
+  });
+
+  it("formats compact response without content type", () => {
+    const compact = {
+      status: 204,
+      statusText: "No Content",
+      size: 0,
+      timing: { total: 0.05 },
+    };
+
+    const output = formatResponseCompact(compact);
+
+    expect(output).toBe("HTTP 204 No Content | 0 bytes | 0.050s");
+  });
+});
+
+describe("compactHeadResponseMap", () => {
+  it("maps full HEAD response to compact form (no headers)", () => {
+    const full: HttpHeadResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {
+        "content-type": "text/html",
+        "content-length": "5000",
+      },
+      timing: { total: 0.15 },
+      contentType: "text/html",
+    };
+
+    const compact = compactHeadResponseMap(full);
+
+    expect(compact.status).toBe(200);
+    expect(compact.statusText).toBe("OK");
+    expect(compact.contentType).toBe("text/html");
+    expect(compact.timing.total).toBe(0.15);
+    expect("headers" in compact).toBe(false);
+  });
+});
+
+describe("formatHeadResponseCompact", () => {
+  it("formats compact HEAD response as single line", () => {
+    const compact = {
+      status: 200,
+      statusText: "OK",
+      contentType: "text/html",
+      timing: { total: 0.1 },
+    };
+
+    const output = formatHeadResponseCompact(compact);
+
+    expect(output).toBe("HTTP 200 OK (text/html) | 0.100s");
+  });
+});

--- a/packages/server-http/__tests__/parsers.test.ts
+++ b/packages/server-http/__tests__/parsers.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCurlOutput,
+  parseCurlHeadOutput,
+  splitHttpBlocks,
+  parseHttpBlock,
+  PARE_META_SEPARATOR,
+} from "../src/lib/parsers.js";
+
+describe("parseHttpBlock", () => {
+  it("parses a simple HTTP/1.1 200 OK response", () => {
+    const block = [
+      "HTTP/1.1 200 OK",
+      "Content-Type: application/json",
+      "Content-Length: 27",
+      "",
+      '{"message":"hello world"}',
+    ].join("\r\n");
+
+    const result = parseHttpBlock(block);
+
+    expect(result.status).toBe(200);
+    expect(result.statusText).toBe("OK");
+    expect(result.headers["content-type"]).toBe("application/json");
+    expect(result.headers["content-length"]).toBe("27");
+    expect(result.body).toBe('{"message":"hello world"}');
+  });
+
+  it("parses a 404 Not Found response", () => {
+    const block = [
+      "HTTP/1.1 404 Not Found",
+      "Content-Type: text/html",
+      "",
+      "<h1>Not Found</h1>",
+    ].join("\r\n");
+
+    const result = parseHttpBlock(block);
+
+    expect(result.status).toBe(404);
+    expect(result.statusText).toBe("Not Found");
+    expect(result.headers["content-type"]).toBe("text/html");
+    expect(result.body).toBe("<h1>Not Found</h1>");
+  });
+
+  it("parses an HTTP/2 response", () => {
+    const block = ["HTTP/2 201 Created", "Content-Type: application/json", "", '{"id":1}'].join(
+      "\r\n",
+    );
+
+    const result = parseHttpBlock(block);
+
+    expect(result.status).toBe(201);
+    expect(result.statusText).toBe("Created");
+  });
+
+  it("handles response with no body (HEAD)", () => {
+    const block = ["HTTP/1.1 200 OK", "Content-Type: text/html", "Content-Length: 1234"].join(
+      "\r\n",
+    );
+
+    const result = parseHttpBlock(block);
+
+    expect(result.status).toBe(200);
+    expect(result.body).toBe("");
+  });
+
+  it("handles headers with colons in values", () => {
+    const block = ["HTTP/1.1 200 OK", "Location: https://example.com:8080/path", "", ""].join(
+      "\r\n",
+    );
+
+    const result = parseHttpBlock(block);
+
+    expect(result.headers["location"]).toBe("https://example.com:8080/path");
+  });
+
+  it("parses response with LF-only line endings", () => {
+    const block = ["HTTP/1.1 200 OK", "Content-Type: text/plain", "", "hello"].join("\n");
+
+    const result = parseHttpBlock(block);
+
+    expect(result.status).toBe(200);
+    expect(result.headers["content-type"]).toBe("text/plain");
+    expect(result.body).toBe("hello");
+  });
+
+  it("normalizes header keys to lowercase", () => {
+    const block = [
+      "HTTP/1.1 200 OK",
+      "X-Custom-Header: value1",
+      "CONTENT-TYPE: text/html",
+      "",
+      "",
+    ].join("\r\n");
+
+    const result = parseHttpBlock(block);
+
+    expect(result.headers["x-custom-header"]).toBe("value1");
+    expect(result.headers["content-type"]).toBe("text/html");
+  });
+});
+
+describe("splitHttpBlocks", () => {
+  it("returns a single block for a simple response", () => {
+    const raw = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nhello";
+    const blocks = splitHttpBlocks(raw);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toContain("HTTP/1.1 200 OK");
+  });
+
+  it("splits redirect chains into multiple blocks", () => {
+    const raw = [
+      "HTTP/1.1 301 Moved Permanently",
+      "Location: https://example.com/new",
+      "",
+      "HTTP/1.1 200 OK",
+      "Content-Type: text/html",
+      "",
+      "<html>ok</html>",
+    ].join("\r\n");
+
+    const blocks = splitHttpBlocks(raw);
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toContain("301");
+    expect(blocks[1]).toContain("200");
+  });
+
+  it("handles three redirects", () => {
+    const raw = [
+      "HTTP/1.1 301 Moved",
+      "Location: /a",
+      "",
+      "HTTP/1.1 302 Found",
+      "Location: /b",
+      "",
+      "HTTP/1.1 200 OK",
+      "",
+      "done",
+    ].join("\r\n");
+
+    const blocks = splitHttpBlocks(raw);
+
+    expect(blocks).toHaveLength(3);
+  });
+
+  it("returns input as single block when no HTTP/ prefix found", () => {
+    const raw = "some plain text output";
+    const blocks = splitHttpBlocks(raw);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toBe(raw);
+  });
+});
+
+describe("parseCurlOutput", () => {
+  it("parses a complete curl -i output with metadata", () => {
+    const stdout = [
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Type: application/json\r\n",
+      "Content-Length: 13\r\n",
+      "\r\n",
+      '{"ok":true}',
+      `\n${PARE_META_SEPARATOR}\n`,
+      "0.250 13",
+    ].join("");
+
+    const result = parseCurlOutput(stdout, "", 0);
+
+    expect(result.status).toBe(200);
+    expect(result.statusText).toBe("OK");
+    expect(result.headers["content-type"]).toBe("application/json");
+    expect(result.body).toBe('{"ok":true}');
+    expect(result.timing.total).toBeCloseTo(0.25);
+    expect(result.size).toBe(13);
+    expect(result.contentType).toBe("application/json");
+  });
+
+  it("parses output without metadata separator", () => {
+    const stdout = [
+      "HTTP/1.1 500 Internal Server Error\r\n",
+      "Content-Type: text/plain\r\n",
+      "\r\n",
+      "error occurred",
+    ].join("");
+
+    const result = parseCurlOutput(stdout, "", 1);
+
+    expect(result.status).toBe(500);
+    expect(result.statusText).toBe("Internal Server Error");
+    expect(result.body).toBe("error occurred");
+    expect(result.timing.total).toBe(0);
+    expect(result.size).toBe(0);
+  });
+
+  it("handles redirect chain and takes the last response", () => {
+    const stdout = [
+      "HTTP/1.1 301 Moved Permanently\r\n",
+      "Location: https://example.com/new\r\n",
+      "\r\n",
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Type: text/html\r\n",
+      "\r\n",
+      "<html>success</html>",
+      `\n${PARE_META_SEPARATOR}\n`,
+      "0.500 21",
+    ].join("");
+
+    const result = parseCurlOutput(stdout, "", 0);
+
+    expect(result.status).toBe(200);
+    expect(result.statusText).toBe("OK");
+    expect(result.body).toBe("<html>success</html>");
+    expect(result.contentType).toBe("text/html");
+  });
+
+  it("handles empty body", () => {
+    const stdout = [
+      "HTTP/1.1 204 No Content\r\n",
+      "\r\n",
+      `\n${PARE_META_SEPARATOR}\n`,
+      "0.100 0",
+    ].join("");
+
+    const result = parseCurlOutput(stdout, "", 0);
+
+    expect(result.status).toBe(204);
+    expect(result.statusText).toBe("No Content");
+    expect(result.body).toBeUndefined();
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("parseCurlHeadOutput", () => {
+  it("returns response without body field", () => {
+    const stdout = [
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Type: text/html\r\n",
+      "Content-Length: 5000\r\n",
+      "\r\n",
+      `\n${PARE_META_SEPARATOR}\n`,
+      "0.150 0",
+    ].join("");
+
+    const result = parseCurlHeadOutput(stdout, "", 0);
+
+    expect(result.status).toBe(200);
+    expect(result.statusText).toBe("OK");
+    expect(result.headers["content-type"]).toBe("text/html");
+    expect(result.headers["content-length"]).toBe("5000");
+    expect(result.timing.total).toBeCloseTo(0.15);
+    expect(result.contentType).toBe("text/html");
+    // HEAD response should not have a body field
+    expect("body" in result).toBe(false);
+  });
+});

--- a/packages/server-http/__tests__/security.test.ts
+++ b/packages/server-http/__tests__/security.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Security tests for the HTTP server package.
+ * Verifies URL scheme validation, header injection prevention,
+ * flag injection protection, and input limit constraints.
+ */
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { assertSafeUrl, assertSafeHeader } from "../src/lib/url-validation.js";
+import { buildCurlArgs } from "../src/tools/request.js";
+
+/** Malicious inputs that must be rejected by flag injection checks. */
+const MALICIOUS_FLAG_INPUTS = [
+  "--output=/etc/passwd",
+  "-o /tmp/evil",
+  "--proxy=evil.com:1234",
+  "--upload-file=/etc/shadow",
+  "-T /etc/shadow",
+  "--create-dirs",
+  "--config=/tmp/evil.conf",
+  "-K /tmp/evil.conf",
+  " --output=test",
+  "\t-o /tmp/x",
+];
+
+describe("security: URL scheme validation", () => {
+  it("allows http:// and https:// only", () => {
+    expect(() => assertSafeUrl("http://api.example.com")).not.toThrow();
+    expect(() => assertSafeUrl("https://api.example.com")).not.toThrow();
+  });
+
+  it("blocks file:// scheme (SSRF / LFI)", () => {
+    expect(() => assertSafeUrl("file:///etc/passwd")).toThrow(/Unsafe URL scheme/);
+    expect(() => assertSafeUrl("FILE:///etc/passwd")).toThrow(/Unsafe URL scheme/);
+  });
+
+  it("blocks ftp:// scheme", () => {
+    expect(() => assertSafeUrl("ftp://evil.com/file")).toThrow(/Unsafe URL scheme/);
+  });
+
+  it("blocks gopher:// scheme (SSRF)", () => {
+    expect(() => assertSafeUrl("gopher://evil.com/")).toThrow(/Unsafe URL scheme/);
+  });
+
+  it("blocks dict:// scheme", () => {
+    expect(() => assertSafeUrl("dict://evil.com/")).toThrow(/Unsafe URL scheme/);
+  });
+
+  it("blocks data: scheme (XSS vector)", () => {
+    expect(() => assertSafeUrl("data:text/html,<script>alert(1)</script>")).toThrow(
+      /Unsafe URL scheme/,
+    );
+  });
+
+  it("blocks javascript: scheme", () => {
+    expect(() => assertSafeUrl("javascript:alert(1)")).toThrow(/Unsafe URL scheme/);
+  });
+});
+
+describe("security: header key/value injection", () => {
+  it("rejects headers with CRLF injection in keys", () => {
+    expect(() => assertSafeHeader("X-Evil\r\nInject: bad", "value")).toThrow();
+  });
+
+  it("rejects headers with CRLF injection in values", () => {
+    expect(() => assertSafeHeader("X-Normal", "value\r\nX-Injected: evil")).toThrow();
+  });
+
+  it("rejects headers with null bytes", () => {
+    expect(() => assertSafeHeader("Key\x00Evil", "value")).toThrow();
+    expect(() => assertSafeHeader("Key", "value\x00evil")).toThrow();
+  });
+});
+
+describe("security: flag injection in header keys/values", () => {
+  it("rejects flag-like header keys", () => {
+    for (const input of MALICIOUS_FLAG_INPUTS) {
+      expect(() => assertNoFlagInjection(input, "header key")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("rejects flag-like header values", () => {
+    for (const input of MALICIOUS_FLAG_INPUTS) {
+      expect(() => assertNoFlagInjection(input, "header value")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts normal header keys and values", () => {
+    expect(() => assertNoFlagInjection("Content-Type", "header key")).not.toThrow();
+    expect(() => assertNoFlagInjection("application/json", "header value")).not.toThrow();
+    expect(() => assertNoFlagInjection("Bearer abc123", "header value")).not.toThrow();
+  });
+});
+
+describe("security: buildCurlArgs safety", () => {
+  it("always includes -s and -S flags (silent + show errors)", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      followRedirects: true,
+    });
+
+    expect(args).toContain("-s");
+    expect(args).toContain("-S");
+  });
+
+  it("includes -i flag for response headers", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      followRedirects: true,
+    });
+
+    expect(args).toContain("-i");
+  });
+
+  it("includes --max-time for timeout", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 10,
+      followRedirects: true,
+    });
+
+    const idx = args.indexOf("--max-time");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("10");
+  });
+
+  it("limits redirects to 10 hops", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      followRedirects: true,
+    });
+
+    const idx = args.indexOf("--max-redirs");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("10");
+  });
+
+  it("does not follow redirects when followRedirects is false", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      followRedirects: false,
+    });
+
+    expect(args).not.toContain("-L");
+    expect(args).not.toContain("--max-redirs");
+  });
+
+  it("places URL as the last argument", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com/api",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: '{"key":"value"}',
+      timeout: 30,
+      followRedirects: true,
+    });
+
+    expect(args[args.length - 1]).toBe("https://example.com/api");
+  });
+
+  it("uses --data-raw for body (not --data)", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "POST",
+      body: '{"key":"value"}',
+      timeout: 30,
+      followRedirects: true,
+    });
+
+    expect(args).toContain("--data-raw");
+    expect(args).not.toContain("--data");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zod .max() input-limit constraints — HTTP tool schemas
+// ---------------------------------------------------------------------------
+
+describe("Zod .max() constraints — HTTP tool schemas", () => {
+  describe("URL (STRING_MAX = 65,536)", () => {
+    const schema = z.string().max(INPUT_LIMITS.STRING_MAX);
+
+    it("accepts a normal URL", () => {
+      expect(schema.safeParse("https://api.example.com/v1/users").success).toBe(true);
+    });
+
+    it("rejects a URL exceeding STRING_MAX", () => {
+      const oversized = "https://example.com/" + "a".repeat(INPUT_LIMITS.STRING_MAX);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("body (STRING_MAX = 65,536)", () => {
+    const schema = z.string().max(INPUT_LIMITS.STRING_MAX);
+
+    it("accepts a normal request body", () => {
+      expect(schema.safeParse('{"key":"value"}').success).toBe(true);
+    });
+
+    it("rejects a body exceeding STRING_MAX", () => {
+      const oversized = "x".repeat(INPUT_LIMITS.STRING_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("header key (SHORT_STRING_MAX = 255)", () => {
+    const schema = z.string().max(INPUT_LIMITS.SHORT_STRING_MAX);
+
+    it("accepts a normal header key", () => {
+      expect(schema.safeParse("Content-Type").success).toBe(true);
+    });
+
+    it("rejects a header key exceeding SHORT_STRING_MAX", () => {
+      const oversized = "H".repeat(INPUT_LIMITS.SHORT_STRING_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("path (PATH_MAX = 4,096)", () => {
+    const schema = z.string().max(INPUT_LIMITS.PATH_MAX);
+
+    it("accepts a normal path", () => {
+      expect(schema.safeParse("/home/user/project").success).toBe(true);
+    });
+
+    it("rejects a path exceeding PATH_MAX", () => {
+      const oversized = "p".repeat(INPUT_LIMITS.PATH_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+});

--- a/packages/server-http/__tests__/url-validation.test.ts
+++ b/packages/server-http/__tests__/url-validation.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { assertSafeUrl, assertSafeHeader } from "../src/lib/url-validation.js";
+
+describe("assertSafeUrl", () => {
+  describe("accepts valid HTTP URLs", () => {
+    const validUrls = [
+      "http://example.com",
+      "https://example.com",
+      "http://localhost:3000",
+      "https://api.example.com/v1/users",
+      "http://192.168.1.1:8080/path",
+      "https://example.com/path?query=1&foo=bar",
+      "https://user:pass@example.com/path",
+      "HTTP://EXAMPLE.COM",
+      "HTTPS://EXAMPLE.COM",
+      "https://example.com/path#fragment",
+    ];
+
+    for (const url of validUrls) {
+      it(`accepts "${url}"`, () => {
+        expect(() => assertSafeUrl(url)).not.toThrow();
+      });
+    }
+  });
+
+  describe("rejects dangerous URL schemes", () => {
+    const dangerousUrls = [
+      "file:///etc/passwd",
+      "ftp://evil.com/file",
+      "gopher://evil.com/",
+      "dict://evil.com/",
+      "data:text/html,<script>alert(1)</script>",
+      "javascript:alert(1)",
+      "ldap://evil.com/",
+      "sftp://evil.com/file",
+      "telnet://evil.com",
+    ];
+
+    for (const url of dangerousUrls) {
+      it(`rejects "${url}"`, () => {
+        expect(() => assertSafeUrl(url)).toThrow(/Unsafe URL scheme/);
+      });
+    }
+  });
+
+  describe("rejects malformed inputs", () => {
+    it("rejects empty string", () => {
+      expect(() => assertSafeUrl("")).toThrow(/must not be empty/);
+    });
+
+    it("rejects whitespace-only string", () => {
+      expect(() => assertSafeUrl("   ")).toThrow(/must not be empty/);
+    });
+
+    it("rejects string without scheme", () => {
+      expect(() => assertSafeUrl("example.com")).toThrow(/Unsafe URL scheme/);
+    });
+
+    it("rejects relative path", () => {
+      expect(() => assertSafeUrl("/path/to/file")).toThrow(/Unsafe URL scheme/);
+    });
+  });
+
+  it("trims whitespace before validation", () => {
+    expect(() => assertSafeUrl("  https://example.com  ")).not.toThrow();
+  });
+
+  it("is case-insensitive for scheme", () => {
+    expect(() => assertSafeUrl("HTTPS://example.com")).not.toThrow();
+    expect(() => assertSafeUrl("Http://example.com")).not.toThrow();
+  });
+});
+
+describe("assertSafeHeader", () => {
+  it("accepts normal header key-value pairs", () => {
+    expect(() => assertSafeHeader("Content-Type", "application/json")).not.toThrow();
+    expect(() => assertSafeHeader("Authorization", "Bearer token123")).not.toThrow();
+    expect(() => assertSafeHeader("X-Custom", "some value")).not.toThrow();
+  });
+
+  it("rejects header key with newline", () => {
+    expect(() => assertSafeHeader("Bad\nKey", "value")).toThrow(/header key/i);
+  });
+
+  it("rejects header key with carriage return", () => {
+    expect(() => assertSafeHeader("Bad\rKey", "value")).toThrow(/header key/i);
+  });
+
+  it("rejects header key with null byte", () => {
+    expect(() => assertSafeHeader("Bad\x00Key", "value")).toThrow(/header key/i);
+  });
+
+  it("rejects header value with newline", () => {
+    expect(() => assertSafeHeader("Key", "bad\nvalue")).toThrow(/header value/i);
+  });
+
+  it("rejects header value with carriage return", () => {
+    expect(() => assertSafeHeader("Key", "bad\rvalue")).toThrow(/header value/i);
+  });
+
+  it("rejects header value with null byte", () => {
+    expect(() => assertSafeHeader("Key", "bad\x00value")).toThrow(/header value/i);
+  });
+});

--- a/packages/server-http/package.json
+++ b/packages/server-http/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@paretools/http",
+  "version": "0.7.0",
+  "mcpName": "io.github.Dave-London/http",
+  "description": "MCP server for HTTP requests (curl) with structured, token-efficient output",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "structured-output",
+    "ai",
+    "ai-agent",
+    "claude",
+    "cursor",
+    "copilot",
+    "token-efficient",
+    "devtools",
+    "cli",
+    "http",
+    "curl",
+    "rest",
+    "api",
+    "request"
+  ],
+  "homepage": "https://github.com/Dave-London/Pare/tree/main/packages/server-http",
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "bin": {
+    "pare-http": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/Pare.git",
+    "directory": "packages/server-http"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@paretools/shared": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@paretools/tsconfig": "workspace:*",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/server-http/src/index.ts
+++ b/packages/server-http/src/index.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerAllTools } from "./tools/index.js";
+
+const server = new McpServer(
+  { name: "@paretools/http", version: "0.7.0" },
+  {
+    instructions:
+      "Structured HTTP request operations via curl (request, get, post, head). Use instead of running curl commands via bash. Returns typed JSON with status, headers, body, timing, and size.",
+  },
+);
+
+registerAllTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/server-http/src/lib/curl-runner.ts
+++ b/packages/server-http/src/lib/curl-runner.ts
@@ -1,0 +1,9 @@
+import { run, type RunResult } from "@paretools/shared";
+
+/**
+ * Executes a curl command with the given arguments.
+ * Uses a generous timeout since HTTP requests can be slow.
+ */
+export async function curlCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("curl", args, { cwd, timeout: 120_000 });
+}

--- a/packages/server-http/src/lib/formatters.ts
+++ b/packages/server-http/src/lib/formatters.ts
@@ -1,0 +1,91 @@
+import type {
+  HttpResponse,
+  HttpHeadResponse,
+  HttpResponseCompact,
+  HttpHeadResponseCompact,
+} from "../schemas/index.js";
+
+/** Formats a full HTTP response into human-readable text. */
+export function formatHttpResponse(data: HttpResponse): string {
+  const lines: string[] = [];
+
+  lines.push(`HTTP ${data.status} ${data.statusText}`);
+
+  if (data.contentType) {
+    lines.push(`Content-Type: ${data.contentType}`);
+  }
+
+  lines.push(`Size: ${data.size} bytes | Time: ${data.timing.total.toFixed(3)}s`);
+
+  const headerCount = Object.keys(data.headers).length;
+  lines.push(`Headers: ${headerCount}`);
+
+  for (const [key, value] of Object.entries(data.headers)) {
+    lines.push(`  ${key}: ${value}`);
+  }
+
+  if (data.body) {
+    const bodyPreview = data.body.length > 500 ? data.body.substring(0, 500) + "..." : data.body;
+    lines.push("");
+    lines.push(bodyPreview);
+  }
+
+  return lines.join("\n");
+}
+
+/** Formats a HEAD response into human-readable text. */
+export function formatHttpHeadResponse(data: HttpHeadResponse): string {
+  const lines: string[] = [];
+
+  lines.push(`HTTP ${data.status} ${data.statusText}`);
+
+  if (data.contentType) {
+    lines.push(`Content-Type: ${data.contentType}`);
+  }
+
+  lines.push(`Time: ${data.timing.total.toFixed(3)}s`);
+
+  const headerCount = Object.keys(data.headers).length;
+  lines.push(`Headers: ${headerCount}`);
+
+  for (const [key, value] of Object.entries(data.headers)) {
+    lines.push(`  ${key}: ${value}`);
+  }
+
+  return lines.join("\n");
+}
+
+// ── Compact types, mappers, and formatters ───────────────────────────
+
+/** Maps full HTTP response to compact form (drop headers and body). */
+export function compactResponseMap(data: HttpResponse): HttpResponseCompact {
+  return {
+    status: data.status,
+    statusText: data.statusText,
+    contentType: data.contentType,
+    size: data.size,
+    timing: data.timing,
+  };
+}
+
+/** Formats compact HTTP response. */
+export function formatResponseCompact(data: HttpResponseCompact): string {
+  const ct = data.contentType ? ` (${data.contentType})` : "";
+  return `HTTP ${data.status} ${data.statusText}${ct} | ${data.size} bytes | ${data.timing.total.toFixed(3)}s`;
+}
+
+/** Maps full HEAD response to compact form (drop headers). */
+export function compactHeadResponseMap(data: HttpHeadResponse): HttpHeadResponseCompact {
+  return {
+    status: data.status,
+    statusText: data.statusText,
+    contentType: data.contentType,
+    timing: data.timing,
+  };
+}
+
+/** Formats compact HEAD response. */
+export function formatHeadResponseCompact(data: HttpHeadResponseCompact): string {
+  const ct = data.contentType ? ` (${data.contentType})` : "";
+  return `HTTP ${data.status} ${data.statusText}${ct} | ${data.timing.total.toFixed(3)}s`;
+}

--- a/packages/server-http/src/lib/parsers.ts
+++ b/packages/server-http/src/lib/parsers.ts
@@ -1,0 +1,171 @@
+import type { HttpResponse, HttpHeadResponse } from "../schemas/index.js";
+
+/** Sentinel appended via curl -w to separate body from metadata. */
+export const PARE_META_SEPARATOR = "---PARE_HTTP_META---";
+
+/**
+ * Represents the raw metadata extracted from curl's -w write-out format.
+ */
+interface CurlMeta {
+  time_total: number;
+  size_download: number;
+}
+
+/**
+ * Parses the combined output from `curl -s -S -i -w '...' URL`.
+ *
+ * The output format is:
+ *   HTTP/x.y STATUS STATUS_TEXT\r\n
+ *   Header: value\r\n
+ *   ...
+ *   \r\n
+ *   <body>
+ *   \n---PARE_HTTP_META---\n
+ *   <time_total> <size_download>
+ *
+ * When following redirects, multiple status+header blocks may appear.
+ * We parse the LAST one (the final response).
+ */
+export function parseCurlOutput(stdout: string, _stderr: string, _exitCode: number): HttpResponse {
+  // Split off the meta section appended by -w
+  const metaSepIdx = stdout.lastIndexOf(PARE_META_SEPARATOR);
+  let metaSection = "";
+  let responsePart = stdout;
+
+  if (metaSepIdx !== -1) {
+    responsePart = stdout.substring(0, metaSepIdx);
+    metaSection = stdout.substring(metaSepIdx + PARE_META_SEPARATOR.length).trim();
+  }
+
+  const meta = parseMetaSection(metaSection);
+
+  // When following redirects, curl with -i outputs multiple response blocks.
+  // Each block starts with HTTP/. We want the LAST one.
+  const blocks = splitHttpBlocks(responsePart);
+  const lastBlock = blocks.length > 0 ? blocks[blocks.length - 1] : responsePart;
+
+  const { status, statusText, headers, body } = parseHttpBlock(lastBlock);
+
+  const contentType = headers["content-type"];
+
+  return {
+    status,
+    statusText,
+    headers,
+    body: body || undefined,
+    timing: { total: meta.time_total },
+    size: meta.size_download,
+    contentType,
+  };
+}
+
+/**
+ * Parses curl output for HEAD requests (no body expected).
+ */
+export function parseCurlHeadOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): HttpHeadResponse {
+  const full = parseCurlOutput(stdout, stderr, exitCode);
+
+  return {
+    status: full.status,
+    statusText: full.statusText,
+    headers: full.headers,
+    timing: full.timing,
+    contentType: full.contentType,
+  };
+}
+
+/**
+ * Splits raw curl `-i` output into separate HTTP response blocks.
+ * Each block starts with `HTTP/` (status line).
+ */
+export function splitHttpBlocks(raw: string): string[] {
+  const blocks: string[] = [];
+  // Match HTTP/ at the start of a line
+  const regex = /^HTTP\//gm;
+  const indices: number[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(raw)) !== null) {
+    indices.push(match.index);
+  }
+
+  if (indices.length === 0) {
+    return [raw];
+  }
+
+  for (let i = 0; i < indices.length; i++) {
+    const start = indices[i];
+    const end = i + 1 < indices.length ? indices[i + 1] : raw.length;
+    blocks.push(raw.substring(start, end));
+  }
+
+  return blocks;
+}
+
+/**
+ * Parses a single HTTP response block into status, headers, and body.
+ */
+export function parseHttpBlock(block: string): {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+} {
+  // Normalize line endings: \r\n -> \n
+  const normalized = block.replace(/\r\n/g, "\n");
+
+  // Split on first double-newline to separate headers from body
+  const headerBodySplit = normalized.indexOf("\n\n");
+  let headerSection: string;
+  let body: string;
+
+  if (headerBodySplit !== -1) {
+    headerSection = normalized.substring(0, headerBodySplit);
+    body = normalized.substring(headerBodySplit + 2);
+  } else {
+    // No body (e.g. HEAD request or empty response)
+    headerSection = normalized;
+    body = "";
+  }
+
+  const lines = headerSection.split("\n");
+  const statusLine = lines[0] || "";
+
+  // Parse status line: HTTP/1.1 200 OK
+  const statusMatch = statusLine.match(/^HTTP\/[\d.]+\s+(\d+)\s*(.*)/);
+  const status = statusMatch ? parseInt(statusMatch[1], 10) : 0;
+  const statusText = statusMatch ? statusMatch[2].trim() : "";
+
+  // Parse headers
+  const headers: Record<string, string> = {};
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    const colonIdx = line.indexOf(":");
+    if (colonIdx > 0) {
+      const key = line.substring(0, colonIdx).trim().toLowerCase();
+      const value = line.substring(colonIdx + 1).trim();
+      headers[key] = value;
+    }
+  }
+
+  // Trim trailing whitespace from body
+  body = body.replace(/\n$/, "");
+
+  return { status, statusText, headers, body };
+}
+
+/**
+ * Parses the metadata section appended by curl's -w format string.
+ * Format: "<time_total> <size_download>"
+ */
+function parseMetaSection(meta: string): CurlMeta {
+  const parts = meta.trim().split(/\s+/);
+  return {
+    time_total: parts[0] ? parseFloat(parts[0]) : 0,
+    size_download: parts[1] ? parseFloat(parts[1]) : 0,
+  };
+}

--- a/packages/server-http/src/lib/url-validation.ts
+++ b/packages/server-http/src/lib/url-validation.ts
@@ -1,0 +1,37 @@
+/**
+ * Validates that a URL uses only http:// or https:// schemes.
+ * Blocks dangerous schemes like file://, ftp://, gopher://, dict://, data:, javascript:, etc.
+ */
+export function assertSafeUrl(url: string): void {
+  const trimmed = url.trim();
+
+  if (!trimmed) {
+    throw new Error("URL must not be empty.");
+  }
+
+  const lower = trimmed.toLowerCase();
+
+  if (!lower.startsWith("http://") && !lower.startsWith("https://")) {
+    throw new Error(`Unsafe URL scheme. Only http:// and https:// are allowed. Got: "${url}"`);
+  }
+}
+
+/**
+ * Validates that a header key or value does not contain newlines or control characters
+ * that could be used for header injection attacks.
+ */
+export function assertSafeHeader(key: string, value: string): void {
+  const UNSAFE_RE = /[\r\n\x00]/;
+
+  if (UNSAFE_RE.test(key)) {
+    throw new Error(
+      `Invalid header key: "${key}". Header keys must not contain newlines or null bytes.`,
+    );
+  }
+
+  if (UNSAFE_RE.test(value)) {
+    throw new Error(
+      `Invalid header value for "${key}". Header values must not contain newlines or null bytes.`,
+    );
+  }
+}

--- a/packages/server-http/src/schemas/index.ts
+++ b/packages/server-http/src/schemas/index.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+/** Zod schema for a single HTTP header key-value pair as a record. */
+export const HttpHeadersSchema = z.record(z.string(), z.string());
+
+/** Zod schema for HTTP timing information. */
+export const HttpTimingSchema = z.object({
+  total: z.number(),
+});
+
+/** Zod schema for the full HTTP response result (used by request, get, post). */
+export const HttpResponseSchema = z.object({
+  status: z.number(),
+  statusText: z.string(),
+  headers: HttpHeadersSchema,
+  body: z.string().optional(),
+  timing: HttpTimingSchema,
+  size: z.number(),
+  contentType: z.string().optional(),
+});
+
+export type HttpResponse = z.infer<typeof HttpResponseSchema>;
+
+/** Zod schema for the HEAD-only HTTP response result (no body). */
+export const HttpHeadResponseSchema = z.object({
+  status: z.number(),
+  statusText: z.string(),
+  headers: HttpHeadersSchema,
+  timing: HttpTimingSchema,
+  contentType: z.string().optional(),
+});
+
+export type HttpHeadResponse = z.infer<typeof HttpHeadResponseSchema>;
+
+/** Compact response: status, timing, size. Drop headers and body. */
+export const HttpResponseCompactSchema = z.object({
+  status: z.number(),
+  statusText: z.string(),
+  contentType: z.string().optional(),
+  size: z.number(),
+  timing: HttpTimingSchema,
+});
+
+export type HttpResponseCompact = z.infer<typeof HttpResponseCompactSchema>;
+
+/** Compact HEAD response: status and timing only. Drop headers. */
+export const HttpHeadResponseCompactSchema = z.object({
+  status: z.number(),
+  statusText: z.string(),
+  contentType: z.string().optional(),
+  timing: HttpTimingSchema,
+});
+
+export type HttpHeadResponseCompact = z.infer<typeof HttpHeadResponseCompactSchema>;

--- a/packages/server-http/src/tools/get.ts
+++ b/packages/server-http/src/tools/get.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { curlCmd } from "../lib/curl-runner.js";
+import { parseCurlOutput } from "../lib/parsers.js";
+import {
+  formatHttpResponse,
+  compactResponseMap,
+  formatResponseCompact,
+} from "../lib/formatters.js";
+import { HttpResponseSchema } from "../schemas/index.js";
+import { assertSafeUrl } from "../lib/url-validation.js";
+import { buildCurlArgs } from "./request.js";
+
+export function registerGetTool(server: McpServer) {
+  server.registerTool(
+    "get",
+    {
+      title: "HTTP GET",
+      description:
+        "Makes an HTTP GET request via curl and returns structured response data. Convenience wrapper for the request tool.",
+      inputSchema: {
+        url: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .describe("The URL to request (http:// or https:// only)"),
+        headers: z
+          .record(
+            z.string().max(INPUT_LIMITS.SHORT_STRING_MAX),
+            z.string().max(INPUT_LIMITS.STRING_MAX),
+          )
+          .optional()
+          .describe("Request headers as key-value pairs"),
+        timeout: z
+          .number()
+          .min(1)
+          .max(300)
+          .optional()
+          .default(30)
+          .describe("Request timeout in seconds (default: 30)"),
+        followRedirects: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Follow HTTP redirects (default: true)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+      },
+      outputSchema: HttpResponseSchema,
+    },
+    async ({ url, headers, timeout, followRedirects, compact, path }) => {
+      assertSafeUrl(url);
+
+      const args = buildCurlArgs({
+        url,
+        method: "GET",
+        headers,
+        timeout: timeout ?? 30,
+        followRedirects: followRedirects ?? true,
+      });
+
+      const cwd = path || process.cwd();
+      const result = await curlCmd(args, cwd);
+      const data = parseCurlOutput(result.stdout, result.stderr, result.exitCode);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatHttpResponse,
+        compactResponseMap,
+        formatResponseCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-http/src/tools/head.ts
+++ b/packages/server-http/src/tools/head.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { curlCmd } from "../lib/curl-runner.js";
+import { parseCurlHeadOutput } from "../lib/parsers.js";
+import {
+  formatHttpHeadResponse,
+  compactHeadResponseMap,
+  formatHeadResponseCompact,
+} from "../lib/formatters.js";
+import { HttpHeadResponseSchema } from "../schemas/index.js";
+import { assertSafeUrl } from "../lib/url-validation.js";
+import { buildCurlArgs } from "./request.js";
+
+export function registerHeadTool(server: McpServer) {
+  server.registerTool(
+    "head",
+    {
+      title: "HTTP HEAD",
+      description:
+        "Makes an HTTP HEAD request via curl and returns structured response headers (no body). Use to check resource existence, content type, or cache headers.",
+      inputSchema: {
+        url: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .describe("The URL to request (http:// or https:// only)"),
+        headers: z
+          .record(
+            z.string().max(INPUT_LIMITS.SHORT_STRING_MAX),
+            z.string().max(INPUT_LIMITS.STRING_MAX),
+          )
+          .optional()
+          .describe("Request headers as key-value pairs"),
+        timeout: z
+          .number()
+          .min(1)
+          .max(300)
+          .optional()
+          .default(30)
+          .describe("Request timeout in seconds (default: 30)"),
+        followRedirects: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Follow HTTP redirects (default: true)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+      },
+      outputSchema: HttpHeadResponseSchema,
+    },
+    async ({ url, headers, timeout, followRedirects, compact, path }) => {
+      assertSafeUrl(url);
+
+      const args = buildCurlArgs({
+        url,
+        method: "HEAD",
+        headers,
+        timeout: timeout ?? 30,
+        followRedirects: followRedirects ?? true,
+      });
+
+      const cwd = path || process.cwd();
+      const result = await curlCmd(args, cwd);
+      const data = parseCurlHeadOutput(result.stdout, result.stderr, result.exitCode);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatHttpHeadResponse,
+        compactHeadResponseMap,
+        formatHeadResponseCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-http/src/tools/index.ts
+++ b/packages/server-http/src/tools/index.ts
@@ -1,0 +1,14 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
+import { registerRequestTool } from "./request.js";
+import { registerGetTool } from "./get.js";
+import { registerPostTool } from "./post.js";
+import { registerHeadTool } from "./head.js";
+
+export function registerAllTools(server: McpServer) {
+  const s = (name: string) => shouldRegisterTool("http", name);
+  if (s("request")) registerRequestTool(server);
+  if (s("get")) registerGetTool(server);
+  if (s("post")) registerPostTool(server);
+  if (s("head")) registerHeadTool(server);
+}

--- a/packages/server-http/src/tools/post.ts
+++ b/packages/server-http/src/tools/post.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { curlCmd } from "../lib/curl-runner.js";
+import { parseCurlOutput } from "../lib/parsers.js";
+import {
+  formatHttpResponse,
+  compactResponseMap,
+  formatResponseCompact,
+} from "../lib/formatters.js";
+import { HttpResponseSchema } from "../schemas/index.js";
+import { assertSafeUrl } from "../lib/url-validation.js";
+import { buildCurlArgs } from "./request.js";
+
+export function registerPostTool(server: McpServer) {
+  server.registerTool(
+    "post",
+    {
+      title: "HTTP POST",
+      description:
+        "Makes an HTTP POST request via curl and returns structured response data. Convenience wrapper for the request tool with required body.",
+      inputSchema: {
+        url: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .describe("The URL to request (http:// or https:// only)"),
+        body: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Request body"),
+        headers: z
+          .record(
+            z.string().max(INPUT_LIMITS.SHORT_STRING_MAX),
+            z.string().max(INPUT_LIMITS.STRING_MAX),
+          )
+          .optional()
+          .describe("Request headers as key-value pairs"),
+        contentType: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .default("application/json")
+          .describe("Content-Type header (default: application/json)"),
+        timeout: z
+          .number()
+          .min(1)
+          .max(300)
+          .optional()
+          .default(30)
+          .describe("Request timeout in seconds (default: 30)"),
+        followRedirects: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Follow HTTP redirects (default: true)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+      },
+      outputSchema: HttpResponseSchema,
+    },
+    async ({ url, body, headers, contentType, timeout, followRedirects, compact, path }) => {
+      assertSafeUrl(url);
+
+      // Merge content-type header with user-supplied headers
+      const mergedHeaders: Record<string, string> = {
+        "Content-Type": contentType ?? "application/json",
+        ...headers,
+      };
+
+      const args = buildCurlArgs({
+        url,
+        method: "POST",
+        headers: mergedHeaders,
+        body,
+        timeout: timeout ?? 30,
+        followRedirects: followRedirects ?? true,
+      });
+
+      const cwd = path || process.cwd();
+      const result = await curlCmd(args, cwd);
+      const data = parseCurlOutput(result.stdout, result.stderr, result.exitCode);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatHttpResponse,
+        compactResponseMap,
+        formatResponseCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-http/src/tools/request.ts
+++ b/packages/server-http/src/tools/request.ts
@@ -1,0 +1,151 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { curlCmd } from "../lib/curl-runner.js";
+import { parseCurlOutput, PARE_META_SEPARATOR } from "../lib/parsers.js";
+import {
+  formatHttpResponse,
+  compactResponseMap,
+  formatResponseCompact,
+} from "../lib/formatters.js";
+import { HttpResponseSchema } from "../schemas/index.js";
+import { assertSafeUrl, assertSafeHeader } from "../lib/url-validation.js";
+
+const METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"] as const;
+
+export function registerRequestTool(server: McpServer) {
+  server.registerTool(
+    "request",
+    {
+      title: "HTTP Request",
+      description:
+        "Makes an HTTP request via curl and returns structured response data (status, headers, body, timing). Use instead of running `curl` in the terminal.",
+      inputSchema: {
+        url: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .describe("The URL to request (http:// or https:// only)"),
+        method: z.enum(METHODS).optional().default("GET").describe("HTTP method (default: GET)"),
+        headers: z
+          .record(
+            z.string().max(INPUT_LIMITS.SHORT_STRING_MAX),
+            z.string().max(INPUT_LIMITS.STRING_MAX),
+          )
+          .optional()
+          .describe("Request headers as key-value pairs"),
+        body: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Request body (for POST, PUT, PATCH)"),
+        timeout: z
+          .number()
+          .min(1)
+          .max(300)
+          .optional()
+          .default(30)
+          .describe("Request timeout in seconds (default: 30)"),
+        followRedirects: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Follow HTTP redirects (default: true)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+      },
+      outputSchema: HttpResponseSchema,
+    },
+    async ({ url, method, headers, body, timeout, followRedirects, compact, path }) => {
+      assertSafeUrl(url);
+
+      const args = buildCurlArgs({
+        url,
+        method: method ?? "GET",
+        headers,
+        body,
+        timeout: timeout ?? 30,
+        followRedirects: followRedirects ?? true,
+      });
+
+      const cwd = path || process.cwd();
+      const result = await curlCmd(args, cwd);
+      const data = parseCurlOutput(result.stdout, result.stderr, result.exitCode);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatHttpResponse,
+        compactResponseMap,
+        formatResponseCompact,
+        compact === false,
+      );
+    },
+  );
+}
+
+/**
+ * Builds the curl argument array from the request parameters.
+ * Exported for reuse in get/post/head tools.
+ */
+export function buildCurlArgs(opts: {
+  url: string;
+  method: string;
+  headers?: Record<string, string>;
+  body?: string;
+  timeout: number;
+  followRedirects: boolean;
+}): string[] {
+  const args: string[] = [
+    "-s", // Silent mode (no progress)
+    "-S", // Show errors
+    "-i", // Include response headers in output
+  ];
+
+  // Write-out format for timing and size metadata
+  const writeOut = `\n${PARE_META_SEPARATOR}\n%{time_total} %{size_download}`;
+  args.push("-w", writeOut);
+
+  // HTTP method
+  args.push("-X", opts.method);
+
+  // Timeout
+  args.push("--max-time", String(opts.timeout));
+
+  // Follow redirects
+  if (opts.followRedirects) {
+    args.push("-L");
+    // Limit redirect hops to prevent infinite loops
+    args.push("--max-redirs", "10");
+  }
+
+  // Custom headers
+  if (opts.headers) {
+    for (const [key, value] of Object.entries(opts.headers)) {
+      assertNoFlagInjection(key, "header key");
+      assertNoFlagInjection(value, "header value");
+      assertSafeHeader(key, value);
+      args.push("-H", `${key}: ${value}`);
+    }
+  }
+
+  // Request body
+  if (opts.body) {
+    args.push("--data-raw", opts.body);
+  }
+
+  // URL must be last
+  args.push(opts.url);
+
+  return args;
+}

--- a/packages/server-http/tsconfig.json
+++ b/packages/server-http/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@paretools/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/server-http/vitest.config.ts
+++ b/packages/server-http/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 60_000,
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 70,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,31 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/server-http:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.26.0(zod@4.3.6)
+      '@paretools/shared':
+        specifier: workspace:*
+        version: link:../shared
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@paretools/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/server-lint:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary

- Add new `@paretools/http` MCP server package wrapping `curl` for structured HTTP operations
- Implements 4 tools: `request` (configurable method), `get`, `post`, `head` (no body in output)
- Full security hardening: URL scheme validation (http/https only), header injection prevention (CRLF/null byte), flag injection protection, input size limits, `--data-raw` for body, redirect hop limit

## Details

### Tools
| Tool | Description |
|------|-------------|
| `request` | Full HTTP request with configurable method, headers, body, timeout, redirect following |
| `get` | Convenience GET wrapper |
| `post` | Convenience POST wrapper with required body and Content-Type header |
| `head` | HEAD request returning headers/timing only (no body) |

### Architecture
Follows exact patterns from existing packages (server-go, server-git, etc.):
- Zod v4 schemas with `outputSchema` for structured responses
- Dual output (human-readable text + typed JSON)
- Compact mode support (auto-compact when structured output exceeds raw CLI tokens)
- `@paretools/shared` integration (runner, validation, output helpers)

### Security
- URL scheme allowlist: only `http://` and `https://` permitted
- Blocks `file://`, `ftp://`, `gopher://`, `dict://`, `data:`, `javascript:`, etc.
- Header injection prevention: rejects keys/values containing `\r`, `\n`, `\x00`
- Flag injection protection via `assertNoFlagInjection` on header keys/values
- Body via `--data-raw` (not `--data`) to prevent `@file` expansion
- Redirect hops limited to 10
- Input size limits via Zod `.max()` constraints

## Test plan

- [x] 85 unit tests passing across 4 test files
  - `parsers.test.ts`: HTTP response parsing, redirect chains, empty body, metadata extraction
  - `formatters.test.ts`: Human-readable and compact output formatting
  - `url-validation.test.ts`: URL scheme validation, header injection prevention
  - `security.test.ts`: Flag injection, buildCurlArgs safety, Zod input limits
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] ESLint clean
- [x] Prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)