### PR TITLE
feat(go): add golangci-lint tool (#263)

### DIFF
--- a/packages/server-go/src/lib/go-runner.ts
+++ b/packages/server-go/src/lib/go-runner.ts
@@ -8,3 +8,7 @@ export async function goCmd(args: string[], cwd?: string): Promise<RunResult> {
 export async function gofmtCmd(args: string[], cwd?: string): Promise<RunResult> {
   return run("gofmt", args, { cwd, timeout: 120_000 });
 }
+
+export async function golangciLintCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("golangci-lint", args, { cwd, timeout: 300_000 });
+}

--- a/packages/server-go/src/schemas/index.ts
+++ b/packages/server-go/src/schemas/index.ts
@@ -124,3 +124,32 @@ export const GoGetResultSchema = z.object({
 });
 
 export type GoGetResult = z.infer<typeof GoGetResultSchema>;
+
+/** Zod schema for a single golangci-lint diagnostic with file location, linter, severity, and message. */
+export const GolangciLintDiagnosticSchema = z.object({
+  file: z.string(),
+  line: z.number(),
+  column: z.number().optional(),
+  linter: z.string(),
+  severity: z.enum(["error", "warning", "info"]),
+  message: z.string(),
+  sourceLine: z.string().optional(),
+});
+
+/** Zod schema for linter-level summary counts. */
+export const GolangciLintLinterSummarySchema = z.object({
+  linter: z.string(),
+  count: z.number(),
+});
+
+/** Zod schema for structured golangci-lint output with diagnostics and summary counts. */
+export const GolangciLintResultSchema = z.object({
+  diagnostics: z.array(GolangciLintDiagnosticSchema).optional(),
+  total: z.number(),
+  errors: z.number(),
+  warnings: z.number(),
+  byLinter: z.array(GolangciLintLinterSummarySchema).optional(),
+});
+
+export type GolangciLintResult = z.infer<typeof GolangciLintResultSchema>;
+export type GolangciLintDiagnostic = z.infer<typeof GolangciLintDiagnosticSchema>;

--- a/packages/server-go/src/tools/golangci-lint.ts
+++ b/packages/server-go/src/tools/golangci-lint.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { golangciLintCmd } from "../lib/go-runner.js";
+import { parseGolangciLintJson } from "../lib/parsers.js";
+import {
+  formatGolangciLint,
+  compactGolangciLintMap,
+  formatGolangciLintCompact,
+} from "../lib/formatters.js";
+import { GolangciLintResultSchema } from "../schemas/index.js";
+
+export function registerGolangciLintTool(server: McpServer) {
+  server.registerTool(
+    "golangci-lint",
+    {
+      title: "golangci-lint",
+      description:
+        "Runs golangci-lint and returns structured lint diagnostics (file, line, linter, severity, message). Use instead of running `golangci-lint` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        patterns: z
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default(["./..."])
+          .describe("File patterns or packages to lint (default: ['./...'])"),
+        config: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to golangci-lint config file"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: GolangciLintResultSchema,
+    },
+    async ({ path, patterns, config, compact }) => {
+      const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
+      if (config) {
+        assertNoFlagInjection(config, "config");
+      }
+
+      const args = ["run", "--out-format", "json"];
+      if (config) {
+        args.push("--config", config);
+      }
+      args.push(...(patterns || ["./..."]));
+
+      const result = await golangciLintCmd(args, cwd);
+      // golangci-lint outputs JSON to stdout even on exit code 1 (issues found)
+      const data = parseGolangciLintJson(result.stdout, result.exitCode);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatGolangciLint,
+        compactGolangciLintMap,
+        formatGolangciLintCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-go/src/tools/index.ts
+++ b/packages/server-go/src/tools/index.ts
@@ -10,6 +10,7 @@ import { registerGenerateTool } from "./generate.js";
 import { registerEnvTool } from "./env.js";
 import { registerListTool } from "./list.js";
 import { registerGetTool } from "./get.js";
+import { registerGolangciLintTool } from "./golangci-lint.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("go", name);
@@ -23,4 +24,5 @@ export function registerAllTools(server: McpServer) {
   if (s("env")) registerEnvTool(server);
   if (s("list")) registerListTool(server);
   if (s("get")) registerGetTool(server);
+  if (s("golangci-lint")) registerGolangciLintTool(server);
 }


### PR DESCRIPTION
## Summary
- Adds `golangci-lint` tool to `@paretools/go` for Go meta-linting with structured JSON output
- Parses `golangci-lint run --out-format json` into diagnostics with file, line, column, linter name, severity, message, and source line
- Includes summary counts by linter and by severity (errors/warnings)
- Input params: `path` (project root), `patterns` (file patterns), `config` (config file path), `compact`
- Full dual output support with compact variant

## Changes
- `src/schemas/index.ts` - Added `GolangciLintResultSchema`, `GolangciLintDiagnosticSchema`, `GolangciLintLinterSummarySchema`
- `src/lib/parsers.ts` - Added `parseGolangciLintJson()` parser for JSON output
- `src/lib/formatters.ts` - Added `formatGolangciLint()`, compact map and formatter
- `src/lib/go-runner.ts` - Added `golangciLintCmd()` runner
- `src/tools/golangci-lint.ts` - New tool registration with input validation
- `src/tools/index.ts` - Registered golangci-lint tool (now 11 tools total)
- `__tests__/parsers.test.ts` - 7 new parser tests
- `__tests__/formatters.test.ts` - 2 new formatter tests
- `__tests__/integration.test.ts` - Integration test for golangci-lint tool

## Test plan
- [x] Parser tests: multiple issues, clean output, empty stdout, malformed JSON, by-linter summary, default severity, null Issues field
- [x] Formatter tests: clean result, result with issues and by-linter summary
- [x] Integration test: structured output or command-not-found error
- [x] Build passes with `turbo run build --filter=@paretools/go...`
- [x] All existing tests still pass (parsers: 25, formatters: 17, compact: 39, security: 23)

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)