### PR TITLE
feat(python): add pyenv tool (#279)

### DIFF
--- a/packages/server-python/__tests__/integration.test.ts
+++ b/packages/server-python/__tests__/integration.test.ts
@@ -29,7 +29,7 @@ describe("@paretools/python integration", () => {
     await transport.close();
   });
 
-  it("lists all 12 tools", async () => {
+  it("lists all 13 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
@@ -40,6 +40,7 @@ describe("@paretools/python integration", () => {
       "pip-install",
       "pip-list",
       "pip-show",
+      "pyenv",
       "pytest",
       "ruff-check",
       "ruff-format",
@@ -358,6 +359,26 @@ describe("@paretools/python integration", () => {
         expect(sc.action).toBe("list");
         expect(Array.isArray(sc.packages)).toBe(true);
         expect(typeof sc.total).toBe("number");
+      }
+    });
+  });
+
+  describe("pyenv", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool(
+        { name: "pyenv", arguments: { action: "version" } },
+        undefined,
+        CALL_TIMEOUT,
+      );
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/pyenv|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(sc.action).toBe("version");
+        expect(typeof sc.success).toBe("boolean");
       }
     });
   });

--- a/packages/server-python/__tests__/pyenv.test.ts
+++ b/packages/server-python/__tests__/pyenv.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from "vitest";
+import { parsePyenvOutput } from "../src/lib/parsers.js";
+import { formatPyenv, compactPyenvMap, formatPyenvCompact } from "../src/lib/formatters.js";
+import type { PyenvResult } from "../src/schemas/index.js";
+
+// ── Parser tests ─────────────────────────────────────────────────────
+
+describe("parsePyenvOutput", () => {
+  describe("versions action", () => {
+    it("parses list of installed versions with --bare output", () => {
+      const stdout = "2.7.18\n3.10.13\n3.11.7\n3.12.0\n";
+      const result = parsePyenvOutput(stdout, "", 0, "versions");
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("versions");
+      expect(result.versions).toEqual(["2.7.18", "3.10.13", "3.11.7", "3.12.0"]);
+    });
+
+    it("parses versions with current marker", () => {
+      const stdout = "  2.7.18\n* 3.12.0 (set by /home/user/.pyenv/version)\n  3.11.7\n";
+      const result = parsePyenvOutput(stdout, "", 0, "versions");
+
+      expect(result.success).toBe(true);
+      expect(result.versions).toContain("3.12.0");
+      expect(result.versions).toContain("2.7.18");
+      expect(result.versions).toContain("3.11.7");
+      expect(result.current).toBe("3.12.0");
+    });
+
+    it("handles empty versions list", () => {
+      const result = parsePyenvOutput("", "", 0, "versions");
+
+      expect(result.success).toBe(true);
+      expect(result.versions).toEqual([]);
+      expect(result.current).toBeUndefined();
+    });
+
+    it("handles failure", () => {
+      const result = parsePyenvOutput("", "pyenv: command not found", 127, "versions");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("pyenv: command not found");
+    });
+  });
+
+  describe("version action", () => {
+    it("parses current version", () => {
+      const stdout = "3.12.0 (set by /home/user/.pyenv/version)\n";
+      const result = parsePyenvOutput(stdout, "", 0, "version");
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("version");
+      expect(result.current).toBe("3.12.0");
+    });
+
+    it("parses system version", () => {
+      const stdout = "system\n";
+      const result = parsePyenvOutput(stdout, "", 0, "version");
+
+      expect(result.success).toBe(true);
+      expect(result.current).toBe("system");
+    });
+
+    it("handles empty output", () => {
+      const result = parsePyenvOutput("", "", 0, "version");
+
+      expect(result.success).toBe(true);
+      expect(result.current).toBeUndefined();
+    });
+  });
+
+  describe("install action", () => {
+    it("parses successful install", () => {
+      const stderr =
+        "Installing Python-3.12.0...\nInstalled Python-3.12.0 to /home/user/.pyenv/versions/3.12.0\n";
+      const result = parsePyenvOutput("", stderr, 0, "install");
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("install");
+      expect(result.installed).toBe("3.12.0");
+    });
+
+    it("handles install failure", () => {
+      const stderr = "python-build: definition not found: 99.99.99\n";
+      const result = parsePyenvOutput("", stderr, 1, "install");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("definition not found");
+    });
+
+    it("handles install with no version extracted", () => {
+      const result = parsePyenvOutput("", "some output", 0, "install");
+
+      expect(result.success).toBe(true);
+      expect(result.installed).toBeUndefined();
+    });
+  });
+
+  describe("local action", () => {
+    it("parses local version query", () => {
+      const stdout = "3.11.7\n";
+      const result = parsePyenvOutput(stdout, "", 0, "local");
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("local");
+      expect(result.localVersion).toBe("3.11.7");
+    });
+
+    it("parses local version set (empty stdout)", () => {
+      const result = parsePyenvOutput("", "", 0, "local");
+
+      expect(result.success).toBe(true);
+      expect(result.localVersion).toBeUndefined();
+    });
+
+    it("handles failure when no local version set", () => {
+      const stderr = "pyenv: no local version configured for this directory\n";
+      const result = parsePyenvOutput("", stderr, 1, "local");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("no local version configured");
+    });
+  });
+
+  describe("global action", () => {
+    it("parses global version query", () => {
+      const stdout = "3.12.0\n";
+      const result = parsePyenvOutput(stdout, "", 0, "global");
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("global");
+      expect(result.globalVersion).toBe("3.12.0");
+    });
+
+    it("parses global version set (empty stdout)", () => {
+      const result = parsePyenvOutput("", "", 0, "global");
+
+      expect(result.success).toBe(true);
+      expect(result.globalVersion).toBeUndefined();
+    });
+  });
+});
+
+// ── Formatter tests ──────────────────────────────────────────────────
+
+describe("formatPyenv", () => {
+  it("formats error result", () => {
+    const data: PyenvResult = {
+      action: "versions",
+      success: false,
+      error: "pyenv: command not found",
+    };
+    expect(formatPyenv(data)).toBe("pyenv versions failed: pyenv: command not found");
+  });
+
+  it("formats empty versions list", () => {
+    const data: PyenvResult = {
+      action: "versions",
+      success: true,
+      versions: [],
+    };
+    expect(formatPyenv(data)).toBe("pyenv: no versions installed.");
+  });
+
+  it("formats versions list with current marker", () => {
+    const data: PyenvResult = {
+      action: "versions",
+      success: true,
+      versions: ["3.10.13", "3.11.7", "3.12.0"],
+      current: "3.12.0",
+    };
+    const output = formatPyenv(data);
+    expect(output).toContain("3 versions installed:");
+    expect(output).toContain("  3.10.13");
+    expect(output).toContain("  3.11.7");
+    expect(output).toContain("  3.12.0 *");
+  });
+
+  it("formats current version", () => {
+    const data: PyenvResult = {
+      action: "version",
+      success: true,
+      current: "3.12.0",
+    };
+    expect(formatPyenv(data)).toBe("pyenv: current version is 3.12.0");
+  });
+
+  it("formats no version set", () => {
+    const data: PyenvResult = {
+      action: "version",
+      success: true,
+    };
+    expect(formatPyenv(data)).toBe("pyenv: no version set.");
+  });
+
+  it("formats successful install", () => {
+    const data: PyenvResult = {
+      action: "install",
+      success: true,
+      installed: "3.12.0",
+    };
+    expect(formatPyenv(data)).toBe("pyenv: installed Python 3.12.0");
+  });
+
+  it("formats install without extracted version", () => {
+    const data: PyenvResult = {
+      action: "install",
+      success: true,
+    };
+    expect(formatPyenv(data)).toBe("pyenv: installation completed.");
+  });
+
+  it("formats local version set", () => {
+    const data: PyenvResult = {
+      action: "local",
+      success: true,
+      localVersion: "3.11.7",
+    };
+    expect(formatPyenv(data)).toBe("pyenv: local version set to 3.11.7");
+  });
+
+  it("formats local version set without version", () => {
+    const data: PyenvResult = {
+      action: "local",
+      success: true,
+    };
+    expect(formatPyenv(data)).toBe("pyenv: local version set.");
+  });
+
+  it("formats global version set", () => {
+    const data: PyenvResult = {
+      action: "global",
+      success: true,
+      globalVersion: "3.12.0",
+    };
+    expect(formatPyenv(data)).toBe("pyenv: global version set to 3.12.0");
+  });
+
+  it("formats global version set without version", () => {
+    const data: PyenvResult = {
+      action: "global",
+      success: true,
+    };
+    expect(formatPyenv(data)).toBe("pyenv: global version set.");
+  });
+});
+
+// ── Compact formatter tests ──────────────────────────────────────────
+
+describe("compactPyenvMap", () => {
+  it("maps full result to compact form", () => {
+    const data: PyenvResult = {
+      action: "versions",
+      success: true,
+      versions: ["3.10.13", "3.11.7", "3.12.0"],
+      current: "3.12.0",
+    };
+    const compact = compactPyenvMap(data);
+
+    expect(compact.action).toBe("versions");
+    expect(compact.success).toBe(true);
+    // Compact drops versions/current/etc.
+    expect((compact as Record<string, unknown>).versions).toBeUndefined();
+  });
+});
+
+describe("formatPyenvCompact", () => {
+  it("formats success", () => {
+    expect(formatPyenvCompact({ action: "versions", success: true })).toBe(
+      "pyenv versions: success.",
+    );
+  });
+
+  it("formats failure", () => {
+    expect(formatPyenvCompact({ action: "install", success: false })).toBe("pyenv install failed.");
+  });
+});

--- a/packages/server-python/src/lib/formatters.ts
+++ b/packages/server-python/src/lib/formatters.ts
@@ -14,6 +14,7 @@ import type {
   CondaInfo,
   CondaEnvList,
   CondaResult,
+  PyenvResult,
 } from "../schemas/index.js";
 
 /** Formats structured pip install results into a human-readable summary of installed packages. */
@@ -581,4 +582,56 @@ export function formatCondaResultCompact(data: CondaResultCompact): string {
     case "env-list":
       return formatCondaEnvListCompact(data as CondaEnvListCompact);
   }
+}
+
+// ── pyenv formatters ─────────────────────────────────────────────────
+
+/** Formats structured pyenv results into a human-readable summary. */
+export function formatPyenv(data: PyenvResult): string {
+  if (!data.success) return `pyenv ${data.action} failed: ${data.error || "unknown error"}`;
+
+  switch (data.action) {
+    case "versions": {
+      if (!data.versions || data.versions.length === 0) return "pyenv: no versions installed.";
+      const lines = [`${data.versions.length} versions installed:`];
+      for (const v of data.versions) {
+        const marker = v === data.current ? " *" : "";
+        lines.push(`  ${v}${marker}`);
+      }
+      return lines.join("\n");
+    }
+    case "version":
+      return data.current ? `pyenv: current version is ${data.current}` : "pyenv: no version set.";
+    case "install":
+      return data.installed
+        ? `pyenv: installed Python ${data.installed}`
+        : "pyenv: installation completed.";
+    case "local":
+      return data.localVersion
+        ? `pyenv: local version set to ${data.localVersion}`
+        : "pyenv: local version set.";
+    case "global":
+      return data.globalVersion
+        ? `pyenv: global version set to ${data.globalVersion}`
+        : "pyenv: global version set.";
+  }
+}
+
+/** Compact pyenv: action + success + key value only. */
+export interface PyenvResultCompact {
+  [key: string]: unknown;
+  action: string;
+  success: boolean;
+}
+
+export function compactPyenvMap(data: PyenvResult): PyenvResultCompact {
+  return {
+    action: data.action,
+    success: data.success,
+  };
+}
+
+export function formatPyenvCompact(data: PyenvResultCompact): string {
+  if (!data.success) return `pyenv ${data.action} failed.`;
+  return `pyenv ${data.action}: success.`;
 }

--- a/packages/server-python/src/lib/python-runner.ts
+++ b/packages/server-python/src/lib/python-runner.ts
@@ -27,3 +27,7 @@ export async function black(args: string[], cwd?: string): Promise<RunResult> {
 export async function conda(args: string[], cwd?: string): Promise<RunResult> {
   return run("conda", args, { cwd, timeout: 120_000 });
 }
+
+export async function pyenv(args: string[], cwd?: string): Promise<RunResult> {
+  return run("pyenv", args, { cwd, timeout: 120_000 });
+}

--- a/packages/server-python/src/schemas/index.ts
+++ b/packages/server-python/src/schemas/index.ts
@@ -230,3 +230,17 @@ export type CondaEnvList = CondaResult & {
   environments: { name: string; path: string; active: boolean }[];
   total: number;
 };
+
+/** Zod schema for structured pyenv output with action results and version info. */
+export const PyenvResultSchema = z.object({
+  action: z.enum(["versions", "version", "install", "local", "global"]),
+  success: z.boolean(),
+  current: z.string().optional(),
+  versions: z.array(z.string()).optional(),
+  installed: z.string().optional(),
+  localVersion: z.string().optional(),
+  globalVersion: z.string().optional(),
+  error: z.string().optional(),
+});
+
+export type PyenvResult = z.infer<typeof PyenvResultSchema>;

--- a/packages/server-python/src/tools/index.ts
+++ b/packages/server-python/src/tools/index.ts
@@ -12,6 +12,7 @@ import { registerUvInstallTool } from "./uv-install.js";
 import { registerUvRunTool } from "./uv-run.js";
 import { registerBlackTool } from "./black.js";
 import { registerCondaTool } from "./conda.js";
+import { registerPyenvTool } from "./pyenv.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("python", name);
@@ -27,4 +28,5 @@ export function registerAllTools(server: McpServer) {
   if (s("uv-run")) registerUvRunTool(server);
   if (s("black")) registerBlackTool(server);
   if (s("conda")) registerCondaTool(server);
+  if (s("pyenv")) registerPyenvTool(server);
 }

--- a/packages/server-python/src/tools/pyenv.ts
+++ b/packages/server-python/src/tools/pyenv.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { pyenv } from "../lib/python-runner.js";
+import { parsePyenvOutput } from "../lib/parsers.js";
+import { formatPyenv, compactPyenvMap, formatPyenvCompact } from "../lib/formatters.js";
+import { PyenvResultSchema } from "../schemas/index.js";
+
+const ACTIONS = ["versions", "version", "install", "local", "global"] as const;
+
+export function registerPyenvTool(server: McpServer) {
+  server.registerTool(
+    "pyenv",
+    {
+      title: "pyenv",
+      description:
+        "Manages Python versions via pyenv. " +
+        "Actions: `versions` (list installed), `version` (show current), " +
+        "`install` (install a version), `local` (set local version), `global` (set global version). " +
+        "Use instead of running `pyenv` in the terminal.",
+      inputSchema: {
+        action: z.enum(ACTIONS).describe("The pyenv action to perform"),
+        version: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Python version string (required for install/local/global, e.g. '3.12.0')"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: PyenvResultSchema,
+    },
+    async ({ action, version, path, compact }) => {
+      const cwd = path || process.cwd();
+      if (version) assertNoFlagInjection(version, "version");
+
+      const args: string[] = [];
+
+      switch (action) {
+        case "versions":
+          args.push("versions", "--bare");
+          break;
+        case "version":
+          args.push("version");
+          break;
+        case "install":
+          if (!version) {
+            return {
+              content: [
+                { type: "text" as const, text: "Error: version is required for install action" },
+              ],
+              isError: true,
+            };
+          }
+          args.push("install", version);
+          break;
+        case "local":
+          if (!version) {
+            // Without a version argument, pyenv local shows the current local version
+            args.push("local");
+          } else {
+            args.push("local", version);
+          }
+          break;
+        case "global":
+          if (!version) {
+            // Without a version argument, pyenv global shows the current global version
+            args.push("global");
+          } else {
+            args.push("global", version);
+          }
+          break;
+      }
+
+      const result = await pyenv(args, cwd);
+      const data = parsePyenvOutput(result.stdout, result.stderr, result.exitCode, action);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatPyenv,
+        compactPyenvMap,
+        formatPyenvCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add `pyenv` tool to `@paretools/python` for Python version management
- Supports 5 actions: `versions` (list installed), `version` (show current), `install` (install a version), `local` (set local version), `global` (set global version)
- Full structured output with Zod schema, dual output, and compact mode

## Changes
- **Schema**: `PyenvResultSchema` with action, success, versions, current, installed, localVersion, globalVersion, error fields
- **Parser**: `parsePyenvOutput()` handles all 5 actions and error cases
- **Formatter**: `formatPyenv()`, `compactPyenvMap()`, `formatPyenvCompact()` for human-readable and compact output
- **Runner**: `pyenv()` function in `python-runner.ts`
- **Tool**: `registerPyenvTool()` with input validation and flag injection protection
- **Tests**: 29 unit tests (parser + formatter + compact), integration test

Closes #279

## Test plan
- [x] 29 unit tests for parser, formatter, and compact functions
- [x] Integration test verifying tool registration and structured output
- [x] All existing tests pass (112 unit + 14 integration)
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)