### PR TITLE
feat(npm): add yarn support (#276)

### DIFF
--- a/packages/server-npm/__tests__/integration.test.ts
+++ b/packages/server-npm/__tests__/integration.test.ts
@@ -94,7 +94,7 @@ describe("@paretools/npm integration", () => {
       const sc = result.structuredContent as Record<string, unknown>;
       expect(sc).toBeDefined();
       // Should auto-detect and include the package manager used
-      expect(["npm", "pnpm"]).toContain(sc.packageManager);
+      expect(["npm", "pnpm", "yarn"]).toContain(sc.packageManager);
     });
   });
 

--- a/packages/server-npm/__tests__/yarn-parsers.test.ts
+++ b/packages/server-npm/__tests__/yarn-parsers.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseYarnAuditJson,
+  parseYarnListJson,
+  parseYarnOutdatedJson,
+  parseInstallOutput,
+} from "../src/lib/parsers.js";
+
+describe("parseYarnAuditJson", () => {
+  it("parses Yarn Classic NDJSON audit output", () => {
+    const lines = [
+      JSON.stringify({
+        type: "auditAdvisory",
+        data: {
+          advisory: {
+            id: 1234,
+            module_name: "lodash",
+            severity: "high",
+            title: "Prototype Pollution",
+            url: "https://npmjs.com/advisories/1234",
+            vulnerable_versions: "<4.17.21",
+            patched_versions: ">=4.17.21",
+          },
+        },
+      }),
+      JSON.stringify({
+        type: "auditSummary",
+        data: {
+          vulnerabilities: { critical: 0, high: 1, moderate: 0, low: 0, info: 0 },
+        },
+      }),
+    ].join("\n");
+
+    const result = parseYarnAuditJson(lines);
+
+    expect(result.vulnerabilities).toHaveLength(1);
+    expect(result.vulnerabilities[0].name).toBe("lodash");
+    expect(result.vulnerabilities[0].severity).toBe("high");
+    expect(result.vulnerabilities[0].title).toBe("Prototype Pollution");
+    expect(result.vulnerabilities[0].fixAvailable).toBe(true);
+    expect(result.summary.total).toBe(1);
+    expect(result.summary.high).toBe(1);
+  });
+
+  it("deduplicates advisories by id", () => {
+    const advisory = {
+      type: "auditAdvisory",
+      data: {
+        advisory: {
+          id: 1234,
+          module_name: "lodash",
+          severity: "high",
+          title: "Prototype Pollution",
+          patched_versions: ">=4.17.21",
+        },
+      },
+    };
+    const lines = [
+      JSON.stringify(advisory),
+      JSON.stringify(advisory), // duplicate
+      JSON.stringify({
+        type: "auditSummary",
+        data: { vulnerabilities: { critical: 0, high: 1, moderate: 0, low: 0, info: 0 } },
+      }),
+    ].join("\n");
+
+    const result = parseYarnAuditJson(lines);
+    expect(result.vulnerabilities).toHaveLength(1);
+  });
+
+  it("handles npm-compatible format (Yarn Berry)", () => {
+    const json = JSON.stringify({
+      vulnerabilities: {
+        express: {
+          severity: "moderate",
+          title: "Open Redirect",
+          via: [{ title: "Open Redirect", url: "https://npmjs.com/advisories/5678" }],
+          range: "<4.19.0",
+          fixAvailable: true,
+        },
+      },
+      metadata: {
+        vulnerabilities: { total: 1, critical: 0, high: 0, moderate: 1, low: 0, info: 0 },
+      },
+    });
+
+    const result = parseYarnAuditJson(json);
+    expect(result.summary.total).toBe(1);
+    expect(result.vulnerabilities[0].name).toBe("express");
+  });
+
+  it("handles empty NDJSON output", () => {
+    const result = parseYarnAuditJson("");
+    expect(result.vulnerabilities).toHaveLength(0);
+    expect(result.summary.total).toBe(0);
+  });
+
+  it("handles advisory with no fix available", () => {
+    const lines = [
+      JSON.stringify({
+        type: "auditAdvisory",
+        data: {
+          advisory: {
+            id: 999,
+            module_name: "no-fix-pkg",
+            severity: "low",
+            title: "Info Leak",
+            patched_versions: "<0.0.0",
+          },
+        },
+      }),
+    ].join("\n");
+
+    const result = parseYarnAuditJson(lines);
+    expect(result.vulnerabilities[0].fixAvailable).toBe(false);
+  });
+});
+
+describe("parseYarnListJson", () => {
+  it("parses Yarn Classic tree format", () => {
+    const json = JSON.stringify({
+      type: "tree",
+      data: {
+        type: "list",
+        trees: [
+          { name: "express@4.18.2", children: [] },
+          {
+            name: "lodash@4.17.21",
+            children: [{ name: "lodash.merge@4.6.2", children: [] }],
+          },
+        ],
+      },
+    });
+
+    const result = parseYarnListJson(json);
+    expect(result.dependencies["express"]).toEqual({ version: "4.18.2" });
+    expect(result.dependencies["lodash"].version).toBe("4.17.21");
+    expect(result.dependencies["lodash"].dependencies?.["lodash.merge"].version).toBe("4.6.2");
+    expect(result.total).toBe(3);
+  });
+
+  it("handles empty tree", () => {
+    const json = JSON.stringify({
+      type: "tree",
+      data: { type: "list", trees: [] },
+    });
+
+    const result = parseYarnListJson(json);
+    expect(result.total).toBe(0);
+    expect(result.dependencies).toEqual({});
+  });
+
+  it("handles npm-compatible format (Yarn Berry)", () => {
+    const json = JSON.stringify({
+      name: "my-project",
+      version: "1.0.0",
+      dependencies: {
+        express: { version: "4.18.2" },
+      },
+    });
+
+    const result = parseYarnListJson(json);
+    expect(result.name).toBe("my-project");
+    expect(result.dependencies["express"].version).toBe("4.18.2");
+  });
+
+  it("handles scoped packages with @ in name", () => {
+    const json = JSON.stringify({
+      type: "tree",
+      data: {
+        type: "list",
+        trees: [{ name: "@types/node@20.11.0", children: [] }],
+      },
+    });
+
+    const result = parseYarnListJson(json);
+    expect(result.dependencies["@types/node"]).toEqual({ version: "20.11.0" });
+  });
+
+  it("returns empty result for invalid input", () => {
+    const result = parseYarnListJson("not valid json at all");
+    expect(result.total).toBe(0);
+    expect(result.dependencies).toEqual({});
+  });
+});
+
+describe("parseYarnOutdatedJson", () => {
+  it("parses Yarn Classic table format", () => {
+    const json = JSON.stringify({
+      type: "table",
+      data: {
+        head: ["Package", "Current", "Wanted", "Latest", "Package Type", "URL"],
+        body: [
+          ["express", "4.17.0", "4.18.2", "5.0.0", "dependencies", "https://expressjs.com"],
+          ["lodash", "4.17.0", "4.17.21", "4.17.21", "devDependencies", "https://lodash.com"],
+        ],
+      },
+    });
+
+    const result = parseYarnOutdatedJson(json);
+    expect(result.total).toBe(2);
+    expect(result.packages[0].name).toBe("express");
+    expect(result.packages[0].current).toBe("4.17.0");
+    expect(result.packages[0].wanted).toBe("4.18.2");
+    expect(result.packages[0].latest).toBe("5.0.0");
+    expect(result.packages[0].type).toBe("dependencies");
+    expect(result.packages[1].name).toBe("lodash");
+    expect(result.packages[1].type).toBe("devDependencies");
+  });
+
+  it("handles empty table", () => {
+    const json = JSON.stringify({
+      type: "table",
+      data: { head: [], body: [] },
+    });
+
+    const result = parseYarnOutdatedJson(json);
+    expect(result.total).toBe(0);
+    expect(result.packages).toEqual([]);
+  });
+
+  it("handles npm-compatible format", () => {
+    const json = JSON.stringify({
+      express: { current: "4.17.0", wanted: "4.18.2", latest: "5.0.0", type: "dependencies" },
+    });
+
+    const result = parseYarnOutdatedJson(json);
+    expect(result.total).toBe(1);
+    expect(result.packages[0].name).toBe("express");
+  });
+
+  it("handles empty NDJSON output", () => {
+    const result = parseYarnOutdatedJson("");
+    expect(result.total).toBe(0);
+    expect(result.packages).toEqual([]);
+  });
+});
+
+describe("parseInstallOutput with yarn-style output", () => {
+  it("parses yarn install output with success message", () => {
+    const output = "success Saved lockfile.\nadded 42 packages in 3.5s\n42 packages in 3s";
+    const result = parseInstallOutput(output, 3.5);
+
+    expect(result.added).toBe(42);
+    expect(result.packages).toBe(42);
+    expect(result.duration).toBe(3.5);
+  });
+
+  it("parses yarn install output with no changes", () => {
+    const output = "success Already up-to-date.\n0 packages in 0s";
+    const result = parseInstallOutput(output, 0.5);
+
+    expect(result.added).toBe(0);
+    expect(result.duration).toBe(0.5);
+  });
+});

--- a/packages/server-npm/__tests__/yarn-runner.test.ts
+++ b/packages/server-npm/__tests__/yarn-runner.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the shared runner before importing the module under test
+vi.mock("@paretools/shared", () => ({
+  run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" }),
+}));
+
+import { yarn, runPm } from "../src/lib/npm-runner.js";
+import { run } from "@paretools/shared";
+
+const mockRun = vi.mocked(run);
+
+beforeEach(() => {
+  mockRun.mockClear();
+});
+
+describe("yarn runner", () => {
+  describe("argument construction", () => {
+    it("passes args array directly to run() with yarn command", async () => {
+      await yarn(["install", "--frozen-lockfile"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "yarn",
+        ["install", "--frozen-lockfile"],
+        expect.objectContaining({}),
+      );
+    });
+
+    it("passes cwd option to run()", async () => {
+      await yarn(["audit", "--json"], "/home/user/project");
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "yarn",
+        ["audit", "--json"],
+        expect.objectContaining({ cwd: "/home/user/project" }),
+      );
+    });
+  });
+
+  describe("timeout logic", () => {
+    it("uses 300s timeout for install", async () => {
+      await yarn(["install"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "yarn",
+        ["install"],
+        expect.objectContaining({ timeout: 300_000 }),
+      );
+    });
+
+    it("uses 300s timeout for add", async () => {
+      await yarn(["add", "express"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "yarn",
+        ["add", "express"],
+        expect.objectContaining({ timeout: 300_000 }),
+      );
+    });
+
+    it("uses 300s timeout for run", async () => {
+      await yarn(["run", "build"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "yarn",
+        ["run", "build"],
+        expect.objectContaining({ timeout: 300_000 }),
+      );
+    });
+
+    it("uses 300s timeout for test", async () => {
+      await yarn(["test"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "yarn",
+        ["test"],
+        expect.objectContaining({ timeout: 300_000 }),
+      );
+    });
+
+    it("uses 60s timeout for audit", async () => {
+      await yarn(["audit", "--json"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "yarn",
+        ["audit", "--json"],
+        expect.objectContaining({ timeout: 60_000 }),
+      );
+    });
+
+    it("uses 60s timeout for outdated", async () => {
+      await yarn(["outdated", "--json"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "yarn",
+        ["outdated", "--json"],
+        expect.objectContaining({ timeout: 60_000 }),
+      );
+    });
+
+    it("uses 60s timeout for list", async () => {
+      await yarn(["list", "--json", "--depth=0"]);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        "yarn",
+        ["list", "--json", "--depth=0"],
+        expect.objectContaining({ timeout: 60_000 }),
+      );
+    });
+  });
+});
+
+describe("runPm with yarn", () => {
+  it("delegates to yarn when pm is yarn", async () => {
+    await runPm("yarn", ["install"]);
+
+    expect(mockRun).toHaveBeenCalledWith("yarn", ["install"], expect.objectContaining({}));
+  });
+
+  it("delegates to npm when pm is npm", async () => {
+    await runPm("npm", ["install"]);
+
+    expect(mockRun).toHaveBeenCalledWith("npm", ["install"], expect.objectContaining({}));
+  });
+
+  it("delegates to pnpm when pm is pnpm", async () => {
+    await runPm("pnpm", ["install"]);
+
+    expect(mockRun).toHaveBeenCalledWith("pnpm", ["install"], expect.objectContaining({}));
+  });
+});

--- a/packages/server-npm/src/lib/detect-pm.ts
+++ b/packages/server-npm/src/lib/detect-pm.ts
@@ -1,11 +1,11 @@
 import { access } from "node:fs/promises";
 import { join } from "node:path";
 
-export type PackageManager = "npm" | "pnpm";
+export type PackageManager = "npm" | "pnpm" | "yarn";
 
 /**
  * Detects the package manager for a given project directory by checking lock files.
- * Priority: pnpm-lock.yaml > package-lock.json > default (npm).
+ * Priority: pnpm-lock.yaml > yarn.lock > package-lock.json > default (npm).
  * If `explicit` is provided, it is returned directly (user override).
  */
 export async function detectPackageManager(
@@ -19,6 +19,13 @@ export async function detectPackageManager(
     return "pnpm";
   } catch {
     // no pnpm-lock.yaml
+  }
+
+  try {
+    await access(join(cwd, "yarn.lock"));
+    return "yarn";
+  } catch {
+    // no yarn.lock
   }
 
   return "npm";

--- a/packages/server-npm/src/lib/npm-runner.ts
+++ b/packages/server-npm/src/lib/npm-runner.ts
@@ -23,7 +23,13 @@ export async function pnpm(args: string[], cwd?: string): Promise<RunResult> {
   return run("pnpm", args, { cwd, timeout: isLongRunning(args) ? 300_000 : 60_000 });
 }
 
+export async function yarn(args: string[], cwd?: string): Promise<RunResult> {
+  return run("yarn", args, { cwd, timeout: isLongRunning(args) ? 300_000 : 60_000 });
+}
+
 /** Run a command with the appropriate package manager. */
 export async function runPm(pm: PackageManager, args: string[], cwd?: string): Promise<RunResult> {
-  return pm === "pnpm" ? pnpm(args, cwd) : npm(args, cwd);
+  if (pm === "pnpm") return pnpm(args, cwd);
+  if (pm === "yarn") return yarn(args, cwd);
+  return npm(args, cwd);
 }

--- a/packages/server-npm/src/lib/pm-input.ts
+++ b/packages/server-npm/src/lib/pm-input.ts
@@ -3,10 +3,10 @@ import { INPUT_LIMITS } from "@paretools/shared";
 
 /** Reusable Zod field for packageManager input on all tools. */
 export const packageManagerInput = z
-  .enum(["npm", "pnpm"])
+  .enum(["npm", "pnpm", "yarn"])
   .optional()
   .describe(
-    "Package manager to use. Auto-detected from lock files if not specified (pnpm-lock.yaml → pnpm, otherwise npm).",
+    "Package manager to use. Auto-detected from lock files if not specified (pnpm-lock.yaml → pnpm, yarn.lock → yarn, otherwise npm).",
   );
 
 /** Reusable Zod field for pnpm workspace --filter. */

--- a/packages/server-npm/src/schemas/index.ts
+++ b/packages/server-npm/src/schemas/index.ts
@@ -2,9 +2,9 @@ import { z } from "zod";
 
 /** Reusable schema field indicating which package manager was used. */
 const packageManagerField = z
-  .enum(["npm", "pnpm"])
+  .enum(["npm", "pnpm", "yarn"])
   .optional()
-  .describe("Package manager that was used (npm or pnpm)");
+  .describe("Package manager that was used (npm, pnpm, or yarn)");
 
 /** Zod schema for structured npm install output including package counts, vulnerabilities, and duration. */
 export const NpmInstallSchema = z.object({

--- a/packages/server-npm/src/tools/audit.ts
+++ b/packages/server-npm/src/tools/audit.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { runPm } from "../lib/npm-runner.js";
 import { detectPackageManager } from "../lib/detect-pm.js";
-import { parseAuditJson, parsePnpmAuditJson } from "../lib/parsers.js";
+import { parseAuditJson, parsePnpmAuditJson, parseYarnAuditJson } from "../lib/parsers.js";
 import { formatAudit } from "../lib/formatters.js";
 import { NpmAuditSchema } from "../schemas/index.js";
 import { packageManagerInput } from "../lib/pm-input.js";
@@ -14,8 +14,9 @@ export function registerAuditTool(server: McpServer) {
     {
       title: "Audit Dependencies",
       description:
-        "Runs npm/pnpm audit and returns structured vulnerability data. " +
-        "Auto-detects pnpm via pnpm-lock.yaml. Use instead of running `npm audit` or `pnpm audit` in the terminal.",
+        "Runs npm/pnpm/yarn audit and returns structured vulnerability data. " +
+        "Auto-detects package manager via lock files (pnpm-lock.yaml → pnpm, yarn.lock → yarn, otherwise npm). " +
+        "Use instead of running `npm audit`, `pnpm audit`, or `yarn audit` in the terminal.",
       inputSchema: {
         path: z
           .string()
@@ -33,7 +34,12 @@ export function registerAuditTool(server: McpServer) {
 
       // audit returns exit code 1 when vulnerabilities are found, which is expected
       const output = result.stdout || result.stderr;
-      const audit = pm === "pnpm" ? parsePnpmAuditJson(output) : parseAuditJson(output);
+      const audit =
+        pm === "pnpm"
+          ? parsePnpmAuditJson(output)
+          : pm === "yarn"
+            ? parseYarnAuditJson(output)
+            : parseAuditJson(output);
       return dualOutput({ ...audit, packageManager: pm }, formatAudit);
     },
   );

--- a/packages/server-npm/src/tools/init.ts
+++ b/packages/server-npm/src/tools/init.ts
@@ -17,7 +17,7 @@ export function registerInitTool(server: McpServer) {
       title: "Init Package",
       description:
         "Initializes a new package.json in the target directory. " +
-        "Works with both npm and pnpm. Returns structured output with the package name, version, and path.",
+        "Works with npm, pnpm, and yarn. Returns structured output with the package name, version, and path.",
       inputSchema: {
         path: z
           .string()

--- a/packages/server-npm/src/tools/install.ts
+++ b/packages/server-npm/src/tools/install.ts
@@ -14,9 +14,9 @@ export function registerInstallTool(server: McpServer) {
     {
       title: "Install Packages",
       description:
-        "Runs npm/pnpm install and returns a structured summary of added/removed packages and vulnerabilities. " +
-        "Use instead of running `npm install` or `pnpm install` in the terminal. " +
-        "Auto-detects pnpm via pnpm-lock.yaml. " +
+        "Runs npm/pnpm/yarn install and returns a structured summary of added/removed packages and vulnerabilities. " +
+        "Use instead of running `npm install`, `pnpm install`, or `yarn install` in the terminal. " +
+        "Auto-detects package manager via lock files (pnpm-lock.yaml → pnpm, yarn.lock → yarn, otherwise npm). " +
         "Lifecycle scripts (preinstall/postinstall) are skipped by default for safety. " +
         "Set ignoreScripts to false if packages need postinstall scripts to work (e.g., esbuild, sharp).",
       inputSchema: {

--- a/packages/server-npm/src/tools/run.ts
+++ b/packages/server-npm/src/tools/run.ts
@@ -14,8 +14,9 @@ export function registerRunTool(server: McpServer) {
     {
       title: "Run Script",
       description:
-        "Runs a package.json script via `npm run <script>` or `pnpm run <script>` and returns structured output with exit code, stdout, stderr, and duration. " +
-        "Auto-detects pnpm via pnpm-lock.yaml. Use instead of running `npm run` or `pnpm run` in the terminal.",
+        "Runs a package.json script via `npm run <script>`, `pnpm run <script>`, or `yarn run <script>` and returns structured output with exit code, stdout, stderr, and duration. " +
+        "Auto-detects package manager via lock files (pnpm-lock.yaml → pnpm, yarn.lock → yarn, otherwise npm). " +
+        "Use instead of running `npm run`, `pnpm run`, or `yarn run` in the terminal.",
       inputSchema: {
         path: z
           .string()

--- a/packages/server-npm/src/tools/search.ts
+++ b/packages/server-npm/src/tools/search.ts
@@ -13,7 +13,7 @@ export function registerSearchTool(server: McpServer) {
       title: "Search npm Registry",
       description:
         "Searches the npm registry for packages matching a query. Use instead of running `npm search` in the terminal. " +
-        "Note: pnpm does not have a search command, so this always uses npm.",
+        "Note: pnpm and yarn do not have a search command, so this always uses npm.",
       inputSchema: {
         query: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Search query string"),
         path: z

--- a/packages/server-npm/src/tools/test.ts
+++ b/packages/server-npm/src/tools/test.ts
@@ -14,8 +14,9 @@ export function registerTestTool(server: McpServer) {
     {
       title: "Run Tests",
       description:
-        "Runs `npm test` or `pnpm test` and returns structured output with exit code, stdout, stderr, and duration. " +
-        "Auto-detects pnpm via pnpm-lock.yaml. Shorthand for running the test script defined in package.json.",
+        "Runs `npm test`, `pnpm test`, or `yarn test` and returns structured output with exit code, stdout, stderr, and duration. " +
+        "Auto-detects package manager via lock files (pnpm-lock.yaml → pnpm, yarn.lock → yarn, otherwise npm). " +
+        "Shorthand for running the test script defined in package.json.",
       inputSchema: {
         path: z
           .string()


### PR DESCRIPTION
## Summary
- Add yarn as a third supported package manager in `@paretools/npm`, alongside npm and pnpm
- Auto-detect yarn projects via `yarn.lock` presence (detection priority: pnpm > yarn > npm)
- Add `"yarn"` to the `packageManager` enum across all 9 tools' input schemas and output schemas
- Implement yarn-specific parsers handling both Yarn Classic (v1) NDJSON and Yarn Berry (v2+) JSON formats for audit, list, and outdated commands
- Add `yarn()` runner function and extend `runPm()` dispatcher
- Handle Yarn Classic's `yarn info --json` wrapper format (`{ type: "inspect", data: {...} }`)
- Add 28 new unit tests across `yarn-runner.test.ts` and `yarn-parsers.test.ts`
- Update `detect-pm.test.ts` with yarn detection and priority tests
- All 238 tests pass

## Test plan
- [x] Unit tests for `detectPackageManager` with yarn.lock detection and priority ordering
- [x] Unit tests for `yarn()` runner function (argument passing, cwd, timeout logic)
- [x] Unit tests for `parseYarnAuditJson` (Classic NDJSON, Berry format, deduplication, empty)
- [x] Unit tests for `parseYarnListJson` (Classic tree, Berry format, scoped packages, invalid input)
- [x] Unit tests for `parseYarnOutdatedJson` (Classic table, npm-compatible, empty)
- [x] Unit tests for `parseInstallOutput` with yarn-style output
- [x] Integration test updated to accept "yarn" in packageManager output
- [x] Build passes (`turbo run build --filter=@paretools/npm`)
- [x] All 238 tests pass (`vitest run` in server-npm)

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)