### PR TITLE
fix(git): deduplicate blame output by grouping lines per commit

### DIFF
--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -233,28 +233,34 @@ export type GitRemoteFull = {
 
 export type GitRemote = z.infer<typeof GitRemoteSchema>;
 
-/** Zod schema for a single blame line entry with commit hash, author, date, line number, and content. */
-export const GitBlameLineSchema = z.object({
+/** Zod schema for a blame commit group with metadata and its attributed lines. */
+export const GitBlameCommitSchema = z.object({
   hash: z.string(),
   author: z.string(),
   date: z.string(),
-  lineNumber: z.number(),
-  content: z.string(),
+  lines: z.array(z.object({ lineNumber: z.number(), content: z.string() })),
 });
 
-/** Zod schema for structured git blame output with per-line annotations and file name. */
+/** Zod schema for structured git blame output grouped by commit. */
 export const GitBlameSchema = z.object({
-  lines: z.union([
-    z.array(GitBlameLineSchema),
-    z.array(z.object({ hash: z.string(), lineNumber: z.number(), content: z.string() })),
+  commits: z.union([
+    z.array(GitBlameCommitSchema),
+    z.array(z.object({ hash: z.string(), lines: z.array(z.number()) })),
   ]),
   file: z.string(),
+  totalLines: z.number(),
 });
 
 /** Full blame data (always returned by parser, before compact projection). */
 export type GitBlameFull = {
-  lines: Array<{ hash: string; author: string; date: string; lineNumber: number; content: string }>;
+  commits: Array<{
+    hash: string;
+    author: string;
+    date: string;
+    lines: Array<{ lineNumber: number; content: string }>;
+  }>;
   file: string;
+  totalLines: number;
 };
 
 export type GitBlame = z.infer<typeof GitBlameSchema>;

--- a/packages/server-git/src/tools/blame.ts
+++ b/packages/server-git/src/tools/blame.ts
@@ -12,7 +12,7 @@ export function registerBlameTool(server: McpServer) {
     {
       title: "Git Blame",
       description:
-        "Shows per-line commit annotations for a file. Returns structured blame data with hash, author, date, line number, and content. Use instead of running `git blame` in the terminal.",
+        "Shows commit annotations for a file, grouped by commit. Returns structured blame data with deduplicated commit metadata (hash, author, date) and their attributed lines. Use instead of running `git blame` in the terminal.",
       inputSchema: {
         path: z
           .string()


### PR DESCRIPTION
## Summary
- Restructures blame output from flat per-line to grouped-by-commit, eliminating duplicated `hash`/`author`/`date` metadata across every line
- Full mode: `commits[]` with `{hash, author, date, lines: [{lineNumber, content}]}` — metadata appears once per commit instead of once per line
- Compact mode: `commits[]` with `{hash, lines: number[]}` — just commit-to-line-number mapping with compressed line ranges in text output
- Reduces structured output by **37-44%** on benchmark scenarios (blame-large: 21,968 → 12,937 tokens)

Closes #212

## Test plan
- [x] 287/287 server-git tests passing
- [x] Parser tests: single commit, multiple commits, interleaved A-B-A pattern, large file (30 lines/5 commits), single-author file, empty
- [x] Formatter tests: grouped output, interleaved sort order, empty
- [x] Compact tests: projection drops author/date/content, line range compression, empty
- [x] Integration tests pass (live blame against real repo)
- [x] TypeScript check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)