### PR TITLE
feat(github): add issue-close tool

### DIFF
--- a/packages/server-github/__tests__/issue-close.test.ts
+++ b/packages/server-github/__tests__/issue-close.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { parseIssueClose } from "../src/lib/parsers.js";
+import { formatIssueClose } from "../src/lib/formatters.js";
+import type { IssueCloseResult } from "../src/schemas/index.js";
+
+// ── Parser tests ────────────────────────────────────────────────────
+
+describe("parseIssueClose", () => {
+  it("parses issue close URL output", () => {
+    const result = parseIssueClose("https://github.com/owner/repo/issues/42\n", 42);
+
+    expect(result.number).toBe(42);
+    expect(result.state).toBe("closed");
+    expect(result.url).toBe("https://github.com/owner/repo/issues/42");
+  });
+
+  it("handles URL without trailing newline", () => {
+    const result = parseIssueClose("https://github.com/owner/repo/issues/1", 1);
+
+    expect(result.number).toBe(1);
+    expect(result.state).toBe("closed");
+    expect(result.url).toBe("https://github.com/owner/repo/issues/1");
+  });
+
+  it("preserves the issue number from the argument", () => {
+    const result = parseIssueClose("https://github.com/owner/repo/issues/99\n", 99);
+
+    expect(result.number).toBe(99);
+  });
+
+  it("always returns state as closed", () => {
+    const result = parseIssueClose("https://github.com/owner/repo/issues/5", 5);
+
+    expect(result.state).toBe("closed");
+  });
+
+  it("trims whitespace from URL", () => {
+    const result = parseIssueClose("  https://github.com/owner/repo/issues/10  \n", 10);
+
+    expect(result.url).toBe("https://github.com/owner/repo/issues/10");
+  });
+});
+
+// ── Formatter tests ─────────────────────────────────────────────────
+
+describe("formatIssueClose", () => {
+  it("formats issue close result", () => {
+    const data: IssueCloseResult = {
+      number: 42,
+      state: "closed",
+      url: "https://github.com/owner/repo/issues/42",
+    };
+    expect(formatIssueClose(data)).toBe(
+      "Closed issue #42: https://github.com/owner/repo/issues/42",
+    );
+  });
+
+  it("formats issue close result with different number", () => {
+    const data: IssueCloseResult = {
+      number: 1,
+      state: "closed",
+      url: "https://github.com/owner/repo/issues/1",
+    };
+    expect(formatIssueClose(data)).toBe("Closed issue #1: https://github.com/owner/repo/issues/1");
+  });
+});

--- a/packages/server-github/__tests__/security.test.ts
+++ b/packages/server-github/__tests__/security.test.ts
@@ -134,6 +134,20 @@ describe("security: issue-create — title validation", () => {
   });
 });
 
+describe("security: issue-close — comment validation", () => {
+  it("rejects flag-like comments", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "comment")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe comments", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "comment")).not.toThrow();
+    }
+  });
+});
+
 describe("security: run-list — branch validation", () => {
   it("rejects flag-like branch names", () => {
     for (const malicious of MALICIOUS_INPUTS) {

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -5,6 +5,7 @@ import type {
   IssueViewResult,
   IssueListResult,
   IssueCreateResult,
+  IssueCloseResult,
   RunViewResult,
   RunListResult,
 } from "../schemas/index.js";
@@ -82,6 +83,11 @@ export function formatIssueList(data: IssueListResult): string {
 /** Formats structured issue create data into human-readable text. */
 export function formatIssueCreate(data: IssueCreateResult): string {
   return `Created issue #${data.number}: ${data.url}`;
+}
+
+/** Formats structured issue close data into human-readable text. */
+export function formatIssueClose(data: IssueCloseResult): string {
+  return `Closed issue #${data.number}: ${data.url}`;
 }
 
 /** Formats structured run view data into human-readable text. */

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -5,6 +5,7 @@ import type {
   IssueViewResult,
   IssueListResult,
   IssueCreateResult,
+  IssueCloseResult,
   RunViewResult,
   RunListResult,
 } from "../schemas/index.js";
@@ -141,6 +142,15 @@ export function parseIssueCreate(stdout: string): IssueCreateResult {
   const match = url.match(/\/issues\/(\d+)$/);
   const number = match ? parseInt(match[1], 10) : 0;
   return { number, url };
+}
+
+/**
+ * Parses `gh issue close` output into structured data.
+ * The gh CLI prints a confirmation URL to stdout. We extract the number from it.
+ */
+export function parseIssueClose(stdout: string, number: number): IssueCloseResult {
+  const url = stdout.trim();
+  return { number, state: "closed", url };
 }
 
 /**

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -96,6 +96,15 @@ export const IssueCreateResultSchema = z.object({
 
 export type IssueCreateResult = z.infer<typeof IssueCreateResultSchema>;
 
+/** Zod schema for structured issue-close output. */
+export const IssueCloseResultSchema = z.object({
+  number: z.number(),
+  state: z.string(),
+  url: z.string(),
+});
+
+export type IssueCloseResult = z.infer<typeof IssueCloseResultSchema>;
+
 // ── Run schemas ──────────────────────────────────────────────────────
 
 /** Zod schema for a single job in a workflow run. */

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -6,6 +6,7 @@ import { registerPrCreateTool } from "./pr-create.js";
 import { registerIssueViewTool } from "./issue-view.js";
 import { registerIssueListTool } from "./issue-list.js";
 import { registerIssueCreateTool } from "./issue-create.js";
+import { registerIssueCloseTool } from "./issue-close.js";
 import { registerRunViewTool } from "./run-view.js";
 import { registerRunListTool } from "./run-list.js";
 
@@ -17,6 +18,7 @@ export function registerAllTools(server: McpServer) {
   if (s("issue-view")) registerIssueViewTool(server);
   if (s("issue-list")) registerIssueListTool(server);
   if (s("issue-create")) registerIssueCreateTool(server);
+  if (s("issue-close")) registerIssueCloseTool(server);
   if (s("run-view")) registerRunViewTool(server);
   if (s("run-list")) registerRunListTool(server);
 }

--- a/packages/server-github/src/tools/issue-close.ts
+++ b/packages/server-github/src/tools/issue-close.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseIssueClose } from "../lib/parsers.js";
+import { formatIssueClose } from "../lib/formatters.js";
+import { IssueCloseResultSchema } from "../schemas/index.js";
+
+export function registerIssueCloseTool(server: McpServer) {
+  server.registerTool(
+    "issue-close",
+    {
+      title: "Issue Close",
+      description:
+        "Closes an issue with an optional comment and reason. Returns structured data with issue number, state, and URL. Use instead of running `gh issue close` in the terminal.",
+      inputSchema: {
+        number: z.number().describe("Issue number"),
+        comment: z.string().max(INPUT_LIMITS.STRING_MAX).optional().describe("Closing comment"),
+        reason: z
+          .enum(["completed", "not planned"])
+          .optional()
+          .describe('Close reason: "completed" or "not planned"'),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+      },
+      outputSchema: IssueCloseResultSchema,
+    },
+    async ({ number, comment, reason, path }) => {
+      const cwd = path || process.cwd();
+
+      if (comment) {
+        assertNoFlagInjection(comment, "comment");
+      }
+
+      const args = ["issue", "close", String(number)];
+      if (comment) {
+        args.push("--comment", comment);
+      }
+      if (reason) {
+        args.push("--reason", reason);
+      }
+
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh issue close failed: ${result.stderr}`);
+      }
+
+      const data = parseIssueClose(result.stdout, number);
+      return dualOutput(data, formatIssueClose);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add new `issue-close` tool to `@paretools/github` that wraps `gh issue close`
- Supports optional `--comment` (with flag injection protection) and `--reason` (Zod enum: `completed` | `not planned`) parameters
- Returns structured JSON with issue number, state, and URL via `IssueCloseResultSchema`

## Changes
- `src/schemas/index.ts` — Add `IssueCloseResultSchema` + type
- `src/lib/parsers.ts` — Add `parseIssueClose()` parser
- `src/lib/formatters.ts` — Add `formatIssueClose()` formatter
- `src/tools/issue-close.ts` — New tool registration (follows `issue-create` pattern)
- `src/tools/index.ts` — Register `issue-close` tool
- `__tests__/issue-close.test.ts` — 7 parser + formatter tests
- `__tests__/security.test.ts` — Flag injection tests for `comment` param

## Test plan
- [x] All 74 tests pass (`pnpm test` in `packages/server-github`)
- [x] Build succeeds (`pnpm build`)
- [x] Security tests verify `assertNoFlagInjection` on comment parameter
- [x] `reason` uses Zod enum — no flag injection possible

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)