### PR TITLE
feat(npm,cargo): add info, search, update, tree tools

### DIFF
--- a/packages/server-cargo/__tests__/integration.test.ts
+++ b/packages/server-cargo/__tests__/integration.test.ts
@@ -29,7 +29,7 @@ describe("@paretools/cargo integration", () => {
     await transport.close();
   });
 
-  it("lists all 9 tools", async () => {
+  it("lists all 11 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
@@ -42,6 +42,8 @@ describe("@paretools/cargo integration", () => {
       "remove",
       "run",
       "test",
+      "tree",
+      "update",
     ]);
   });
 

--- a/packages/server-cargo/__tests__/update-tree.test.ts
+++ b/packages/server-cargo/__tests__/update-tree.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import { parseCargoUpdateOutput, parseCargoTreeOutput } from "../src/lib/parsers.js";
+import {
+  formatCargoUpdate,
+  compactUpdateMap,
+  formatUpdateCompact,
+  formatCargoTree,
+  compactTreeMap,
+  formatTreeCompact,
+} from "../src/lib/formatters.js";
+import type { CargoUpdateResult, CargoTreeResult } from "../src/schemas/index.js";
+
+// ── parseCargoUpdateOutput ───────────────────────────────────────────
+
+describe("parseCargoUpdateOutput", () => {
+  it("parses successful update with output", () => {
+    const stderr = [
+      "    Updating crates.io index",
+      "    Updating serde v1.0.200 -> v1.0.217",
+      "    Updating tokio v1.40.0 -> v1.41.1",
+    ].join("\n");
+
+    const result = parseCargoUpdateOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Updating serde v1.0.200 -> v1.0.217");
+    expect(result.output).toContain("Updating tokio v1.40.0 -> v1.41.1");
+  });
+
+  it("parses successful update with no changes", () => {
+    const result = parseCargoUpdateOutput("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("");
+  });
+
+  it("parses failed update", () => {
+    const stderr = "error: no package `nonexistent` found in any registry";
+    const result = parseCargoUpdateOutput("", stderr, 101);
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("no package `nonexistent` found");
+  });
+
+  it("combines stdout and stderr", () => {
+    const result = parseCargoUpdateOutput("stdout line", "stderr line", 0);
+
+    expect(result.output).toContain("stdout line");
+    expect(result.output).toContain("stderr line");
+  });
+});
+
+// ── parseCargoTreeOutput ─────────────────────────────────────────────
+
+describe("parseCargoTreeOutput", () => {
+  it("parses tree output and counts unique packages", () => {
+    const stdout = [
+      "my-app v0.1.0 (/home/user/project)",
+      "├── serde v1.0.217",
+      "│   └── serde_derive v1.0.217 (proc-macro)",
+      "├── tokio v1.41.1",
+      "│   ├── bytes v1.5.0",
+      "│   ├── mio v0.8.11",
+      "│   └── pin-project-lite v0.2.13",
+      "└── anyhow v1.0.89",
+    ].join("\n");
+
+    const result = parseCargoTreeOutput(stdout);
+
+    expect(result.tree).toContain("my-app v0.1.0");
+    expect(result.tree).toContain("serde v1.0.217");
+    // my-app, serde, serde_derive, tokio, bytes, mio, pin-project-lite, anyhow = 8
+    expect(result.packages).toBe(8);
+  });
+
+  it("counts unique package names (no duplicates)", () => {
+    const stdout = [
+      "my-app v0.1.0 (/home/user/project)",
+      "├── serde v1.0.217",
+      "│   └── serde_derive v1.0.217 (proc-macro)",
+      "└── serde v1.0.217",
+    ].join("\n");
+
+    const result = parseCargoTreeOutput(stdout);
+
+    // "serde" appears twice but is counted once, plus "my-app" and "serde_derive"
+    expect(result.packages).toBe(3);
+  });
+
+  it("handles empty tree output", () => {
+    const result = parseCargoTreeOutput("");
+
+    expect(result.tree).toBe("");
+    expect(result.packages).toBe(0);
+  });
+
+  it("handles single root package", () => {
+    const stdout = "my-app v0.1.0 (/home/user/project)";
+    const result = parseCargoTreeOutput(stdout);
+
+    expect(result.tree).toBe("my-app v0.1.0 (/home/user/project)");
+    expect(result.packages).toBe(1);
+  });
+
+  it("handles packages with underscores and hyphens", () => {
+    const stdout = [
+      "my-app v0.1.0",
+      "├── pin-project-lite v0.2.13",
+      "├── serde_derive v1.0.217",
+      "└── my_crate v0.1.0",
+    ].join("\n");
+
+    const result = parseCargoTreeOutput(stdout);
+
+    expect(result.packages).toBe(4);
+  });
+});
+
+// ── formatCargoUpdate ────────────────────────────────────────────────
+
+describe("formatCargoUpdate", () => {
+  it("formats successful update with output", () => {
+    const data: CargoUpdateResult = {
+      success: true,
+      output: "Updating serde v1.0.200 -> v1.0.217",
+    };
+    const output = formatCargoUpdate(data);
+    expect(output).toContain("cargo update: success");
+    expect(output).toContain("Updating serde v1.0.200 -> v1.0.217");
+  });
+
+  it("formats successful update with no output", () => {
+    const data: CargoUpdateResult = { success: true, output: "" };
+    expect(formatCargoUpdate(data)).toBe("cargo update: success.");
+  });
+
+  it("formats failed update", () => {
+    const data: CargoUpdateResult = {
+      success: false,
+      output: "error: no package found",
+    };
+    const output = formatCargoUpdate(data);
+    expect(output).toContain("cargo update: failed");
+    expect(output).toContain("error: no package found");
+  });
+});
+
+// ── compactUpdateMap ─────────────────────────────────────────────────
+
+describe("compactUpdateMap", () => {
+  it("strips output text and keeps success flag", () => {
+    const data: CargoUpdateResult = {
+      success: true,
+      output: "Updating serde v1.0.200 -> v1.0.217\nUpdating tokio v1.40.0 -> v1.41.1",
+    };
+    const compact = compactUpdateMap(data);
+    expect(compact).toEqual({ success: true });
+    expect(compact).not.toHaveProperty("output");
+  });
+});
+
+// ── formatUpdateCompact ──────────────────────────────────────────────
+
+describe("formatUpdateCompact", () => {
+  it("formats compact update success", () => {
+    expect(formatUpdateCompact({ success: true })).toBe("cargo update: success");
+  });
+
+  it("formats compact update failure", () => {
+    expect(formatUpdateCompact({ success: false })).toBe("cargo update: failed");
+  });
+});
+
+// ── formatCargoTree ──────────────────────────────────────────────────
+
+describe("formatCargoTree", () => {
+  it("formats tree with package count", () => {
+    const data: CargoTreeResult = {
+      tree: "my-app v0.1.0\n├── serde v1.0.217",
+      packages: 2,
+    };
+    const output = formatCargoTree(data);
+    expect(output).toContain("cargo tree: 2 unique packages");
+    expect(output).toContain("my-app v0.1.0");
+    expect(output).toContain("serde v1.0.217");
+  });
+
+  it("formats tree with empty tree text", () => {
+    const data: CargoTreeResult = { tree: "", packages: 0 };
+    expect(formatCargoTree(data)).toBe("cargo tree: 0 unique packages");
+  });
+});
+
+// ── compactTreeMap ───────────────────────────────────────────────────
+
+describe("compactTreeMap", () => {
+  it("strips tree text and keeps package count", () => {
+    const data: CargoTreeResult = {
+      tree: "my-app v0.1.0\n├── serde v1.0.217\n└── tokio v1.41.1",
+      packages: 3,
+    };
+    const compact = compactTreeMap(data);
+    expect(compact).toEqual({ packages: 3 });
+    expect(compact).not.toHaveProperty("tree");
+  });
+});
+
+// ── formatTreeCompact ────────────────────────────────────────────────
+
+describe("formatTreeCompact", () => {
+  it("formats compact tree output", () => {
+    expect(formatTreeCompact({ packages: 5 })).toBe("cargo tree: 5 unique packages");
+  });
+
+  it("formats compact tree with zero packages", () => {
+    expect(formatTreeCompact({ packages: 0 })).toBe("cargo tree: 0 unique packages");
+  });
+});

--- a/packages/server-cargo/src/lib/formatters.ts
+++ b/packages/server-cargo/src/lib/formatters.ts
@@ -7,6 +7,8 @@ import type {
   CargoRemoveResult,
   CargoFmtResult,
   CargoDocResult,
+  CargoUpdateResult,
+  CargoTreeResult,
 } from "../schemas/index.js";
 
 // ── Compact types ────────────────────────────────────────────────────
@@ -279,4 +281,55 @@ export function formatDocCompact(data: CargoDocCompact): string {
   const status = data.success ? "success" : "failed";
   if (data.warnings === 0) return `cargo doc: ${status}.`;
   return `cargo doc: ${status} (${data.warnings} warning(s))`;
+}
+
+// ── Update formatters ────────────────────────────────────────────────
+
+/** Formats structured cargo update output into a human-readable summary. */
+export function formatCargoUpdate(data: CargoUpdateResult): string {
+  const status = data.success ? "success" : "failed";
+  if (!data.output) return `cargo update: ${status}.`;
+  return `cargo update: ${status}\n${data.output}`;
+}
+
+/** Compact update: success flag only, no output text. */
+export interface CargoUpdateCompact {
+  [key: string]: unknown;
+  success: boolean;
+}
+
+export function compactUpdateMap(data: CargoUpdateResult): CargoUpdateCompact {
+  return {
+    success: data.success,
+  };
+}
+
+export function formatUpdateCompact(data: CargoUpdateCompact): string {
+  const status = data.success ? "success" : "failed";
+  return `cargo update: ${status}`;
+}
+
+// ── Tree formatters ──────────────────────────────────────────────────
+
+/** Formats structured cargo tree output into a human-readable summary. */
+export function formatCargoTree(data: CargoTreeResult): string {
+  const lines = [`cargo tree: ${data.packages} unique packages`];
+  if (data.tree) lines.push(data.tree);
+  return lines.join("\n");
+}
+
+/** Compact tree: package count only, no full tree text. */
+export interface CargoTreeCompact {
+  [key: string]: unknown;
+  packages: number;
+}
+
+export function compactTreeMap(data: CargoTreeResult): CargoTreeCompact {
+  return {
+    packages: data.packages,
+  };
+}
+
+export function formatTreeCompact(data: CargoTreeCompact): string {
+  return `cargo tree: ${data.packages} unique packages`;
 }

--- a/packages/server-cargo/src/schemas/index.ts
+++ b/packages/server-cargo/src/schemas/index.ts
@@ -100,3 +100,19 @@ export const CargoDocResultSchema = z.object({
 });
 
 export type CargoDocResult = z.infer<typeof CargoDocResultSchema>;
+
+/** Zod schema for structured cargo update output with success flag and output text. */
+export const CargoUpdateResultSchema = z.object({
+  success: z.boolean(),
+  output: z.string(),
+});
+
+export type CargoUpdateResult = z.infer<typeof CargoUpdateResultSchema>;
+
+/** Zod schema for structured cargo tree output with tree text and unique package count. */
+export const CargoTreeResultSchema = z.object({
+  tree: z.string(),
+  packages: z.number(),
+});
+
+export type CargoTreeResult = z.infer<typeof CargoTreeResultSchema>;

--- a/packages/server-cargo/src/tools/index.ts
+++ b/packages/server-cargo/src/tools/index.ts
@@ -9,6 +9,8 @@ import { registerRemoveTool } from "./remove.js";
 import { registerFmtTool } from "./fmt.js";
 import { registerDocTool } from "./doc.js";
 import { registerCheckTool } from "./check.js";
+import { registerUpdateTool } from "./update.js";
+import { registerTreeTool } from "./tree.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("cargo", name);
@@ -21,4 +23,6 @@ export function registerAllTools(server: McpServer) {
   if (s("fmt")) registerFmtTool(server);
   if (s("doc")) registerDocTool(server);
   if (s("check")) registerCheckTool(server);
+  if (s("update")) registerUpdateTool(server);
+  if (s("tree")) registerTreeTool(server);
 }

--- a/packages/server-cargo/src/tools/tree.ts
+++ b/packages/server-cargo/src/tools/tree.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { cargo } from "../lib/cargo-runner.js";
+import { parseCargoTreeOutput } from "../lib/parsers.js";
+import { formatCargoTree, compactTreeMap, formatTreeCompact } from "../lib/formatters.js";
+import { CargoTreeResultSchema } from "../schemas/index.js";
+
+export function registerTreeTool(server: McpServer) {
+  server.registerTool(
+    "tree",
+    {
+      title: "Cargo Tree",
+      description:
+        "Displays the dependency tree for a Rust project. " +
+        "Use instead of running `cargo tree` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        depth: z.number().optional().describe("Maximum depth of the dependency tree to display"),
+        package: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Focus on a specific package in the tree"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: CargoTreeResultSchema,
+    },
+    async ({ path, depth, package: pkg, compact }) => {
+      const cwd = path || process.cwd();
+
+      if (pkg) {
+        assertNoFlagInjection(pkg, "package");
+      }
+
+      const args = ["tree"];
+      if (depth !== undefined) {
+        args.push("--depth", String(depth));
+      }
+      if (pkg) {
+        args.push("-p", pkg);
+      }
+
+      const result = await cargo(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`cargo tree failed: ${result.stderr}`);
+      }
+
+      const data = parseCargoTreeOutput(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatCargoTree,
+        compactTreeMap,
+        formatTreeCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-cargo/src/tools/update.ts
+++ b/packages/server-cargo/src/tools/update.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { cargo } from "../lib/cargo-runner.js";
+import { parseCargoUpdateOutput } from "../lib/parsers.js";
+import { formatCargoUpdate, compactUpdateMap, formatUpdateCompact } from "../lib/formatters.js";
+import { CargoUpdateResultSchema } from "../schemas/index.js";
+
+export function registerUpdateTool(server: McpServer) {
+  server.registerTool(
+    "update",
+    {
+      title: "Cargo Update",
+      description:
+        "Updates dependencies in the lock file. Optionally updates a single package. " +
+        "Use instead of running `cargo update` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        package: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Specific package to update (e.g. 'serde'). Omit to update all."),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: CargoUpdateResultSchema,
+    },
+    async ({ path, package: pkg, compact }) => {
+      const cwd = path || process.cwd();
+
+      if (pkg) {
+        assertNoFlagInjection(pkg, "package");
+      }
+
+      const args = ["update"];
+      if (pkg) {
+        args.push("-p", pkg);
+      }
+
+      const result = await cargo(args, cwd);
+      const data = parseCargoUpdateOutput(result.stdout, result.stderr, result.exitCode);
+      return compactDualOutput(
+        data,
+        result.stdout + result.stderr,
+        formatCargoUpdate,
+        compactUpdateMap,
+        formatUpdateCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-npm/__tests__/info-search.test.ts
+++ b/packages/server-npm/__tests__/info-search.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect } from "vitest";
+import { parseInfoJson, parseSearchJson } from "../src/lib/parsers.js";
+import {
+  formatInfo,
+  compactInfoMap,
+  formatInfoCompact,
+  formatSearch,
+  compactSearchMap,
+  formatSearchCompact,
+} from "../src/lib/formatters.js";
+import type { NpmInfo, NpmSearch } from "../src/schemas/index.js";
+
+// ── parseInfoJson ────────────────────────────────────────────────────
+
+describe("parseInfoJson", () => {
+  it("parses full package info with all fields", () => {
+    const json = JSON.stringify({
+      name: "express",
+      version: "4.18.2",
+      description: "Fast, unopinionated, minimalist web framework",
+      homepage: "http://expressjs.com/",
+      license: "MIT",
+      dependencies: {
+        accepts: "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.1",
+      },
+      dist: {
+        tarball: "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+        fileCount: 214,
+        unpackedSize: 220551,
+      },
+    });
+
+    const result = parseInfoJson(json);
+
+    expect(result.name).toBe("express");
+    expect(result.version).toBe("4.18.2");
+    expect(result.description).toBe("Fast, unopinionated, minimalist web framework");
+    expect(result.homepage).toBe("http://expressjs.com/");
+    expect(result.license).toBe("MIT");
+    expect(result.dependencies).toEqual({
+      accepts: "~1.3.8",
+      "array-flatten": "1.1.1",
+      "body-parser": "1.20.1",
+    });
+    expect(result.dist?.tarball).toBe("https://registry.npmjs.org/express/-/express-4.18.2.tgz");
+    expect(result.dist?.fileCount).toBe(214);
+    expect(result.dist?.unpackedSize).toBe(220551);
+  });
+
+  it("handles minimal package info", () => {
+    const json = JSON.stringify({
+      name: "tiny-pkg",
+      version: "1.0.0",
+      description: "A tiny package",
+    });
+
+    const result = parseInfoJson(json);
+
+    expect(result.name).toBe("tiny-pkg");
+    expect(result.version).toBe("1.0.0");
+    expect(result.description).toBe("A tiny package");
+    expect(result.homepage).toBeUndefined();
+    expect(result.license).toBeUndefined();
+    expect(result.dependencies).toBeUndefined();
+    expect(result.dist).toBeUndefined();
+  });
+
+  it("defaults name to 'unknown' when missing", () => {
+    const json = JSON.stringify({ version: "1.0.0", description: "test" });
+    const result = parseInfoJson(json);
+    expect(result.name).toBe("unknown");
+  });
+
+  it("defaults version to '0.0.0' when missing", () => {
+    const json = JSON.stringify({ name: "test", description: "test" });
+    const result = parseInfoJson(json);
+    expect(result.version).toBe("0.0.0");
+  });
+
+  it("defaults description to empty string when missing", () => {
+    const json = JSON.stringify({ name: "test", version: "1.0.0" });
+    const result = parseInfoJson(json);
+    expect(result.description).toBe("");
+  });
+
+  it("omits empty dependencies object", () => {
+    const json = JSON.stringify({
+      name: "test",
+      version: "1.0.0",
+      description: "",
+      dependencies: {},
+    });
+    const result = parseInfoJson(json);
+    expect(result.dependencies).toBeUndefined();
+  });
+
+  it("omits dist when empty", () => {
+    const json = JSON.stringify({
+      name: "test",
+      version: "1.0.0",
+      description: "",
+      dist: {},
+    });
+    const result = parseInfoJson(json);
+    expect(result.dist).toBeUndefined();
+  });
+
+  it("throws on invalid JSON", () => {
+    expect(() => parseInfoJson("not valid json")).toThrow();
+  });
+});
+
+// ── parseSearchJson ──────────────────────────────────────────────────
+
+describe("parseSearchJson", () => {
+  it("parses search results with all fields", () => {
+    const json = JSON.stringify([
+      {
+        name: "express",
+        version: "4.18.2",
+        description: "Fast web framework",
+        author: { name: "TJ Holowaychuk" },
+        date: "2022-10-08T00:00:00.000Z",
+      },
+      {
+        name: "koa",
+        version: "2.14.2",
+        description: "Koa web framework",
+        author: { name: "TJ Holowaychuk" },
+        date: "2023-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const result = parseSearchJson(json);
+
+    expect(result.total).toBe(2);
+    expect(result.packages).toHaveLength(2);
+    expect(result.packages[0].name).toBe("express");
+    expect(result.packages[0].version).toBe("4.18.2");
+    expect(result.packages[0].description).toBe("Fast web framework");
+    expect(result.packages[0].author).toBe("TJ Holowaychuk");
+    expect(result.packages[0].date).toBe("2022-10-08T00:00:00.000Z");
+    expect(result.packages[1].name).toBe("koa");
+  });
+
+  it("handles author as a string", () => {
+    const json = JSON.stringify([
+      {
+        name: "pkg",
+        version: "1.0.0",
+        description: "test",
+        author: "John Doe",
+      },
+    ]);
+
+    const result = parseSearchJson(json);
+    expect(result.packages[0].author).toBe("John Doe");
+  });
+
+  it("handles empty search results", () => {
+    const result = parseSearchJson("[]");
+    expect(result.total).toBe(0);
+    expect(result.packages).toEqual([]);
+  });
+
+  it("handles missing optional fields", () => {
+    const json = JSON.stringify([
+      {
+        name: "simple-pkg",
+        version: "0.1.0",
+        description: "Simple package",
+      },
+    ]);
+
+    const result = parseSearchJson(json);
+
+    expect(result.packages[0].name).toBe("simple-pkg");
+    expect(result.packages[0].author).toBeUndefined();
+    expect(result.packages[0].date).toBeUndefined();
+  });
+
+  it("defaults missing fields gracefully", () => {
+    const json = JSON.stringify([{}]);
+    const result = parseSearchJson(json);
+
+    expect(result.packages[0].name).toBe("unknown");
+    expect(result.packages[0].version).toBe("0.0.0");
+    expect(result.packages[0].description).toBe("");
+  });
+
+  it("handles non-array JSON by returning empty results", () => {
+    const json = JSON.stringify({ name: "not-an-array" });
+    const result = parseSearchJson(json);
+    expect(result.total).toBe(0);
+    expect(result.packages).toEqual([]);
+  });
+
+  it("throws on invalid JSON", () => {
+    expect(() => parseSearchJson("not valid json")).toThrow();
+  });
+});
+
+// ── formatInfo ───────────────────────────────────────────────────────
+
+describe("formatInfo", () => {
+  it("formats full info with all fields", () => {
+    const data: NpmInfo = {
+      name: "express",
+      version: "4.18.2",
+      description: "Fast web framework",
+      homepage: "http://expressjs.com/",
+      license: "MIT",
+      dependencies: { accepts: "~1.3.8", "body-parser": "1.20.1" },
+      dist: { fileCount: 214, unpackedSize: 220551 },
+    };
+    const output = formatInfo(data);
+    expect(output).toContain("express@4.18.2");
+    expect(output).toContain("Fast web framework");
+    expect(output).toContain("License: MIT");
+    expect(output).toContain("Homepage: http://expressjs.com/");
+    expect(output).toContain("Dependencies: 2");
+    expect(output).toContain("accepts: ~1.3.8");
+    expect(output).toContain("Files: 214");
+    expect(output).toContain("Unpacked size: 220551");
+  });
+
+  it("formats minimal info", () => {
+    const data: NpmInfo = {
+      name: "tiny",
+      version: "1.0.0",
+      description: "",
+    };
+    const output = formatInfo(data);
+    expect(output).toBe("tiny@1.0.0");
+  });
+});
+
+// ── compactInfoMap ───────────────────────────────────────────────────
+
+describe("compactInfoMap", () => {
+  it("strips dependencies and dist, keeps core fields", () => {
+    const data: NpmInfo = {
+      name: "express",
+      version: "4.18.2",
+      description: "Fast web framework",
+      homepage: "http://expressjs.com/",
+      license: "MIT",
+      dependencies: { accepts: "~1.3.8" },
+      dist: { fileCount: 214 },
+    };
+    const compact = compactInfoMap(data);
+    expect(compact.name).toBe("express");
+    expect(compact.version).toBe("4.18.2");
+    expect(compact.description).toBe("Fast web framework");
+    expect(compact.license).toBe("MIT");
+    expect(compact.homepage).toBe("http://expressjs.com/");
+    expect(compact).not.toHaveProperty("dependencies");
+    expect(compact).not.toHaveProperty("dist");
+  });
+
+  it("omits license and homepage when not present", () => {
+    const data: NpmInfo = {
+      name: "pkg",
+      version: "1.0.0",
+      description: "test",
+    };
+    const compact = compactInfoMap(data);
+    expect(compact.license).toBeUndefined();
+    expect(compact.homepage).toBeUndefined();
+  });
+});
+
+// ── formatInfoCompact ────────────────────────────────────────────────
+
+describe("formatInfoCompact", () => {
+  it("formats compact info output", () => {
+    const output = formatInfoCompact({
+      name: "express",
+      version: "4.18.2",
+      description: "Fast web framework",
+      license: "MIT",
+      homepage: "http://expressjs.com/",
+    });
+    expect(output).toContain("express@4.18.2");
+    expect(output).toContain("Fast web framework");
+    expect(output).toContain("License: MIT");
+    expect(output).toContain("Homepage: http://expressjs.com/");
+  });
+
+  it("formats minimal compact info", () => {
+    const output = formatInfoCompact({
+      name: "tiny",
+      version: "1.0.0",
+      description: "",
+    });
+    expect(output).toBe("tiny@1.0.0");
+  });
+});
+
+// ── formatSearch ─────────────────────────────────────────────────────
+
+describe("formatSearch", () => {
+  it("formats search results with author", () => {
+    const data: NpmSearch = {
+      packages: [
+        {
+          name: "express",
+          version: "4.18.2",
+          description: "Fast web framework",
+          author: "TJ",
+        },
+      ],
+      total: 1,
+    };
+    const output = formatSearch(data);
+    expect(output).toContain("1 packages found:");
+    expect(output).toContain("express@4.18.2 — Fast web framework by TJ");
+  });
+
+  it("formats empty search results", () => {
+    const data: NpmSearch = { packages: [], total: 0 };
+    expect(formatSearch(data)).toBe("No packages found.");
+  });
+
+  it("formats search results without author", () => {
+    const data: NpmSearch = {
+      packages: [{ name: "pkg", version: "1.0.0", description: "A package" }],
+      total: 1,
+    };
+    const output = formatSearch(data);
+    expect(output).toContain("pkg@1.0.0 — A package");
+    expect(output).not.toContain(" by ");
+  });
+});
+
+// ── compactSearchMap ─────────────────────────────────────────────────
+
+describe("compactSearchMap", () => {
+  it("strips author and date fields", () => {
+    const data: NpmSearch = {
+      packages: [
+        {
+          name: "express",
+          version: "4.18.2",
+          description: "Fast web framework",
+          author: "TJ",
+          date: "2022-10-08",
+        },
+      ],
+      total: 1,
+    };
+    const compact = compactSearchMap(data);
+    expect(compact.total).toBe(1);
+    expect(compact.packages[0]).toEqual({
+      name: "express",
+      version: "4.18.2",
+      description: "Fast web framework",
+    });
+    expect(compact.packages[0]).not.toHaveProperty("author");
+    expect(compact.packages[0]).not.toHaveProperty("date");
+  });
+});
+
+// ── formatSearchCompact ──────────────────────────────────────────────
+
+describe("formatSearchCompact", () => {
+  it("formats compact search results", () => {
+    const output = formatSearchCompact({
+      packages: [{ name: "express", version: "4.18.2", description: "Fast web framework" }],
+      total: 1,
+    });
+    expect(output).toContain("1 packages found:");
+    expect(output).toContain("express@4.18.2 — Fast web framework");
+  });
+
+  it("formats empty compact results", () => {
+    expect(formatSearchCompact({ packages: [], total: 0 })).toBe("No packages found.");
+  });
+});

--- a/packages/server-npm/__tests__/integration.test.ts
+++ b/packages/server-npm/__tests__/integration.test.ts
@@ -26,10 +26,20 @@ describe("@paretools/npm integration", () => {
     await transport.close();
   });
 
-  it("lists all 7 tools", async () => {
+  it("lists all 9 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
-    expect(names).toEqual(["audit", "init", "install", "list", "outdated", "run", "test"]);
+    expect(names).toEqual([
+      "audit",
+      "info",
+      "init",
+      "install",
+      "list",
+      "outdated",
+      "run",
+      "search",
+      "test",
+    ]);
   });
 
   describe("list", () => {

--- a/packages/server-npm/src/schemas/index.ts
+++ b/packages/server-npm/src/schemas/index.ts
@@ -119,3 +119,39 @@ export const NpmInitSchema = z.object({
 });
 
 export type NpmInit = z.infer<typeof NpmInitSchema>;
+
+/** Zod schema for structured npm info output with package metadata. */
+export const NpmInfoSchema = z.object({
+  name: z.string(),
+  version: z.string(),
+  description: z.string(),
+  homepage: z.string().optional(),
+  license: z.string().optional(),
+  dependencies: z.record(z.string(), z.string()).optional(),
+  dist: z
+    .object({
+      tarball: z.string().optional(),
+      fileCount: z.number().optional(),
+      unpackedSize: z.number().optional(),
+    })
+    .optional(),
+});
+
+export type NpmInfo = z.infer<typeof NpmInfoSchema>;
+
+/** Zod schema for a single package entry in npm search results. */
+export const NpmSearchPackageSchema = z.object({
+  name: z.string(),
+  version: z.string(),
+  description: z.string(),
+  author: z.string().optional(),
+  date: z.string().optional(),
+});
+
+/** Zod schema for structured npm search output with matching packages. */
+export const NpmSearchSchema = z.object({
+  packages: z.array(NpmSearchPackageSchema),
+  total: z.number(),
+});
+
+export type NpmSearch = z.infer<typeof NpmSearchSchema>;

--- a/packages/server-npm/src/tools/index.ts
+++ b/packages/server-npm/src/tools/index.ts
@@ -7,6 +7,8 @@ import { registerListTool } from "./list.js";
 import { registerRunTool } from "./run.js";
 import { registerTestTool } from "./test.js";
 import { registerInitTool } from "./init.js";
+import { registerInfoTool } from "./info.js";
+import { registerSearchTool } from "./search.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("npm", name);
@@ -17,4 +19,6 @@ export function registerAllTools(server: McpServer) {
   if (s("run")) registerRunTool(server);
   if (s("test")) registerTestTool(server);
   if (s("init")) registerInitTool(server);
+  if (s("info")) registerInfoTool(server);
+  if (s("search")) registerSearchTool(server);
 }

--- a/packages/server-npm/src/tools/info.ts
+++ b/packages/server-npm/src/tools/info.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { npm } from "../lib/npm-runner.js";
+import { parseInfoJson } from "../lib/parsers.js";
+import { formatInfo, compactInfoMap, formatInfoCompact } from "../lib/formatters.js";
+import { NpmInfoSchema } from "../schemas/index.js";
+
+export function registerInfoTool(server: McpServer) {
+  server.registerTool(
+    "info",
+    {
+      title: "npm Info",
+      description:
+        "Shows detailed package metadata from the npm registry. Use instead of running `npm info` in the terminal.",
+      inputSchema: {
+        package: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .describe("Package name to look up (e.g. 'express', 'lodash@4.17.21')"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: NpmInfoSchema,
+    },
+    async ({ package: pkg, path, compact }) => {
+      const cwd = path || process.cwd();
+      assertNoFlagInjection(pkg, "package");
+
+      const result = await npm(["info", pkg, "--json"], cwd);
+
+      if (result.exitCode !== 0 && !result.stdout) {
+        throw new Error(`npm info failed: ${result.stderr}`);
+      }
+
+      const info = parseInfoJson(result.stdout);
+      return compactDualOutput(
+        info,
+        result.stdout,
+        formatInfo,
+        compactInfoMap,
+        formatInfoCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-npm/src/tools/search.ts
+++ b/packages/server-npm/src/tools/search.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { npm } from "../lib/npm-runner.js";
+import { parseSearchJson } from "../lib/parsers.js";
+import { formatSearch, compactSearchMap, formatSearchCompact } from "../lib/formatters.js";
+import { NpmSearchSchema } from "../schemas/index.js";
+
+export function registerSearchTool(server: McpServer) {
+  server.registerTool(
+    "search",
+    {
+      title: "npm Search",
+      description:
+        "Searches the npm registry for packages matching a query. Use instead of running `npm search` in the terminal.",
+      inputSchema: {
+        query: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Search query string"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        limit: z
+          .number()
+          .optional()
+          .default(20)
+          .describe("Maximum number of results to return (default: 20)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: NpmSearchSchema,
+    },
+    async ({ query, path, limit, compact }) => {
+      const cwd = path || process.cwd();
+      assertNoFlagInjection(query, "query");
+
+      const args = ["search", query, "--json"];
+      if (limit !== undefined) {
+        args.push(`--searchlimit=${limit}`);
+      }
+
+      const result = await npm(args, cwd);
+
+      if (result.exitCode !== 0 && !result.stdout) {
+        throw new Error(`npm search failed: ${result.stderr}`);
+      }
+
+      const search = parseSearchJson(result.stdout || "[]");
+      return compactDualOutput(
+        search,
+        result.stdout || "[]",
+        formatSearch,
+        compactSearchMap,
+        formatSearchCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- **npm**: Add `info` tool (`npm info --json`) for registry package metadata and `search` tool (`npm search --json`) for searching the npm registry
- **cargo**: Add `update` tool (`cargo update`) for updating lock file dependencies and `tree` tool (`cargo tree`) for displaying dependency trees
- All four tools include Zod schemas, parsers, formatters, compact mode support, security validation (assertNoFlagInjection), and comprehensive tests

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All 178 npm package tests pass (including new info/search parser, formatter, compact, and integration tests)
- [x] All 193 cargo package tests pass (including new update/tree parser, formatter, compact, and integration tests)
- [x] Integration tests updated to reflect new tool counts (npm: 7 -> 9, cargo: 9 -> 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)