### PR TITLE
feat(git): add rebase tool (#236)

### DIFF
--- a/packages/server-git/__tests__/rebase.test.ts
+++ b/packages/server-git/__tests__/rebase.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { parseRebase } from "../src/lib/parsers.js";
+import { formatRebase } from "../src/lib/formatters.js";
+import type { GitRebase } from "../src/schemas/index.js";
+
+describe("parseRebase", () => {
+  it("parses successful rebase", () => {
+    const stdout = "Successfully rebased and updated refs/heads/feature.";
+    const result = parseRebase(stdout, "", "main", "feature");
+
+    expect(result.success).toBe(true);
+    expect(result.branch).toBe("main");
+    expect(result.current).toBe("feature");
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("parses rebase with conflicts", () => {
+    const stderr = `Auto-merging src/index.ts
+CONFLICT (content): Merge conflict in src/index.ts
+Auto-merging src/utils.ts
+CONFLICT (content): Merge conflict in src/utils.ts
+error: could not apply abc1234... Fix the thing
+hint: Resolve all conflicts manually, mark them as resolved with
+hint: "git add/rm <conflicted_files>", then run "git rebase --continue".`;
+
+    const result = parseRebase("", stderr, "main", "feature");
+
+    expect(result.success).toBe(false);
+    expect(result.branch).toBe("main");
+    expect(result.current).toBe("feature");
+    expect(result.conflicts).toEqual(["src/index.ts", "src/utils.ts"]);
+  });
+
+  it("parses rebase with single conflict", () => {
+    const stderr = `CONFLICT (content): Merge conflict in README.md
+error: could not apply abc1234... Update readme`;
+
+    const result = parseRebase("", stderr, "main", "feature");
+
+    expect(result.success).toBe(false);
+    expect(result.conflicts).toEqual(["README.md"]);
+  });
+
+  it("parses rebase with add/add conflict", () => {
+    const stderr = `CONFLICT (add/add): Merge conflict in new-file.ts`;
+
+    const result = parseRebase("", stderr, "main", "feature");
+
+    expect(result.success).toBe(false);
+    expect(result.conflicts).toEqual(["new-file.ts"]);
+  });
+
+  it("parses rebase abort (branch is empty when aborting)", () => {
+    const stdout = "";
+    const stderr = "";
+    // When the tool invokes --abort, it passes branch="" to the parser
+    const result = parseRebase(stdout, stderr, "", "feature");
+
+    expect(result.success).toBe(true);
+    expect(result.branch).toBe("");
+    expect(result.current).toBe("feature");
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("parses rebase continue success", () => {
+    const stdout = "Successfully rebased and updated refs/heads/feature.";
+    const result = parseRebase(stdout, "", "main", "feature");
+
+    expect(result.success).toBe(true);
+    expect(result.branch).toBe("main");
+    expect(result.current).toBe("feature");
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("parses rebase with Applying lines", () => {
+    const stdout = `Applying: Fix the first thing
+Applying: Fix the second thing
+Applying: Fix the third thing`;
+
+    const result = parseRebase(stdout, "", "main", "feature");
+
+    expect(result.rebasedCommits).toBe(3);
+    expect(result.branch).toBe("main");
+    expect(result.current).toBe("feature");
+  });
+
+  it("handles empty output (already up to date)", () => {
+    const stdout = "Current branch feature is up to date.";
+    const result = parseRebase(stdout, "", "main", "feature");
+
+    expect(result.success).toBe(true);
+    expect(result.branch).toBe("main");
+    expect(result.conflicts).toEqual([]);
+  });
+});
+
+describe("formatRebase", () => {
+  it("formats successful rebase", () => {
+    const data: GitRebase = {
+      success: true,
+      branch: "main",
+      current: "feature",
+      conflicts: [],
+      rebasedCommits: 3,
+    };
+    const output = formatRebase(data);
+
+    expect(output).toContain("Rebased 'feature' onto 'main'");
+    expect(output).toContain("3 commit(s) rebased");
+  });
+
+  it("formats rebase with conflicts", () => {
+    const data: GitRebase = {
+      success: false,
+      branch: "main",
+      current: "feature",
+      conflicts: ["src/index.ts", "src/utils.ts"],
+    };
+    const output = formatRebase(data);
+
+    expect(output).toContain("paused with conflicts");
+    expect(output).toContain("Conflicts: src/index.ts, src/utils.ts");
+  });
+
+  it("formats rebase abort", () => {
+    const data: GitRebase = {
+      success: true,
+      branch: "",
+      current: "feature",
+      conflicts: [],
+    };
+    const output = formatRebase(data);
+
+    expect(output).toBe("Rebase aborted on 'feature'");
+  });
+
+  it("formats successful rebase without commit count", () => {
+    const data: GitRebase = {
+      success: true,
+      branch: "main",
+      current: "feature",
+      conflicts: [],
+    };
+    const output = formatRebase(data);
+
+    expect(output).toBe("Rebased 'feature' onto 'main'");
+  });
+
+  it("formats rebase with conflicts but no conflict file list", () => {
+    const data: GitRebase = {
+      success: false,
+      branch: "main",
+      current: "feature",
+      conflicts: [],
+    };
+    const output = formatRebase(data);
+
+    expect(output).toContain("paused with conflicts");
+    expect(output).not.toContain("Conflicts:");
+  });
+});

--- a/packages/server-git/__tests__/security.test.ts
+++ b/packages/server-git/__tests__/security.test.ts
@@ -252,6 +252,20 @@ describe("security: merge tool — message validation", () => {
   });
 });
 
+describe("security: rebase tool — branch validation", () => {
+  it("rejects flag-like branch names", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "branch")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe branch names", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "branch")).not.toThrow();
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Zod .max() input-limit constraints — Git tool schemas
 // ---------------------------------------------------------------------------

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -18,6 +18,7 @@ import type {
   GitReset,
   GitCherryPick,
   GitMerge,
+  GitRebase,
 } from "../schemas/index.js";
 
 /** Formats structured git status data into a human-readable summary string. */
@@ -390,6 +391,29 @@ export function formatCherryPick(cp: GitCherryPick): string {
     return "Cherry-pick completed (no commits applied)";
   }
   return `Cherry-pick applied ${cp.applied.length} commit(s): ${cp.applied.join(", ")}`;
+}
+
+// ── Rebase formatters ─────────────────────────────────────────────────
+
+/** Formats structured git rebase data into a human-readable rebase summary. */
+export function formatRebase(r: GitRebase): string {
+  if (!r.success) {
+    const parts = [`Rebase of '${r.current}' onto '${r.branch}' paused with conflicts`];
+    if (r.conflicts.length > 0) {
+      parts.push(`Conflicts: ${r.conflicts.join(", ")}`);
+    }
+    return parts.join("\n");
+  }
+
+  if (!r.branch) {
+    return `Rebase aborted on '${r.current}'`;
+  }
+
+  const parts = [`Rebased '${r.current}' onto '${r.branch}'`];
+  if (r.rebasedCommits !== undefined) {
+    parts.push(`${r.rebasedCommits} commit(s) rebased`);
+  }
+  return parts.join("\n");
 }
 
 // ── Merge formatters ──────────────────────────────────────────────────

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -299,3 +299,14 @@ export const GitMergeSchema = z.object({
 });
 
 export type GitMerge = z.infer<typeof GitMergeSchema>;
+
+/** Zod schema for structured git rebase output with success status, branch info, conflicts, and rebased commit count. */
+export const GitRebaseSchema = z.object({
+  success: z.boolean(),
+  branch: z.string(),
+  current: z.string(),
+  conflicts: z.array(z.string()),
+  rebasedCommits: z.number().optional(),
+});
+
+export type GitRebase = z.infer<typeof GitRebaseSchema>;

--- a/packages/server-git/src/tools/index.ts
+++ b/packages/server-git/src/tools/index.ts
@@ -19,6 +19,7 @@ import { registerRestoreTool } from "./restore.js";
 import { registerResetTool } from "./reset.js";
 import { registerCherryPickTool } from "./cherry-pick.js";
 import { registerMergeTool } from "./merge.js";
+import { registerRebaseTool } from "./rebase.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("git", name);
@@ -41,4 +42,5 @@ export function registerAllTools(server: McpServer) {
   if (s("reset")) registerResetTool(server);
   if (s("cherry-pick")) registerCherryPickTool(server);
   if (s("merge")) registerMergeTool(server);
+  if (s("rebase")) registerRebaseTool(server);
 }

--- a/packages/server-git/src/tools/rebase.ts
+++ b/packages/server-git/src/tools/rebase.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseRebase } from "../lib/parsers.js";
+import { formatRebase } from "../lib/formatters.js";
+import { GitRebaseSchema } from "../schemas/index.js";
+
+export function registerRebaseTool(server: McpServer) {
+  server.registerTool(
+    "rebase",
+    {
+      title: "Git Rebase",
+      description:
+        "Rebases the current branch onto a target branch. Supports abort and continue for conflict resolution. Returns structured data with success status, branch info, conflicts, and rebased commit count. Use instead of running `git rebase` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        branch: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Target branch to rebase onto (required unless abort/continue)"),
+        abort: z.boolean().optional().default(false).describe("Abort in-progress rebase"),
+        continue: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Continue after conflict resolution"),
+      },
+      outputSchema: GitRebaseSchema,
+    },
+    async (params) => {
+      const cwd = params.path || process.cwd();
+      const branch = params.branch;
+      const abort = params.abort;
+      const cont = params.continue;
+
+      // Get current branch before rebase
+      const currentResult = await git(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+      const current = currentResult.exitCode === 0 ? currentResult.stdout.trim() : "unknown";
+
+      // Handle abort
+      if (abort) {
+        const result = await git(["rebase", "--abort"], cwd);
+        if (result.exitCode !== 0) {
+          throw new Error(`git rebase --abort failed: ${result.stderr}`);
+        }
+        const rebaseResult = parseRebase(result.stdout, result.stderr, "", current);
+        return dualOutput(rebaseResult, formatRebase);
+      }
+
+      // Handle continue
+      if (cont) {
+        const result = await git(["rebase", "--continue"], cwd);
+
+        // Continue can fail if there are still conflicts
+        if (result.exitCode !== 0) {
+          const combined = `${result.stdout}\n${result.stderr}`;
+          if (/CONFLICT/.test(combined) || /could not apply/.test(combined)) {
+            const rebaseResult = parseRebase(result.stdout, result.stderr, branch || "", current);
+            return dualOutput(rebaseResult, formatRebase);
+          }
+          throw new Error(`git rebase --continue failed: ${result.stderr}`);
+        }
+
+        const rebaseResult = parseRebase(result.stdout, result.stderr, branch || "", current);
+        return dualOutput(rebaseResult, formatRebase);
+      }
+
+      // Normal rebase — branch is required
+      if (!branch) {
+        throw new Error("branch is required for rebase (unless using abort or continue)");
+      }
+
+      assertNoFlagInjection(branch, "branch");
+
+      // Count commits that will be rebased using git log
+      const logResult = await git(["log", "--oneline", `${branch}..HEAD`], cwd);
+      const commitCount =
+        logResult.exitCode === 0
+          ? logResult.stdout.trim().split("\n").filter(Boolean).length
+          : undefined;
+
+      const args = ["rebase", branch];
+      const result = await git(args, cwd);
+
+      // Rebase can exit non-zero for conflicts — still produce useful output
+      if (result.exitCode !== 0) {
+        const combined = `${result.stdout}\n${result.stderr}`;
+        if (/CONFLICT/.test(combined)) {
+          const rebaseResult = parseRebase(result.stdout, result.stderr, branch, current);
+          // Override rebasedCommits with our pre-counted value
+          if (commitCount !== undefined) {
+            rebaseResult.rebasedCommits = commitCount;
+          }
+          return dualOutput(rebaseResult, formatRebase);
+        }
+        throw new Error(`git rebase failed: ${result.stderr}`);
+      }
+
+      const rebaseResult = parseRebase(result.stdout, result.stderr, branch, current);
+      // Override rebasedCommits with our pre-counted value
+      if (commitCount !== undefined) {
+        rebaseResult.rebasedCommits = commitCount;
+      }
+      return dualOutput(rebaseResult, formatRebase);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add a new `rebase` tool to `@paretools/git` that wraps `git rebase` for rebasing branches onto a target
- Supports `--abort` and `--continue` for conflict resolution workflows
- On conflicts, returns `success: false` with a list of conflicted files (does NOT throw)
- Tracks rebased commit count via `git log <branch>..HEAD` before rebase

## Schema

**Input:** `path`, `branch` (target), `abort`, `continue`
**Output (GitRebaseSchema):** `success`, `branch`, `current`, `conflicts[]`, `rebasedCommits?`

## Changes
- `src/schemas/index.ts` — Add `GitRebaseSchema` + `GitRebase` type
- `src/lib/parsers.ts` — Add `parseRebase()` with conflict detection
- `src/lib/formatters.ts` — Add `formatRebase()` for human-readable output
- `src/tools/rebase.ts` — New tool registration with `assertNoFlagInjection` on branch
- `src/tools/index.ts` — Register rebase tool (tool count: 15 → 16)

## Test plan
- [x] Parser tests: success, conflict (single + multiple + add/add), abort, continue, Applying lines
- [x] Formatter tests: success with/without commit count, conflicts, abort
- [x] Integration tests: successful rebase with diverged branches, conflict detection + abort, flag-injection rejection, missing branch error
- [x] Security tests: `assertNoFlagInjection` on branch parameter
- [x] CRLF normalization in integration tests for Windows
- [x] All 312 tests pass (13 new rebase + 4 integration + security)

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)