### PR TITLE
chore: align remaining 6 packages to 0.8.1

### DIFF
--- a/.changeset/align-to-081.md
+++ b/.changeset/align-to-081.md
@@ -1,0 +1,10 @@
+---
+"@paretools/cargo": patch
+"@paretools/go": patch
+"@paretools/github": patch
+"@paretools/http": patch
+"@paretools/make": patch
+"@paretools/search": patch
+---
+
+Align remaining packages from 0.8.0 to 0.8.1 for consistent monorepo versioning.


### PR DESCRIPTION
## Summary
- Patch changeset for cargo, go, github, http, make, search (currently 0.8.0 → 0.8.1)
- Ensures all 14 packages are at 0.8.1 for consistent versioning

Follows up on PR #258 which bumped these from 0.7.1 → 0.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)