### PR TITLE
feat(git): add tag, stash-list, stash, remote, blame tools

### DIFF
--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -30,11 +30,12 @@ describe("@paretools/git integration", () => {
     await transport.close();
   });
 
-  it("lists all 10 tools", async () => {
+  it("lists all 15 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
       "add",
+      "blame",
       "branch",
       "checkout",
       "commit",
@@ -42,8 +43,12 @@ describe("@paretools/git integration", () => {
       "log",
       "pull",
       "push",
+      "remote",
       "show",
+      "stash",
+      "stash-list",
       "status",
+      "tag",
     ]);
   });
 

--- a/packages/server-git/__tests__/security.test.ts
+++ b/packages/server-git/__tests__/security.test.ts
@@ -138,6 +138,24 @@ describe("security: diff tool — ref validation", () => {
   });
 });
 
+describe("security: blame tool — file path validation", () => {
+  it("rejects flag-like file paths", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "file")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: stash tool — message validation", () => {
+  it("rejects flag-like stash messages", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "stash message")).toThrow(
+        /must not start with "-"/,
+      );
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Zod .max() input-limit constraints — Git tool schemas
 // ---------------------------------------------------------------------------

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -9,6 +9,11 @@ import type {
   GitPush,
   GitPull,
   GitCheckout,
+  GitTagFull,
+  GitStashListFull,
+  GitStash,
+  GitRemoteFull,
+  GitBlameFull,
 } from "../schemas/index.js";
 
 /** Formats structured git status data into a human-readable summary string. */
@@ -177,4 +182,137 @@ export function compactShowMap(s: GitShow): GitShowCompact {
 
 export function formatShowCompact(s: GitShowCompact): string {
   return `${s.hashShort} ${s.message}`;
+}
+
+// ── Tag formatters ───────────────────────────────────────────────────
+
+/** Formats structured git tag data into a human-readable tag listing. */
+export function formatTag(t: GitTagFull): string {
+  if (t.tags.length === 0) return "No tags found";
+  return t.tags
+    .map((tag) => {
+      const parts = [tag.name];
+      if (tag.date) parts.push(tag.date);
+      if (tag.message) parts.push(tag.message);
+      return parts.join("  ");
+    })
+    .join("\n");
+}
+
+/** Compact tag: just tag names as string array + total. */
+export interface GitTagCompact {
+  [key: string]: unknown;
+  tags: string[];
+  total: number;
+}
+
+export function compactTagMap(t: GitTagFull): GitTagCompact {
+  return {
+    tags: t.tags.map((tag) => tag.name),
+    total: t.total,
+  };
+}
+
+export function formatTagCompact(t: GitTagCompact): string {
+  if (t.tags.length === 0) return "No tags found";
+  return t.tags.join("\n");
+}
+
+// ── Stash list formatters ────────────────────────────────────────────
+
+/** Formats structured git stash list data into a human-readable stash listing. */
+export function formatStashList(s: GitStashListFull): string {
+  if (s.stashes.length === 0) return "No stashes found";
+  return s.stashes.map((st) => `stash@{${st.index}}: ${st.message} (${st.date})`).join("\n");
+}
+
+/** Compact stash list: just index + message as string array + total. */
+export interface GitStashListCompact {
+  [key: string]: unknown;
+  stashes: string[];
+  total: number;
+}
+
+export function compactStashListMap(s: GitStashListFull): GitStashListCompact {
+  return {
+    stashes: s.stashes.map((st) => `stash@{${st.index}}: ${st.message}`),
+    total: s.total,
+  };
+}
+
+export function formatStashListCompact(s: GitStashListCompact): string {
+  if (s.stashes.length === 0) return "No stashes found";
+  return s.stashes.join("\n");
+}
+
+// ── Stash formatters ─────────────────────────────────────────────────
+
+/** Formats structured git stash result into a human-readable summary. */
+export function formatStash(s: GitStash): string {
+  return s.message;
+}
+
+// ── Remote formatters ────────────────────────────────────────────────
+
+/** Formats structured git remote data into a human-readable remote listing. */
+export function formatRemote(r: GitRemoteFull): string {
+  if (r.remotes.length === 0) return "No remotes configured";
+  return r.remotes
+    .map(
+      (remote) =>
+        `${remote.name}\t${remote.fetchUrl} (fetch)\n${remote.name}\t${remote.pushUrl} (push)`,
+    )
+    .join("\n");
+}
+
+/** Compact remote: just name as string array + total. */
+export interface GitRemoteCompact {
+  [key: string]: unknown;
+  remotes: string[];
+  total: number;
+}
+
+export function compactRemoteMap(r: GitRemoteFull): GitRemoteCompact {
+  return {
+    remotes: r.remotes.map((remote) => remote.name),
+    total: r.total,
+  };
+}
+
+export function formatRemoteCompact(r: GitRemoteCompact): string {
+  if (r.remotes.length === 0) return "No remotes configured";
+  return r.remotes.join("\n");
+}
+
+// ── Blame formatters ─────────────────────────────────────────────────
+
+/** Formats structured git blame data into a human-readable annotated file view. */
+export function formatBlame(b: GitBlameFull): string {
+  if (b.lines.length === 0) return `No blame data for ${b.file}`;
+  return b.lines
+    .map((l) => `${l.hash} (${l.author} ${l.date}) ${l.lineNumber}: ${l.content}`)
+    .join("\n");
+}
+
+/** Compact blame: hash + lineNumber + content only, no author/date. */
+export interface GitBlameCompact {
+  [key: string]: unknown;
+  lines: Array<{ hash: string; lineNumber: number; content: string }>;
+  file: string;
+}
+
+export function compactBlameMap(b: GitBlameFull): GitBlameCompact {
+  return {
+    lines: b.lines.map((l) => ({
+      hash: l.hash,
+      lineNumber: l.lineNumber,
+      content: l.content,
+    })),
+    file: b.file,
+  };
+}
+
+export function formatBlameCompact(b: GitBlameCompact): string {
+  if (b.lines.length === 0) return `No blame data for ${b.file}`;
+  return b.lines.map((l) => `${l.hash} ${l.lineNumber}: ${l.content}`).join("\n");
 }

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -160,3 +160,101 @@ export const GitCheckoutSchema = z.object({
 });
 
 export type GitCheckout = z.infer<typeof GitCheckoutSchema>;
+
+/** Zod schema for a single tag entry with name, optional date, and optional message. */
+export const GitTagEntrySchema = z.object({
+  name: z.string(),
+  date: z.string().optional(),
+  message: z.string().optional(),
+});
+
+/** Zod schema for structured git tag output with tag list and total count. */
+export const GitTagSchema = z.object({
+  tags: z.union([z.array(GitTagEntrySchema), z.array(z.string())]),
+  total: z.number(),
+});
+
+/** Full tag data (always returned by parser, before compact projection). */
+export type GitTagFull = {
+  tags: Array<{ name: string; date?: string; message?: string }>;
+  total: number;
+};
+
+export type GitTag = z.infer<typeof GitTagSchema>;
+
+/** Zod schema for a single stash entry with index, message, and date. */
+export const GitStashEntrySchema = z.object({
+  index: z.number(),
+  message: z.string(),
+  date: z.string(),
+});
+
+/** Zod schema for structured git stash list output with stash entries and total count. */
+export const GitStashListSchema = z.object({
+  stashes: z.union([z.array(GitStashEntrySchema), z.array(z.string())]),
+  total: z.number(),
+});
+
+/** Full stash list data (always returned by parser, before compact projection). */
+export type GitStashListFull = {
+  stashes: Array<{ index: number; message: string; date: string }>;
+  total: number;
+};
+
+export type GitStashList = z.infer<typeof GitStashListSchema>;
+
+/** Zod schema for structured git stash push/pop/apply/drop output. */
+export const GitStashSchema = z.object({
+  action: z.enum(["push", "pop", "apply", "drop"]),
+  success: z.boolean(),
+  message: z.string(),
+});
+
+export type GitStash = z.infer<typeof GitStashSchema>;
+
+/** Zod schema for a single remote entry with name, fetch URL, and push URL. */
+export const GitRemoteEntrySchema = z.object({
+  name: z.string(),
+  fetchUrl: z.string(),
+  pushUrl: z.string(),
+});
+
+/** Zod schema for structured git remote output with remote list and total count. */
+export const GitRemoteSchema = z.object({
+  remotes: z.union([z.array(GitRemoteEntrySchema), z.array(z.string())]),
+  total: z.number(),
+});
+
+/** Full remote data (always returned by parser, before compact projection). */
+export type GitRemoteFull = {
+  remotes: Array<{ name: string; fetchUrl: string; pushUrl: string }>;
+  total: number;
+};
+
+export type GitRemote = z.infer<typeof GitRemoteSchema>;
+
+/** Zod schema for a single blame line entry with commit hash, author, date, line number, and content. */
+export const GitBlameLineSchema = z.object({
+  hash: z.string(),
+  author: z.string(),
+  date: z.string(),
+  lineNumber: z.number(),
+  content: z.string(),
+});
+
+/** Zod schema for structured git blame output with per-line annotations and file name. */
+export const GitBlameSchema = z.object({
+  lines: z.union([
+    z.array(GitBlameLineSchema),
+    z.array(z.object({ hash: z.string(), lineNumber: z.number(), content: z.string() })),
+  ]),
+  file: z.string(),
+});
+
+/** Full blame data (always returned by parser, before compact projection). */
+export type GitBlameFull = {
+  lines: Array<{ hash: string; author: string; date: string; lineNumber: number; content: string }>;
+  file: string;
+};
+
+export type GitBlame = z.infer<typeof GitBlameSchema>;

--- a/packages/server-git/src/tools/blame.ts
+++ b/packages/server-git/src/tools/blame.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseBlameOutput } from "../lib/parsers.js";
+import { formatBlame, compactBlameMap, formatBlameCompact } from "../lib/formatters.js";
+import { GitBlameSchema } from "../schemas/index.js";
+
+export function registerBlameTool(server: McpServer) {
+  server.registerTool(
+    "blame",
+    {
+      title: "Git Blame",
+      description:
+        "Shows per-line commit annotations for a file. Returns structured blame data with hash, author, date, line number, and content. Use instead of running `git blame` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        file: z.string().max(INPUT_LIMITS.PATH_MAX).describe("File path to blame"),
+        startLine: z.number().optional().describe("Start line number for blame range"),
+        endLine: z.number().optional().describe("End line number for blame range"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: GitBlameSchema,
+    },
+    async ({ path, file, startLine, endLine, compact }) => {
+      const cwd = path || process.cwd();
+
+      assertNoFlagInjection(file, "file");
+
+      const args = ["blame", "--porcelain"];
+      if (startLine !== undefined && endLine !== undefined) {
+        args.push(`-L${startLine},${endLine}`);
+      } else if (startLine !== undefined) {
+        args.push(`-L${startLine},`);
+      }
+      args.push("--", file);
+
+      const result = await git(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`git blame failed: ${result.stderr}`);
+      }
+
+      const blame = parseBlameOutput(result.stdout, file);
+      return compactDualOutput(
+        blame,
+        result.stdout,
+        formatBlame,
+        compactBlameMap,
+        formatBlameCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-git/src/tools/index.ts
+++ b/packages/server-git/src/tools/index.ts
@@ -10,6 +10,11 @@ import { registerCommitTool } from "./commit.js";
 import { registerPushTool } from "./push.js";
 import { registerPullTool } from "./pull.js";
 import { registerCheckoutTool } from "./checkout.js";
+import { registerTagTool } from "./tag.js";
+import { registerStashListTool } from "./stash-list.js";
+import { registerStashTool } from "./stash.js";
+import { registerRemoteTool } from "./remote.js";
+import { registerBlameTool } from "./blame.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("git", name);
@@ -23,4 +28,9 @@ export function registerAllTools(server: McpServer) {
   if (s("push")) registerPushTool(server);
   if (s("pull")) registerPullTool(server);
   if (s("checkout")) registerCheckoutTool(server);
+  if (s("tag")) registerTagTool(server);
+  if (s("stash-list")) registerStashListTool(server);
+  if (s("stash")) registerStashTool(server);
+  if (s("remote")) registerRemoteTool(server);
+  if (s("blame")) registerBlameTool(server);
 }

--- a/packages/server-git/src/tools/remote.ts
+++ b/packages/server-git/src/tools/remote.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseRemoteOutput } from "../lib/parsers.js";
+import { formatRemote, compactRemoteMap, formatRemoteCompact } from "../lib/formatters.js";
+import { GitRemoteSchema } from "../schemas/index.js";
+
+export function registerRemoteTool(server: McpServer) {
+  server.registerTool(
+    "remote",
+    {
+      title: "Git Remote",
+      description:
+        "Lists remote repositories with fetch and push URLs. Returns structured remote data. Use instead of running `git remote -v` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: GitRemoteSchema,
+    },
+    async ({ path, compact }) => {
+      const cwd = path || process.cwd();
+      const args = ["remote", "-v"];
+
+      const result = await git(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`git remote failed: ${result.stderr}`);
+      }
+
+      const remotes = parseRemoteOutput(result.stdout);
+      return compactDualOutput(
+        remotes,
+        result.stdout,
+        formatRemote,
+        compactRemoteMap,
+        formatRemoteCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-git/src/tools/stash-list.ts
+++ b/packages/server-git/src/tools/stash-list.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseStashListOutput } from "../lib/parsers.js";
+import { formatStashList, compactStashListMap, formatStashListCompact } from "../lib/formatters.js";
+import { GitStashListSchema } from "../schemas/index.js";
+
+export function registerStashListTool(server: McpServer) {
+  server.registerTool(
+    "stash-list",
+    {
+      title: "Git Stash List",
+      description:
+        "Lists all stash entries with index, message, and date. Returns structured stash data. Use instead of running `git stash list` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: GitStashListSchema,
+    },
+    async ({ path, compact }) => {
+      const cwd = path || process.cwd();
+      const args = ["stash", "list", "--format=%gd\t%gs\t%ci"];
+
+      const result = await git(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`git stash list failed: ${result.stderr}`);
+      }
+
+      const stashList = parseStashListOutput(result.stdout);
+      return compactDualOutput(
+        stashList,
+        result.stdout,
+        formatStashList,
+        compactStashListMap,
+        formatStashListCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-git/src/tools/stash.ts
+++ b/packages/server-git/src/tools/stash.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseStashOutput } from "../lib/parsers.js";
+import { formatStash } from "../lib/formatters.js";
+import { GitStashSchema } from "../schemas/index.js";
+
+export function registerStashTool(server: McpServer) {
+  server.registerTool(
+    "stash",
+    {
+      title: "Git Stash",
+      description:
+        "Pushes, pops, applies, or drops stash entries. Returns structured result with action, success, and message. Use instead of running `git stash` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        action: z.enum(["push", "pop", "apply", "drop"]).describe("Stash action to perform"),
+        message: z
+          .string()
+          .max(INPUT_LIMITS.MESSAGE_MAX)
+          .optional()
+          .describe("Stash message (only used with push action)"),
+        index: z
+          .number()
+          .optional()
+          .describe("Stash index for pop/apply/drop (e.g., 0 for stash@{0})"),
+      },
+      outputSchema: GitStashSchema,
+    },
+    async ({ path, action, message, index }) => {
+      const cwd = path || process.cwd();
+      const args = ["stash"];
+
+      if (action === "push") {
+        args.push("push");
+        if (message) {
+          assertNoFlagInjection(message, "stash message");
+          args.push("-m", message);
+        }
+      } else {
+        args.push(action);
+        if (index !== undefined) {
+          args.push(`stash@{${index}}`);
+        }
+      }
+
+      const result = await git(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`git stash ${action} failed: ${result.stderr}`);
+      }
+
+      const stashResult = parseStashOutput(result.stdout, result.stderr, action);
+      return dualOutput(stashResult, formatStash);
+    },
+  );
+}

--- a/packages/server-git/src/tools/tag.ts
+++ b/packages/server-git/src/tools/tag.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseTagOutput } from "../lib/parsers.js";
+import { formatTag, compactTagMap, formatTagCompact } from "../lib/formatters.js";
+import { GitTagSchema } from "../schemas/index.js";
+
+export function registerTagTool(server: McpServer) {
+  server.registerTool(
+    "tag",
+    {
+      title: "Git Tag",
+      description:
+        "Lists tags sorted by creation date. Returns structured tag data with name, date, and message. Use instead of running `git tag` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: GitTagSchema,
+    },
+    async ({ path, compact }) => {
+      const cwd = path || process.cwd();
+      const args = [
+        "tag",
+        "-l",
+        "--sort=-creatordate",
+        "--format=%(refname:short)\t%(creatordate:iso-strict)\t%(subject)",
+      ];
+
+      const result = await git(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`git tag failed: ${result.stderr}`);
+      }
+
+      const tags = parseTagOutput(result.stdout);
+      return compactDualOutput(
+        tags,
+        result.stdout,
+        formatTag,
+        compactTagMap,
+        formatTagCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add 5 new tools to `@paretools/git`: `tag`, `stash-list`, `stash`, `remote`, `blame`
- Each tool follows existing patterns: Zod output schemas, structured parsers, human-readable formatters, compact mode support, and security validation (assertNoFlagInjection)
- Full test coverage: parser tests, formatter tests, compact mode tests, security tests, and updated integration test (10 -> 15 tools)

## New Tools

| Tool | Wraps | Compact Mode |
|---|---|---|
| `tag` | `git tag -l --sort=-creatordate --format=...` | Tag names only |
| `stash-list` | `git stash list --format=...` | Index + message strings |
| `stash` | `git stash push/pop/apply/drop` | N/A (write tool) |
| `remote` | `git remote -v` | Remote names only |
| `blame` | `git blame --porcelain` | Hash + lineNumber + content |

## Test plan
- [x] All 277 tests pass (`npx vitest run`)
- [x] Build succeeds (`pnpm build`)
- [x] Lint passes (0 errors, 0 warnings)
- [x] Format check passes
- [x] Integration test updated to verify 15 tools registered
- [x] Security tests added for blame file path and stash message validation
- [x] Parser tests cover edge cases (empty output, multiple entries, porcelain format)
- [x] Compact mode tests verify field stripping and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)