### PR TITLE
feat(git): add reset tool — unstage files

### DIFF
--- a/packages/server-git/__tests__/formatters.test.ts
+++ b/packages/server-git/__tests__/formatters.test.ts
@@ -15,6 +15,7 @@ import {
   formatStash,
   formatRemote,
   formatBlame,
+  formatReset,
 } from "../src/lib/formatters.js";
 import type {
   GitStatus,
@@ -32,6 +33,7 @@ import type {
   GitStash,
   GitRemoteFull,
   GitBlameFull,
+  GitReset,
 } from "../src/schemas/index.js";
 
 describe("formatStatus", () => {
@@ -696,5 +698,22 @@ describe("formatBlame", () => {
   it("formats empty blame output", () => {
     const blame: GitBlameFull = { commits: [], file: "empty.ts", totalLines: 0 };
     expect(formatBlame(blame)).toBe("No blame data for empty.ts");
+  });
+});
+
+describe("formatReset", () => {
+  it("formats reset with unstaged files", () => {
+    const data: GitReset = { ref: "HEAD", unstaged: ["src/a.ts", "src/b.ts"] };
+    expect(formatReset(data)).toBe("Reset to HEAD: unstaged 2 file(s): src/a.ts, src/b.ts");
+  });
+
+  it("formats reset with no unstaged files", () => {
+    const data: GitReset = { ref: "HEAD", unstaged: [] };
+    expect(formatReset(data)).toBe("Reset to HEAD — no files unstaged");
+  });
+
+  it("formats reset with single file", () => {
+    const data: GitReset = { ref: "HEAD", unstaged: ["README.md"] };
+    expect(formatReset(data)).toBe("Reset to HEAD: unstaged 1 file(s): README.md");
   });
 });

--- a/packages/server-git/__tests__/parsers.test.ts
+++ b/packages/server-git/__tests__/parsers.test.ts
@@ -15,6 +15,7 @@ import {
   parseStashOutput,
   parseRemoteOutput,
   parseBlameOutput,
+  parseReset,
 } from "../src/lib/parsers.js";
 
 describe("parseStatus", () => {
@@ -692,5 +693,29 @@ describe("parseBlameOutput", () => {
     expect(result.file).toBe("empty-file.ts");
     expect(result.totalLines).toBe(0);
     expect(result.commits).toEqual([]);
+  });
+});
+
+describe("parseReset", () => {
+  it("parses unstaged files from reset output", () => {
+    const stdout = "Unstaged changes after reset:\nM\tsrc/index.ts\nM\tsrc/app.ts\n";
+    const result = parseReset(stdout, "", "HEAD");
+
+    expect(result.ref).toBe("HEAD");
+    expect(result.unstaged).toEqual(["src/index.ts", "src/app.ts"]);
+  });
+
+  it("handles empty output", () => {
+    const result = parseReset("", "", "HEAD");
+
+    expect(result.ref).toBe("HEAD");
+    expect(result.unstaged).toEqual([]);
+  });
+
+  it("parses output with various status types", () => {
+    const stdout = "Unstaged changes after reset:\nM\tmodified.ts\nD\tdeleted.ts\nA\tadded.ts\n";
+    const result = parseReset(stdout, "", "HEAD");
+
+    expect(result.unstaged).toEqual(["modified.ts", "deleted.ts", "added.ts"]);
   });
 });

--- a/packages/server-git/__tests__/reset.test.ts
+++ b/packages/server-git/__tests__/reset.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { parseReset } from "../src/lib/parsers.js";
+import { formatReset } from "../src/lib/formatters.js";
+import type { GitReset } from "../src/schemas/index.js";
+
+describe("parseReset", () => {
+  it("parses unstaged files from git reset output", () => {
+    const stdout = "Unstaged changes after reset:\nM\tsrc/index.ts\nM\tsrc/app.ts\n";
+
+    const result = parseReset(stdout, "", "HEAD");
+
+    expect(result.ref).toBe("HEAD");
+    expect(result.unstaged).toEqual(["src/index.ts", "src/app.ts"]);
+  });
+
+  it("parses deleted files from reset output", () => {
+    const stdout = "Unstaged changes after reset:\nD\told-file.ts\n";
+
+    const result = parseReset(stdout, "", "HEAD");
+
+    expect(result.ref).toBe("HEAD");
+    expect(result.unstaged).toEqual(["old-file.ts"]);
+  });
+
+  it("parses added files from reset output", () => {
+    const stdout = "Unstaged changes after reset:\nA\tnew-file.ts\n";
+
+    const result = parseReset(stdout, "", "HEAD");
+
+    expect(result.ref).toBe("HEAD");
+    expect(result.unstaged).toEqual(["new-file.ts"]);
+  });
+
+  it("handles empty output (nothing was staged)", () => {
+    const result = parseReset("", "", "HEAD");
+
+    expect(result.ref).toBe("HEAD");
+    expect(result.unstaged).toEqual([]);
+  });
+
+  it("handles output with no file lines", () => {
+    const result = parseReset("Unstaged changes after reset:\n", "", "HEAD");
+
+    expect(result.ref).toBe("HEAD");
+    expect(result.unstaged).toEqual([]);
+  });
+
+  it("uses the provided ref", () => {
+    const result = parseReset("", "", "abc1234");
+
+    expect(result.ref).toBe("abc1234");
+    expect(result.unstaged).toEqual([]);
+  });
+
+  it("parses mixed status types", () => {
+    const stdout = [
+      "Unstaged changes after reset:",
+      "M\tmodified.ts",
+      "D\tdeleted.ts",
+      "A\tadded.ts",
+    ].join("\n");
+
+    const result = parseReset(stdout, "", "HEAD");
+
+    expect(result.unstaged).toEqual(["modified.ts", "deleted.ts", "added.ts"]);
+  });
+
+  it("handles output in stderr (some git versions)", () => {
+    const stderr = "Unstaged changes after reset:\nM\tsrc/file.ts\n";
+
+    const result = parseReset("", stderr, "HEAD");
+
+    expect(result.unstaged).toEqual(["src/file.ts"]);
+  });
+});
+
+describe("formatReset", () => {
+  it("formats reset with unstaged files", () => {
+    const data: GitReset = { ref: "HEAD", unstaged: ["src/a.ts", "src/b.ts"] };
+    expect(formatReset(data)).toBe("Reset to HEAD: unstaged 2 file(s): src/a.ts, src/b.ts");
+  });
+
+  it("formats reset with no unstaged files", () => {
+    const data: GitReset = { ref: "HEAD", unstaged: [] };
+    expect(formatReset(data)).toBe("Reset to HEAD — no files unstaged");
+  });
+
+  it("formats reset with single unstaged file", () => {
+    const data: GitReset = { ref: "HEAD", unstaged: ["README.md"] };
+    expect(formatReset(data)).toBe("Reset to HEAD: unstaged 1 file(s): README.md");
+  });
+
+  it("formats reset with custom ref", () => {
+    const data: GitReset = { ref: "abc1234", unstaged: ["file.ts"] };
+    expect(formatReset(data)).toBe("Reset to abc1234: unstaged 1 file(s): file.ts");
+  });
+});

--- a/packages/server-git/__tests__/security.test.ts
+++ b/packages/server-git/__tests__/security.test.ts
@@ -214,6 +214,28 @@ describe("security: restore tool — files validation", () => {
   });
 });
 
+describe("security: reset tool — ref validation", () => {
+  it("rejects flag-like refs", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "ref")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: reset tool — files validation", () => {
+  it("rejects flag-like file paths", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "files")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe file paths", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "files")).not.toThrow();
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Zod .max() input-limit constraints — Git tool schemas
 // ---------------------------------------------------------------------------

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -15,6 +15,7 @@ import type {
   GitRemoteFull,
   GitBlameFull,
   GitRestore,
+  GitReset,
 } from "../schemas/index.js";
 
 /** Formats structured git status data into a human-readable summary string. */
@@ -106,6 +107,12 @@ export function formatRestore(r: GitRestore): string {
   const mode = r.staged ? "staged" : "working tree";
   const src = r.source !== "HEAD" ? ` from ${r.source}` : "";
   return `Restored ${r.restored.length} file(s) (${mode})${src}: ${r.restored.join(", ")}`;
+}
+
+/** Formats structured git reset data into a human-readable reset summary. */
+export function formatReset(r: GitReset): string {
+  if (r.unstaged.length === 0) return `Reset to ${r.ref} — no files unstaged`;
+  return `Reset to ${r.ref}: unstaged ${r.unstaged.length} file(s): ${r.unstaged.join(", ")}`;
 }
 
 // ── Compact types, mappers, and formatters ───────────────────────────

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -271,3 +271,11 @@ export const GitRestoreSchema = z.object({
 });
 
 export type GitRestore = z.infer<typeof GitRestoreSchema>;
+
+/** Zod schema for structured git reset output with ref and list of unstaged files. */
+export const GitResetSchema = z.object({
+  ref: z.string(),
+  unstaged: z.array(z.string()),
+});
+
+export type GitReset = z.infer<typeof GitResetSchema>;

--- a/packages/server-git/src/tools/index.ts
+++ b/packages/server-git/src/tools/index.ts
@@ -16,6 +16,7 @@ import { registerStashTool } from "./stash.js";
 import { registerRemoteTool } from "./remote.js";
 import { registerBlameTool } from "./blame.js";
 import { registerRestoreTool } from "./restore.js";
+import { registerResetTool } from "./reset.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("git", name);
@@ -35,4 +36,5 @@ export function registerAllTools(server: McpServer) {
   if (s("remote")) registerRemoteTool(server);
   if (s("blame")) registerBlameTool(server);
   if (s("restore")) registerRestoreTool(server);
+  if (s("reset")) registerResetTool(server);
 }

--- a/packages/server-git/src/tools/reset.ts
+++ b/packages/server-git/src/tools/reset.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseReset } from "../lib/parsers.js";
+import { formatReset } from "../lib/formatters.js";
+import { GitResetSchema } from "../schemas/index.js";
+
+export function registerResetTool(server: McpServer) {
+  server.registerTool(
+    "reset",
+    {
+      title: "Git Reset",
+      description:
+        "Unstages files by resetting them to a ref (default: HEAD). Returns structured data with the ref and list of unstaged files. Use instead of running `git reset` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        files: z
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("File paths to unstage (omit to unstage all)"),
+        ref: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .default("HEAD")
+          .describe("Ref to reset to (default: HEAD)"),
+      },
+      outputSchema: GitResetSchema,
+    },
+    async ({ path, files, ref }) => {
+      const cwd = path || process.cwd();
+
+      assertNoFlagInjection(ref, "ref");
+
+      // Build args: git reset <ref> -- [files...]
+      const args = ["reset", ref];
+
+      if (files && files.length > 0) {
+        for (const f of files) {
+          assertNoFlagInjection(f, "files");
+        }
+        args.push("--", ...files);
+      }
+
+      const result = await git(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`git reset failed: ${result.stderr}`);
+      }
+
+      const resetResult = parseReset(result.stdout, result.stderr, ref);
+      return dualOutput(resetResult, formatReset);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a new `reset` tool to `@paretools/git` that wraps `git reset HEAD -- <files>` to unstage files
- Returns structured JSON with `ref` (the ref reset to) and `unstaged` (list of files that were unstaged)
- Follows the exact patterns of existing tools (add, checkout, etc.) with full security validation

## Changes
- **`src/schemas/index.ts`** — Added `GitResetSchema` with `ref` (string) and `unstaged` (string[]) fields
- **`src/lib/parsers.ts`** — Added `parseReset()` that extracts unstaged file paths from git reset output (M/D/A tab-separated lines)
- **`src/lib/formatters.ts`** — Added `formatReset()` for human-readable output
- **`src/tools/reset.ts`** — New tool registration with `dualOutput()`, input validation via `assertNoFlagInjection` on both `ref` and `files` params, Zod `.max()` limits on all inputs
- **`src/tools/index.ts`** — Wired up the reset tool (now 16 tools total)
- **`__tests__/reset.test.ts`** — 12 unit tests for parser and formatter
- **`__tests__/security.test.ts`** — Security tests for flag injection on `ref` and `files` params
- **`__tests__/integration.test.ts`** — 4 integration tests: unstage single file, unstage all, flag-injection rejection for ref and files
- **`__tests__/parsers.test.ts`** and **`__tests__/formatters.test.ts`** — Added parseReset/formatReset to centralized test files

## Test plan
- [x] All 318 tests pass (12 new reset tests + 4 integration tests + security tests)
- [x] Build succeeds with `pnpm build`
- [x] Integration tests verify: stage a file, reset it, verify structured output
- [x] Flag injection blocked for `--hard`, `--force`, etc. on both `ref` and `files` params

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)