### PR TITLE
feat(github): add pr-comment and issue-comment tools

### DIFF
--- a/packages/server-github/__tests__/formatters.test.ts
+++ b/packages/server-github/__tests__/formatters.test.ts
@@ -3,6 +3,7 @@ import {
   formatPrView,
   formatPrList,
   formatPrCreate,
+  formatComment,
   formatIssueView,
   formatIssueList,
   formatIssueCreate,
@@ -25,6 +26,7 @@ import type {
   PrViewResult,
   PrListResult,
   PrCreateResult,
+  CommentResult,
   IssueViewResult,
   IssueListResult,
   IssueCreateResult,
@@ -155,6 +157,28 @@ describe("formatPrCreate", () => {
   it("formats PR create result", () => {
     const data: PrCreateResult = { number: 99, url: "https://github.com/owner/repo/pull/99" };
     expect(formatPrCreate(data)).toBe("Created PR #99: https://github.com/owner/repo/pull/99");
+  });
+});
+
+// ── Comment ──────────────────────────────────────────────────────────
+
+describe("formatComment", () => {
+  it("formats comment result for PR comment", () => {
+    const data: CommentResult = {
+      url: "https://github.com/owner/repo/pull/42#issuecomment-123456",
+    };
+    expect(formatComment(data)).toBe(
+      "Comment added: https://github.com/owner/repo/pull/42#issuecomment-123456",
+    );
+  });
+
+  it("formats comment result for issue comment", () => {
+    const data: CommentResult = {
+      url: "https://github.com/owner/repo/issues/15#issuecomment-789012",
+    };
+    expect(formatComment(data)).toBe(
+      "Comment added: https://github.com/owner/repo/issues/15#issuecomment-789012",
+    );
   });
 });
 

--- a/packages/server-github/__tests__/issue-comment.test.ts
+++ b/packages/server-github/__tests__/issue-comment.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { parseComment } from "../src/lib/parsers.js";
+import { formatComment } from "../src/lib/formatters.js";
+import type { CommentResult } from "../src/schemas/index.js";
+
+describe("parseComment (issue-comment)", () => {
+  it("parses comment URL from stdout", () => {
+    const result = parseComment("https://github.com/owner/repo/issues/15#issuecomment-789012\n");
+
+    expect(result.url).toBe("https://github.com/owner/repo/issues/15#issuecomment-789012");
+  });
+
+  it("handles URL without trailing newline", () => {
+    const result = parseComment("https://github.com/owner/repo/issues/1#issuecomment-1");
+    expect(result.url).toBe("https://github.com/owner/repo/issues/1#issuecomment-1");
+  });
+
+  it("handles empty output", () => {
+    const result = parseComment("");
+    expect(result.url).toBe("");
+  });
+
+  it("trims whitespace from output", () => {
+    const result = parseComment("  https://github.com/owner/repo/issues/5#issuecomment-555  \n");
+    expect(result.url).toBe("https://github.com/owner/repo/issues/5#issuecomment-555");
+  });
+});
+
+describe("formatComment (issue-comment)", () => {
+  it("formats comment result", () => {
+    const data: CommentResult = {
+      url: "https://github.com/owner/repo/issues/15#issuecomment-789012",
+    };
+    expect(formatComment(data)).toBe(
+      "Comment added: https://github.com/owner/repo/issues/15#issuecomment-789012",
+    );
+  });
+});

--- a/packages/server-github/__tests__/parsers.test.ts
+++ b/packages/server-github/__tests__/parsers.test.ts
@@ -3,6 +3,7 @@ import {
   parsePrView,
   parsePrList,
   parsePrCreate,
+  parseComment,
   parseIssueView,
   parseIssueList,
   parseIssueCreate,
@@ -174,6 +175,24 @@ describe("parsePrCreate", () => {
     const result = parsePrCreate("https://github.com/unknown-format");
     expect(result.number).toBe(0);
     expect(result.url).toBe("https://github.com/unknown-format");
+  });
+});
+
+describe("parseComment", () => {
+  it("parses comment URL from stdout", () => {
+    const result = parseComment("https://github.com/owner/repo/pull/42#issuecomment-123456\n");
+
+    expect(result.url).toBe("https://github.com/owner/repo/pull/42#issuecomment-123456");
+  });
+
+  it("handles URL without trailing newline", () => {
+    const result = parseComment("https://github.com/owner/repo/issues/1#issuecomment-1");
+    expect(result.url).toBe("https://github.com/owner/repo/issues/1#issuecomment-1");
+  });
+
+  it("handles empty output", () => {
+    const result = parseComment("");
+    expect(result.url).toBe("");
   });
 });
 

--- a/packages/server-github/__tests__/pr-comment.test.ts
+++ b/packages/server-github/__tests__/pr-comment.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { parseComment } from "../src/lib/parsers.js";
+import { formatComment } from "../src/lib/formatters.js";
+import type { CommentResult } from "../src/schemas/index.js";
+
+describe("parseComment (pr-comment)", () => {
+  it("parses comment URL from stdout", () => {
+    const result = parseComment("https://github.com/owner/repo/pull/42#issuecomment-123456\n");
+
+    expect(result.url).toBe("https://github.com/owner/repo/pull/42#issuecomment-123456");
+  });
+
+  it("handles URL without trailing newline", () => {
+    const result = parseComment("https://github.com/owner/repo/pull/1#issuecomment-1");
+    expect(result.url).toBe("https://github.com/owner/repo/pull/1#issuecomment-1");
+  });
+
+  it("handles empty output", () => {
+    const result = parseComment("");
+    expect(result.url).toBe("");
+  });
+
+  it("trims whitespace from output", () => {
+    const result = parseComment("  https://github.com/owner/repo/pull/10#issuecomment-999  \n");
+    expect(result.url).toBe("https://github.com/owner/repo/pull/10#issuecomment-999");
+  });
+});
+
+describe("formatComment (pr-comment)", () => {
+  it("formats comment result", () => {
+    const data: CommentResult = {
+      url: "https://github.com/owner/repo/pull/42#issuecomment-123456",
+    };
+    expect(formatComment(data)).toBe(
+      "Comment added: https://github.com/owner/repo/pull/42#issuecomment-123456",
+    );
+  });
+});

--- a/packages/server-github/__tests__/security.test.ts
+++ b/packages/server-github/__tests__/security.test.ts
@@ -148,6 +148,34 @@ describe("security: issue-close — comment validation", () => {
   });
 });
 
+describe("security: pr-comment — body validation", () => {
+  it("rejects flag-like body text", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "body")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe body text", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "body")).not.toThrow();
+    }
+  });
+});
+
+describe("security: issue-comment — body validation", () => {
+  it("rejects flag-like body text", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "body")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe body text", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "body")).not.toThrow();
+    }
+  });
+});
+
 describe("security: run-list — branch validation", () => {
   it("rejects flag-like branch names", () => {
     for (const malicious of MALICIOUS_INPUTS) {

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -3,6 +3,7 @@ import type {
   PrListResult,
   PrCreateResult,
   PrMergeResult,
+  CommentResult,
   IssueViewResult,
   IssueListResult,
   IssueCreateResult,
@@ -53,6 +54,11 @@ export function formatPrCreate(data: PrCreateResult): string {
 /** Formats structured PR merge data into human-readable text. */
 export function formatPrMerge(data: PrMergeResult): string {
   return `Merged PR #${data.number} via ${data.method}: ${data.url}`;
+}
+
+/** Formats structured comment result into human-readable text. */
+export function formatComment(data: CommentResult): string {
+  return `Comment added: ${data.url}`;
 }
 
 /** Formats structured issue view data into human-readable text. */

--- a/packages/server-github/src/lib/gh-runner.ts
+++ b/packages/server-github/src/lib/gh-runner.ts
@@ -1,5 +1,12 @@
 import { run, type RunResult } from "@paretools/shared";
 
-export async function ghCmd(args: string[], cwd?: string): Promise<RunResult> {
-  return run("gh", args, { cwd, timeout: 30_000 });
+export interface GhCmdOptions {
+  cwd?: string;
+  /** Data to write to the child process's stdin (e.g., for --body-file -). */
+  stdin?: string;
+}
+
+export async function ghCmd(args: string[], cwdOrOpts?: string | GhCmdOptions): Promise<RunResult> {
+  const opts = typeof cwdOrOpts === "string" ? { cwd: cwdOrOpts } : cwdOrOpts;
+  return run("gh", args, { cwd: opts?.cwd, timeout: 30_000, stdin: opts?.stdin });
 }

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -3,6 +3,7 @@ import type {
   PrListResult,
   PrCreateResult,
   PrMergeResult,
+  CommentResult,
   IssueViewResult,
   IssueListResult,
   IssueCreateResult,
@@ -96,6 +97,15 @@ export function parsePrMerge(stdout: string, number: number, method: string): Pr
   const urlMatch = stdout.match(/(https:\/\/github\.com\/[^\s]+\/pull\/\d+)/);
   const url = urlMatch ? urlMatch[1] : "";
   return { number, merged: true, method, url };
+}
+
+/**
+ * Parses `gh pr comment` / `gh issue comment` output into structured data.
+ * The gh CLI prints the new comment URL to stdout.
+ */
+export function parseComment(stdout: string): CommentResult {
+  const url = stdout.trim();
+  return { url };
 }
 
 /**

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -115,6 +115,15 @@ export const IssueCloseResultSchema = z.object({
 
 export type IssueCloseResult = z.infer<typeof IssueCloseResultSchema>;
 
+// ── Comment schemas (shared by pr-comment and issue-comment) ─────────
+
+/** Zod schema for structured comment result output. */
+export const CommentResultSchema = z.object({
+  url: z.string(),
+});
+
+export type CommentResult = z.infer<typeof CommentResultSchema>;
+
 // ── Run schemas ──────────────────────────────────────────────────────
 
 /** Zod schema for a single job in a workflow run. */

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -4,10 +4,12 @@ import { registerPrViewTool } from "./pr-view.js";
 import { registerPrListTool } from "./pr-list.js";
 import { registerPrCreateTool } from "./pr-create.js";
 import { registerPrMergeTool } from "./pr-merge.js";
+import { registerPrCommentTool } from "./pr-comment.js";
 import { registerIssueViewTool } from "./issue-view.js";
 import { registerIssueListTool } from "./issue-list.js";
 import { registerIssueCreateTool } from "./issue-create.js";
 import { registerIssueCloseTool } from "./issue-close.js";
+import { registerIssueCommentTool } from "./issue-comment.js";
 import { registerRunViewTool } from "./run-view.js";
 import { registerRunListTool } from "./run-list.js";
 
@@ -17,10 +19,12 @@ export function registerAllTools(server: McpServer) {
   if (s("pr-list")) registerPrListTool(server);
   if (s("pr-create")) registerPrCreateTool(server);
   if (s("pr-merge")) registerPrMergeTool(server);
+  if (s("pr-comment")) registerPrCommentTool(server);
   if (s("issue-view")) registerIssueViewTool(server);
   if (s("issue-list")) registerIssueListTool(server);
   if (s("issue-create")) registerIssueCreateTool(server);
   if (s("issue-close")) registerIssueCloseTool(server);
+  if (s("issue-comment")) registerIssueCommentTool(server);
   if (s("run-view")) registerRunViewTool(server);
   if (s("run-list")) registerRunListTool(server);
 }

--- a/packages/server-github/src/tools/issue-comment.ts
+++ b/packages/server-github/src/tools/issue-comment.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseComment } from "../lib/parsers.js";
+import { formatComment } from "../lib/formatters.js";
+import { CommentResultSchema } from "../schemas/index.js";
+
+export function registerIssueCommentTool(server: McpServer) {
+  server.registerTool(
+    "issue-comment",
+    {
+      title: "Issue Comment",
+      description:
+        "Adds a comment to an issue. Returns structured data with the comment URL. Use instead of running `gh issue comment` in the terminal.",
+      inputSchema: {
+        number: z.number().describe("Issue number"),
+        body: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Comment text"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+      },
+      outputSchema: CommentResultSchema,
+    },
+    async ({ number, body, path }) => {
+      const cwd = path || process.cwd();
+
+      assertNoFlagInjection(body, "body");
+
+      const args = ["issue", "comment", String(number), "--body-file", "-"];
+
+      const result = await ghCmd(args, { cwd, stdin: body });
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh issue comment failed: ${result.stderr}`);
+      }
+
+      const data = parseComment(result.stdout);
+      return dualOutput(data, formatComment);
+    },
+  );
+}

--- a/packages/server-github/src/tools/pr-comment.ts
+++ b/packages/server-github/src/tools/pr-comment.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseComment } from "../lib/parsers.js";
+import { formatComment } from "../lib/formatters.js";
+import { CommentResultSchema } from "../schemas/index.js";
+
+export function registerPrCommentTool(server: McpServer) {
+  server.registerTool(
+    "pr-comment",
+    {
+      title: "PR Comment",
+      description:
+        "Adds a comment to a pull request. Returns structured data with the comment URL. Use instead of running `gh pr comment` in the terminal.",
+      inputSchema: {
+        number: z.number().describe("Pull request number"),
+        body: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Comment text"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+      },
+      outputSchema: CommentResultSchema,
+    },
+    async ({ number, body, path }) => {
+      const cwd = path || process.cwd();
+
+      assertNoFlagInjection(body, "body");
+
+      const args = ["pr", "comment", String(number), "--body-file", "-"];
+
+      const result = await ghCmd(args, { cwd, stdin: body });
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh pr comment failed: ${result.stderr}`);
+      }
+
+      const data = parseComment(result.stdout);
+      return dualOutput(data, formatComment);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `pr-comment` tool that wraps `gh pr comment` to add comments to pull requests
- Adds `issue-comment` tool that wraps `gh issue comment` to add comments to issues
- Both tools pass comment body via stdin (`--body-file -`) to avoid shell metacharacter issues on Windows
- Shared `CommentResultSchema` returns the comment URL
- Updated `ghCmd` to accept `GhCmdOptions` with optional `stdin` field (backward-compatible)

Closes #246, closes #241

## Changes
| File | Change |
|---|---|
| `src/schemas/index.ts` | Added `CommentResultSchema` and `CommentResult` type |
| `src/lib/gh-runner.ts` | Added `GhCmdOptions` interface, updated `ghCmd` to accept stdin |
| `src/lib/parsers.ts` | Added `parseComment()` shared parser |
| `src/lib/formatters.ts` | Added `formatComment()` shared formatter |
| `src/tools/pr-comment.ts` | New tool registration |
| `src/tools/issue-comment.ts` | New tool registration |
| `src/tools/index.ts` | Registered both new tools |
| `__tests__/pr-comment.test.ts` | Parser/formatter tests for pr-comment |
| `__tests__/issue-comment.test.ts` | Parser/formatter tests for issue-comment |
| `__tests__/security.test.ts` | Security tests for body param flag injection |
| `__tests__/parsers.test.ts` | Added parseComment tests |
| `__tests__/formatters.test.ts` | Added formatComment tests |

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All 84 tests pass (`pnpm test` in server-github)
- [x] Security tests verify `assertNoFlagInjection` on body param
- [x] Parser tests cover URL parsing, empty output, whitespace trimming
- [x] Formatter tests cover both PR and issue comment formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)