### PR TITLE
feat(go): add env, list, get tools

### DIFF
--- a/packages/server-go/__tests__/security.test.ts
+++ b/packages/server-go/__tests__/security.test.ts
@@ -114,6 +114,40 @@ describe("security: go run — buildArgs validation", () => {
   });
 });
 
+describe("security: go list — packages validation", () => {
+  it("rejects flag-like package patterns", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "packages")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe package patterns", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "packages")).not.toThrow();
+    }
+  });
+});
+
+describe("security: go get — packages validation", () => {
+  it("rejects flag-like package specifiers", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "packages")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe package specifiers", () => {
+    const safePackages = [
+      "github.com/pkg/errors@latest",
+      "github.com/stretchr/testify@v1.9.0",
+      "golang.org/x/tools@latest",
+      "./...",
+    ];
+    for (const safe of safePackages) {
+      expect(() => assertNoFlagInjection(safe, "packages")).not.toThrow();
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Zod .max() input-limit constraints — Go tool schemas
 // ---------------------------------------------------------------------------

--- a/packages/server-go/src/schemas/index.ts
+++ b/packages/server-go/src/schemas/index.ts
@@ -88,3 +88,39 @@ export const GoGenerateResultSchema = z.object({
 });
 
 export type GoGenerateResult = z.infer<typeof GoGenerateResultSchema>;
+
+/** Zod schema for structured go env output with environment variables and key fields. */
+export const GoEnvResultSchema = z.object({
+  vars: z.record(z.string(), z.string()),
+  goroot: z.string(),
+  gopath: z.string(),
+  goversion: z.string(),
+  goos: z.string(),
+  goarch: z.string(),
+});
+
+export type GoEnvResult = z.infer<typeof GoEnvResultSchema>;
+
+/** Zod schema for a single Go package from go list output. */
+export const GoListPackageSchema = z.object({
+  dir: z.string(),
+  importPath: z.string(),
+  name: z.string(),
+  goFiles: z.array(z.string()).optional(),
+});
+
+/** Zod schema for structured go list output with package list and total count. */
+export const GoListResultSchema = z.object({
+  packages: z.array(GoListPackageSchema),
+  total: z.number(),
+});
+
+export type GoListResult = z.infer<typeof GoListResultSchema>;
+
+/** Zod schema for structured go get output with success status and output text. */
+export const GoGetResultSchema = z.object({
+  success: z.boolean(),
+  output: z.string().optional(),
+});
+
+export type GoGetResult = z.infer<typeof GoGetResultSchema>;

--- a/packages/server-go/src/tools/env.ts
+++ b/packages/server-go/src/tools/env.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { goCmd } from "../lib/go-runner.js";
+import { parseGoEnvOutput } from "../lib/parsers.js";
+import { formatGoEnv, compactEnvMap, formatEnvCompact } from "../lib/formatters.js";
+import { GoEnvResultSchema } from "../schemas/index.js";
+
+export function registerEnvTool(server: McpServer) {
+  server.registerTool(
+    "env",
+    {
+      title: "Go Env",
+      description:
+        "Returns Go environment variables as structured JSON. Optionally request specific variables. Use instead of running `go env` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        vars: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Specific environment variables to query (e.g., ['GOROOT', 'GOPATH'])"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: GoEnvResultSchema,
+    },
+    async ({ path, vars, compact }) => {
+      const cwd = path || process.cwd();
+      const args = ["env", "-json", ...(vars || [])];
+      const result = await goCmd(args, cwd);
+      const data = parseGoEnvOutput(result.stdout);
+      const rawOutput = result.stdout.trim();
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatGoEnv,
+        compactEnvMap,
+        formatEnvCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-go/src/tools/get.ts
+++ b/packages/server-go/src/tools/get.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { goCmd } from "../lib/go-runner.js";
+import { parseGoGetOutput } from "../lib/parsers.js";
+import { formatGoGet, compactGetMap, formatGetCompact } from "../lib/formatters.js";
+import { GoGetResultSchema } from "../schemas/index.js";
+
+export function registerGetTool(server: McpServer) {
+  server.registerTool(
+    "get",
+    {
+      title: "Go Get",
+      description:
+        "Downloads and installs Go packages and their dependencies. Use instead of running `go get` in the terminal.",
+      inputSchema: {
+        packages: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .describe("Packages to install (e.g., ['github.com/pkg/errors@latest'])"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: GoGetResultSchema,
+    },
+    async ({ packages, path, compact }) => {
+      const cwd = path || process.cwd();
+      for (const p of packages) {
+        assertNoFlagInjection(p, "packages");
+      }
+      const args = ["get", ...packages];
+      const result = await goCmd(args, cwd);
+      const data = parseGoGetOutput(result.stdout, result.stderr, result.exitCode);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatGoGet,
+        compactGetMap,
+        formatGetCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-go/src/tools/index.ts
+++ b/packages/server-go/src/tools/index.ts
@@ -7,6 +7,9 @@ import { registerRunTool } from "./run.js";
 import { registerModTidyTool } from "./mod-tidy.js";
 import { registerFmtTool } from "./fmt.js";
 import { registerGenerateTool } from "./generate.js";
+import { registerEnvTool } from "./env.js";
+import { registerListTool } from "./list.js";
+import { registerGetTool } from "./get.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("go", name);
@@ -17,4 +20,7 @@ export function registerAllTools(server: McpServer) {
   if (s("mod-tidy")) registerModTidyTool(server);
   if (s("fmt")) registerFmtTool(server);
   if (s("generate")) registerGenerateTool(server);
+  if (s("env")) registerEnvTool(server);
+  if (s("list")) registerListTool(server);
+  if (s("get")) registerGetTool(server);
 }

--- a/packages/server-go/src/tools/list.ts
+++ b/packages/server-go/src/tools/list.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { goCmd } from "../lib/go-runner.js";
+import { parseGoListOutput } from "../lib/parsers.js";
+import { formatGoList, compactListMap, formatListCompact } from "../lib/formatters.js";
+import { GoListResultSchema } from "../schemas/index.js";
+
+export function registerListTool(server: McpServer) {
+  server.registerTool(
+    "list",
+    {
+      title: "Go List",
+      description:
+        "Lists Go packages and returns structured package information (dir, importPath, name, goFiles). Use instead of running `go list` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        packages: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default(["./..."])
+          .describe("Package patterns to list (default: ['./...'])"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: GoListResultSchema,
+    },
+    async ({ path, packages, compact }) => {
+      const cwd = path || process.cwd();
+      for (const p of packages ?? []) {
+        assertNoFlagInjection(p, "packages");
+      }
+      const args = ["list", "-json", ...(packages || ["./..."])];
+      const result = await goCmd(args, cwd);
+      const data = parseGoListOutput(result.stdout);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatGoList,
+        compactListMap,
+        formatListCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Add `env` tool: returns Go environment variables via `go env -json` with optional specific variable filtering and key field extraction (goroot, gopath, goversion, goos, goarch)
- Add `list` tool: lists Go packages via `go list -json` with structured package info (dir, importPath, name, goFiles) and flag injection protection on package patterns
- Add `get` tool: downloads and installs Go packages via `go get` with flag injection protection on package specifiers

Expands `@paretools/go` from 7 to 10 tools. Each tool follows existing patterns with full Zod schemas, parsers, formatters, compact mode support, and comprehensive test coverage.

## Test plan

- [x] All 223 tests pass (`npx vitest run` in `packages/server-go`)
- [x] Parser tests cover env JSON parsing, list JSONL parsing, get output parsing
- [x] Formatter tests cover human-readable output for all three tools
- [x] Compact mode tests verify token reduction (key fields only for env, count only for list, success only for get)
- [x] Fidelity tests verify no information loss from raw CLI output
- [x] Security tests verify flag injection protection on list packages and get packages
- [x] Integration tests verify tool registration (10 tools) and structured output schemas
- [x] Build passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)