### PR TITLE
feat(python): add pip-list, pip-show, ruff-format tools

### DIFF
--- a/packages/server-python/__tests__/security.test.ts
+++ b/packages/server-python/__tests__/security.test.ts
@@ -129,6 +129,34 @@ describe("security: pip-audit — requirements validation", () => {
   });
 });
 
+describe("security: pip-show — package validation", () => {
+  it("rejects flag-like package names", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "package")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe package names", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "package")).not.toThrow();
+    }
+  });
+});
+
+describe("security: ruff-format — patterns validation", () => {
+  it("rejects flag-like patterns", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "patterns")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe patterns", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "patterns")).not.toThrow();
+    }
+  });
+});
+
 describe("security: uv-install — packages and requirements validation", () => {
   it("rejects flag-like packages", () => {
     for (const malicious of MALICIOUS_INPUTS) {

--- a/packages/server-python/src/schemas/index.ts
+++ b/packages/server-python/src/schemas/index.ts
@@ -130,3 +130,40 @@ export const BlackResultSchema = z.object({
 });
 
 export type BlackResult = z.infer<typeof BlackResultSchema>;
+
+/** Zod schema for a single pip list package entry with name and version. */
+export const PipListPackageSchema = z.object({
+  name: z.string(),
+  version: z.string(),
+});
+
+/** Zod schema for structured pip list output with packages and total count. */
+export const PipListSchema = z.object({
+  packages: z.array(PipListPackageSchema),
+  total: z.number(),
+});
+
+export type PipList = z.infer<typeof PipListSchema>;
+
+/** Zod schema for structured pip show output with package metadata. */
+export const PipShowSchema = z.object({
+  name: z.string(),
+  version: z.string(),
+  summary: z.string(),
+  homepage: z.string().optional(),
+  author: z.string().optional(),
+  license: z.string().optional(),
+  location: z.string().optional(),
+  requires: z.array(z.string()),
+});
+
+export type PipShow = z.infer<typeof PipShowSchema>;
+
+/** Zod schema for structured ruff format output with success status, file counts, and file list. */
+export const RuffFormatResultSchema = z.object({
+  success: z.boolean(),
+  filesChanged: z.number(),
+  files: z.array(z.string()).optional(),
+});
+
+export type RuffFormatResult = z.infer<typeof RuffFormatResultSchema>;

--- a/packages/server-python/src/tools/index.ts
+++ b/packages/server-python/src/tools/index.ts
@@ -1,8 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { shouldRegisterTool } from "@paretools/shared";
 import { registerPipInstallTool } from "./pip-install.js";
+import { registerPipListTool } from "./pip-list.js";
+import { registerPipShowTool } from "./pip-show.js";
 import { registerMypyTool } from "./mypy.js";
 import { registerRuffTool } from "./ruff.js";
+import { registerRuffFormatTool } from "./ruff-format.js";
 import { registerPipAuditTool } from "./pip-audit.js";
 import { registerPytestTool } from "./pytest.js";
 import { registerUvInstallTool } from "./uv-install.js";
@@ -12,8 +15,11 @@ import { registerBlackTool } from "./black.js";
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("python", name);
   if (s("pip-install")) registerPipInstallTool(server);
+  if (s("pip-list")) registerPipListTool(server);
+  if (s("pip-show")) registerPipShowTool(server);
   if (s("mypy")) registerMypyTool(server);
   if (s("ruff-check")) registerRuffTool(server);
+  if (s("ruff-format")) registerRuffFormatTool(server);
   if (s("pip-audit")) registerPipAuditTool(server);
   if (s("pytest")) registerPytestTool(server);
   if (s("uv-install")) registerUvInstallTool(server);

--- a/packages/server-python/src/tools/pip-list.ts
+++ b/packages/server-python/src/tools/pip-list.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { pip } from "../lib/python-runner.js";
+import { parsePipListJson } from "../lib/parsers.js";
+import { formatPipList, compactPipListMap, formatPipListCompact } from "../lib/formatters.js";
+import { PipListSchema } from "../schemas/index.js";
+
+export function registerPipListTool(server: McpServer) {
+  server.registerTool(
+    "pip-list",
+    {
+      title: "pip List",
+      description:
+        "Runs pip list and returns a structured list of installed packages. " +
+        "Use instead of running `pip list` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: PipListSchema,
+    },
+    async ({ path, compact }) => {
+      const cwd = path || process.cwd();
+
+      const result = await pip(["list", "--format", "json"], cwd);
+      const data = parsePipListJson(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatPipList,
+        compactPipListMap,
+        formatPipListCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-python/src/tools/pip-show.ts
+++ b/packages/server-python/src/tools/pip-show.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { pip } from "../lib/python-runner.js";
+import { parsePipShowOutput } from "../lib/parsers.js";
+import { formatPipShow, compactPipShowMap, formatPipShowCompact } from "../lib/formatters.js";
+import { PipShowSchema } from "../schemas/index.js";
+
+export function registerPipShowTool(server: McpServer) {
+  server.registerTool(
+    "pip-show",
+    {
+      title: "pip Show",
+      description:
+        "Runs pip show and returns structured package metadata (name, version, summary, dependencies). " +
+        "Use instead of running `pip show` in the terminal.",
+      inputSchema: {
+        package: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Package name to show"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: PipShowSchema,
+    },
+    async (input) => {
+      const pkg = input["package"];
+      const path = input["path"] as string | undefined;
+      const compact = input["compact"] as boolean | undefined;
+      const cwd = path || process.cwd();
+      assertNoFlagInjection(pkg as string, "package");
+
+      const result = await pip(["show", pkg as string], cwd);
+      const data = parsePipShowOutput(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatPipShow,
+        compactPipShowMap,
+        formatPipShowCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-python/src/tools/ruff-format.ts
+++ b/packages/server-python/src/tools/ruff-format.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ruff } from "../lib/python-runner.js";
+import { parseRuffFormatOutput } from "../lib/parsers.js";
+import {
+  formatRuffFormat,
+  compactRuffFormatMap,
+  formatRuffFormatCompact,
+} from "../lib/formatters.js";
+import { RuffFormatResultSchema } from "../schemas/index.js";
+
+export function registerRuffFormatTool(server: McpServer) {
+  server.registerTool(
+    "ruff-format",
+    {
+      title: "ruff Format",
+      description:
+        "Runs ruff format and returns structured results (files changed, file list). " +
+        "Use instead of running `ruff format` in the terminal.",
+      inputSchema: {
+        patterns: z
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default(["."])
+          .describe('Files or directories to format (default: ["."])'),
+        check: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Check mode (report without modifying files)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: RuffFormatResultSchema,
+    },
+    async ({ patterns, check, path, compact }) => {
+      const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
+      const args = ["format", ...(patterns || ["."])];
+      if (check) args.push("--check");
+
+      const result = await ruff(args, cwd);
+      const data = parseRuffFormatOutput(result.stdout, result.stderr, result.exitCode);
+      return compactDualOutput(
+        data,
+        result.stderr,
+        formatRuffFormat,
+        compactRuffFormatMap,
+        formatRuffFormatCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- **pip-list**: Runs `pip list --format json` and returns a structured array of installed packages with name/version and total count
- **pip-show**: Runs `pip show <package>` and returns structured package metadata (name, version, summary, homepage, author, license, location, requires). Includes `assertNoFlagInjection` on the package name input
- **ruff-format**: Runs `ruff format [--check] [paths...]` and returns structured results with success status, files changed count, and optional file list. Mirrors the existing `black` tool pattern. Includes `assertNoFlagInjection` on each pattern

All three tools follow existing patterns with full Zod output schemas, parsers, formatters, compact mode support, and comprehensive test coverage (parsers, formatters, compact, security, fidelity, integration).

Total tools in `@paretools/python`: 8 → 11

## Test plan

- [x] All 224 tests pass (`vitest run` in `packages/server-python`)
- [x] TypeScript check clean (`tsc --noEmit`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting clean (`prettier --check`)
- [ ] Integration tests verify tool registration (11 tools listed)
- [ ] Integration tests verify structured output for each new tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)