### PR TITLE
feat(github): add pr-merge tool (#245)

### DIFF
--- a/packages/server-github/__tests__/pr-merge.test.ts
+++ b/packages/server-github/__tests__/pr-merge.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { parsePrMerge } from "../src/lib/parsers.js";
+import { formatPrMerge } from "../src/lib/formatters.js";
+import type { PrMergeResult } from "../src/schemas/index.js";
+
+// ── Parser tests ────────────────────────────────────────────────────
+
+describe("parsePrMerge", () => {
+  it("parses merge output with PR URL", () => {
+    const stdout =
+      "✓ Squashed and merged pull request #42\nhttps://github.com/owner/repo/pull/42\n";
+
+    const result = parsePrMerge(stdout, 42, "squash");
+
+    expect(result.number).toBe(42);
+    expect(result.merged).toBe(true);
+    expect(result.method).toBe("squash");
+    expect(result.url).toBe("https://github.com/owner/repo/pull/42");
+  });
+
+  it("parses merge output with rebase method", () => {
+    const stdout = "✓ Rebased and merged pull request #7\nhttps://github.com/owner/repo/pull/7\n";
+
+    const result = parsePrMerge(stdout, 7, "rebase");
+
+    expect(result.number).toBe(7);
+    expect(result.merged).toBe(true);
+    expect(result.method).toBe("rebase");
+    expect(result.url).toBe("https://github.com/owner/repo/pull/7");
+  });
+
+  it("parses merge output with merge method", () => {
+    const stdout = "✓ Merged pull request #100\nhttps://github.com/owner/repo/pull/100\n";
+
+    const result = parsePrMerge(stdout, 100, "merge");
+
+    expect(result.number).toBe(100);
+    expect(result.merged).toBe(true);
+    expect(result.method).toBe("merge");
+    expect(result.url).toBe("https://github.com/owner/repo/pull/100");
+  });
+
+  it("handles output without URL", () => {
+    const stdout = "✓ Squashed and merged pull request #5\n";
+
+    const result = parsePrMerge(stdout, 5, "squash");
+
+    expect(result.number).toBe(5);
+    expect(result.merged).toBe(true);
+    expect(result.method).toBe("squash");
+    expect(result.url).toBe("");
+  });
+
+  it("handles delete-branch output with URL", () => {
+    const stdout =
+      "✓ Squashed and merged pull request #3\nhttps://github.com/owner/repo/pull/3\n✓ Deleted branch feat/test\n";
+
+    const result = parsePrMerge(stdout, 3, "squash");
+
+    expect(result.number).toBe(3);
+    expect(result.merged).toBe(true);
+    expect(result.url).toBe("https://github.com/owner/repo/pull/3");
+  });
+});
+
+// ── Formatter tests ─────────────────────────────────────────────────
+
+describe("formatPrMerge", () => {
+  it("formats merge result with squash", () => {
+    const data: PrMergeResult = {
+      number: 42,
+      merged: true,
+      method: "squash",
+      url: "https://github.com/owner/repo/pull/42",
+    };
+    expect(formatPrMerge(data)).toBe(
+      "Merged PR #42 via squash: https://github.com/owner/repo/pull/42",
+    );
+  });
+
+  it("formats merge result with rebase", () => {
+    const data: PrMergeResult = {
+      number: 7,
+      merged: true,
+      method: "rebase",
+      url: "https://github.com/owner/repo/pull/7",
+    };
+    expect(formatPrMerge(data)).toBe(
+      "Merged PR #7 via rebase: https://github.com/owner/repo/pull/7",
+    );
+  });
+
+  it("formats merge result with merge", () => {
+    const data: PrMergeResult = {
+      number: 100,
+      merged: true,
+      method: "merge",
+      url: "https://github.com/owner/repo/pull/100",
+    };
+    expect(formatPrMerge(data)).toBe(
+      "Merged PR #100 via merge: https://github.com/owner/repo/pull/100",
+    );
+  });
+});

--- a/packages/server-github/__tests__/security.test.ts
+++ b/packages/server-github/__tests__/security.test.ts
@@ -148,6 +148,23 @@ describe("security: run-list — branch validation", () => {
   });
 });
 
+describe("security: pr-merge — method enum validation", () => {
+  const methodSchema = z.enum(["squash", "merge", "rebase"]);
+
+  it("accepts valid merge methods", () => {
+    expect(methodSchema.safeParse("squash").success).toBe(true);
+    expect(methodSchema.safeParse("merge").success).toBe(true);
+    expect(methodSchema.safeParse("rebase").success).toBe(true);
+  });
+
+  it("rejects invalid merge methods", () => {
+    expect(methodSchema.safeParse("--exec=rm -rf /").success).toBe(false);
+    expect(methodSchema.safeParse("-v").success).toBe(false);
+    expect(methodSchema.safeParse("invalid").success).toBe(false);
+    expect(methodSchema.safeParse("").success).toBe(false);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Zod .max() input-limit constraints — GitHub tool schemas
 // ---------------------------------------------------------------------------

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -2,6 +2,7 @@ import type {
   PrViewResult,
   PrListResult,
   PrCreateResult,
+  PrMergeResult,
   IssueViewResult,
   IssueListResult,
   IssueCreateResult,
@@ -46,6 +47,11 @@ export function formatPrList(data: PrListResult): string {
 /** Formats structured PR create data into human-readable text. */
 export function formatPrCreate(data: PrCreateResult): string {
   return `Created PR #${data.number}: ${data.url}`;
+}
+
+/** Formats structured PR merge data into human-readable text. */
+export function formatPrMerge(data: PrMergeResult): string {
+  return `Merged PR #${data.number} via ${data.method}: ${data.url}`;
 }
 
 /** Formats structured issue view data into human-readable text. */

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -2,6 +2,7 @@ import type {
   PrViewResult,
   PrListResult,
   PrCreateResult,
+  PrMergeResult,
   IssueViewResult,
   IssueListResult,
   IssueCreateResult,
@@ -84,6 +85,16 @@ export function parsePrCreate(stdout: string): PrCreateResult {
   const match = url.match(/\/pull\/(\d+)$/);
   const number = match ? parseInt(match[1], 10) : 0;
   return { number, url };
+}
+
+/**
+ * Parses `gh pr merge` output into structured data.
+ * The gh CLI prints a confirmation message with the PR URL on success.
+ */
+export function parsePrMerge(stdout: string, number: number, method: string): PrMergeResult {
+  const urlMatch = stdout.match(/(https:\/\/github\.com\/[^\s]+\/pull\/\d+)/);
+  const url = urlMatch ? urlMatch[1] : "";
+  return { number, merged: true, method, url };
 }
 
 /**

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -54,6 +54,16 @@ export const PrCreateResultSchema = z.object({
 
 export type PrCreateResult = z.infer<typeof PrCreateResultSchema>;
 
+/** Zod schema for structured pr-merge output. */
+export const PrMergeResultSchema = z.object({
+  number: z.number(),
+  merged: z.boolean(),
+  method: z.string(),
+  url: z.string(),
+});
+
+export type PrMergeResult = z.infer<typeof PrMergeResultSchema>;
+
 // ── Issue schemas ────────────────────────────────────────────────────
 
 /** Zod schema for structured issue-view output. */

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -3,6 +3,7 @@ import { shouldRegisterTool } from "@paretools/shared";
 import { registerPrViewTool } from "./pr-view.js";
 import { registerPrListTool } from "./pr-list.js";
 import { registerPrCreateTool } from "./pr-create.js";
+import { registerPrMergeTool } from "./pr-merge.js";
 import { registerIssueViewTool } from "./issue-view.js";
 import { registerIssueListTool } from "./issue-list.js";
 import { registerIssueCreateTool } from "./issue-create.js";
@@ -14,6 +15,7 @@ export function registerAllTools(server: McpServer) {
   if (s("pr-view")) registerPrViewTool(server);
   if (s("pr-list")) registerPrListTool(server);
   if (s("pr-create")) registerPrCreateTool(server);
+  if (s("pr-merge")) registerPrMergeTool(server);
   if (s("issue-view")) registerIssueViewTool(server);
   if (s("issue-list")) registerIssueListTool(server);
   if (s("issue-create")) registerIssueCreateTool(server);

--- a/packages/server-github/src/tools/pr-merge.ts
+++ b/packages/server-github/src/tools/pr-merge.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parsePrMerge } from "../lib/parsers.js";
+import { formatPrMerge } from "../lib/formatters.js";
+import { PrMergeResultSchema } from "../schemas/index.js";
+
+export function registerPrMergeTool(server: McpServer) {
+  server.registerTool(
+    "pr-merge",
+    {
+      title: "PR Merge",
+      description:
+        "Merges a pull request by number. Returns structured data with merge status, method, and URL. Use instead of running `gh pr merge` in the terminal.",
+      inputSchema: {
+        number: z.number().describe("Pull request number"),
+        method: z
+          .enum(["squash", "merge", "rebase"])
+          .optional()
+          .default("squash")
+          .describe("Merge method (default: squash)"),
+        deleteBranch: z.boolean().optional().default(false).describe("Delete branch after merge"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: PrMergeResultSchema,
+    },
+    async ({ number, method, deleteBranch, path }) => {
+      const cwd = path || process.cwd();
+
+      const args = ["pr", "merge", String(number), `--${method}`];
+      if (deleteBranch) args.push("--delete-branch");
+
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh pr merge failed: ${result.stderr}`);
+      }
+
+      const data = parsePrMerge(result.stdout, number, method);
+      return dualOutput(data, formatPrMerge);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add new `pr-merge` tool to `@paretools/github` MCP server that wraps `gh pr merge`
- Supports configurable merge method (`squash` | `merge` | `rebase`, default: `squash`) and optional `--delete-branch`
- Returns structured output: `{ number, merged, method, url }`

## Changes
- **`src/schemas/index.ts`** — Added `PrMergeResultSchema` and `PrMergeResult` type
- **`src/lib/parsers.ts`** — Added `parsePrMerge()` to extract URL from gh CLI output
- **`src/lib/formatters.ts`** — Added `formatPrMerge()` for human-readable text
- **`src/tools/pr-merge.ts`** — New tool registration with input validation
- **`src/tools/index.ts`** — Wired up `registerPrMergeTool`
- **`__tests__/pr-merge.test.ts`** — Parser and formatter unit tests (8 tests)
- **`__tests__/security.test.ts`** — Enum validation security tests for `method` parameter

## Security
- `method` is a Zod enum — no flag injection possible
- `number` is numeric — no flag injection possible  
- `path` uses `.max(INPUT_LIMITS.PATH_MAX)` constraint

## Test plan
- [x] All 75 tests pass (`pnpm test` in server-github)
- [x] TypeScript build succeeds
- [x] Prettier formatting verified

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)