### PR TITLE
fix(test): restore message field in test failure compact mode (#206)

### DIFF
--- a/packages/server-test/src/lib/formatters.ts
+++ b/packages/server-test/src/lib/formatters.ts
@@ -31,7 +31,7 @@ export function formatCoverage(c: Coverage): string {
 
 // ── Compact types, mappers, and formatters ───────────────────────────
 
-/** Compact test run: summary + framework + failure names only (no messages, stacks, expected/actual). */
+/** Compact test run: summary + framework + failure names and messages (no stacks, expected/actual). */
 export interface TestRunCompact {
   [key: string]: unknown;
   framework: string;
@@ -42,14 +42,17 @@ export interface TestRunCompact {
     skipped: number;
     duration: number;
   };
-  failures: Array<{ name: string }>;
+  failures: Array<{ name: string; message?: string }>;
 }
 
 export function compactTestRunMap(r: TestRun): TestRunCompact {
   return {
     framework: r.framework,
     summary: { ...r.summary },
-    failures: r.failures.map((f) => ({ name: f.name })),
+    failures: r.failures.map((f) => ({
+      name: f.name,
+      ...(f.message ? { message: f.message } : {}),
+    })),
   };
 }
 
@@ -60,7 +63,7 @@ export function formatTestRunCompact(r: TestRunCompact): string {
   ];
 
   for (const f of r.failures) {
-    parts.push(`  FAIL ${f.name}`);
+    parts.push(`  FAIL ${f.name}${f.message ? `: ${f.message}` : ""}`);
   }
 
   return parts.join("\n");


### PR DESCRIPTION
## Summary
- Restores `message` to the compact test failure projection so AI agents can understand what failed
- Keeps dropping `stack`, `expected`, `actual`, `file`, `line` in compact mode (these are verbose and often redundant)
- Updates compact formatter to display `FAIL name: message` instead of just `FAIL name`

Closes #206

## Test plan
- [x] Compact mapper includes message when present, omits when absent
- [x] Compact formatter shows "FAIL name: message" format
- [x] Still strips stack, expected, actual, file, line from compact
- [x] All 25 formatter tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)