### PR TITLE
feat(docker): add compose-logs tool (#283)

### DIFF
--- a/packages/server-docker/__tests__/integration.test.ts
+++ b/packages/server-docker/__tests__/integration.test.ts
@@ -26,12 +26,13 @@ describe("@paretools/docker integration", () => {
     await transport.close();
   });
 
-  it("lists all 13 tools", async () => {
+  it("lists all 14 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
       "build",
       "compose-down",
+      "compose-logs",
       "compose-ps",
       "compose-up",
       "exec",
@@ -221,6 +222,26 @@ describe("@paretools/docker integration", () => {
         const sc = result.structuredContent as Record<string, unknown>;
         expect(sc).toBeDefined();
         expect(Array.isArray(sc.volumes)).toBe(true);
+        expect(sc.total).toEqual(expect.any(Number));
+      }
+    });
+  });
+
+  describe("compose-logs", () => {
+    it("returns error or structured data when called without docker", async () => {
+      const result = await client.callTool({
+        name: "compose-logs",
+        arguments: { path: "C:\\nonexistent-path-for-testing" },
+      });
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/docker|compose|not found|failed|error|no configuration/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(Array.isArray(sc.services)).toBe(true);
+        expect(Array.isArray(sc.entries)).toBe(true);
         expect(sc.total).toEqual(expect.any(Number));
       }
     });

--- a/packages/server-docker/src/schemas/index.ts
+++ b/packages/server-docker/src/schemas/index.ts
@@ -178,3 +178,21 @@ export const DockerComposePsSchema = z.object({
 });
 
 export type DockerComposePs = z.infer<typeof DockerComposePsSchema>;
+
+/** Zod schema for a single compose log entry with timestamp, service, and message. */
+export const ComposeLogEntrySchema = z.object({
+  timestamp: z.string().optional(),
+  service: z.string(),
+  message: z.string(),
+});
+
+/** Zod schema for structured docker compose logs output with service-separated log entries. */
+export const DockerComposeLogsSchema = z.object({
+  services: z.array(z.string()),
+  entries: z.array(ComposeLogEntrySchema),
+  total: z.number(),
+  isTruncated: z.boolean().optional(),
+  totalEntries: z.number().optional(),
+});
+
+export type DockerComposeLogs = z.infer<typeof DockerComposeLogsSchema>;

--- a/packages/server-docker/src/tools/compose-logs.ts
+++ b/packages/server-docker/src/tools/compose-logs.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { docker } from "../lib/docker-runner.js";
+import { parseComposeLogsOutput } from "../lib/parsers.js";
+import {
+  formatComposeLogs,
+  compactComposeLogsMap,
+  formatComposeLogsCompact,
+} from "../lib/formatters.js";
+import { DockerComposeLogsSchema } from "../schemas/index.js";
+
+export function registerComposeLogsTool(server: McpServer) {
+  server.registerTool(
+    "compose-logs",
+    {
+      title: "Docker Compose Logs",
+      description:
+        "Retrieves Docker Compose service logs as structured entries. Use instead of running `docker compose logs` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Directory containing docker-compose.yml"),
+        services: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default([])
+          .describe("Specific services to get logs for (default: all)"),
+        tail: z
+          .number()
+          .optional()
+          .describe("Number of lines to return per service (passed to --tail)"),
+        since: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Show logs since timestamp (e.g., '10m', '2024-01-01')"),
+        timestamps: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Include timestamps in output (default: true)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: DockerComposeLogsSchema,
+    },
+    async ({ path, services, tail, since, timestamps, compact }) => {
+      if (since) assertNoFlagInjection(since, "since");
+      if (services) {
+        for (const s of services) {
+          assertNoFlagInjection(s, "services");
+        }
+      }
+
+      const args = ["compose", "logs", "--no-color"];
+      if (timestamps) args.push("--timestamps");
+      if (tail != null) args.push("--tail", String(tail));
+      if (since) args.push("--since", since);
+      if (services && services.length > 0) {
+        args.push(...services);
+      }
+
+      const result = await docker(args, path);
+      const output = result.stdout || result.stderr;
+
+      if (result.exitCode !== 0 && !output.trim()) {
+        const errorMsg = result.stderr || result.stdout || "Unknown error";
+        throw new Error(`docker compose logs failed: ${errorMsg.trim()}`);
+      }
+
+      const data = parseComposeLogsOutput(output);
+
+      return compactDualOutput(
+        data,
+        output,
+        formatComposeLogs,
+        compactComposeLogsMap,
+        formatComposeLogsCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-docker/src/tools/index.ts
+++ b/packages/server-docker/src/tools/index.ts
@@ -13,6 +13,7 @@ import { registerInspectTool } from "./inspect.js";
 import { registerNetworkLsTool } from "./network-ls.js";
 import { registerVolumeLsTool } from "./volume-ls.js";
 import { registerComposePsTool } from "./compose-ps.js";
+import { registerComposeLogsTool } from "./compose-logs.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("docker", name);
@@ -29,4 +30,5 @@ export function registerAllTools(server: McpServer) {
   if (s("network-ls")) registerNetworkLsTool(server);
   if (s("volume-ls")) registerVolumeLsTool(server);
   if (s("compose-ps")) registerComposePsTool(server);
+  if (s("compose-logs")) registerComposeLogsTool(server);
 }


### PR DESCRIPTION
## Summary
- Adds `compose-logs` tool to `@paretools/docker` for structured Docker Compose log retrieval
- Parses `docker compose logs` output into service-separated entries with timestamp, service, and message fields
- Supports `tail`, `since`, `timestamps`, and `services` filtering options
- Includes Zod output schema, dual output with compact mode, parser, formatter, and integration tests

## Test plan
- [x] Parser tests: multi-service logs, timestamps, no timestamps, empty output, truncation, pipe-less lines
- [x] Formatter tests: with/without timestamps, truncated output, empty logs
- [x] Integration test: tool registration, structured output validation
- [x] All 340 tests pass (10 test files)

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)