### PR TITLE
feat(python): add conda tool (#278)

### DIFF
--- a/packages/server-python/__tests__/integration.test.ts
+++ b/packages/server-python/__tests__/integration.test.ts
@@ -29,11 +29,12 @@ describe("@paretools/python integration", () => {
     await transport.close();
   });
 
-  it("lists all 11 tools", async () => {
+  it("lists all 12 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
       "black",
+      "conda",
       "mypy",
       "pip-audit",
       "pip-install",
@@ -295,6 +296,68 @@ describe("@paretools/python integration", () => {
         expect(sc).toBeDefined();
         expect(typeof sc.success).toBe("boolean");
         expect(typeof sc.filesChanged).toBe("number");
+      }
+    });
+  });
+
+  describe("conda", () => {
+    it("returns structured data for info action or a command-not-found error", async () => {
+      const result = await client.callTool(
+        { name: "conda", arguments: { action: "info" } },
+        undefined,
+        CALL_TIMEOUT,
+      );
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/conda|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(sc.action).toBe("info");
+        expect(typeof sc.condaVersion).toBe("string");
+        expect(typeof sc.platform).toBe("string");
+        expect(typeof sc.pythonVersion).toBe("string");
+        expect(typeof sc.defaultPrefix).toBe("string");
+        expect(Array.isArray(sc.channels)).toBe(true);
+      }
+    });
+
+    it("returns structured data for env-list action or a command-not-found error", async () => {
+      const result = await client.callTool(
+        { name: "conda", arguments: { action: "env-list" } },
+        undefined,
+        CALL_TIMEOUT,
+      );
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/conda|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(sc.action).toBe("env-list");
+        expect(Array.isArray(sc.environments)).toBe(true);
+        expect(typeof sc.total).toBe("number");
+      }
+    });
+
+    it("returns structured data for list action or a command-not-found error", async () => {
+      const result = await client.callTool(
+        { name: "conda", arguments: { action: "list" } },
+        undefined,
+        CALL_TIMEOUT,
+      );
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/conda|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(sc.action).toBe("list");
+        expect(Array.isArray(sc.packages)).toBe(true);
+        expect(typeof sc.total).toBe("number");
       }
     });
   });

--- a/packages/server-python/src/lib/python-runner.ts
+++ b/packages/server-python/src/lib/python-runner.ts
@@ -23,3 +23,7 @@ export async function uv(args: string[], cwd?: string): Promise<RunResult> {
 export async function black(args: string[], cwd?: string): Promise<RunResult> {
   return run("black", args, { cwd, timeout: 120_000 });
 }
+
+export async function conda(args: string[], cwd?: string): Promise<RunResult> {
+  return run("conda", args, { cwd, timeout: 120_000 });
+}

--- a/packages/server-python/src/schemas/index.ts
+++ b/packages/server-python/src/schemas/index.ts
@@ -167,3 +167,66 @@ export const RuffFormatResultSchema = z.object({
 });
 
 export type RuffFormatResult = z.infer<typeof RuffFormatResultSchema>;
+
+/** Zod schema for a single conda package entry with name, version, and channel. */
+export const CondaPackageSchema = z.object({
+  name: z.string(),
+  version: z.string(),
+  channel: z.string(),
+  buildString: z.string().optional(),
+});
+
+/** Zod schema for a single conda environment entry. */
+export const CondaEnvSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  active: z.boolean(),
+});
+
+/** Zod schema for structured conda output covering list, info, and env-list actions. */
+export const CondaResultSchema = z.object({
+  action: z.enum(["list", "info", "env-list"]),
+  // list fields
+  packages: z.array(CondaPackageSchema).optional(),
+  total: z.number().optional(),
+  environment: z.string().optional(),
+  // info fields
+  condaVersion: z.string().optional(),
+  platform: z.string().optional(),
+  pythonVersion: z.string().optional(),
+  defaultPrefix: z.string().optional(),
+  activePrefix: z.string().optional(),
+  channels: z.array(z.string()).optional(),
+  envsDirs: z.array(z.string()).optional(),
+  pkgsDirs: z.array(z.string()).optional(),
+  // env-list fields
+  environments: z.array(CondaEnvSchema).optional(),
+});
+
+export type CondaResult = z.infer<typeof CondaResultSchema>;
+
+/** Narrowed type for conda list action. */
+export type CondaList = CondaResult & {
+  action: "list";
+  packages: { name: string; version: string; channel: string; buildString?: string }[];
+  total: number;
+};
+
+/** Narrowed type for conda info action. */
+export type CondaInfo = CondaResult & {
+  action: "info";
+  condaVersion: string;
+  platform: string;
+  pythonVersion: string;
+  defaultPrefix: string;
+  channels: string[];
+  envsDirs: string[];
+  pkgsDirs: string[];
+};
+
+/** Narrowed type for conda env-list action. */
+export type CondaEnvList = CondaResult & {
+  action: "env-list";
+  environments: { name: string; path: string; active: boolean }[];
+  total: number;
+};

--- a/packages/server-python/src/tools/conda.ts
+++ b/packages/server-python/src/tools/conda.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { conda } from "../lib/python-runner.js";
+import { parseCondaListJson, parseCondaInfoJson, parseCondaEnvListJson } from "../lib/parsers.js";
+import {
+  formatCondaResult,
+  compactCondaResultMap,
+  formatCondaResultCompact,
+} from "../lib/formatters.js";
+import { CondaResultSchema } from "../schemas/index.js";
+
+export function registerCondaTool(server: McpServer) {
+  server.registerTool(
+    "conda",
+    {
+      title: "Conda",
+      description:
+        "Runs conda commands (list, info, env-list) and returns structured JSON output. " +
+        "Use instead of running `conda` in the terminal.",
+      inputSchema: {
+        action: z
+          .enum(["list", "info", "env-list"])
+          .describe("Conda action to perform: list packages, show info, or list environments"),
+        name: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe(
+            "Environment name (used with 'list' action to list packages in a specific env)",
+          ),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: CondaResultSchema,
+    },
+    async ({ action, name, path, compact }) => {
+      const cwd = path || process.cwd();
+
+      switch (action) {
+        case "list": {
+          const args = ["list", "--json"];
+          if (name) args.push("--name", name);
+          const result = await conda(args, cwd);
+          const data = parseCondaListJson(result.stdout, name);
+          return compactDualOutput(
+            data,
+            result.stdout,
+            formatCondaResult,
+            compactCondaResultMap,
+            formatCondaResultCompact,
+            compact === false,
+          );
+        }
+        case "info": {
+          const result = await conda(["info", "--json"], cwd);
+          const data = parseCondaInfoJson(result.stdout);
+          return compactDualOutput(
+            data,
+            result.stdout,
+            formatCondaResult,
+            compactCondaResultMap,
+            formatCondaResultCompact,
+            compact === false,
+          );
+        }
+        case "env-list": {
+          // Get env list and info (for active prefix) in parallel
+          const [envResult, infoResult] = await Promise.all([
+            conda(["env", "list", "--json"], cwd),
+            conda(["info", "--json"], cwd),
+          ]);
+          let activePrefix: string | undefined;
+          try {
+            const infoData = JSON.parse(infoResult.stdout);
+            activePrefix = infoData.active_prefix || undefined;
+          } catch {
+            // ignore parse errors for active prefix detection
+          }
+          const data = parseCondaEnvListJson(envResult.stdout, activePrefix);
+          return compactDualOutput(
+            data,
+            envResult.stdout,
+            formatCondaResult,
+            compactCondaResultMap,
+            formatCondaResultCompact,
+            compact === false,
+          );
+        }
+      }
+    },
+  );
+}

--- a/packages/server-python/src/tools/index.ts
+++ b/packages/server-python/src/tools/index.ts
@@ -11,6 +11,7 @@ import { registerPytestTool } from "./pytest.js";
 import { registerUvInstallTool } from "./uv-install.js";
 import { registerUvRunTool } from "./uv-run.js";
 import { registerBlackTool } from "./black.js";
+import { registerCondaTool } from "./conda.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("python", name);
@@ -25,4 +26,5 @@ export function registerAllTools(server: McpServer) {
   if (s("uv-install")) registerUvInstallTool(server);
   if (s("uv-run")) registerUvRunTool(server);
   if (s("black")) registerBlackTool(server);
+  if (s("conda")) registerCondaTool(server);
 }


### PR DESCRIPTION
## Summary
- Adds `conda` tool to `@paretools/python` for environment and package management
- Supports three read-only actions: `list` (packages), `info` (conda metadata), and `env-list` (environments)
- Uses `conda --json` flags for structured output parsing
- Includes Zod output schema, parser, formatter with compact variants, and full unit + integration tests

## Test plan
- [x] Parser tests for all 3 actions (valid JSON, empty, invalid, edge cases)
- [x] Formatter tests for all 3 actions (empty, populated, with/without optional fields)
- [x] Integration tests verifying structured output or graceful command-not-found handling
- [x] All 249 tests passing locally

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)