### PR TITLE
fix(npm): flatten nested deps with > delimited paths in compact mode

### DIFF
--- a/packages/server-npm/__tests__/compact.test.ts
+++ b/packages/server-npm/__tests__/compact.test.ts
@@ -59,6 +59,39 @@ describe("compactListMap", () => {
 
     expect(compact.dependencies).toEqual({ express: "4.18.2" });
   });
+
+  it("flattens nested dependencies with > delimited paths", () => {
+    const list: NpmList = {
+      name: "my-app",
+      version: "1.0.0",
+      dependencies: {
+        express: {
+          version: "4.18.2",
+          dependencies: {
+            "body-parser": {
+              version: "1.20.1",
+              dependencies: {
+                bytes: { version: "3.1.2" },
+              },
+            },
+            "content-type": { version: "1.0.5" },
+          },
+        },
+        lodash: { version: "4.17.21" },
+      },
+      total: 5,
+    };
+
+    const compact = compactListMap(list);
+
+    expect(compact.dependencies).toEqual({
+      express: "4.18.2",
+      "express>body-parser": "1.20.1",
+      "express>body-parser>bytes": "3.1.2",
+      "express>content-type": "1.0.5",
+      lodash: "4.17.21",
+    });
+  });
 });
 
 describe("formatListCompact", () => {

--- a/packages/server-npm/src/lib/formatters.ts
+++ b/packages/server-npm/src/lib/formatters.ts
@@ -121,15 +121,16 @@ export interface NpmListCompact {
 
 export function compactListMap(data: NpmList): NpmListCompact {
   const deps: Record<string, string> = {};
-  function flatten(d: Record<string, NpmListDep>) {
+  function flatten(d: Record<string, NpmListDep>, prefix: string) {
     for (const [name, dep] of Object.entries(d)) {
-      deps[name] = dep.version;
+      const key = prefix ? `${prefix}>${name}` : name;
+      deps[key] = dep.version;
       if (dep.dependencies) {
-        flatten(dep.dependencies);
+        flatten(dep.dependencies, key);
       }
     }
   }
-  flatten(data.dependencies);
+  flatten(data.dependencies, "");
   return {
     name: data.name,
     version: data.version,


### PR DESCRIPTION
## Summary
- Flatten nested dependencies in `compactListMap` using `>` delimited paths (e.g. `express>body-parser>bytes`) instead of flat names
- This preserves the nesting structure in compact output, making it clear which deps are transitive
- Added test for deeply nested dependency flattening

Closes #214

## Test plan
- [x] All 180 npm tests pass
- [x] TypeScript compiles cleanly
- [x] New test verifies 3-level deep nesting produces correct `>` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)