### PR TITLE
feat(github): add pr-update and issue-update tools

### DIFF
--- a/packages/server-github/__tests__/issue-update.test.ts
+++ b/packages/server-github/__tests__/issue-update.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { parseIssueUpdate } from "../src/lib/parsers.js";
+import { formatIssueUpdate } from "../src/lib/formatters.js";
+import type { EditResult } from "../src/schemas/index.js";
+
+// -- Parser tests -------------------------------------------------------------
+
+describe("parseIssueUpdate", () => {
+  it("parses issue edit URL output", () => {
+    const stdout = "https://github.com/owner/repo/issues/42\n";
+    const result = parseIssueUpdate(stdout, 42);
+
+    expect(result.number).toBe(42);
+    expect(result.url).toBe("https://github.com/owner/repo/issues/42");
+  });
+
+  it("handles URL without trailing newline", () => {
+    const result = parseIssueUpdate("https://github.com/owner/repo/issues/7", 7);
+
+    expect(result.number).toBe(7);
+    expect(result.url).toBe("https://github.com/owner/repo/issues/7");
+  });
+
+  it("preserves the issue number from the argument", () => {
+    const result = parseIssueUpdate("https://github.com/owner/repo/issues/99\n", 99);
+
+    expect(result.number).toBe(99);
+  });
+
+  it("returns empty URL when no URL found in output", () => {
+    const result = parseIssueUpdate("Edited issue #5\n", 5);
+
+    expect(result.number).toBe(5);
+    expect(result.url).toBe("");
+  });
+
+  it("extracts URL from multiline output", () => {
+    const stdout = "Updated title\nhttps://github.com/owner/repo/issues/10\nDone.\n";
+    const result = parseIssueUpdate(stdout, 10);
+
+    expect(result.url).toBe("https://github.com/owner/repo/issues/10");
+  });
+});
+
+// -- Formatter tests ----------------------------------------------------------
+
+describe("formatIssueUpdate", () => {
+  it("formats issue update result", () => {
+    const data: EditResult = {
+      number: 42,
+      url: "https://github.com/owner/repo/issues/42",
+    };
+    expect(formatIssueUpdate(data)).toBe(
+      "Updated issue #42: https://github.com/owner/repo/issues/42",
+    );
+  });
+
+  it("formats issue update result with different number", () => {
+    const data: EditResult = {
+      number: 1,
+      url: "https://github.com/owner/repo/issues/1",
+    };
+    expect(formatIssueUpdate(data)).toBe(
+      "Updated issue #1: https://github.com/owner/repo/issues/1",
+    );
+  });
+});

--- a/packages/server-github/__tests__/pr-update.test.ts
+++ b/packages/server-github/__tests__/pr-update.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { parsePrUpdate } from "../src/lib/parsers.js";
+import { formatPrUpdate } from "../src/lib/formatters.js";
+import type { EditResult } from "../src/schemas/index.js";
+
+// -- Parser tests -------------------------------------------------------------
+
+describe("parsePrUpdate", () => {
+  it("parses PR edit URL output", () => {
+    const stdout = "https://github.com/owner/repo/pull/42\n";
+    const result = parsePrUpdate(stdout, 42);
+
+    expect(result.number).toBe(42);
+    expect(result.url).toBe("https://github.com/owner/repo/pull/42");
+  });
+
+  it("handles URL without trailing newline", () => {
+    const result = parsePrUpdate("https://github.com/owner/repo/pull/7", 7);
+
+    expect(result.number).toBe(7);
+    expect(result.url).toBe("https://github.com/owner/repo/pull/7");
+  });
+
+  it("preserves the PR number from the argument", () => {
+    const result = parsePrUpdate("https://github.com/owner/repo/pull/99\n", 99);
+
+    expect(result.number).toBe(99);
+  });
+
+  it("returns empty URL when no URL found in output", () => {
+    const result = parsePrUpdate("Edited pull request #5\n", 5);
+
+    expect(result.number).toBe(5);
+    expect(result.url).toBe("");
+  });
+
+  it("extracts URL from multiline output", () => {
+    const stdout = "Updated title\nhttps://github.com/owner/repo/pull/10\nDone.\n";
+    const result = parsePrUpdate(stdout, 10);
+
+    expect(result.url).toBe("https://github.com/owner/repo/pull/10");
+  });
+});
+
+// -- Formatter tests ----------------------------------------------------------
+
+describe("formatPrUpdate", () => {
+  it("formats PR update result", () => {
+    const data: EditResult = {
+      number: 42,
+      url: "https://github.com/owner/repo/pull/42",
+    };
+    expect(formatPrUpdate(data)).toBe("Updated PR #42: https://github.com/owner/repo/pull/42");
+  });
+
+  it("formats PR update result with different number", () => {
+    const data: EditResult = {
+      number: 1,
+      url: "https://github.com/owner/repo/pull/1",
+    };
+    expect(formatPrUpdate(data)).toBe("Updated PR #1: https://github.com/owner/repo/pull/1");
+  });
+});

--- a/packages/server-github/__tests__/security.test.ts
+++ b/packages/server-github/__tests__/security.test.ts
@@ -176,6 +176,88 @@ describe("security: issue-comment — body validation", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// pr-update / issue-update security tests
+// ---------------------------------------------------------------------------
+
+describe("security: pr-update — title validation", () => {
+  it("rejects flag-like titles", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "title")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe titles", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "title")).not.toThrow();
+    }
+  });
+});
+
+describe("security: pr-update / issue-update — addLabels validation", () => {
+  it("rejects flag-like labels in addLabels", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "addLabels")).toThrow(
+        /must not start with "-"/,
+      );
+    }
+  });
+
+  it("accepts safe labels in addLabels", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "addLabels")).not.toThrow();
+    }
+  });
+});
+
+describe("security: pr-update / issue-update — removeLabels validation", () => {
+  it("rejects flag-like labels in removeLabels", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "removeLabels")).toThrow(
+        /must not start with "-"/,
+      );
+    }
+  });
+
+  it("accepts safe labels in removeLabels", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "removeLabels")).not.toThrow();
+    }
+  });
+});
+
+describe("security: pr-update / issue-update — addAssignees validation", () => {
+  it("rejects flag-like assignees in addAssignees", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "addAssignees")).toThrow(
+        /must not start with "-"/,
+      );
+    }
+  });
+
+  it("accepts safe assignees in addAssignees", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "addAssignees")).not.toThrow();
+    }
+  });
+});
+
+describe("security: pr-update / issue-update — removeAssignees validation", () => {
+  it("rejects flag-like assignees in removeAssignees", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "removeAssignees")).toThrow(
+        /must not start with "-"/,
+      );
+    }
+  });
+
+  it("accepts safe assignees in removeAssignees", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "removeAssignees")).not.toThrow();
+    }
+  });
+});
+
 describe("security: run-list — branch validation", () => {
   it("rejects flag-like branch names", () => {
     for (const malicious of MALICIOUS_INPUTS) {

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -5,6 +5,7 @@ import type {
   PrMergeResult,
   CommentResult,
   PrReviewResult,
+  EditResult,
   IssueViewResult,
   IssueListResult,
   IssueCreateResult,
@@ -67,6 +68,11 @@ export function formatPrReview(data: PrReviewResult): string {
   return `Reviewed PR #${data.number} (${data.event}): ${data.url}`;
 }
 
+/** Formats structured PR update data into human-readable text. */
+export function formatPrUpdate(data: EditResult): string {
+  return `Updated PR #${data.number}: ${data.url}`;
+}
+
 /** Formats structured issue view data into human-readable text. */
 export function formatIssueView(data: IssueViewResult): string {
   const lines = [
@@ -106,6 +112,11 @@ export function formatIssueCreate(data: IssueCreateResult): string {
 /** Formats structured issue close data into human-readable text. */
 export function formatIssueClose(data: IssueCloseResult): string {
   return `Closed issue #${data.number}: ${data.url}`;
+}
+
+/** Formats structured issue update data into human-readable text. */
+export function formatIssueUpdate(data: EditResult): string {
+  return `Updated issue #${data.number}: ${data.url}`;
 }
 
 /** Formats structured run view data into human-readable text. */

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -5,6 +5,7 @@ import type {
   PrMergeResult,
   CommentResult,
   PrReviewResult,
+  EditResult,
   IssueViewResult,
   IssueListResult,
   IssueCreateResult,
@@ -87,6 +88,16 @@ export function parsePrCreate(stdout: string): PrCreateResult {
   const url = stdout.trim();
   const match = url.match(/\/pull\/(\d+)$/);
   const number = match ? parseInt(match[1], 10) : 0;
+  return { number, url };
+}
+
+/**
+ * Parses `gh pr edit` output into structured data.
+ * The gh CLI prints the PR URL to stdout on success.
+ */
+export function parsePrUpdate(stdout: string, number: number): EditResult {
+  const urlMatch = stdout.match(/(https:\/\/github\.com\/[^\s]+\/pull\/\d+)/);
+  const url = urlMatch ? urlMatch[1] : "";
   return { number, url };
 }
 
@@ -183,6 +194,16 @@ export function parseIssueCreate(stdout: string): IssueCreateResult {
 export function parseIssueClose(stdout: string, number: number): IssueCloseResult {
   const url = stdout.trim();
   return { number, state: "closed", url };
+}
+
+/**
+ * Parses `gh issue edit` output into structured data.
+ * The gh CLI prints the issue URL to stdout on success.
+ */
+export function parseIssueUpdate(stdout: string, number: number): EditResult {
+  const urlMatch = stdout.match(/(https:\/\/github\.com\/[^\s]+\/issues\/\d+)/);
+  const url = urlMatch ? urlMatch[1] : "";
+  return { number, url };
 }
 
 /**

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -133,6 +133,14 @@ export const CommentResultSchema = z.object({
 
 export type CommentResult = z.infer<typeof CommentResultSchema>;
 
+/** Zod schema for structured pr-update / issue-update output. */
+export const EditResultSchema = z.object({
+  number: z.number(),
+  url: z.string(),
+});
+
+export type EditResult = z.infer<typeof EditResultSchema>;
+
 // ── Run schemas ──────────────────────────────────────────────────────
 
 /** Zod schema for a single job in a workflow run. */

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -6,11 +6,13 @@ import { registerPrCreateTool } from "./pr-create.js";
 import { registerPrMergeTool } from "./pr-merge.js";
 import { registerPrCommentTool } from "./pr-comment.js";
 import { registerPrReviewTool } from "./pr-review.js";
+import { registerPrUpdateTool } from "./pr-update.js";
 import { registerIssueViewTool } from "./issue-view.js";
 import { registerIssueListTool } from "./issue-list.js";
 import { registerIssueCreateTool } from "./issue-create.js";
 import { registerIssueCloseTool } from "./issue-close.js";
 import { registerIssueCommentTool } from "./issue-comment.js";
+import { registerIssueUpdateTool } from "./issue-update.js";
 import { registerRunViewTool } from "./run-view.js";
 import { registerRunListTool } from "./run-list.js";
 
@@ -22,11 +24,13 @@ export function registerAllTools(server: McpServer) {
   if (s("pr-merge")) registerPrMergeTool(server);
   if (s("pr-comment")) registerPrCommentTool(server);
   if (s("pr-review")) registerPrReviewTool(server);
+  if (s("pr-update")) registerPrUpdateTool(server);
   if (s("issue-view")) registerIssueViewTool(server);
   if (s("issue-list")) registerIssueListTool(server);
   if (s("issue-create")) registerIssueCreateTool(server);
   if (s("issue-close")) registerIssueCloseTool(server);
   if (s("issue-comment")) registerIssueCommentTool(server);
+  if (s("issue-update")) registerIssueUpdateTool(server);
   if (s("run-view")) registerRunViewTool(server);
   if (s("run-list")) registerRunListTool(server);
 }

--- a/packages/server-github/src/tools/issue-update.ts
+++ b/packages/server-github/src/tools/issue-update.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseIssueUpdate } from "../lib/parsers.js";
+import { formatIssueUpdate } from "../lib/formatters.js";
+import { EditResultSchema } from "../schemas/index.js";
+
+export function registerIssueUpdateTool(server: McpServer) {
+  server.registerTool(
+    "issue-update",
+    {
+      title: "Issue Update",
+      description:
+        "Updates issue metadata (title, body, labels, assignees). Returns structured data with issue number and URL. Use instead of running `gh issue edit` in the terminal.",
+      inputSchema: {
+        number: z.number().describe("Issue number"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        title: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("New issue title"),
+        body: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("New issue body/description"),
+        addLabels: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Labels to add"),
+        removeLabels: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Labels to remove"),
+        addAssignees: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Assignees to add"),
+        removeAssignees: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Assignees to remove"),
+      },
+      outputSchema: EditResultSchema,
+    },
+    async ({
+      number,
+      path,
+      title,
+      body,
+      addLabels,
+      removeLabels,
+      addAssignees,
+      removeAssignees,
+    }) => {
+      const cwd = path || process.cwd();
+
+      if (title) assertNoFlagInjection(title, "title");
+      if (addLabels) {
+        for (const label of addLabels) {
+          assertNoFlagInjection(label, "addLabels");
+        }
+      }
+      if (removeLabels) {
+        for (const label of removeLabels) {
+          assertNoFlagInjection(label, "removeLabels");
+        }
+      }
+      if (addAssignees) {
+        for (const assignee of addAssignees) {
+          assertNoFlagInjection(assignee, "addAssignees");
+        }
+      }
+      if (removeAssignees) {
+        for (const assignee of removeAssignees) {
+          assertNoFlagInjection(assignee, "removeAssignees");
+        }
+      }
+
+      const args = ["issue", "edit", String(number)];
+      if (title) args.push("--title", title);
+      if (addLabels && addLabels.length > 0) {
+        for (const label of addLabels) {
+          args.push("--add-label", label);
+        }
+      }
+      if (removeLabels && removeLabels.length > 0) {
+        for (const label of removeLabels) {
+          args.push("--remove-label", label);
+        }
+      }
+      if (addAssignees && addAssignees.length > 0) {
+        for (const assignee of addAssignees) {
+          args.push("--add-assignee", assignee);
+        }
+      }
+      if (removeAssignees && removeAssignees.length > 0) {
+        for (const assignee of removeAssignees) {
+          args.push("--remove-assignee", assignee);
+        }
+      }
+      if (body) {
+        args.push("--body-file", "-");
+      }
+
+      const result = await ghCmd(args, body ? { cwd, stdin: body } : { cwd });
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh issue edit failed: ${result.stderr}`);
+      }
+
+      const data = parseIssueUpdate(result.stdout, number);
+      return dualOutput(data, formatIssueUpdate);
+    },
+  );
+}

--- a/packages/server-github/src/tools/pr-update.ts
+++ b/packages/server-github/src/tools/pr-update.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parsePrUpdate } from "../lib/parsers.js";
+import { formatPrUpdate } from "../lib/formatters.js";
+import { EditResultSchema } from "../schemas/index.js";
+
+export function registerPrUpdateTool(server: McpServer) {
+  server.registerTool(
+    "pr-update",
+    {
+      title: "PR Update",
+      description:
+        "Updates pull request metadata (title, body, labels, assignees). Returns structured data with PR number and URL. Use instead of running `gh pr edit` in the terminal.",
+      inputSchema: {
+        number: z.number().describe("Pull request number"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        title: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("New pull request title"),
+        body: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("New pull request body/description"),
+        addLabels: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Labels to add"),
+        removeLabels: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Labels to remove"),
+        addAssignees: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Assignees to add"),
+        removeAssignees: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Assignees to remove"),
+      },
+      outputSchema: EditResultSchema,
+    },
+    async ({
+      number,
+      path,
+      title,
+      body,
+      addLabels,
+      removeLabels,
+      addAssignees,
+      removeAssignees,
+    }) => {
+      const cwd = path || process.cwd();
+
+      if (title) assertNoFlagInjection(title, "title");
+      if (addLabels) {
+        for (const label of addLabels) {
+          assertNoFlagInjection(label, "addLabels");
+        }
+      }
+      if (removeLabels) {
+        for (const label of removeLabels) {
+          assertNoFlagInjection(label, "removeLabels");
+        }
+      }
+      if (addAssignees) {
+        for (const assignee of addAssignees) {
+          assertNoFlagInjection(assignee, "addAssignees");
+        }
+      }
+      if (removeAssignees) {
+        for (const assignee of removeAssignees) {
+          assertNoFlagInjection(assignee, "removeAssignees");
+        }
+      }
+
+      const args = ["pr", "edit", String(number)];
+      if (title) args.push("--title", title);
+      if (addLabels && addLabels.length > 0) {
+        for (const label of addLabels) {
+          args.push("--add-label", label);
+        }
+      }
+      if (removeLabels && removeLabels.length > 0) {
+        for (const label of removeLabels) {
+          args.push("--remove-label", label);
+        }
+      }
+      if (addAssignees && addAssignees.length > 0) {
+        for (const assignee of addAssignees) {
+          args.push("--add-assignee", assignee);
+        }
+      }
+      if (removeAssignees && removeAssignees.length > 0) {
+        for (const assignee of removeAssignees) {
+          args.push("--remove-assignee", assignee);
+        }
+      }
+      if (body) {
+        args.push("--body-file", "-");
+      }
+
+      const result = await ghCmd(args, body ? { cwd, stdin: body } : { cwd });
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh pr edit failed: ${result.stderr}`);
+      }
+
+      const data = parsePrUpdate(result.stdout, number);
+      return dualOutput(data, formatPrUpdate);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `pr-update` tool wrapping `gh pr edit` to update PR metadata (title, body, labels, assignees)
- Adds `issue-update` tool wrapping `gh issue edit` to update issue metadata (title, body, labels, assignees)
- Extends `ghCmd` to support stdin passthrough for `--body-file -` pattern (avoids cmd-line length limits)
- Adds shared `EditResultSchema` for both tools' output (number + url)

Closes #239, closes #242

## Changes
- `src/schemas/index.ts` — new `EditResultSchema` + `EditResult` type
- `src/lib/gh-runner.ts` — `ghCmd` now accepts `GhCmdOptions` with optional `stdin`
- `src/lib/parsers.ts` — `parsePrUpdate()` and `parseIssueUpdate()`
- `src/lib/formatters.ts` — `formatPrUpdate()` and `formatIssueUpdate()`
- `src/tools/pr-update.ts` — new tool registration
- `src/tools/issue-update.ts` — new tool registration
- `src/tools/index.ts` — registers both new tools

## Security
- `assertNoFlagInjection()` on title, each label (add/remove), each assignee (add/remove)
- Body passed via stdin (`--body-file -`) — never as a CLI arg
- Zod `.max()` constraints on all string and array inputs

## Test plan
- [x] Parser tests for `parsePrUpdate` (5 cases) and `parseIssueUpdate` (5 cases)
- [x] Formatter tests for `formatPrUpdate` (2 cases) and `formatIssueUpdate` (2 cases)
- [x] Security tests: flag injection for title, addLabels, removeLabels, addAssignees, removeAssignees (10 test blocks)
- [x] All 108 tests in server-github pass
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)