### PR TITLE
feat(build): add turbo tool (#281)

### DIFF
--- a/packages/server-build/__tests__/turbo.test.ts
+++ b/packages/server-build/__tests__/turbo.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from "vitest";
+import { parseTurboOutput } from "../src/lib/parsers.js";
+import { formatTurbo } from "../src/lib/formatters.js";
+import type { TurboResult } from "../src/schemas/index.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TURBO_SUCCESS_ALL_CACHED = [
+  " Tasks:    3 successful, 3 total",
+  " Cached:   3 cached, 3 total",
+  "  Time:    103ms >>> FULL TURBO",
+  "",
+  "@paretools/shared#build: cache hit, replaying logs abc123 (100ms)",
+  "@paretools/git#build: cache hit, replaying logs def456 (150ms)",
+  "@paretools/build#build: cache hit, replaying logs ghi789 (200ms)",
+].join("\n");
+
+const TURBO_SUCCESS_PARTIAL_CACHE = [
+  "@paretools/shared#build: cache hit, replaying logs abc123 (100ms)",
+  "@paretools/git#build: cache miss, executing def456 (2.5s)",
+  "@paretools/build#build: cache miss, executing ghi789 (3.1s)",
+  "",
+  " Tasks:    3 successful, 3 total",
+  " Cached:   1 cached, 3 total",
+  "  Time:    5.8s",
+].join("\n");
+
+const TURBO_FAILURE = [
+  "@paretools/shared#build: cache hit, replaying logs abc123 (100ms)",
+  "@paretools/git#build: command exited (1)",
+  "",
+  " Tasks:    1 successful, 2 total",
+  " Cached:   1 cached, 2 total",
+  "  Time:    3.2s",
+].join("\n");
+
+const TURBO_NO_TASKS = [
+  "",
+  " Tasks:    0 successful, 0 total",
+  " Cached:   0 cached, 0 total",
+  "  Time:    50ms",
+].join("\n");
+
+const TURBO_MIXED_OUTPUT = [
+  "some preamble text",
+  "@paretools/shared#test: cache miss, executing abc123 (1.5s)",
+  "  > vitest run",
+  "  PASS tests/foo.test.ts",
+  "@paretools/git#test: cache hit, replaying logs def456 (200ms)",
+  "more output",
+  " Tasks:    2 successful, 2 total",
+  " Cached:   1 cached, 2 total",
+  "  Time:    2.1s",
+].join("\n");
+
+const TURBO_ERROR_OUTPUT = [
+  "@paretools/shared#build: cache miss, executing abc123 (500ms)",
+  "@paretools/git#build: ERROR something went wrong",
+  "",
+  " Tasks:    1 successful, 2 total",
+  " Cached:   0 cached, 2 total",
+  "  Time:    1.5s",
+].join("\n");
+
+// ---------------------------------------------------------------------------
+// Parser tests
+// ---------------------------------------------------------------------------
+
+describe("parseTurboOutput", () => {
+  it("parses fully cached successful run", () => {
+    const result = parseTurboOutput(TURBO_SUCCESS_ALL_CACHED, "", 0, 0.1);
+
+    expect(result.success).toBe(true);
+    expect(result.totalTasks).toBe(3);
+    expect(result.cached).toBe(3);
+    expect(result.tasks).toHaveLength(3);
+    expect(result.passed).toBe(3);
+    expect(result.failed).toBe(0);
+
+    expect(result.tasks[0]).toEqual({
+      package: "@paretools/shared",
+      task: "build",
+      status: "pass",
+      duration: "100ms",
+      cache: "hit",
+    });
+  });
+
+  it("parses partially cached successful run", () => {
+    const result = parseTurboOutput(TURBO_SUCCESS_PARTIAL_CACHE, "", 0, 5.8);
+
+    expect(result.success).toBe(true);
+    expect(result.totalTasks).toBe(3);
+    expect(result.cached).toBe(1);
+    expect(result.passed).toBe(3);
+    expect(result.failed).toBe(0);
+
+    // First task is cached
+    expect(result.tasks[0].cache).toBe("hit");
+    expect(result.tasks[0].package).toBe("@paretools/shared");
+
+    // Second task is a miss
+    expect(result.tasks[1].cache).toBe("miss");
+    expect(result.tasks[1].package).toBe("@paretools/git");
+    expect(result.tasks[1].duration).toBe("2.5s");
+  });
+
+  it("parses failed run with exit code 1", () => {
+    const result = parseTurboOutput(TURBO_FAILURE, "", 1, 3.2);
+
+    expect(result.success).toBe(false);
+    expect(result.totalTasks).toBe(2);
+    expect(result.cached).toBe(1);
+    expect(result.passed).toBe(1);
+    expect(result.failed).toBe(1);
+
+    const failedTask = result.tasks.find((t) => t.status === "fail");
+    expect(failedTask).toBeDefined();
+    expect(failedTask!.package).toBe("@paretools/git");
+    expect(failedTask!.task).toBe("build");
+  });
+
+  it("handles empty output with no tasks", () => {
+    const result = parseTurboOutput(TURBO_NO_TASKS, "", 0, 0.05);
+
+    expect(result.success).toBe(true);
+    expect(result.totalTasks).toBe(0);
+    expect(result.tasks).toEqual([]);
+    expect(result.passed).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.cached).toBe(0);
+  });
+
+  it("handles mixed output with log noise", () => {
+    const result = parseTurboOutput(TURBO_MIXED_OUTPUT, "", 0, 2.1);
+
+    expect(result.success).toBe(true);
+    expect(result.totalTasks).toBe(2);
+    expect(result.tasks).toHaveLength(2);
+    expect(result.cached).toBe(1);
+
+    expect(result.tasks[0].package).toBe("@paretools/shared");
+    expect(result.tasks[0].task).toBe("test");
+    expect(result.tasks[0].cache).toBe("miss");
+
+    expect(result.tasks[1].package).toBe("@paretools/git");
+    expect(result.tasks[1].task).toBe("test");
+    expect(result.tasks[1].cache).toBe("hit");
+  });
+
+  it("parses ERROR task lines", () => {
+    const result = parseTurboOutput(TURBO_ERROR_OUTPUT, "", 1, 1.5);
+
+    expect(result.success).toBe(false);
+    expect(result.totalTasks).toBe(2);
+    expect(result.passed).toBe(1);
+    expect(result.failed).toBe(1);
+
+    const failedTask = result.tasks.find((t) => t.status === "fail");
+    expect(failedTask).toBeDefined();
+    expect(failedTask!.package).toBe("@paretools/git");
+    expect(failedTask!.cache).toBe("miss");
+  });
+
+  it("preserves duration exactly", () => {
+    const result = parseTurboOutput("", "", 0, 7.891);
+    expect(result.duration).toBe(7.891);
+  });
+
+  it("handles completely empty output", () => {
+    const result = parseTurboOutput("", "", 0, 0.1);
+
+    expect(result.success).toBe(true);
+    expect(result.tasks).toEqual([]);
+    expect(result.totalTasks).toBe(0);
+    expect(result.passed).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.cached).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Formatter tests
+// ---------------------------------------------------------------------------
+
+describe("formatTurbo", () => {
+  it("formats successful run with cached tasks", () => {
+    const data: TurboResult = {
+      success: true,
+      duration: 2.5,
+      tasks: [
+        {
+          package: "@paretools/shared",
+          task: "build",
+          status: "pass",
+          duration: "100ms",
+          cache: "hit",
+        },
+        {
+          package: "@paretools/git",
+          task: "build",
+          status: "pass",
+          duration: "2.5s",
+          cache: "miss",
+        },
+      ],
+      totalTasks: 2,
+      passed: 2,
+      failed: 0,
+      cached: 1,
+    };
+    const output = formatTurbo(data);
+    expect(output).toContain("turbo: 2 tasks completed in 2.5s");
+    expect(output).toContain("1 cached");
+    expect(output).toContain("@paretools/shared#build: pass [hit] (100ms)");
+    expect(output).toContain("@paretools/git#build: pass [miss] (2.5s)");
+  });
+
+  it("formats successful run with no cached tasks", () => {
+    const data: TurboResult = {
+      success: true,
+      duration: 5.0,
+      tasks: [{ package: "web", task: "lint", status: "pass", duration: "3s", cache: "miss" }],
+      totalTasks: 1,
+      passed: 1,
+      failed: 0,
+      cached: 0,
+    };
+    const output = formatTurbo(data);
+    expect(output).toContain("turbo: 1 tasks completed in 5s");
+    expect(output).not.toContain("cached");
+  });
+
+  it("formats failed run with errors", () => {
+    const data: TurboResult = {
+      success: false,
+      duration: 3.2,
+      tasks: [
+        {
+          package: "@paretools/shared",
+          task: "build",
+          status: "pass",
+          duration: "100ms",
+          cache: "hit",
+        },
+        { package: "@paretools/git", task: "build", status: "fail", cache: "miss" },
+      ],
+      totalTasks: 2,
+      passed: 1,
+      failed: 1,
+      cached: 1,
+    };
+    const output = formatTurbo(data);
+    expect(output).toContain("turbo: failed (3.2s)");
+    expect(output).toContain("1 passed");
+    expect(output).toContain("1 failed");
+    expect(output).toContain("@paretools/git#build: fail [miss]");
+  });
+
+  it("formats empty run with no tasks", () => {
+    const data: TurboResult = {
+      success: true,
+      duration: 0.1,
+      tasks: [],
+      totalTasks: 0,
+      passed: 0,
+      failed: 0,
+      cached: 0,
+    };
+    const output = formatTurbo(data);
+    expect(output).toContain("turbo: 0 tasks completed in 0.1s");
+  });
+});

--- a/packages/server-build/src/lib/build-runner.ts
+++ b/packages/server-build/src/lib/build-runner.ts
@@ -24,3 +24,7 @@ export async function viteCmd(args: string[], cwd?: string): Promise<RunResult> 
 export async function webpackCmd(args: string[], cwd?: string): Promise<RunResult> {
   return run("npx", ["webpack", ...args], { cwd, timeout: 300_000 });
 }
+
+export async function turboCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("npx", ["turbo", ...args], { cwd, timeout: 300_000 });
+}

--- a/packages/server-build/src/schemas/index.ts
+++ b/packages/server-build/src/schemas/index.ts
@@ -191,3 +191,50 @@ export interface WebpackResult {
   warnings: string[];
   modules?: number;
 }
+
+// ---------------------------------------------------------------------------
+// turbo
+// ---------------------------------------------------------------------------
+
+/** Zod schema for a single Turbo task result entry with package name, task, status, duration, and cache info. */
+export const TurboTaskSchema = z.object({
+  package: z.string(),
+  task: z.string(),
+  status: z.enum(["pass", "fail"]),
+  duration: z.string().optional(),
+  cache: z.enum(["hit", "miss"]).optional(),
+});
+
+/** Zod schema for structured Turbo run output with per-package task results and summary counts.
+ *  In compact mode, the tasks array is omitted; only summary counts are returned. */
+export const TurboResultSchema = z.object({
+  success: z.boolean(),
+  duration: z.number(),
+  tasks: z.array(TurboTaskSchema).optional(),
+  totalTasks: z.number(),
+  passed: z.number(),
+  failed: z.number(),
+  cached: z.number(),
+});
+
+/** Full turbo task entry. */
+export interface TurboTask {
+  [key: string]: unknown;
+  package: string;
+  task: string;
+  status: "pass" | "fail";
+  duration?: string;
+  cache?: "hit" | "miss";
+}
+
+/** Full turbo result -- always returned by the parser. */
+export interface TurboResult {
+  [key: string]: unknown;
+  success: boolean;
+  duration: number;
+  tasks: TurboTask[];
+  totalTasks: number;
+  passed: number;
+  failed: number;
+  cached: number;
+}

--- a/packages/server-build/src/tools/index.ts
+++ b/packages/server-build/src/tools/index.ts
@@ -5,6 +5,7 @@ import { registerBuildTool } from "./build.js";
 import { registerEsbuildTool } from "./esbuild.js";
 import { registerViteBuildTool } from "./vite-build.js";
 import { registerWebpackTool } from "./webpack.js";
+import { registerTurboTool } from "./turbo.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("build", name);
@@ -13,4 +14,5 @@ export function registerAllTools(server: McpServer) {
   if (s("esbuild")) registerEsbuildTool(server);
   if (s("vite-build")) registerViteBuildTool(server);
   if (s("webpack")) registerWebpackTool(server);
+  if (s("turbo")) registerTurboTool(server);
 }

--- a/packages/server-build/src/tools/turbo.ts
+++ b/packages/server-build/src/tools/turbo.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { turboCmd } from "../lib/build-runner.js";
+import { parseTurboOutput } from "../lib/parsers.js";
+import { formatTurbo, compactTurboMap, formatTurboCompact } from "../lib/formatters.js";
+import { TurboResultSchema } from "../schemas/index.js";
+
+export function registerTurboTool(server: McpServer) {
+  server.registerTool(
+    "turbo",
+    {
+      title: "turbo",
+      description:
+        "Runs Turborepo tasks and returns structured per-package results with cache hit/miss info. Use instead of running `turbo` in the terminal.",
+      inputSchema: {
+        task: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .describe("Turbo task to run (e.g., 'build', 'test', 'lint')"),
+        filter: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Package filter (e.g., '@scope/pkg' or 'pkg...')"),
+        concurrency: z.number().optional().describe("Maximum number of concurrent tasks"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: TurboResultSchema,
+    },
+    async ({ task, filter, concurrency, path, compact }) => {
+      const cwd = path || process.cwd();
+      assertNoFlagInjection(task, "task");
+      if (filter) assertNoFlagInjection(filter, "filter");
+
+      const cliArgs: string[] = ["run", task, "--output-logs=new-only"];
+
+      if (filter) cliArgs.push("--filter", filter);
+      if (concurrency !== undefined) cliArgs.push("--concurrency", String(concurrency));
+
+      const start = Date.now();
+      const result = await turboCmd(cliArgs, cwd);
+      const duration = Math.round((Date.now() - start) / 100) / 10;
+      const rawOutput = result.stdout + "\n" + result.stderr;
+
+      const data = parseTurboOutput(result.stdout, result.stderr, result.exitCode, duration);
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatTurbo,
+        compactTurboMap,
+        formatTurboCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `turbo` tool to `@paretools/build` for Turborepo task orchestration
- Wraps `turbo run <task>` with `--output-logs=new-only` and parses output
- Returns per-package task status (pass/fail), duration, and cache hit/miss info
- Includes summary counts: totalTasks, passed, failed, cached
- Input params: task (required), filter, concurrency, path, compact
- Full Zod output schema with dual output via `compactDualOutput()`
- Security: `assertNoFlagInjection` on task and filter params

## Changes
- `src/schemas/index.ts` — TurboTaskSchema, TurboResultSchema, TypeScript interfaces
- `src/lib/build-runner.ts` — turboCmd runner function
- `src/lib/parsers.ts` — parseTurboOutput with regex-based task line and summary extraction
- `src/lib/formatters.ts` — formatTurbo, compactTurboMap, formatTurboCompact
- `src/tools/turbo.ts` — tool registration with input validation
- `src/tools/index.ts` — register turbo tool
- `__tests__/turbo.test.ts` — 12 parser and formatter unit tests
- `__tests__/compact.test.ts` — 6 turbo compact tests
- `__tests__/integration.test.ts` — integration test with structured output validation

## Test plan
- [x] All 175 tests pass (10 test files)
- [x] Build succeeds with `turbo run build --filter=@paretools/build`
- [x] Integration test validates structured output from live turbo execution
- [x] Flag injection blocked on task and filter params

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)