### PR TITLE
feat(lint): add shellcheck tool (#291)

### DIFF
--- a/packages/server-lint/__tests__/integration.test.ts
+++ b/packages/server-lint/__tests__/integration.test.ts
@@ -36,7 +36,7 @@ describe("@paretools/lint integration", () => {
     await transport.close();
   });
 
-  it("lists all 7 tools", async () => {
+  it("lists all 8 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
@@ -46,6 +46,7 @@ describe("@paretools/lint integration", () => {
       "lint",
       "oxlint",
       "prettier-format",
+      "shellcheck",
       "stylelint",
     ]);
   });

--- a/packages/server-lint/src/lib/lint-runner.ts
+++ b/packages/server-lint/src/lib/lint-runner.ts
@@ -19,3 +19,7 @@ export async function stylelintCmd(args: string[], cwd?: string): Promise<RunRes
 export async function oxlintCmd(args: string[], cwd?: string): Promise<RunResult> {
   return run("npx", ["oxlint", ...args], { cwd, timeout: 120_000 });
 }
+
+export async function shellcheckCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("shellcheck", args, { cwd, timeout: 120_000 });
+}

--- a/packages/server-lint/src/tools/index.ts
+++ b/packages/server-lint/src/tools/index.ts
@@ -7,6 +7,7 @@ import { registerBiomeCheckTool } from "./biome-check.js";
 import { registerBiomeFormatTool } from "./biome-format.js";
 import { registerStylelintTool } from "./stylelint.js";
 import { registerOxlintTool } from "./oxlint.js";
+import { registerShellcheckTool } from "./shellcheck.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("lint", name);
@@ -17,4 +18,5 @@ export function registerAllTools(server: McpServer) {
   if (s("biome-format")) registerBiomeFormatTool(server);
   if (s("stylelint")) registerStylelintTool(server);
   if (s("oxlint")) registerOxlintTool(server);
+  if (s("shellcheck")) registerShellcheckTool(server);
 }

--- a/packages/server-lint/src/tools/shellcheck.ts
+++ b/packages/server-lint/src/tools/shellcheck.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { shellcheckCmd } from "../lib/lint-runner.js";
+import { parseShellcheckJson } from "../lib/parsers.js";
+import { formatLint, compactLintMap, formatLintCompact } from "../lib/formatters.js";
+import { LintResultSchema } from "../schemas/index.js";
+
+export function registerShellcheckTool(server: McpServer) {
+  server.registerTool(
+    "shellcheck",
+    {
+      title: "ShellCheck",
+      description:
+        "Runs ShellCheck (shell script linter) and returns structured diagnostics (file, line, rule, severity, message). Use instead of running `shellcheck` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        patterns: z
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default(["."])
+          .describe("File patterns to check (default: ['.'])"),
+        severity: z
+          .enum(["error", "warning", "info", "style"])
+          .optional()
+          .describe("Minimum severity level to report (default: style)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: LintResultSchema,
+    },
+    async ({ path, patterns, severity, compact }) => {
+      const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
+      const args = ["--format=json"];
+      if (severity) {
+        args.push(`--severity=${severity}`);
+      }
+      args.push(...(patterns || ["."]));
+
+      const result = await shellcheckCmd(args, cwd);
+      const data = parseShellcheckJson(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatLint,
+        compactLintMap,
+        formatLintCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a `shellcheck` tool to `@paretools/lint` that wraps [ShellCheck](https://www.shellcheck.net/) with `--format=json` and returns structured diagnostics
- Accepts `patterns` (files to check), `severity` (minimum severity level: error/warning/info/style), and `compact` parameters
- Reuses existing `LintResultSchema`, `formatLint`, and `compactLintMap` for consistent output across all lint tools
- Maps ShellCheck levels (`error`, `warning`, `info`, `style`) to the standard diagnostic severity enum, and formats SC codes as rule names (e.g. `SC2086`)

## Changes
- `src/tools/shellcheck.ts` — new tool registration following oxlint/stylelint patterns
- `src/tools/index.ts` — register shellcheck tool with `shouldRegisterTool` guard
- `src/lib/lint-runner.ts` — add `shellcheckCmd()` runner (direct command, not npx)
- `src/lib/parsers.ts` — add `parseShellcheckJson()` parser for shellcheck JSON output
- `__tests__/parsers.test.ts` — 7 parser tests (errors/warnings/style, clean output, invalid JSON, missing code, non-array JSON)
- `__tests__/lint-runner.test.ts` — 5 runner tests (arg construction, severity, multi-file, cwd, return value)
- `__tests__/integration.test.ts` — updated tool count from 7 to 8

## Test plan
- [x] All 161 unit tests pass (parsers, formatters, lint-runner, compact, fidelity, security)
- [ ] Integration tests pass with shellcheck installed
- [ ] Manual test: run shellcheck tool against a shell script with known issues

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)