### PR TITLE
fix(shared,git): remove cmd.exe percent escaping, add copied to diff schema

### DIFF
--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -130,7 +130,7 @@ export interface GitDiffCompact {
   [key: string]: unknown;
   files: Array<{
     file: string;
-    status: "added" | "modified" | "deleted" | "renamed";
+    status: "added" | "modified" | "deleted" | "renamed" | "copied";
     additions: number;
     deletions: number;
   }>;

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -44,7 +44,7 @@ export type GitLog = z.infer<typeof GitLogSchema>;
 /** Zod schema for a single file entry in a git diff with additions, deletions, and status. */
 export const GitDiffFileSchema = z.object({
   file: z.string(),
-  status: z.enum(["added", "modified", "deleted", "renamed"]),
+  status: z.enum(["added", "modified", "deleted", "renamed", "copied"]),
   additions: z.number(),
   deletions: z.number(),
   oldFile: z.string().optional(),


### PR DESCRIPTION
## Summary

- **Remove percent escaping from `escapeCmdArg`** (`shared/src/runner.ts`): The function was escaping `%` to `%%` to prevent cmd.exe environment variable expansion. However, `%%` only collapses to `%` in batch files, not in the `cmd.exe /d /s /c` context Node.js uses with `shell: true`. This caused git format specifiers (e.g., `--format=%H`) to be double-escaped — git received `%%H` and interpreted it as its own escape for literal `%`, outputting `%H` instead of the actual hash value.
- **Add `copied` to diff file status enum** (`server-git/src/schemas/index.ts`, `server-git/src/lib/formatters.ts`): Git copy detection (`diff -C`) can produce a `copied` status that was not in the Zod enum, causing schema validation failures.

## Test plan

- [x] Updated 6 existing `escapeCmdArg` tests to remove `%%` expectations
- [x] Added new test verifying git format specifiers pass through unchanged
- [x] All 178 shared tests pass
- [x] All 282 server-git tests pass
- [x] Full monorepo build passes

Fixes #218, fixes #219

Generated with [Claude Code](https://claude.com/claude-code)