### PR TITLE
perf(npm): remove resolved URLs from npm list schema (#209)

### DIFF
--- a/packages/server-npm/__tests__/compact.test.ts
+++ b/packages/server-npm/__tests__/compact.test.ts
@@ -10,11 +10,9 @@ describe("compactListMap", () => {
       dependencies: {
         express: {
           version: "4.18.2",
-          resolved: "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
         },
         lodash: {
           version: "4.17.21",
-          resolved: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
         },
       },
       total: 2,

--- a/packages/server-npm/__tests__/fidelity.test.ts
+++ b/packages/server-npm/__tests__/fidelity.test.ts
@@ -421,17 +421,13 @@ describe("fidelity: npm list", () => {
     expect(result.dependencies["typescript"].version).toBe("5.3.3");
   });
 
-  it("preserves resolved URLs when present", () => {
+  it("strips resolved URLs from output", () => {
     const result = parseListJson(LIST_BASIC);
 
-    expect(result.dependencies["express"].resolved).toBe(
-      "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-    );
-    expect(result.dependencies["zod"].resolved).toBe(
-      "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-    );
-    // typescript has no resolved field
-    expect(result.dependencies["typescript"].resolved).toBeUndefined();
+    // resolved URLs are intentionally omitted to save tokens
+    expect(result.dependencies["express"]).not.toHaveProperty("resolved");
+    expect(result.dependencies["zod"]).not.toHaveProperty("resolved");
+    expect(result.dependencies["typescript"]).not.toHaveProperty("resolved");
   });
 
   it("preserves package name and version for scoped packages", () => {

--- a/packages/server-npm/__tests__/parsers.test.ts
+++ b/packages/server-npm/__tests__/parsers.test.ts
@@ -141,6 +141,7 @@ describe("parseListJson", () => {
     expect(result.version).toBe("1.0.0");
     expect(result.total).toBe(2);
     expect(result.dependencies.express.version).toBe("4.18.2");
+    expect(result.dependencies.express).not.toHaveProperty("resolved");
     expect(result.dependencies.zod.version).toBe("3.25.0");
   });
 

--- a/packages/server-npm/src/lib/parsers.ts
+++ b/packages/server-npm/src/lib/parsers.ts
@@ -107,7 +107,6 @@ export function parseListJson(jsonStr: string): NpmList {
       const dep = v as any;
       const entry: NpmListDep = {
         version: dep.version ?? "unknown",
-        ...(dep.resolved ? { resolved: dep.resolved } : {}),
       };
       if (dep.dependencies && Object.keys(dep.dependencies).length > 0) {
         entry.dependencies = parseDeps(dep.dependencies);

--- a/packages/server-npm/src/schemas/index.ts
+++ b/packages/server-npm/src/schemas/index.ts
@@ -68,14 +68,12 @@ export type NpmOutdated = z.infer<typeof NpmOutdatedSchema>;
 /** A single dependency entry in the npm dependency list (recursive for nested deps). */
 export interface NpmListDep {
   version: string;
-  resolved?: string;
   dependencies?: Record<string, NpmListDep>;
 }
 
-/** Zod schema for a single dependency entry in an npm list with version, optional resolved URL, and nested dependencies. */
+/** Zod schema for a single dependency entry in an npm list with version and nested dependencies. */
 export const NpmListDepSchema: z.ZodType<NpmListDep> = z.object({
   version: z.string(),
-  resolved: z.string().optional(),
   dependencies: z
     .record(
       z.string(),


### PR DESCRIPTION
## Summary
- Removes `resolved` field from `NpmListDepSchema` interface, Zod schema, and parser
- Registry URLs (e.g., `https://registry.npmjs.org/express/-/express-4.18.2.tgz`) add significant token overhead and are almost never needed by AI agents
- Use `npm info <package>` for registry URL when needed

Closes #209

## Test plan
- [x] Parser strips resolved URLs from output even when present in npm JSON
- [x] Schema and interface no longer include `resolved` field
- [x] Compact test fixtures updated
- [x] Fidelity test updated to verify resolved is stripped
- [x] All 179 npm tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)