### PR TITLE
perf(docker): truncate container IDs to 12 chars and prefer relative timestamps (#208)

### DIFF
--- a/packages/server-docker/src/lib/parsers.ts
+++ b/packages/server-docker/src/lib/parsers.ts
@@ -21,13 +21,13 @@ export function parsePsJson(stdout: string): DockerPs {
   const containers = lines.map((line) => {
     const c = JSON.parse(line);
     return {
-      id: c.ID ?? c.Id ?? "",
+      id: (c.ID ?? c.Id ?? "").slice(0, 12),
       name: c.Names ?? c.Name ?? "",
       image: c.Image ?? "",
       status: c.Status ?? "",
       state: (c.State ?? "created").toLowerCase(),
       ports: parsePorts(c.Ports ?? ""),
-      created: c.CreatedAt ?? c.RunningFor ?? "",
+      created: c.RunningFor ?? c.CreatedAt ?? "",
     };
   });
 


### PR DESCRIPTION
## Summary
- Truncates container IDs to 12 characters in full mode parser, matching compact mode and `docker ps` default behavior
- Prefers `RunningFor` (relative timestamps like "2 hours ago") over `CreatedAt` (verbose ISO 8601) for shorter output
- Falls back to `CreatedAt` when `RunningFor` is not available

Closes #208

## Test plan
- [x] Long 64-char IDs are truncated to 12 characters
- [x] `RunningFor` is preferred over `CreatedAt` when both present
- [x] Falls back to `CreatedAt` when `RunningFor` is absent
- [x] All 325 existing docker tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)