### PR TITLE
feat(git): add log-graph tool (#269)

### DIFF
--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -30,7 +30,7 @@ describe("@paretools/git integration", () => {
     await transport.close();
   });
 
-  it("lists all 20 tools", async () => {
+  it("lists all 21 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
@@ -42,6 +42,7 @@ describe("@paretools/git integration", () => {
       "commit",
       "diff",
       "log",
+      "log-graph",
       "merge",
       "pull",
       "push",
@@ -96,6 +97,31 @@ describe("@paretools/git integration", () => {
       expect(first.hashShort).toEqual(expect.any(String));
       expect(first.author).toEqual(expect.any(String));
       expect(first.date).toEqual(expect.any(String));
+      expect(first.message).toEqual(expect.any(String));
+    });
+  });
+
+  describe("log-graph", () => {
+    it("returns structured graph topology", async () => {
+      const result = await client.callTool({
+        name: "log-graph",
+        arguments: { maxCount: 5, compact: false },
+      });
+
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      expect(Array.isArray(sc.commits)).toBe(true);
+      expect(sc.total).toEqual(expect.any(Number));
+
+      const commits = sc.commits as Record<string, unknown>[];
+      // Should have at least one actual commit
+      const realCommits = commits.filter((c) => c.hashShort !== "");
+      expect(realCommits.length).toBeGreaterThan(0);
+      expect(realCommits.length).toBeLessThanOrEqual(5);
+
+      const first = realCommits[0];
+      expect(first.graph).toEqual(expect.any(String));
+      expect(first.hashShort).toEqual(expect.any(String));
       expect(first.message).toEqual(expect.any(String));
     });
   });

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -310,3 +310,25 @@ export const GitRebaseSchema = z.object({
 });
 
 export type GitRebase = z.infer<typeof GitRebaseSchema>;
+
+/** Zod schema for a single log-graph commit entry with graph characters, hash, message, and refs. */
+export const GitLogGraphEntrySchema = z.object({
+  graph: z.string(),
+  hashShort: z.string(),
+  message: z.string(),
+  refs: z.string().optional(),
+});
+
+/** Zod schema for structured git log --graph output with commits array and total count. */
+export const GitLogGraphSchema = z.object({
+  commits: z.array(GitLogGraphEntrySchema),
+  total: z.number(),
+});
+
+/** Full log-graph data (always returned by parser, before compact projection). */
+export type GitLogGraphFull = {
+  commits: Array<{ graph: string; hashShort: string; message: string; refs?: string }>;
+  total: number;
+};
+
+export type GitLogGraph = z.infer<typeof GitLogGraphSchema>;

--- a/packages/server-git/src/tools/index.ts
+++ b/packages/server-git/src/tools/index.ts
@@ -20,11 +20,13 @@ import { registerResetTool } from "./reset.js";
 import { registerCherryPickTool } from "./cherry-pick.js";
 import { registerMergeTool } from "./merge.js";
 import { registerRebaseTool } from "./rebase.js";
+import { registerLogGraphTool } from "./log-graph.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("git", name);
   if (s("status")) registerStatusTool(server);
   if (s("log")) registerLogTool(server);
+  if (s("log-graph")) registerLogGraphTool(server);
   if (s("diff")) registerDiffTool(server);
   if (s("branch")) registerBranchTool(server);
   if (s("show")) registerShowTool(server);

--- a/packages/server-git/src/tools/log-graph.ts
+++ b/packages/server-git/src/tools/log-graph.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { assertNoFlagInjection } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseLogGraph } from "../lib/parsers.js";
+import { formatLogGraph, compactLogGraphMap, formatLogGraphCompact } from "../lib/formatters.js";
+import { GitLogGraphSchema } from "../schemas/index.js";
+
+export function registerLogGraphTool(server: McpServer) {
+  server.registerTool(
+    "log-graph",
+    {
+      title: "Git Log Graph",
+      description:
+        "Returns visual branch topology as structured data. Wraps `git log --graph --oneline --decorate`. Use instead of running `git log --graph` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        maxCount: z
+          .number()
+          .optional()
+          .default(20)
+          .describe("Number of commits to return (default: 20)"),
+        ref: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Branch, tag, or commit to start from"),
+        all: z.boolean().optional().default(false).describe("Show all branches (--all)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: GitLogGraphSchema,
+    },
+    async ({ path, maxCount, ref, all, compact }) => {
+      const cwd = path || process.cwd();
+      const args = ["log", "--graph", "--oneline", "--decorate", `--max-count=${maxCount ?? 20}`];
+
+      if (all) {
+        args.push("--all");
+      }
+
+      if (ref) {
+        assertNoFlagInjection(ref, "ref");
+        args.push(ref);
+      }
+
+      const result = await git(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`git log --graph failed: ${result.stderr}`);
+      }
+
+      const logGraph = parseLogGraph(result.stdout);
+      return compactDualOutput(
+        logGraph,
+        result.stdout,
+        formatLogGraph,
+        compactLogGraphMap,
+        formatLogGraphCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add a new `log-graph` tool to `@paretools/git` that wraps `git log --graph --oneline --decorate`
- Returns visual branch topology as structured JSON with graph characters, short hashes, messages, and refs
- Supports `maxCount`, `ref`, `all` (show all branches), and `compact` parameters
- Includes full parser, formatter, compact variants, and comprehensive tests (parser, formatter, compact, integration)

Closes #269

## Test plan
- [x] Parser tests: linear graph, branching/merge graph, empty output, commits with/without refs, multiple refs
- [x] Formatter tests: graph with commits and refs, continuation lines, empty graph
- [x] Compact tests: filters out graph-only lines, uses short keys (g/h/m/r), handles refs presence/absence
- [x] Integration test: verifies structured output from a real git repo
- [x] All 161 tests pass across parsers (57), formatters (46), compact (25), integration (33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)