### PR TITLE
chore: add changeset to align remaining packages to 0.8.1

### DIFF
--- a/.changeset/align-versions-081.md
+++ b/.changeset/align-versions-081.md
@@ -1,0 +1,10 @@
+---
+"@paretools/cargo": patch
+"@paretools/go": patch
+"@paretools/github": patch
+"@paretools/http": patch
+"@paretools/make": patch
+"@paretools/search": patch
+---
+
+Align all packages to 0.8.1 for consistent versioning across the monorepo.


### PR DESCRIPTION
## Summary
- Adds a patch changeset for the 6 packages that landed at 0.8.0 (cargo, go, github, http, make, search)
- Once merged, the existing version packages PR #258 will regenerate with all 14 packages at 0.8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)