### PR TITLE
feat(lint): add stylelint and oxlint tools

### DIFF
--- a/packages/server-lint/__tests__/integration.test.ts
+++ b/packages/server-lint/__tests__/integration.test.ts
@@ -26,7 +26,7 @@ describe("@paretools/lint integration", () => {
     await transport.close();
   });
 
-  it("lists all 5 tools", async () => {
+  it("lists all 7 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
@@ -34,7 +34,9 @@ describe("@paretools/lint integration", () => {
       "biome-format",
       "format-check",
       "lint",
+      "oxlint",
       "prettier-format",
+      "stylelint",
     ]);
   });
 
@@ -149,6 +151,50 @@ describe("@paretools/lint integration", () => {
       expect(sc.filesChanged).toEqual(expect.any(Number));
       // files may be omitted in compact mode
       expect(sc.files === undefined || Array.isArray(sc.files)).toBe(true);
+    }, 60_000);
+  });
+
+  describe("stylelint", () => {
+    it("returns structured result even when stylelint is not configured", async () => {
+      const pkgPath = resolve(__dirname, "..");
+      const result = await client.callTool({
+        name: "stylelint",
+        arguments: { path: pkgPath, patterns: ["."] },
+      });
+
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      expect(sc.total).toEqual(expect.any(Number));
+      expect(sc.errors).toEqual(expect.any(Number));
+      expect(sc.warnings).toEqual(expect.any(Number));
+      expect(sc.fixable).toEqual(expect.any(Number));
+      // diagnostics may be omitted in compact mode
+      expect(sc.diagnostics === undefined || Array.isArray(sc.diagnostics)).toBe(true);
+    }, 60_000);
+  });
+
+  describe("oxlint", () => {
+    it("returns structured result even when oxlint is not installed", async () => {
+      const pkgPath = resolve(__dirname, "..");
+      const result = await client.callTool({
+        name: "oxlint",
+        arguments: { path: pkgPath, patterns: ["src/"] },
+      });
+
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      expect(sc.total).toEqual(expect.any(Number));
+      expect(sc.errors).toEqual(expect.any(Number));
+      expect(sc.warnings).toEqual(expect.any(Number));
+      expect(sc.fixable).toEqual(expect.any(Number));
+      // diagnostics may be omitted in compact mode
+      expect(sc.diagnostics === undefined || Array.isArray(sc.diagnostics)).toBe(true);
     }, 60_000);
   });
 });

--- a/packages/server-lint/__tests__/security.test.ts
+++ b/packages/server-lint/__tests__/security.test.ts
@@ -92,6 +92,34 @@ describe("security: format-check (Prettier) — patterns validation", () => {
   });
 });
 
+describe("security: stylelint — patterns validation", () => {
+  it("rejects flag-like patterns", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "patterns")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe patterns", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "patterns")).not.toThrow();
+    }
+  });
+});
+
+describe("security: oxlint — patterns validation", () => {
+  it("rejects flag-like patterns", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "patterns")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe patterns", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "patterns")).not.toThrow();
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Zod .max() input-limit constraints — Lint tool schemas
 // ---------------------------------------------------------------------------

--- a/packages/server-lint/src/lib/lint-runner.ts
+++ b/packages/server-lint/src/lib/lint-runner.ts
@@ -11,3 +11,11 @@ export async function prettier(args: string[], cwd?: string): Promise<RunResult>
 export async function biome(args: string[], cwd?: string): Promise<RunResult> {
   return run("npx", ["@biomejs/biome", ...args], { cwd });
 }
+
+export async function stylelintCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("npx", ["stylelint", ...args], { cwd, timeout: 120_000 });
+}
+
+export async function oxlintCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("npx", ["oxlint", ...args], { cwd, timeout: 120_000 });
+}

--- a/packages/server-lint/src/tools/index.ts
+++ b/packages/server-lint/src/tools/index.ts
@@ -5,6 +5,8 @@ import { registerFormatCheckTool } from "./format-check.js";
 import { registerPrettierFormatTool } from "./prettier-format.js";
 import { registerBiomeCheckTool } from "./biome-check.js";
 import { registerBiomeFormatTool } from "./biome-format.js";
+import { registerStylelintTool } from "./stylelint.js";
+import { registerOxlintTool } from "./oxlint.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("lint", name);
@@ -13,4 +15,6 @@ export function registerAllTools(server: McpServer) {
   if (s("prettier-format")) registerPrettierFormatTool(server);
   if (s("biome-check")) registerBiomeCheckTool(server);
   if (s("biome-format")) registerBiomeFormatTool(server);
+  if (s("stylelint")) registerStylelintTool(server);
+  if (s("oxlint")) registerOxlintTool(server);
 }

--- a/packages/server-lint/src/tools/oxlint.ts
+++ b/packages/server-lint/src/tools/oxlint.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { oxlintCmd } from "../lib/lint-runner.js";
+import { parseOxlintJson } from "../lib/parsers.js";
+import { formatLint, compactLintMap, formatLintCompact } from "../lib/formatters.js";
+import { LintResultSchema } from "../schemas/index.js";
+
+export function registerOxlintTool(server: McpServer) {
+  server.registerTool(
+    "oxlint",
+    {
+      title: "Oxlint Check",
+      description:
+        "Runs Oxlint and returns structured diagnostics (file, line, rule, severity, message). Use instead of running `oxlint` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        patterns: z
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default(["."])
+          .describe("File patterns to lint (default: ['.'])"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: LintResultSchema,
+    },
+    async ({ path, patterns, compact }) => {
+      const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
+      const args = ["--format", "json", ...(patterns || ["."])];
+
+      const result = await oxlintCmd(args, cwd);
+      const data = parseOxlintJson(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatLint,
+        compactLintMap,
+        formatLintCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-lint/src/tools/stylelint.ts
+++ b/packages/server-lint/src/tools/stylelint.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { stylelintCmd } from "../lib/lint-runner.js";
+import { parseStylelintJson } from "../lib/parsers.js";
+import { formatLint, compactLintMap, formatLintCompact } from "../lib/formatters.js";
+import { LintResultSchema } from "../schemas/index.js";
+
+export function registerStylelintTool(server: McpServer) {
+  server.registerTool(
+    "stylelint",
+    {
+      title: "Stylelint Check",
+      description:
+        "Runs Stylelint and returns structured diagnostics (file, line, rule, severity, message). Use instead of running `stylelint` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        patterns: z
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default(["."])
+          .describe("File patterns to lint (default: ['.'])"),
+        fix: z.boolean().optional().default(false).describe("Auto-fix problems"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: LintResultSchema,
+    },
+    async ({ path, patterns, fix, compact }) => {
+      const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
+      const args = ["--formatter", "json", ...(patterns || ["."])];
+      if (fix) args.push("--fix");
+
+      const result = await stylelintCmd(args, cwd);
+      const data = parseStylelintJson(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatLint,
+        compactLintMap,
+        formatLintCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add **stylelint** tool: runs Stylelint with `--formatter json`, parses JSON array output into structured `LintResult` diagnostics with file/line/column/rule/severity/message fields. Supports `--fix` flag and compact mode.
- Add **oxlint** tool: runs Oxlint with `--format json`, parses NDJSON output into structured `LintResult` diagnostics. Supports compact mode.
- Both tools reuse the existing `LintResultSchema`, `formatLint`, and compact helpers for consistent output across all lint tools (ESLint, Biome, Stylelint, Oxlint).
- Adds runner functions (`stylelintCmd`, `oxlintCmd`) with 120s timeout.
- All user-supplied patterns validated with `assertNoFlagInjection` for security.
- Expands the server from 5 to 7 registered tools.

## Test plan
- [x] Unit tests for `parseStylelintJson` parser (mixed errors/warnings, clean output, invalid JSON, null source)
- [x] Unit tests for `parseOxlintJson` parser (NDJSON with errors/warnings, clean output, invalid JSON lines, missing ruleId, summary line skipping)
- [x] Fidelity tests verifying all fields preserved from realistic Stylelint and Oxlint CLI output
- [x] Runner tests verifying `stylelintCmd` and `oxlintCmd` argument construction and timeout
- [x] Security tests verifying flag injection protection for both tools
- [x] Integration test updated to expect 7 tools and verify structured output from both new tools
- [x] All 161 tests pass, build succeeds, lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)