### PR TITLE
fix(docker): cap logs full mode output to prevent unbounded tokens (#205)

### DIFF
--- a/packages/server-docker/__tests__/formatters.test.ts
+++ b/packages/server-docker/__tests__/formatters.test.ts
@@ -148,6 +148,20 @@ describe("formatLogs", () => {
     const output = formatLogs(data);
     expect(output).toContain("idle-app (0 lines)");
   });
+
+  it("formats truncated logs with truncation indicator", () => {
+    const data: DockerLogs = {
+      container: "busy-app",
+      lines: ["line 1", "line 2"],
+      total: 2,
+      isTruncated: true,
+      totalLines: 500,
+    };
+    const output = formatLogs(data);
+    expect(output).toContain("busy-app (2 of 500 lines, truncated)");
+    expect(output).toContain("line 1");
+    expect(output).toContain("line 2");
+  });
 });
 
 describe("formatImages", () => {

--- a/packages/server-docker/__tests__/parsers.test.ts
+++ b/packages/server-docker/__tests__/parsers.test.ts
@@ -259,6 +259,40 @@ describe("parseLogsOutput", () => {
     expect(result.lines).toEqual([]);
     expect(result.total).toBe(0);
   });
+
+  it("truncates lines when limit is exceeded", () => {
+    const lines = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`);
+    const stdout = lines.join("\n");
+    const result = parseLogsOutput(stdout, "busy-app", 50);
+
+    expect(result.lines).toHaveLength(50);
+    expect(result.total).toBe(50);
+    expect(result.isTruncated).toBe(true);
+    expect(result.totalLines).toBe(200);
+    expect(result.lines[0]).toBe("line 1");
+    expect(result.lines[49]).toBe("line 50");
+  });
+
+  it("does not truncate when lines are within limit", () => {
+    const stdout = "line 1\nline 2\nline 3";
+    const result = parseLogsOutput(stdout, "small-app", 100);
+
+    expect(result.lines).toHaveLength(3);
+    expect(result.total).toBe(3);
+    expect(result.isTruncated).toBeUndefined();
+    expect(result.totalLines).toBeUndefined();
+  });
+
+  it("does not truncate when no limit is provided", () => {
+    const lines = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`);
+    const stdout = lines.join("\n");
+    const result = parseLogsOutput(stdout, "unlimited-app");
+
+    expect(result.lines).toHaveLength(200);
+    expect(result.total).toBe(200);
+    expect(result.isTruncated).toBeUndefined();
+    expect(result.totalLines).toBeUndefined();
+  });
 });
 
 describe("parseImagesJson", () => {

--- a/packages/server-docker/src/lib/formatters.ts
+++ b/packages/server-docker/src/lib/formatters.ts
@@ -44,7 +44,10 @@ export function formatBuild(data: DockerBuild): string {
 
 /** Formats structured Docker logs data into a human-readable output with container name and line count. */
 export function formatLogs(data: DockerLogs): string {
-  return `${data.container} (${data.total} lines)\n${data.lines.join("\n")}`;
+  const header = data.isTruncated
+    ? `${data.container} (${data.total} of ${data.totalLines} lines, truncated)`
+    : `${data.container} (${data.total} lines)`;
+  return `${header}\n${data.lines.join("\n")}`;
 }
 
 /** Formats structured Docker image data into a human-readable listing with repository, tag, and size. */

--- a/packages/server-docker/src/lib/parsers.ts
+++ b/packages/server-docker/src/lib/parsers.ts
@@ -103,13 +103,17 @@ export function parseBuildOutput(
   };
 }
 
-/** Parses `docker logs` output into structured data with container name and log lines. */
-export function parseLogsOutput(stdout: string, container: string): DockerLogs {
-  const lines = stdout.split("\n").filter(Boolean);
+/** Parses `docker logs` output into structured data with container name and log lines. Caps output to `limit` lines when provided. */
+export function parseLogsOutput(stdout: string, container: string, limit?: number): DockerLogs {
+  const allLines = stdout.split("\n").filter(Boolean);
+  const totalLines = allLines.length;
+  const isTruncated = limit != null && totalLines > limit;
+  const lines = isTruncated ? allLines.slice(0, limit) : allLines;
   return {
     container,
     lines,
     total: lines.length,
+    ...(isTruncated ? { isTruncated: true, totalLines } : {}),
   };
 }
 

--- a/packages/server-docker/src/schemas/index.ts
+++ b/packages/server-docker/src/schemas/index.ts
@@ -43,6 +43,8 @@ export const DockerLogsSchema = z.object({
   container: z.string(),
   lines: z.array(z.string()),
   total: z.number(),
+  isTruncated: z.boolean().optional(),
+  totalLines: z.number().optional(),
 });
 
 export type DockerLogs = z.infer<typeof DockerLogsSchema>;


### PR DESCRIPTION
## Summary
- Adds `limit` input parameter (default: 100) to the docker `logs` tool that caps structured output lines in full mode
- When lines exceed the limit, the response includes `isTruncated: true` and `totalLines` with the original count before truncation
- Compact mode head/tail sampling behavior is unchanged

Closes #205

## Test plan
- [x] Parser tests: truncation when limit exceeded, no truncation within limit, no truncation without limit
- [x] Formatter tests: truncated logs show "X of Y lines, truncated" header
- [x] All 326 existing docker tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)