### PR TITLE
feat(git): add cherry-pick tool — apply specific commits

### DIFF
--- a/packages/server-git/__tests__/cherry-pick.test.ts
+++ b/packages/server-git/__tests__/cherry-pick.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { assertNoFlagInjection } from "@paretools/shared";
+import { parseCherryPick } from "../src/lib/parsers.js";
+import { formatCherryPick } from "../src/lib/formatters.js";
+import type { GitCherryPick } from "../src/schemas/index.js";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const SERVER_PATH = resolve(__dirname, "../dist/index.js");
+
+// ── Parser tests ─────────────────────────────────────────────────────
+
+describe("parseCherryPick", () => {
+  it("parses successful single-commit cherry-pick", () => {
+    const result = parseCherryPick(
+      "[main abc1234] Cherry-picked commit\n 1 file changed, 2 insertions(+)",
+      "",
+      0,
+      ["abc1234"],
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.applied).toEqual(["abc1234"]);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("parses successful multi-commit cherry-pick", () => {
+    const result = parseCherryPick("some output", "", 0, ["abc1234", "def5678", "ghi9012"]);
+
+    expect(result.success).toBe(true);
+    expect(result.applied).toEqual(["abc1234", "def5678", "ghi9012"]);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("parses cherry-pick with conflicts", () => {
+    const stderr = [
+      "error: could not apply abc1234... Fix bug",
+      "CONFLICT (content): Merge conflict in src/index.ts",
+      "CONFLICT (content): Merge conflict in src/utils.ts",
+    ].join("\n");
+
+    const result = parseCherryPick("", stderr, 1, ["abc1234"]);
+
+    expect(result.success).toBe(false);
+    expect(result.applied).toEqual([]);
+    expect(result.conflicts).toEqual(["src/index.ts", "src/utils.ts"]);
+  });
+
+  it("parses abort result", () => {
+    const result = parseCherryPick("", "cherry-pick abort", 0, []);
+
+    expect(result.success).toBe(true);
+    expect(result.applied).toEqual([]);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("parses no-commit cherry-pick (exit 0)", () => {
+    const result = parseCherryPick("", "", 0, ["abc1234"]);
+
+    expect(result.success).toBe(true);
+    expect(result.applied).toEqual(["abc1234"]);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("handles non-zero exit code without conflicts", () => {
+    const result = parseCherryPick("", "fatal: bad revision 'nonexistent'", 128, ["nonexistent"]);
+
+    expect(result.success).toBe(false);
+    expect(result.applied).toEqual([]);
+    expect(result.conflicts).toEqual([]);
+  });
+});
+
+// ── Formatter tests ──────────────────────────────────────────────────
+
+describe("formatCherryPick", () => {
+  it("formats successful single-commit cherry-pick", () => {
+    const data: GitCherryPick = {
+      success: true,
+      applied: ["abc1234"],
+      conflicts: [],
+    };
+    const output = formatCherryPick(data);
+
+    expect(output).toBe("Cherry-pick applied 1 commit(s): abc1234");
+  });
+
+  it("formats successful multi-commit cherry-pick", () => {
+    const data: GitCherryPick = {
+      success: true,
+      applied: ["abc1234", "def5678"],
+      conflicts: [],
+    };
+    const output = formatCherryPick(data);
+
+    expect(output).toBe("Cherry-pick applied 2 commit(s): abc1234, def5678");
+  });
+
+  it("formats cherry-pick with conflicts", () => {
+    const data: GitCherryPick = {
+      success: false,
+      applied: [],
+      conflicts: ["src/index.ts", "src/utils.ts"],
+    };
+    const output = formatCherryPick(data);
+
+    expect(output).toContain("Cherry-pick paused due to conflicts:");
+    expect(output).toContain("CONFLICT: src/index.ts");
+    expect(output).toContain("CONFLICT: src/utils.ts");
+  });
+
+  it("formats failed cherry-pick without conflicts", () => {
+    const data: GitCherryPick = {
+      success: false,
+      applied: [],
+      conflicts: [],
+    };
+    const output = formatCherryPick(data);
+
+    expect(output).toBe("Cherry-pick failed");
+  });
+
+  it("formats abort (no commits applied)", () => {
+    const data: GitCherryPick = {
+      success: true,
+      applied: [],
+      conflicts: [],
+    };
+    const output = formatCherryPick(data);
+
+    expect(output).toBe("Cherry-pick completed (no commits applied)");
+  });
+});
+
+// ── Security tests ───────────────────────────────────────────────────
+
+describe("security: cherry-pick tool — commits validation", () => {
+  const MALICIOUS_INPUTS = [
+    "--force",
+    "--amend",
+    "-rf",
+    "--no-verify",
+    "--exec=rm -rf /",
+    "-u",
+    "--delete",
+    "--hard",
+    "--output=/etc/passwd",
+    "-D",
+    "--set-upstream",
+    "--all",
+    "-m",
+    " --force",
+    "\t--delete",
+    "   -rf",
+  ];
+
+  it("rejects flag-like commit hashes", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "commits")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe commit hashes", () => {
+    const safeInputs = [
+      "abc1234",
+      "abc1234567890abcdef1234567890abcdef123456",
+      "HEAD",
+      "HEAD~3",
+      "main",
+      "feature/test",
+    ];
+    for (const safe of safeInputs) {
+      expect(() => assertNoFlagInjection(safe, "commits")).not.toThrow();
+    }
+  });
+});
+
+// ── Integration tests ────────────────────────────────────────────────
+
+describe("@paretools/git cherry-pick integration", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+  let tempDir: string;
+
+  function gitInTemp(args: string[]) {
+    return execFileSync("git", args, {
+      cwd: tempDir,
+      encoding: "utf-8",
+    });
+  }
+
+  beforeAll(async () => {
+    // Create a temp repo with an initial commit
+    tempDir = mkdtempSync(join(tmpdir(), "pare-git-cherrypick-"));
+    gitInTemp(["init"]);
+    gitInTemp(["config", "user.email", "test@pare.dev"]);
+    gitInTemp(["config", "user.name", "Pare Cherry-Pick Test"]);
+    writeFileSync(join(tempDir, "initial.txt"), "hello\n");
+    gitInTemp(["add", "."]);
+    gitInTemp(["commit", "-m", "Initial commit"]);
+
+    // Create a second commit on a side branch to cherry-pick from
+    gitInTemp(["checkout", "-b", "feature-branch"]);
+    writeFileSync(join(tempDir, "feature.txt"), "feature content\n");
+    gitInTemp(["add", "feature.txt"]);
+    gitInTemp(["commit", "-m", "Add feature file"]);
+
+    // Create a third commit on the side branch
+    writeFileSync(join(tempDir, "feature2.txt"), "feature2 content\n");
+    gitInTemp(["add", "feature2.txt"]);
+    gitInTemp(["commit", "-m", "Add second feature file"]);
+
+    // Switch back to the default branch
+    // Get the default branch name (could be main or master)
+    const branches = gitInTemp(["branch"]).trim().split("\n");
+    const defaultBranch = branches
+      .find((b) => !b.includes("feature-branch"))
+      ?.replace("*", "")
+      .trim();
+    if (defaultBranch) {
+      gitInTemp(["checkout", defaultBranch]);
+    }
+
+    // Spawn the MCP server
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [SERVER_PATH],
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "test-client-cherry-pick", version: "1.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await transport.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("cherry-picks a single commit from another branch", async () => {
+    // Get the hash of the first feature commit
+    const logOutput = gitInTemp(["log", "feature-branch", "--oneline"]);
+    const lines = logOutput.trim().replace(/\r\n/g, "\n").split("\n");
+    // The second-to-last line is "Add feature file" (first feature commit)
+    const featureCommitLine = lines.find((l) => l.includes("Add feature file"));
+    const commitHash = featureCommitLine?.split(" ")[0];
+    expect(commitHash).toBeDefined();
+
+    const result = await client.callTool({
+      name: "cherry-pick",
+      arguments: { path: tempDir, commits: [commitHash!] },
+    });
+
+    expect(result.content).toBeDefined();
+    expect(Array.isArray(result.content)).toBe(true);
+
+    const sc = result.structuredContent as Record<string, unknown>;
+    expect(sc).toBeDefined();
+    expect(sc.success).toBe(true);
+    expect(Array.isArray(sc.applied)).toBe(true);
+    expect((sc.applied as string[]).length).toBe(1);
+    expect(sc.conflicts).toEqual([]);
+  });
+
+  it("cherry-picks with noCommit flag", async () => {
+    // Get the hash of the second feature commit
+    const logOutput = gitInTemp(["log", "feature-branch", "--oneline"]);
+    const lines = logOutput.trim().replace(/\r\n/g, "\n").split("\n");
+    const featureCommitLine = lines.find((l) => l.includes("Add second feature file"));
+    const commitHash = featureCommitLine?.split(" ")[0];
+    expect(commitHash).toBeDefined();
+
+    const result = await client.callTool({
+      name: "cherry-pick",
+      arguments: { path: tempDir, commits: [commitHash!], noCommit: true },
+    });
+
+    const sc = result.structuredContent as Record<string, unknown>;
+    expect(sc).toBeDefined();
+    expect(sc.success).toBe(true);
+    expect(sc.conflicts).toEqual([]);
+
+    // Clean up the staged changes
+    gitInTemp(["checkout", "--", "."]);
+    gitInTemp(["clean", "-fd"]);
+  });
+
+  it("rejects flag-injection in commits", async () => {
+    const result = await client.callTool({
+      name: "cherry-pick",
+      arguments: { path: tempDir, commits: ["--force"] },
+    });
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("rejects empty commits array when not using abort/continue", async () => {
+    const result = await client.callTool({
+      name: "cherry-pick",
+      arguments: { path: tempDir, commits: [] },
+    });
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("lists cherry-pick in available tools", async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("cherry-pick");
+  });
+});

--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -38,6 +38,7 @@ describe("@paretools/git integration", () => {
       "blame",
       "branch",
       "checkout",
+      "cherry-pick",
       "commit",
       "diff",
       "log",

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -16,6 +16,7 @@ import type {
   GitBlameFull,
   GitRestore,
   GitReset,
+  GitCherryPick,
 } from "../schemas/index.js";
 
 /** Formats structured git status data into a human-readable summary string. */
@@ -372,4 +373,20 @@ function compressLineRanges(nums: number[]): string {
 export function formatBlameCompact(b: GitBlameCompact): string {
   if (b.totalLines === 0) return `No blame data for ${b.file}`;
   return b.commits.map((c) => `${c.hash}: lines ${compressLineRanges(c.lines)}`).join("\n");
+}
+
+// ── Cherry-pick formatters ───────────────────────────────────────────
+
+/** Formats structured git cherry-pick data into a human-readable summary. */
+export function formatCherryPick(cp: GitCherryPick): string {
+  if (!cp.success && cp.conflicts.length > 0) {
+    return `Cherry-pick paused due to conflicts:\n${cp.conflicts.map((f) => `  CONFLICT: ${f}`).join("\n")}`;
+  }
+  if (!cp.success) {
+    return "Cherry-pick failed";
+  }
+  if (cp.applied.length === 0) {
+    return "Cherry-pick completed (no commits applied)";
+  }
+  return `Cherry-pick applied ${cp.applied.length} commit(s): ${cp.applied.join(", ")}`;
 }

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -279,3 +279,12 @@ export const GitResetSchema = z.object({
 });
 
 export type GitReset = z.infer<typeof GitResetSchema>;
+
+/** Zod schema for structured git cherry-pick output with applied commits and conflict list. */
+export const GitCherryPickSchema = z.object({
+  success: z.boolean(),
+  applied: z.array(z.string()),
+  conflicts: z.array(z.string()),
+});
+
+export type GitCherryPick = z.infer<typeof GitCherryPickSchema>;

--- a/packages/server-git/src/tools/cherry-pick.ts
+++ b/packages/server-git/src/tools/cherry-pick.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseCherryPick } from "../lib/parsers.js";
+import { formatCherryPick } from "../lib/formatters.js";
+import { GitCherryPickSchema } from "../schemas/index.js";
+
+export function registerCherryPickTool(server: McpServer) {
+  server.registerTool(
+    "cherry-pick",
+    {
+      title: "Git Cherry-Pick",
+      description:
+        "Applies specific commits to the current branch. Returns structured data with applied commits and any conflicts. Use instead of running `git cherry-pick` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        commits: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .default([])
+          .describe("Commit hashes to cherry-pick"),
+        abort: z.boolean().optional().default(false).describe("Abort in-progress cherry-pick"),
+        continue: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Continue after resolving conflicts"),
+        noCommit: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Apply changes without committing (-n)"),
+      },
+      outputSchema: GitCherryPickSchema,
+    },
+    async (input) => {
+      const cwd = input.path || process.cwd();
+      const commits = input.commits;
+      const abort = input.abort;
+      const cont = input.continue;
+      const noCommit = input.noCommit;
+
+      // Handle abort
+      if (abort) {
+        const result = await git(["cherry-pick", "--abort"], cwd);
+        if (result.exitCode !== 0) {
+          throw new Error(`git cherry-pick --abort failed: ${result.stderr}`);
+        }
+        const parsed = parseCherryPick(result.stdout, result.stderr, result.exitCode, []);
+        return dualOutput(parsed, formatCherryPick);
+      }
+
+      // Handle continue
+      if (cont) {
+        const result = await git(["cherry-pick", "--continue"], cwd);
+        const parsed = parseCherryPick(result.stdout, result.stderr, result.exitCode, commits);
+        if (result.exitCode !== 0 && parsed.conflicts.length === 0) {
+          throw new Error(`git cherry-pick --continue failed: ${result.stderr}`);
+        }
+        return dualOutput(parsed, formatCherryPick);
+      }
+
+      // Validate commits
+      if (commits.length === 0) {
+        throw new Error("commits array is required when not using abort or continue");
+      }
+
+      for (const c of commits) {
+        assertNoFlagInjection(c, "commits");
+      }
+
+      // Build cherry-pick args
+      const args = ["cherry-pick"];
+      if (noCommit) args.push("-n");
+      args.push(...commits);
+
+      const result = await git(args, cwd);
+
+      // On conflicts, do NOT throw — return success: false with conflict list
+      const parsed = parseCherryPick(result.stdout, result.stderr, result.exitCode, commits);
+      if (result.exitCode !== 0 && parsed.conflicts.length === 0) {
+        throw new Error(`git cherry-pick failed: ${result.stderr}`);
+      }
+
+      return dualOutput(parsed, formatCherryPick);
+    },
+  );
+}

--- a/packages/server-git/src/tools/index.ts
+++ b/packages/server-git/src/tools/index.ts
@@ -17,6 +17,7 @@ import { registerRemoteTool } from "./remote.js";
 import { registerBlameTool } from "./blame.js";
 import { registerRestoreTool } from "./restore.js";
 import { registerResetTool } from "./reset.js";
+import { registerCherryPickTool } from "./cherry-pick.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("git", name);
@@ -37,4 +38,5 @@ export function registerAllTools(server: McpServer) {
   if (s("blame")) registerBlameTool(server);
   if (s("restore")) registerRestoreTool(server);
   if (s("reset")) registerResetTool(server);
+  if (s("cherry-pick")) registerCherryPickTool(server);
 }


### PR DESCRIPTION
## Summary
- Adds a new `cherry-pick` tool to `@paretools/git` that wraps `git cherry-pick` with structured JSON output
- Supports applying one or more commits, `--abort`, `--continue`, and `-n` (noCommit) flags
- On conflicts, returns `success: false` with a conflict file list instead of throwing, following the same pattern as the `pull` tool

## Implementation
- **Schema**: `GitCherryPickSchema` — `{ success, applied[], conflicts[] }`
- **Parser**: `parseCherryPick()` — detects conflicts via `CONFLICT` pattern in stderr, handles abort/continue/success/failure modes
- **Formatter**: `formatCherryPick()` — human-readable summary
- **Tool**: `cherry-pick` registered in tools/index.ts with full input validation
- **Security**: `assertNoFlagInjection()` on each commit hash; Zod `.max()` on all inputs

## Testing (18 new tests)
- Parser: single commit, multi-commit, conflict detection, abort, no-commit, non-zero exit without conflicts
- Formatter: all output variants (success, conflicts, failure, abort)
- Security: flag-injection rejection and safe input acceptance
- Integration: cherry-pick from another branch, noCommit flag, flag-injection rejection, empty commits validation, tool listing

Closes #237

## Test plan
- [x] All 311 existing tests pass
- [x] 18 new cherry-pick tests pass
- [x] TypeScript type-checks cleanly (0 errors)
- [x] Integration tests verify MCP server lists 16 tools (was 15)
- [x] CRLF normalized in integration tests for Windows compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)