### PR TITLE
feat(github): add pr-review tool — submit PR review

### DIFF
--- a/packages/server-github/__tests__/pr-review.test.ts
+++ b/packages/server-github/__tests__/pr-review.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { parsePrReview } from "../src/lib/parsers.js";
+import { formatPrReview } from "../src/lib/formatters.js";
+import type { PrReviewResult } from "../src/schemas/index.js";
+
+// ── Parser tests ────────────────────────────────────────────────────
+
+describe("parsePrReview", () => {
+  it("parses approve review output with PR URL", () => {
+    const stdout = "✓ Approved pull request #42\nhttps://github.com/owner/repo/pull/42\n";
+
+    const result = parsePrReview(stdout, 42, "approve");
+
+    expect(result.number).toBe(42);
+    expect(result.event).toBe("approve");
+    expect(result.url).toBe("https://github.com/owner/repo/pull/42");
+  });
+
+  it("parses request-changes review output", () => {
+    const stdout = "✓ Requested changes to pull request #7\nhttps://github.com/owner/repo/pull/7\n";
+
+    const result = parsePrReview(stdout, 7, "request-changes");
+
+    expect(result.number).toBe(7);
+    expect(result.event).toBe("request-changes");
+    expect(result.url).toBe("https://github.com/owner/repo/pull/7");
+  });
+
+  it("parses comment review output", () => {
+    const stdout = "✓ Reviewed pull request #100\nhttps://github.com/owner/repo/pull/100\n";
+
+    const result = parsePrReview(stdout, 100, "comment");
+
+    expect(result.number).toBe(100);
+    expect(result.event).toBe("comment");
+    expect(result.url).toBe("https://github.com/owner/repo/pull/100");
+  });
+
+  it("handles output without URL", () => {
+    const stdout = "✓ Approved pull request #5\n";
+
+    const result = parsePrReview(stdout, 5, "approve");
+
+    expect(result.number).toBe(5);
+    expect(result.event).toBe("approve");
+    expect(result.url).toBe("");
+  });
+
+  it("preserves number and event from arguments", () => {
+    const stdout = "some unexpected output\n";
+
+    const result = parsePrReview(stdout, 99, "comment");
+
+    expect(result.number).toBe(99);
+    expect(result.event).toBe("comment");
+    expect(result.url).toBe("");
+  });
+});
+
+// ── Formatter tests ─────────────────────────────────────────────────
+
+describe("formatPrReview", () => {
+  it("formats approve review result", () => {
+    const data: PrReviewResult = {
+      number: 42,
+      event: "approve",
+      url: "https://github.com/owner/repo/pull/42",
+    };
+    expect(formatPrReview(data)).toBe(
+      "Reviewed PR #42 (approve): https://github.com/owner/repo/pull/42",
+    );
+  });
+
+  it("formats request-changes review result", () => {
+    const data: PrReviewResult = {
+      number: 7,
+      event: "request-changes",
+      url: "https://github.com/owner/repo/pull/7",
+    };
+    expect(formatPrReview(data)).toBe(
+      "Reviewed PR #7 (request-changes): https://github.com/owner/repo/pull/7",
+    );
+  });
+
+  it("formats comment review result", () => {
+    const data: PrReviewResult = {
+      number: 100,
+      event: "comment",
+      url: "https://github.com/owner/repo/pull/100",
+    };
+    expect(formatPrReview(data)).toBe(
+      "Reviewed PR #100 (comment): https://github.com/owner/repo/pull/100",
+    );
+  });
+});

--- a/packages/server-github/__tests__/security.test.ts
+++ b/packages/server-github/__tests__/security.test.ts
@@ -190,6 +190,37 @@ describe("security: run-list — branch validation", () => {
   });
 });
 
+describe("security: pr-review — body validation", () => {
+  it("rejects flag-like body values", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "body")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe body values", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "body")).not.toThrow();
+    }
+  });
+});
+
+describe("security: pr-review — event enum validation", () => {
+  const eventSchema = z.enum(["approve", "request-changes", "comment"]);
+
+  it("accepts valid review events", () => {
+    expect(eventSchema.safeParse("approve").success).toBe(true);
+    expect(eventSchema.safeParse("request-changes").success).toBe(true);
+    expect(eventSchema.safeParse("comment").success).toBe(true);
+  });
+
+  it("rejects invalid review events", () => {
+    expect(eventSchema.safeParse("--exec=rm -rf /").success).toBe(false);
+    expect(eventSchema.safeParse("-v").success).toBe(false);
+    expect(eventSchema.safeParse("invalid").success).toBe(false);
+    expect(eventSchema.safeParse("").success).toBe(false);
+  });
+});
+
 describe("security: pr-merge — method enum validation", () => {
   const methodSchema = z.enum(["squash", "merge", "rebase"]);
 

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -4,6 +4,7 @@ import type {
   PrCreateResult,
   PrMergeResult,
   CommentResult,
+  PrReviewResult,
   IssueViewResult,
   IssueListResult,
   IssueCreateResult,
@@ -59,6 +60,11 @@ export function formatPrMerge(data: PrMergeResult): string {
 /** Formats structured comment result into human-readable text. */
 export function formatComment(data: CommentResult): string {
   return `Comment added: ${data.url}`;
+}
+
+/** Formats structured PR review data into human-readable text. */
+export function formatPrReview(data: PrReviewResult): string {
+  return `Reviewed PR #${data.number} (${data.event}): ${data.url}`;
 }
 
 /** Formats structured issue view data into human-readable text. */

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -4,6 +4,7 @@ import type {
   PrCreateResult,
   PrMergeResult,
   CommentResult,
+  PrReviewResult,
   IssueViewResult,
   IssueListResult,
   IssueCreateResult,
@@ -106,6 +107,16 @@ export function parsePrMerge(stdout: string, number: number, method: string): Pr
 export function parseComment(stdout: string): CommentResult {
   const url = stdout.trim();
   return { url };
+}
+
+/**
+ * Parses `gh pr review` output into structured data.
+ * The gh CLI prints a confirmation message with the PR URL on success.
+ */
+export function parsePrReview(stdout: string, number: number, event: string): PrReviewResult {
+  const urlMatch = stdout.match(/(https:\/\/github\.com\/[^\s]+\/pull\/\d+)/);
+  const url = urlMatch ? urlMatch[1] : "";
+  return { number, event, url };
 }
 
 /**

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -64,6 +64,15 @@ export const PrMergeResultSchema = z.object({
 
 export type PrMergeResult = z.infer<typeof PrMergeResultSchema>;
 
+/** Zod schema for structured pr-review output. */
+export const PrReviewResultSchema = z.object({
+  number: z.number(),
+  event: z.string(),
+  url: z.string(),
+});
+
+export type PrReviewResult = z.infer<typeof PrReviewResultSchema>;
+
 // ── Issue schemas ────────────────────────────────────────────────────
 
 /** Zod schema for structured issue-view output. */

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -5,6 +5,7 @@ import { registerPrListTool } from "./pr-list.js";
 import { registerPrCreateTool } from "./pr-create.js";
 import { registerPrMergeTool } from "./pr-merge.js";
 import { registerPrCommentTool } from "./pr-comment.js";
+import { registerPrReviewTool } from "./pr-review.js";
 import { registerIssueViewTool } from "./issue-view.js";
 import { registerIssueListTool } from "./issue-list.js";
 import { registerIssueCreateTool } from "./issue-create.js";
@@ -20,6 +21,7 @@ export function registerAllTools(server: McpServer) {
   if (s("pr-create")) registerPrCreateTool(server);
   if (s("pr-merge")) registerPrMergeTool(server);
   if (s("pr-comment")) registerPrCommentTool(server);
+  if (s("pr-review")) registerPrReviewTool(server);
   if (s("issue-view")) registerIssueViewTool(server);
   if (s("issue-list")) registerIssueListTool(server);
   if (s("issue-create")) registerIssueCreateTool(server);

--- a/packages/server-github/src/tools/pr-review.ts
+++ b/packages/server-github/src/tools/pr-review.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parsePrReview } from "../lib/parsers.js";
+import { formatPrReview } from "../lib/formatters.js";
+import { PrReviewResultSchema } from "../schemas/index.js";
+
+export function registerPrReviewTool(server: McpServer) {
+  server.registerTool(
+    "pr-review",
+    {
+      title: "PR Review",
+      description:
+        "Submits a review on a pull request (approve, request-changes, or comment). Returns structured data with the review event and URL. Use instead of running `gh pr review` in the terminal.",
+      inputSchema: {
+        number: z.number().describe("Pull request number"),
+        event: z
+          .enum(["approve", "request-changes", "comment"])
+          .describe("Review type: approve, request-changes, or comment"),
+        body: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Review body (required for request-changes and comment)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+      },
+      outputSchema: PrReviewResultSchema,
+    },
+    async ({ number, event, body, path }) => {
+      const cwd = path || process.cwd();
+
+      if (body) {
+        assertNoFlagInjection(body, "body");
+      }
+
+      // request-changes and comment require a body
+      if ((event === "request-changes" || event === "comment") && !body) {
+        throw new Error(`Review body is required for "${event}" reviews.`);
+      }
+
+      const args = ["pr", "review", String(number), `--${event}`];
+
+      // Pass body via stdin (--body-file -) to avoid shell escaping issues
+      let stdin: string | undefined;
+      if (body) {
+        args.push("--body-file", "-");
+        stdin = body;
+      }
+
+      const result = await ghCmd(args, { cwd, stdin });
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh pr review failed: ${result.stderr}`);
+      }
+
+      const data = parsePrReview(result.stdout, number, event);
+      return dualOutput(data, formatPrReview);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a new `pr-review` tool to `@paretools/github` that wraps `gh pr review` to submit PR reviews (approve, request-changes, comment)
- Passes review body via stdin (`--body-file -`) to avoid shell escaping issues on Windows
- Extends `ghCmd` helper to support optional stdin parameter
- Includes full test coverage: parser tests (5), formatter tests (3), and security tests (4)

## Changes
- **Schema**: `PrReviewResultSchema` with `number`, `event`, `url` fields
- **Parser**: `parsePrReview` extracts PR URL from `gh` CLI output
- **Formatter**: `formatPrReview` produces human-readable text
- **Tool**: `pr-review.ts` with input validation (`assertNoFlagInjection` on body, Zod enum on event)
- **gh-runner**: Extended `ghCmd` to accept optional `stdin` parameter
- **Registration**: Added to `tools/index.ts` with `shouldRegisterTool` filter

Closes #238

## Test plan
- [x] Parser tests: approve, request-changes, comment, missing URL, unexpected output
- [x] Formatter tests: approve, request-changes, comment
- [x] Security tests: flag injection on body, enum validation on event
- [x] Build passes (`tsc`)
- [x] All 96 tests pass (12 new + 84 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)