### PR TITLE
fix(shared,git): add shell override to runner, disable for git on Windows

### DIFF
--- a/packages/server-git/src/lib/git-runner.ts
+++ b/packages/server-git/src/lib/git-runner.ts
@@ -5,5 +5,7 @@ export async function git(
   cwd?: string,
   opts?: Pick<RunOptions, "stdin">,
 ): Promise<RunResult> {
-  return run("git", args, { cwd, ...opts });
+  // git is a native executable — disable shell mode to prevent cmd.exe from
+  // misinterpreting <> in format strings (e.g., --format="%an <%ae>").
+  return run("git", args, { cwd, shell: false, ...opts });
 }


### PR DESCRIPTION
## Summary

- The git log/show format string `%an <%ae>` contains angle brackets that cmd.exe interprets as I/O redirects when `shell:true` is used via Node.js `execFile`
- This caused the MCP git log/show tools to return literal format codes (`%h`, `%s`, `%D`) instead of actual commit data on Windows
- Add optional `shell` field to `RunOptions` so callers can override the default `shell: true` on Windows
- The git runner now passes `shell: false` since `git.exe` is a native executable that doesn't need cmd.exe wrapping

## Test plan

- [x] Local: all 293 server-git tests pass
- [x] Local: all 178 shared tests pass
- [x] Verified `shell:false` correctly returns parsed commit data on Windows
- [ ] CI: Windows tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)