### PR TITLE
feat(cargo): add cargo audit tool (#264)

### DIFF
--- a/packages/server-cargo/src/schemas/index.ts
+++ b/packages/server-cargo/src/schemas/index.ts
@@ -116,3 +116,33 @@ export const CargoTreeResultSchema = z.object({
 });
 
 export type CargoTreeResult = z.infer<typeof CargoTreeResultSchema>;
+
+/** Zod schema for a single cargo audit vulnerability entry with advisory ID, package, severity, and fix info. */
+export const CargoAuditVulnSchema = z.object({
+  id: z.string().describe("Advisory ID (e.g. RUSTSEC-2022-0090)"),
+  package: z.string().describe("Affected crate name"),
+  version: z.string().describe("Installed version of the affected crate"),
+  severity: z
+    .enum(["critical", "high", "medium", "low", "informational", "unknown"])
+    .describe("Severity level derived from CVSS"),
+  title: z.string().describe("Short description of the vulnerability"),
+  url: z.string().optional().describe("URL with more information"),
+  patched: z.array(z.string()).describe("Version requirements that fix the vulnerability"),
+  unaffected: z.array(z.string()).optional().describe("Version requirements not affected"),
+});
+
+/** Zod schema for structured cargo audit output with vulnerability list and severity summary. */
+export const CargoAuditResultSchema = z.object({
+  vulnerabilities: z.array(CargoAuditVulnSchema),
+  summary: z.object({
+    total: z.number(),
+    critical: z.number(),
+    high: z.number(),
+    medium: z.number(),
+    low: z.number(),
+    informational: z.number(),
+    unknown: z.number(),
+  }),
+});
+
+export type CargoAuditResult = z.infer<typeof CargoAuditResultSchema>;

--- a/packages/server-cargo/src/tools/audit.ts
+++ b/packages/server-cargo/src/tools/audit.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { cargo } from "../lib/cargo-runner.js";
+import { parseCargoAuditJson } from "../lib/parsers.js";
+import { formatCargoAudit, compactAuditMap, formatAuditCompact } from "../lib/formatters.js";
+import { CargoAuditResultSchema } from "../schemas/index.js";
+
+export function registerAuditTool(server: McpServer) {
+  server.registerTool(
+    "audit",
+    {
+      title: "Cargo Audit",
+      description:
+        "Runs cargo audit and returns structured vulnerability data. Use instead of running `cargo audit` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: CargoAuditResultSchema,
+    },
+    async ({ path, compact }) => {
+      const cwd = path || process.cwd();
+      const result = await cargo(["audit", "--json"], cwd);
+
+      // cargo audit returns exit code 1 when vulnerabilities are found, which is expected
+      const output = result.stdout || result.stderr;
+      const data = parseCargoAuditJson(output);
+      return compactDualOutput(
+        data,
+        output,
+        formatCargoAudit,
+        compactAuditMap,
+        formatAuditCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-cargo/src/tools/index.ts
+++ b/packages/server-cargo/src/tools/index.ts
@@ -11,6 +11,7 @@ import { registerDocTool } from "./doc.js";
 import { registerCheckTool } from "./check.js";
 import { registerUpdateTool } from "./update.js";
 import { registerTreeTool } from "./tree.js";
+import { registerAuditTool } from "./audit.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("cargo", name);
@@ -25,4 +26,5 @@ export function registerAllTools(server: McpServer) {
   if (s("check")) registerCheckTool(server);
   if (s("update")) registerUpdateTool(server);
   if (s("tree")) registerTreeTool(server);
+  if (s("audit")) registerAuditTool(server);
 }


### PR DESCRIPTION
## Summary
- Adds `cargo audit` tool to `@paretools/cargo` for Rust dependency vulnerability scanning
- Wraps `cargo audit --json` and parses output into structured vulnerability data
- Each vulnerability includes advisory ID, package name/version, severity (derived from CVSS score), title, URL, and patched/unaffected version ranges
- Summary counts by severity level (critical, high, medium, low, informational, unknown)
- Full dual output support (human-readable text + structured JSON) with compact mode
- Zod output schema for type-safe structured content

## Changes
- `src/schemas/index.ts` — Added `CargoAuditVulnSchema` and `CargoAuditResultSchema`
- `src/lib/parsers.ts` — Added `parseCargoAuditJson()` with CVSS-to-severity mapping
- `src/lib/formatters.ts` — Added `formatCargoAudit()`, `compactAuditMap()`, `formatAuditCompact()`
- `src/tools/audit.ts` — New tool registration file
- `src/tools/index.ts` — Registered audit tool (now 12 tools total)

## Test plan
- [x] Parser tests: vulnerabilities with CVSS scores, empty list, missing fields, severity mapping
- [x] Formatter tests: no vulnerabilities, with patched versions, compact output
- [x] Integration test: structured output validation or graceful error handling
- [x] All 203 tests pass

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)