### PR TITLE
feat(git): add merge tool -- merge branches

### DIFF
--- a/packages/server-git/__tests__/merge.test.ts
+++ b/packages/server-git/__tests__/merge.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "vitest";
+import { parseMerge, parseMergeAbort } from "../src/lib/parsers.js";
+import { formatMerge } from "../src/lib/formatters.js";
+import { assertNoFlagInjection } from "@paretools/shared";
+import type { GitMerge } from "../src/schemas/index.js";
+
+// ── Parser tests ─────────────────────────────────────────────────────
+
+describe("parseMerge", () => {
+  it("parses fast-forward merge", () => {
+    const stdout =
+      "Updating abc1234..def5678\nFast-forward\n file.txt | 1 +\n 1 file changed, 1 insertion(+)";
+    const result = parseMerge(stdout, "", "feature");
+
+    expect(result.merged).toBe(true);
+    expect(result.fastForward).toBe(true);
+    expect(result.branch).toBe("feature");
+    expect(result.conflicts).toEqual([]);
+    expect(result.commitHash).toBe("def5678");
+  });
+
+  it("parses non-fast-forward (3-way) merge", () => {
+    const stdout =
+      "Merge made by the 'ort' strategy.\n file.txt | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)";
+    const stderr = "";
+    const result = parseMerge(stdout, stderr, "feature/auth");
+
+    expect(result.merged).toBe(true);
+    expect(result.fastForward).toBe(false);
+    expect(result.branch).toBe("feature/auth");
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("parses merge with conflicts", () => {
+    const stdout =
+      "Auto-merging src/index.ts\nCONFLICT (content): Merge conflict in src/index.ts\nAuto-merging README.md\nCONFLICT (content): Merge conflict in README.md\nAutomatic merge failed; fix conflicts and then commit the result.";
+    const result = parseMerge(stdout, "", "feature/breaking");
+
+    expect(result.merged).toBe(false);
+    expect(result.fastForward).toBe(false);
+    expect(result.branch).toBe("feature/breaking");
+    expect(result.conflicts).toEqual(["src/index.ts", "README.md"]);
+    expect(result.commitHash).toBeUndefined();
+  });
+
+  it("parses single conflict", () => {
+    const stdout =
+      "Auto-merging app.ts\nCONFLICT (content): Merge conflict in app.ts\nAutomatic merge failed; fix conflicts and then commit the result.";
+    const result = parseMerge(stdout, "", "hotfix");
+
+    expect(result.merged).toBe(false);
+    expect(result.conflicts).toEqual(["app.ts"]);
+  });
+
+  it("parses merge with add/add conflict", () => {
+    const stdout =
+      "CONFLICT (add/add): Merge conflict in new-file.ts\nAutomatic merge failed; fix conflicts and then commit the result.";
+    const result = parseMerge(stdout, "", "add-branch");
+
+    expect(result.merged).toBe(false);
+    expect(result.conflicts).toEqual(["new-file.ts"]);
+  });
+
+  it("handles already up-to-date merge", () => {
+    const stdout = "Already up to date.";
+    const result = parseMerge(stdout, "", "main");
+
+    expect(result.merged).toBe(true);
+    expect(result.fastForward).toBe(false);
+    expect(result.branch).toBe("main");
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("extracts commit hash from fast-forward range", () => {
+    const stdout = "Updating a1b2c3d..e4f5a6b\nFast-forward";
+    const result = parseMerge(stdout, "", "feature");
+
+    expect(result.commitHash).toBe("e4f5a6b");
+  });
+
+  it("handles merge with recursive strategy", () => {
+    const stdout =
+      "Merge made by the 'recursive' strategy.\n src/app.ts | 5 +++++\n 1 file changed, 5 insertions(+)";
+    const result = parseMerge(stdout, "", "legacy-branch");
+
+    expect(result.merged).toBe(true);
+    expect(result.fastForward).toBe(false);
+    expect(result.branch).toBe("legacy-branch");
+  });
+});
+
+describe("parseMergeAbort", () => {
+  it("returns merge-aborted result", () => {
+    const result = parseMergeAbort("", "");
+
+    expect(result.merged).toBe(false);
+    expect(result.fastForward).toBe(false);
+    expect(result.branch).toBe("");
+    expect(result.conflicts).toEqual([]);
+  });
+});
+
+// ── Formatter tests ──────────────────────────────────────────────────
+
+describe("formatMerge", () => {
+  it("formats fast-forward merge", () => {
+    const data: GitMerge = {
+      merged: true,
+      fastForward: true,
+      branch: "feature",
+      conflicts: [],
+      commitHash: "abc1234",
+    };
+    expect(formatMerge(data)).toBe("Fast-forward merge of 'feature' (abc1234)");
+  });
+
+  it("formats non-fast-forward merge", () => {
+    const data: GitMerge = {
+      merged: true,
+      fastForward: false,
+      branch: "feature/auth",
+      conflicts: [],
+      commitHash: "def5678",
+    };
+    expect(formatMerge(data)).toBe("Merged 'feature/auth' (def5678)");
+  });
+
+  it("formats merge without commit hash", () => {
+    const data: GitMerge = {
+      merged: true,
+      fastForward: false,
+      branch: "main",
+      conflicts: [],
+    };
+    expect(formatMerge(data)).toBe("Merged 'main'");
+  });
+
+  it("formats merge with conflicts", () => {
+    const data: GitMerge = {
+      merged: false,
+      fastForward: false,
+      branch: "feature/breaking",
+      conflicts: ["src/index.ts", "README.md"],
+    };
+    expect(formatMerge(data)).toBe(
+      "Merge of 'feature/breaking' failed with 2 conflict(s): src/index.ts, README.md",
+    );
+  });
+
+  it("formats single conflict", () => {
+    const data: GitMerge = {
+      merged: false,
+      fastForward: false,
+      branch: "hotfix",
+      conflicts: ["app.ts"],
+    };
+    expect(formatMerge(data)).toBe("Merge of 'hotfix' failed with 1 conflict(s): app.ts");
+  });
+
+  it("formats merge abort", () => {
+    const data: GitMerge = {
+      merged: false,
+      fastForward: false,
+      branch: "",
+      conflicts: [],
+    };
+    expect(formatMerge(data)).toBe("Merge aborted");
+  });
+});
+
+// ── Security tests ───────────────────────────────────────────────────
+
+describe("security: merge tool — branch validation", () => {
+  const MALICIOUS_INPUTS = [
+    "--force",
+    "--amend",
+    "-rf",
+    "--no-verify",
+    "--exec=rm -rf /",
+    "-u",
+    "--delete",
+    "--hard",
+    "--output=/etc/passwd",
+    "-D",
+    " --force",
+    "\t--delete",
+  ];
+
+  it("rejects flag-like branch names", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "branch")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: merge tool — message validation", () => {
+  const MALICIOUS_INPUTS = [
+    "--force",
+    "--amend",
+    "-rf",
+    "--no-verify",
+    "--exec=rm -rf /",
+    " --force",
+    "\t--delete",
+  ];
+
+  it("rejects flag-like merge messages", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "message")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe merge messages", () => {
+    const safe = ["Merge feature into main", "Release v2.0", "Merge branch 'hotfix'"];
+    for (const msg of safe) {
+      expect(() => assertNoFlagInjection(msg, "message")).not.toThrow();
+    }
+  });
+});

--- a/packages/server-git/__tests__/security.test.ts
+++ b/packages/server-git/__tests__/security.test.ts
@@ -236,6 +236,22 @@ describe("security: reset tool — files validation", () => {
   });
 });
 
+describe("security: merge tool — branch validation", () => {
+  it("rejects flag-like branch names", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "branch")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
+describe("security: merge tool — message validation", () => {
+  it("rejects flag-like merge messages", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "message")).toThrow(/must not start with "-"/);
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Zod .max() input-limit constraints — Git tool schemas
 // ---------------------------------------------------------------------------

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -17,6 +17,7 @@ import type {
   GitRestore,
   GitReset,
   GitCherryPick,
+  GitMerge,
 } from "../schemas/index.js";
 
 /** Formats structured git status data into a human-readable summary string. */
@@ -389,4 +390,28 @@ export function formatCherryPick(cp: GitCherryPick): string {
     return "Cherry-pick completed (no commits applied)";
   }
   return `Cherry-pick applied ${cp.applied.length} commit(s): ${cp.applied.join(", ")}`;
+}
+
+// ── Merge formatters ──────────────────────────────────────────────────
+
+/** Formats structured git merge data into a human-readable merge summary. */
+export function formatMerge(m: GitMerge): string {
+  if (!m.merged && m.conflicts.length > 0) {
+    return `Merge of '${m.branch}' failed with ${m.conflicts.length} conflict(s): ${m.conflicts.join(", ")}`;
+  }
+
+  if (!m.merged && m.branch === "") {
+    return "Merge aborted";
+  }
+
+  const parts: string[] = [];
+  if (m.fastForward) {
+    parts.push(`Fast-forward merge of '${m.branch}'`);
+  } else {
+    parts.push(`Merged '${m.branch}'`);
+  }
+  if (m.commitHash) {
+    parts.push(`(${m.commitHash})`);
+  }
+  return parts.join(" ");
 }

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -288,3 +288,14 @@ export const GitCherryPickSchema = z.object({
 });
 
 export type GitCherryPick = z.infer<typeof GitCherryPickSchema>;
+
+/** Zod schema for structured git merge output with merge status, conflicts, and optional commit hash. */
+export const GitMergeSchema = z.object({
+  merged: z.boolean(),
+  fastForward: z.boolean(),
+  branch: z.string(),
+  conflicts: z.array(z.string()),
+  commitHash: z.string().optional(),
+});
+
+export type GitMerge = z.infer<typeof GitMergeSchema>;

--- a/packages/server-git/src/tools/index.ts
+++ b/packages/server-git/src/tools/index.ts
@@ -18,6 +18,7 @@ import { registerBlameTool } from "./blame.js";
 import { registerRestoreTool } from "./restore.js";
 import { registerResetTool } from "./reset.js";
 import { registerCherryPickTool } from "./cherry-pick.js";
+import { registerMergeTool } from "./merge.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("git", name);
@@ -39,4 +40,5 @@ export function registerAllTools(server: McpServer) {
   if (s("restore")) registerRestoreTool(server);
   if (s("reset")) registerResetTool(server);
   if (s("cherry-pick")) registerCherryPickTool(server);
+  if (s("merge")) registerMergeTool(server);
 }

--- a/packages/server-git/src/tools/merge.ts
+++ b/packages/server-git/src/tools/merge.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseMerge, parseMergeAbort } from "../lib/parsers.js";
+import { formatMerge } from "../lib/formatters.js";
+import { GitMergeSchema } from "../schemas/index.js";
+
+export function registerMergeTool(server: McpServer) {
+  server.registerTool(
+    "merge",
+    {
+      title: "Git Merge",
+      description:
+        "Merges a branch into the current branch. Returns structured data with merge status, fast-forward detection, conflicts, and commit hash. Use instead of running `git merge` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        branch: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Branch to merge"),
+        noFf: z.boolean().optional().default(false).describe("Force merge commit (--no-ff)"),
+        abort: z.boolean().optional().default(false).describe("Abort in-progress merge (--abort)"),
+        message: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Custom merge commit message"),
+      },
+      outputSchema: GitMergeSchema,
+    },
+    async ({ path, branch, noFf, abort, message }) => {
+      const cwd = path || process.cwd();
+
+      // Handle --abort
+      if (abort) {
+        const result = await git(["merge", "--abort"], cwd);
+        if (result.exitCode !== 0) {
+          throw new Error(`git merge --abort failed: ${result.stderr}`);
+        }
+        const mergeResult = parseMergeAbort(result.stdout, result.stderr);
+        return dualOutput(mergeResult, formatMerge);
+      }
+
+      assertNoFlagInjection(branch, "branch");
+      if (message) {
+        assertNoFlagInjection(message, "message");
+      }
+
+      // Build merge args
+      const args = ["merge"];
+      if (noFf) args.push("--no-ff");
+      if (message) args.push("-m", message);
+      args.push(branch);
+
+      const result = await git(args, cwd);
+
+      // Merge can exit non-zero for conflicts but still produce useful output
+      if (result.exitCode !== 0) {
+        const combined = `${result.stdout}\n${result.stderr}`;
+        if (/CONFLICT/.test(combined)) {
+          const mergeResult = parseMerge(result.stdout, result.stderr, branch);
+          return dualOutput(mergeResult, formatMerge);
+        }
+        throw new Error(`git merge failed: ${result.stderr}`);
+      }
+
+      const mergeResult = parseMerge(result.stdout, result.stderr, branch);
+      return dualOutput(mergeResult, formatMerge);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add a `merge` tool to `@paretools/git` that wraps `git merge` for fast-forward and 3-way merges with structured conflict reporting
- On conflicts, returns structured data (`merged: false`, `conflicts: [...]`) instead of throwing, enabling LLM agents to handle conflicts gracefully
- Supports `--no-ff`, `--abort`, and custom merge commit messages

## Schema Design

**Input:** `branch` (required), `path`, `noFf`, `abort`, `message`  
**Output (GitMergeSchema):** `merged`, `fastForward`, `branch`, `conflicts`, `commitHash`

## Implementation
- **Schema:** `GitMergeSchema` in `schemas/index.ts`
- **Parser:** `parseMerge()` + `parseMergeAbort()` in `parsers.ts` -- detects ff/non-ff, extracts conflicts and commit hash
- **Formatter:** `formatMerge()` in `formatters.ts`
- **Tool:** `merge.ts` with `assertNoFlagInjection()` on `branch` and `message`
- **Registration:** Added to `tools/index.ts` (now 16 tools)

## Test plan
- [x] 8 parser tests (ff, non-ff, conflict, add/add conflict, already up-to-date, abort, recursive strategy, hash extraction)
- [x] 6 formatter tests (ff, non-ff, no hash, conflicts, single conflict, abort)
- [x] 4 security tests (flag-injection on branch + message in both merge.test.ts and security.test.ts)
- [x] 5 integration tests via MCP client (ff merge, --no-ff merge, conflict reporting, flag-injection on branch, flag-injection on message)
- [x] All 402 tests pass (including all existing tests)

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)