### PR TITLE
feat(github): add pr-checks tool (#267)

### DIFF
--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -6,6 +6,7 @@ import type {
   CommentResult,
   PrReviewResult,
   EditResult,
+  PrChecksResult,
   IssueViewResult,
   IssueListResult,
   IssueCreateResult,
@@ -71,6 +72,43 @@ export function formatPrReview(data: PrReviewResult): string {
 /** Formats structured PR update data into human-readable text. */
 export function formatPrUpdate(data: EditResult): string {
   return `Updated PR #${data.number}: ${data.url}`;
+}
+
+/** Formats structured PR checks data into human-readable text. */
+export function formatPrChecks(data: PrChecksResult): string {
+  const { summary } = data;
+  const lines = [
+    `PR #${data.pr}: ${summary.total} checks (${summary.passed} passed, ${summary.failed} failed, ${summary.pending} pending)`,
+  ];
+  for (const c of data.checks) {
+    const workflow = c.workflow ? ` [${c.workflow}]` : "";
+    lines.push(`  ${c.name}: ${c.state} (${c.bucket})${workflow}`);
+  }
+  return lines.join("\n");
+}
+
+/** Compact PR checks: summary only, no individual checks. */
+export interface PrChecksCompact {
+  [key: string]: unknown;
+  pr: number;
+  total: number;
+  passed: number;
+  failed: number;
+  pending: number;
+}
+
+export function compactPrChecksMap(data: PrChecksResult): PrChecksCompact {
+  return {
+    pr: data.pr,
+    total: data.summary.total,
+    passed: data.summary.passed,
+    failed: data.summary.failed,
+    pending: data.summary.pending,
+  };
+}
+
+export function formatPrChecksCompact(data: PrChecksCompact): string {
+  return `PR #${data.pr}: ${data.total} checks (${data.passed} passed, ${data.failed} failed, ${data.pending} pending)`;
 }
 
 /** Formats structured issue view data into human-readable text. */

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -141,6 +141,42 @@ export const EditResultSchema = z.object({
 
 export type EditResult = z.infer<typeof EditResultSchema>;
 
+// ── PR Checks schemas ───────────────────────────────────────────────
+
+/** Zod schema for a single check entry from `gh pr checks`. */
+export const PrChecksItemSchema = z.object({
+  name: z.string(),
+  state: z.string(),
+  bucket: z.string(),
+  description: z.string(),
+  event: z.string(),
+  workflow: z.string(),
+  link: z.string(),
+  startedAt: z.string(),
+  completedAt: z.string(),
+});
+
+/** Zod schema for summary counts of PR checks. */
+export const PrChecksSummarySchema = z.object({
+  total: z.number(),
+  passed: z.number(),
+  failed: z.number(),
+  pending: z.number(),
+  skipped: z.number(),
+  cancelled: z.number(),
+});
+
+/** Zod schema for structured pr-checks output. */
+export const PrChecksResultSchema = z.object({
+  pr: z.number(),
+  checks: z.array(PrChecksItemSchema),
+  summary: PrChecksSummarySchema,
+});
+
+export type PrChecksItem = z.infer<typeof PrChecksItemSchema>;
+export type PrChecksSummary = z.infer<typeof PrChecksSummarySchema>;
+export type PrChecksResult = z.infer<typeof PrChecksResultSchema>;
+
 // ── Run schemas ──────────────────────────────────────────────────────
 
 /** Zod schema for a single job in a workflow run. */

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -7,6 +7,7 @@ import { registerPrMergeTool } from "./pr-merge.js";
 import { registerPrCommentTool } from "./pr-comment.js";
 import { registerPrReviewTool } from "./pr-review.js";
 import { registerPrUpdateTool } from "./pr-update.js";
+import { registerPrChecksTool } from "./pr-checks.js";
 import { registerIssueViewTool } from "./issue-view.js";
 import { registerIssueListTool } from "./issue-list.js";
 import { registerIssueCreateTool } from "./issue-create.js";
@@ -25,6 +26,7 @@ export function registerAllTools(server: McpServer) {
   if (s("pr-comment")) registerPrCommentTool(server);
   if (s("pr-review")) registerPrReviewTool(server);
   if (s("pr-update")) registerPrUpdateTool(server);
+  if (s("pr-checks")) registerPrChecksTool(server);
   if (s("issue-view")) registerIssueViewTool(server);
   if (s("issue-list")) registerIssueListTool(server);
   if (s("issue-create")) registerIssueCreateTool(server);

--- a/packages/server-github/src/tools/pr-checks.ts
+++ b/packages/server-github/src/tools/pr-checks.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parsePrChecks } from "../lib/parsers.js";
+import { formatPrChecks, compactPrChecksMap, formatPrChecksCompact } from "../lib/formatters.js";
+import { PrChecksResultSchema } from "../schemas/index.js";
+
+const PR_CHECKS_FIELDS = "name,state,bucket,description,event,workflow,link,startedAt,completedAt";
+
+export function registerPrChecksTool(server: McpServer) {
+  server.registerTool(
+    "pr-checks",
+    {
+      title: "PR Checks",
+      description:
+        "Lists check/status results for a pull request. Returns structured data with check names, states, conclusions, URLs, and summary counts (passed, failed, pending). Use instead of running `gh pr checks` in the terminal.",
+      inputSchema: {
+        pr: z.number().describe("Pull request number"),
+        repo: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository in OWNER/REPO format (default: current repo)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: PrChecksResultSchema,
+    },
+    async ({ pr, repo, compact }) => {
+      const args = ["pr", "checks", String(pr), "--json", PR_CHECKS_FIELDS];
+      if (repo) {
+        args.push("--repo", repo);
+      }
+      const result = await ghCmd(args);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh pr checks failed: ${result.stderr}`);
+      }
+
+      const data = parsePrChecks(result.stdout, pr);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatPrChecks,
+        compactPrChecksMap,
+        formatPrChecksCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `pr-checks` tool to `@paretools/github` that wraps `gh pr checks --json`
- Returns structured check data: name, state, bucket, workflow, timestamps, detail URLs
- Includes summary counts (passed, failed, pending, skipped, cancelled)
- Supports compact output mode via `dualOutput()`
- Input params: `pr` (required number), `repo` (optional OWNER/REPO), `compact`

## Changes
- **Schema**: `PrChecksResultSchema` with `PrChecksItemSchema` and `PrChecksSummarySchema`
- **Parser**: `parsePrChecks` with bucket-based summary computation
- **Formatter**: `formatPrChecks`, `compactPrChecksMap`, `formatPrChecksCompact`
- **Tool**: `pr-checks` registered in tools index
- **Tests**: 4 parser tests + 3 formatter tests (all passing)

## Test plan
- [x] Parser tests: full JSON, empty list, missing fields, all bucket types
- [x] Formatter tests: full output, compact mapping, workflow tag omission
- [x] Build passes with `turbo run build --filter=@paretools/github`
- [x] All 147 tests pass in server-github package

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)