### PR TITLE
perf(npm): remove fileCount/unpackedSize from npm info dist (#211)

### DIFF
--- a/packages/server-npm/__tests__/info-search.test.ts
+++ b/packages/server-npm/__tests__/info-search.test.ts
@@ -45,8 +45,8 @@ describe("parseInfoJson", () => {
       "body-parser": "1.20.1",
     });
     expect(result.dist?.tarball).toBe("https://registry.npmjs.org/express/-/express-4.18.2.tgz");
-    expect(result.dist?.fileCount).toBe(214);
-    expect(result.dist?.unpackedSize).toBe(220551);
+    expect(result.dist).not.toHaveProperty("fileCount");
+    expect(result.dist).not.toHaveProperty("unpackedSize");
   });
 
   it("handles minimal package info", () => {
@@ -213,7 +213,7 @@ describe("formatInfo", () => {
       homepage: "http://expressjs.com/",
       license: "MIT",
       dependencies: { accepts: "~1.3.8", "body-parser": "1.20.1" },
-      dist: { fileCount: 214, unpackedSize: 220551 },
+      dist: { tarball: "https://registry.npmjs.org/express/-/express-4.18.2.tgz" },
     };
     const output = formatInfo(data);
     expect(output).toContain("express@4.18.2");
@@ -222,8 +222,7 @@ describe("formatInfo", () => {
     expect(output).toContain("Homepage: http://expressjs.com/");
     expect(output).toContain("Dependencies: 2");
     expect(output).toContain("accepts: ~1.3.8");
-    expect(output).toContain("Files: 214");
-    expect(output).toContain("Unpacked size: 220551");
+    expect(output).toContain("Tarball: https://registry.npmjs.org/express/-/express-4.18.2.tgz");
   });
 
   it("formats minimal info", () => {
@@ -248,7 +247,7 @@ describe("compactInfoMap", () => {
       homepage: "http://expressjs.com/",
       license: "MIT",
       dependencies: { accepts: "~1.3.8" },
-      dist: { fileCount: 214 },
+      dist: { tarball: "https://registry.npmjs.org/express/-/express-4.18.2.tgz" },
     };
     const compact = compactInfoMap(data);
     expect(compact.name).toBe("express");

--- a/packages/server-npm/src/lib/formatters.ts
+++ b/packages/server-npm/src/lib/formatters.ts
@@ -161,10 +161,8 @@ export function formatInfo(data: NpmInfo): string {
       lines.push(`  ${name}: ${version}`);
     }
   }
-  if (data.dist) {
-    if (data.dist.fileCount !== undefined) lines.push(`Files: ${data.dist.fileCount}`);
-    if (data.dist.unpackedSize !== undefined)
-      lines.push(`Unpacked size: ${data.dist.unpackedSize}`);
+  if (data.dist?.tarball) {
+    lines.push(`Tarball: ${data.dist.tarball}`);
   }
   return lines.join("\n");
 }

--- a/packages/server-npm/src/lib/parsers.ts
+++ b/packages/server-npm/src/lib/parsers.ts
@@ -203,12 +203,8 @@ export function parseInfoJson(jsonStr: string): NpmInfo {
   if (data.dependencies && Object.keys(data.dependencies).length > 0) {
     result.dependencies = data.dependencies;
   }
-  if (data.dist) {
-    const dist: NpmInfo["dist"] = {};
-    if (data.dist.tarball) dist.tarball = data.dist.tarball;
-    if (data.dist.fileCount !== undefined) dist.fileCount = data.dist.fileCount;
-    if (data.dist.unpackedSize !== undefined) dist.unpackedSize = data.dist.unpackedSize;
-    if (Object.keys(dist).length > 0) result.dist = dist;
+  if (data.dist?.tarball) {
+    result.dist = { tarball: data.dist.tarball };
   }
 
   return result;

--- a/packages/server-npm/src/schemas/index.ts
+++ b/packages/server-npm/src/schemas/index.ts
@@ -138,8 +138,6 @@ export const NpmInfoSchema = z.object({
   dist: z
     .object({
       tarball: z.string().optional(),
-      fileCount: z.number().optional(),
-      unpackedSize: z.number().optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
## Summary
- Removes `dist.fileCount` and `dist.unpackedSize` from `NpmInfoSchema` and parser output
- Keeps only `dist.tarball` (the actual download URL, marginally useful)
- Compact mode already drops `dist` entirely, unchanged
- Formatter now shows tarball URL instead of file/size metadata

Closes #211

## Test plan
- [x] Parser strips fileCount/unpackedSize, keeps tarball
- [x] Formatter shows tarball URL
- [x] Compact mode still drops dist entirely
- [x] All 179 npm tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)