### PR TITLE
feat(github): add gh api tool (#266)

### DIFF
--- a/packages/server-github/__tests__/api.test.ts
+++ b/packages/server-github/__tests__/api.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { parseApi } from "../src/lib/parsers.js";
+import { formatApi } from "../src/lib/formatters.js";
+import type { ApiResult } from "../src/schemas/index.js";
+
+// ── Parser tests ────────────────────────────────────────────────────
+
+describe("parseApi", () => {
+  it("parses JSON response with exit code 0", () => {
+    const json = JSON.stringify({ login: "octocat", id: 1 });
+    const result = parseApi(json, 0, "/user", "GET");
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ login: "octocat", id: 1 });
+    expect(result.endpoint).toBe("/user");
+    expect(result.method).toBe("GET");
+  });
+
+  it("parses JSON array response", () => {
+    const json = JSON.stringify([{ number: 1 }, { number: 2 }]);
+    const result = parseApi(json, 0, "repos/owner/repo/pulls", "GET");
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual([{ number: 1 }, { number: 2 }]);
+    expect(result.endpoint).toBe("repos/owner/repo/pulls");
+  });
+
+  it("returns 422 status for non-zero exit code", () => {
+    const result = parseApi("", 1, "/user", "GET");
+
+    expect(result.status).toBe(422);
+  });
+
+  it("falls back to raw string when stdout is not JSON", () => {
+    const result = parseApi("some plain text output\n", 0, "/endpoint", "POST");
+
+    expect(result.status).toBe(200);
+    expect(result.body).toBe("some plain text output\n");
+  });
+
+  it("handles empty stdout", () => {
+    const result = parseApi("", 0, "repos/owner/repo/issues", "DELETE");
+
+    expect(result.status).toBe(200);
+    expect(result.body).toBe("");
+    expect(result.method).toBe("DELETE");
+  });
+
+  it("preserves nested JSON structures", () => {
+    const json = JSON.stringify({
+      data: {
+        repository: {
+          issues: { totalCount: 5 },
+        },
+      },
+    });
+    const result = parseApi(json, 0, "graphql", "POST");
+
+    expect(result.status).toBe(200);
+    expect((result.body as Record<string, unknown>).data).toBeDefined();
+  });
+});
+
+// ── Formatter tests ─────────────────────────────────────────────────
+
+describe("formatApi", () => {
+  it("formats a JSON object response", () => {
+    const data: ApiResult = {
+      status: 200,
+      body: { login: "octocat", id: 1 },
+      endpoint: "/user",
+      method: "GET",
+    };
+    const output = formatApi(data);
+
+    expect(output).toContain("GET /user → 200");
+    expect(output).toContain('"login": "octocat"');
+  });
+
+  it("formats a string body response", () => {
+    const data: ApiResult = {
+      status: 200,
+      body: "plain text",
+      endpoint: "/endpoint",
+      method: "POST",
+    };
+    const output = formatApi(data);
+
+    expect(output).toContain("POST /endpoint → 200");
+    expect(output).toContain("plain text");
+  });
+
+  it("truncates long body output", () => {
+    const longBody = "x".repeat(600);
+    const data: ApiResult = {
+      status: 200,
+      body: longBody,
+      endpoint: "/endpoint",
+      method: "GET",
+    };
+    const output = formatApi(data);
+
+    expect(output).toContain("...");
+    // The body preview should be truncated at 500 chars + "..."
+    expect(output.length).toBeLessThan(600);
+  });
+
+  it("formats error status", () => {
+    const data: ApiResult = {
+      status: 422,
+      body: { message: "Validation Failed" },
+      endpoint: "repos/owner/repo/pulls",
+      method: "POST",
+    };
+    const output = formatApi(data);
+
+    expect(output).toContain("POST repos/owner/repo/pulls → 422");
+    expect(output).toContain("Validation Failed");
+  });
+});

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -14,6 +14,7 @@ import type {
   RunViewResult,
   RunListResult,
   RunRerunResult,
+  ApiResult,
 } from "../schemas/index.js";
 
 // ── Full formatters ──────────────────────────────────────────────────
@@ -376,4 +377,13 @@ export function formatRunRerun(data: RunRerunResult): string {
   const mode = data.failedOnly ? "failed jobs only" : "all jobs";
   const urlPart = data.url ? `: ${data.url}` : "";
   return `Rerun requested for run #${data.runId} (${mode})${urlPart}`;
+}
+
+// ── API ─────────────────────────────────────────────────────────────
+
+/** Formats structured API result into human-readable text. */
+export function formatApi(data: ApiResult): string {
+  const bodyStr = typeof data.body === "string" ? data.body : JSON.stringify(data.body, null, 2);
+  const preview = bodyStr.length > 500 ? bodyStr.slice(0, 500) + "..." : bodyStr;
+  return `${data.method} ${data.endpoint} → ${data.status}\n${preview}`;
 }

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -14,6 +14,7 @@ import type {
   RunViewResult,
   RunListResult,
   RunRerunResult,
+  ApiResult,
 } from "../schemas/index.js";
 
 /**
@@ -337,4 +338,27 @@ export function parseRunRerun(
     failedOnly,
     url,
   };
+}
+
+/**
+ * Parses `gh api` stdout into structured API result data.
+ * Attempts to parse stdout as JSON; falls back to raw string body.
+ */
+export function parseApi(
+  stdout: string,
+  exitCode: number,
+  endpoint: string,
+  method: string,
+): ApiResult {
+  // gh api returns exit code 0 for success. Map to HTTP-like status codes.
+  const status = exitCode === 0 ? 200 : 422;
+
+  let body: unknown;
+  try {
+    body = JSON.parse(stdout);
+  } catch {
+    body = stdout;
+  }
+
+  return { status, body, endpoint, method };
 }

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -230,3 +230,15 @@ export const RunRerunResultSchema = z.object({
 });
 
 export type RunRerunResult = z.infer<typeof RunRerunResultSchema>;
+
+// ── API schemas ─────────────────────────────────────────────────────
+
+/** Zod schema for structured gh api output. */
+export const ApiResultSchema = z.object({
+  status: z.number(),
+  body: z.unknown(),
+  endpoint: z.string(),
+  method: z.string(),
+});
+
+export type ApiResult = z.infer<typeof ApiResultSchema>;

--- a/packages/server-github/src/tools/api.ts
+++ b/packages/server-github/src/tools/api.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseApi } from "../lib/parsers.js";
+import { formatApi } from "../lib/formatters.js";
+import { ApiResultSchema } from "../schemas/index.js";
+
+export function registerApiTool(server: McpServer) {
+  server.registerTool(
+    "api",
+    {
+      title: "GitHub API",
+      description:
+        "Makes arbitrary GitHub API calls via `gh api`. Supports all HTTP methods, request bodies, field parameters, pagination, and jq filtering. Returns structured data with status, parsed JSON body, endpoint, and method. Use instead of running `gh api` in the terminal.",
+      inputSchema: {
+        endpoint: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .describe("GitHub API endpoint (e.g., repos/owner/repo/pulls, /user)"),
+        method: z
+          .enum(["GET", "POST", "PATCH", "DELETE", "PUT"])
+          .optional()
+          .default("GET")
+          .describe("HTTP method (default: GET)"),
+        body: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("JSON request body as key-value pairs (sent via --input)"),
+        fields: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe("Key-value pairs sent as --raw-field parameters"),
+        paginate: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Enable pagination (--paginate). Fetches all pages."),
+        jq: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("jq filter expression to apply to the response"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+      },
+      outputSchema: ApiResultSchema,
+    },
+    async ({ endpoint, method, body, fields, paginate, jq, path }) => {
+      const cwd = path || process.cwd();
+
+      const args = ["api", endpoint, "--method", method!];
+
+      if (paginate) {
+        args.push("--paginate");
+      }
+
+      if (jq) {
+        args.push("--jq", jq);
+      }
+
+      // Add --raw-field for each field entry
+      if (fields) {
+        for (const [key, value] of Object.entries(fields)) {
+          args.push("--raw-field", `${key}=${value}`);
+        }
+      }
+
+      // Pass JSON body via stdin using --input -
+      let stdin: string | undefined;
+      if (body) {
+        args.push("--input", "-");
+        stdin = JSON.stringify(body);
+      }
+
+      const result = await ghCmd(args, { cwd, stdin });
+
+      if (result.exitCode !== 0 && result.stderr) {
+        throw new Error(`gh api failed: ${result.stderr}`);
+      }
+
+      const data = parseApi(result.stdout, result.exitCode, endpoint, method!);
+      return dualOutput(data, formatApi);
+    },
+  );
+}

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -17,6 +17,7 @@ import { registerIssueUpdateTool } from "./issue-update.js";
 import { registerRunViewTool } from "./run-view.js";
 import { registerRunListTool } from "./run-list.js";
 import { registerRunRerunTool } from "./run-rerun.js";
+import { registerApiTool } from "./api.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("github", name);
@@ -37,4 +38,5 @@ export function registerAllTools(server: McpServer) {
   if (s("run-view")) registerRunViewTool(server);
   if (s("run-list")) registerRunListTool(server);
   if (s("run-rerun")) registerRunRerunTool(server);
+  if (s("api")) registerApiTool(server);
 }


### PR DESCRIPTION
## Summary
- Adds generic `api` tool to `@paretools/github` for arbitrary GitHub REST/GraphQL API calls via `gh api`
- Supports GET/POST/PATCH/DELETE/PUT methods, JSON request bodies, raw-field parameters, pagination, and jq filtering
- Returns structured response with status code, parsed JSON body, endpoint, and method
- Includes Zod output schema, parser, formatter, and 10 unit tests

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)