### PR TITLE
feat(docker): add compose-build tool (#284)

### DIFF
--- a/packages/server-docker/src/index.ts
+++ b/packages/server-docker/src/index.ts
@@ -8,7 +8,7 @@ const server = new McpServer(
   { name: "@paretools/docker", version: "0.7.0" },
   {
     instructions:
-      "Structured Docker operations (ps, build, logs, images, run, exec, compose-up, compose-down, pull). Use instead of running docker commands via bash. Returns typed JSON with structured container, image, and build data.",
+      "Structured Docker operations (ps, build, logs, images, run, exec, compose-up, compose-down, compose-build, pull). Use instead of running docker commands via bash. Returns typed JSON with structured container, image, and build data.",
   },
 );
 

--- a/packages/server-docker/src/schemas/index.ts
+++ b/packages/server-docker/src/schemas/index.ts
@@ -196,3 +196,22 @@ export const DockerComposeLogsSchema = z.object({
 });
 
 export type DockerComposeLogs = z.infer<typeof DockerComposeLogsSchema>;
+
+/** Zod schema for a single service build result in docker compose build output. */
+export const ComposeBuildServiceSchema = z.object({
+  service: z.string(),
+  success: z.boolean(),
+  duration: z.number().optional(),
+  error: z.string().optional(),
+});
+
+/** Zod schema for structured docker compose build output with per-service build status. */
+export const DockerComposeBuildSchema = z.object({
+  success: z.boolean(),
+  services: z.array(ComposeBuildServiceSchema),
+  built: z.number(),
+  failed: z.number(),
+  duration: z.number(),
+});
+
+export type DockerComposeBuild = z.infer<typeof DockerComposeBuildSchema>;

--- a/packages/server-docker/src/tools/compose-build.ts
+++ b/packages/server-docker/src/tools/compose-build.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { docker } from "../lib/docker-runner.js";
+import { parseComposeBuildOutput } from "../lib/parsers.js";
+import {
+  formatComposeBuild,
+  compactComposeBuildMap,
+  formatComposeBuildCompact,
+} from "../lib/formatters.js";
+import { DockerComposeBuildSchema } from "../schemas/index.js";
+
+export function registerComposeBuildTool(server: McpServer) {
+  server.registerTool(
+    "compose-build",
+    {
+      title: "Docker Compose Build",
+      description:
+        "Builds Docker Compose service images and returns structured per-service build status. Use instead of running `docker compose build` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Directory containing docker-compose.yml (default: cwd)"),
+        services: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default([])
+          .describe("Specific services to build (default: all)"),
+        noCache: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not use cache when building images (default: false)"),
+        pull: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Always pull a newer version of the base image (default: false)"),
+        buildArgs: z
+          .record(z.string(), z.string().max(INPUT_LIMITS.STRING_MAX))
+          .optional()
+          .default({})
+          .describe("Build arguments as key-value pairs (e.g., {NODE_ENV: 'production'})"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: DockerComposeBuildSchema,
+    },
+    async ({ path, services, noCache, pull, buildArgs, compact }) => {
+      if (services) {
+        for (const s of services) {
+          assertNoFlagInjection(s, "services");
+        }
+      }
+      if (buildArgs) {
+        for (const [key, value] of Object.entries(buildArgs) as [string, string][]) {
+          assertNoFlagInjection(key, "buildArgs key");
+          assertNoFlagInjection(value, "buildArgs value");
+        }
+      }
+
+      const args = ["compose", "build"];
+      if (noCache) args.push("--no-cache");
+      if (pull) args.push("--pull");
+      if (buildArgs) {
+        for (const [key, value] of Object.entries(buildArgs) as [string, string][]) {
+          args.push("--build-arg", `${key}=${value}`);
+        }
+      }
+      if (services && services.length > 0) {
+        args.push(...services);
+      }
+
+      const start = Date.now();
+      const result = await docker(args, path);
+      const duration = Math.round((Date.now() - start) / 100) / 10;
+
+      const data = parseComposeBuildOutput(result.stdout, result.stderr, result.exitCode, duration);
+
+      if (result.exitCode !== 0 && data.built === 0 && data.services.length === 0) {
+        const errorMsg = result.stderr || result.stdout || "Unknown error";
+        throw new Error(`docker compose build failed: ${errorMsg.trim()}`);
+      }
+
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatComposeBuild,
+        compactComposeBuildMap,
+        formatComposeBuildCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-docker/src/tools/index.ts
+++ b/packages/server-docker/src/tools/index.ts
@@ -14,6 +14,7 @@ import { registerNetworkLsTool } from "./network-ls.js";
 import { registerVolumeLsTool } from "./volume-ls.js";
 import { registerComposePsTool } from "./compose-ps.js";
 import { registerComposeLogsTool } from "./compose-logs.js";
+import { registerComposeBuildTool } from "./compose-build.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("docker", name);
@@ -31,4 +32,5 @@ export function registerAllTools(server: McpServer) {
   if (s("volume-ls")) registerVolumeLsTool(server);
   if (s("compose-ps")) registerComposePsTool(server);
   if (s("compose-logs")) registerComposeLogsTool(server);
+  if (s("compose-build")) registerComposeBuildTool(server);
 }


### PR DESCRIPTION
## Summary
- Add `compose-build` tool to `@paretools/docker` that runs `docker compose build` with structured per-service build status output
- Supports `--no-cache`, `--pull`, and `--build-arg` flags with flag injection protection on service names and build arg keys/values
- Includes Zod output schema, dual output via `compactDualOutput()`, parser, formatter, compact variants, and full test coverage (unit + integration)

Closes #284

## Test plan
- [x] Parser tests: successful multi-service build, failure, empty output, build step discovery, Building lines, internal filtering
- [x] Formatter tests: successful build, failed build, partial failure, empty build
- [x] Integration tests: structured output validation, flag injection rejection on services and buildArgs
- [x] All 343 existing docker tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)