### PR TITLE
feat(npm): add nvm tool (#277)

### DIFF
--- a/packages/server-npm/__tests__/integration.test.ts
+++ b/packages/server-npm/__tests__/integration.test.ts
@@ -26,7 +26,7 @@ describe("@paretools/npm integration", () => {
     await transport.close();
   });
 
-  it("lists all 9 tools", async () => {
+  it("lists all 10 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
@@ -35,6 +35,7 @@ describe("@paretools/npm integration", () => {
       "init",
       "install",
       "list",
+      "nvm",
       "outdated",
       "run",
       "search",

--- a/packages/server-npm/__tests__/nvm.test.ts
+++ b/packages/server-npm/__tests__/nvm.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { parseNvmOutput } from "../src/lib/parsers.js";
+import { formatNvm } from "../src/lib/formatters.js";
+import type { NvmResult } from "../src/schemas/index.js";
+
+describe("parseNvmOutput", () => {
+  it("parses nvm-windows list output", () => {
+    const listOutput = [
+      "  * 20.11.1 (Currently using 64-bit executable)",
+      "    18.19.0",
+      "    16.20.2",
+    ].join("\n");
+
+    const result = parseNvmOutput(listOutput, "");
+
+    expect(result.current).toBe("v20.11.1");
+    expect(result.versions).toEqual(["v20.11.1", "v18.19.0", "v16.20.2"]);
+  });
+
+  it("parses Unix nvm list output", () => {
+    const listOutput = [
+      "->     v20.11.1",
+      "       v18.19.0",
+      "       v16.20.2",
+      "default -> 20.11.1 (-> v20.11.1)",
+      "node -> stable (-> v20.11.1) (default)",
+      "stable -> 20.11 (-> v20.11.1) (default)",
+      "lts/* -> lts/iron (-> v20.11.1)",
+    ].join("\n");
+
+    const result = parseNvmOutput(listOutput, "");
+
+    expect(result.current).toBe("v20.11.1");
+    expect(result.versions).toEqual(["v20.11.1", "v18.19.0", "v16.20.2"]);
+    expect(result.default).toBe("v20.11.1");
+  });
+
+  it("parses current from fallback when not in list", () => {
+    const listOutput = ["    18.19.0", "    16.20.2"].join("\n");
+
+    const result = parseNvmOutput(listOutput, "v20.11.1");
+
+    expect(result.current).toBe("v20.11.1");
+    expect(result.versions).toEqual(["v18.19.0", "v16.20.2"]);
+  });
+
+  it("handles empty list output", () => {
+    const result = parseNvmOutput("", "");
+
+    expect(result.current).toBe("none");
+    expect(result.versions).toEqual([]);
+  });
+
+  it("handles 'No installations recognized.' message", () => {
+    const result = parseNvmOutput("No installations recognized.", "");
+
+    expect(result.current).toBe("none");
+    expect(result.versions).toEqual([]);
+  });
+
+  it("normalizes versions without v prefix", () => {
+    const listOutput = "  * 20.11.1 (Currently using 64-bit executable)";
+    const result = parseNvmOutput(listOutput, "");
+
+    expect(result.current).toBe("v20.11.1");
+    expect(result.versions).toEqual(["v20.11.1"]);
+  });
+
+  it("handles current-only output", () => {
+    const result = parseNvmOutput("", "v22.0.0");
+
+    expect(result.current).toBe("v22.0.0");
+    expect(result.versions).toEqual([]);
+  });
+
+  it("handles current output without v prefix", () => {
+    const result = parseNvmOutput("", "22.0.0");
+
+    expect(result.current).toBe("v22.0.0");
+  });
+});
+
+describe("formatNvm", () => {
+  it("formats nvm result with versions", () => {
+    const data: NvmResult = {
+      current: "v20.11.1",
+      versions: ["v20.11.1", "v18.19.0", "v16.20.2"],
+    };
+    const output = formatNvm(data);
+    expect(output).toContain("Current: v20.11.1");
+    expect(output).toContain("Installed (3):");
+    expect(output).toContain("  v20.11.1 (current)");
+    expect(output).toContain("  v18.19.0");
+    expect(output).toContain("  v16.20.2");
+    expect(output).not.toContain("v18.19.0 (current)");
+  });
+
+  it("formats nvm result with default version", () => {
+    const data: NvmResult = {
+      current: "v20.11.1",
+      versions: ["v20.11.1"],
+      default: "v20.11.1",
+    };
+    const output = formatNvm(data);
+    expect(output).toContain("Default: v20.11.1");
+  });
+
+  it("formats nvm result with no versions", () => {
+    const data: NvmResult = {
+      current: "none",
+      versions: [],
+    };
+    const output = formatNvm(data);
+    expect(output).toContain("Current: none");
+    expect(output).toContain("No versions installed.");
+  });
+});

--- a/packages/server-npm/src/lib/formatters.ts
+++ b/packages/server-npm/src/lib/formatters.ts
@@ -9,6 +9,7 @@ import type {
   NpmInit,
   NpmInfo,
   NpmSearch,
+  NvmResult,
 } from "../schemas/index.js";
 
 /** Formats structured npm install data into a human-readable summary of added/removed packages. */
@@ -235,6 +236,26 @@ export function formatSearchCompact(data: NpmSearchCompact): string {
   const lines = [`${data.total} packages found:`];
   for (const pkg of data.packages) {
     lines.push(`  ${pkg.name}@${pkg.version} — ${pkg.description}`);
+  }
+  return lines.join("\n");
+}
+
+// ── Nvm formatters ───────────────────────────────────────────────────
+
+/** Formats structured nvm data into a human-readable version summary. */
+export function formatNvm(data: NvmResult): string {
+  const lines = [`Current: ${data.current}`];
+  if (data.default) {
+    lines.push(`Default: ${data.default}`);
+  }
+  if (data.versions.length > 0) {
+    lines.push(`Installed (${data.versions.length}):`);
+    for (const v of data.versions) {
+      const marker = v === data.current ? " (current)" : "";
+      lines.push(`  ${v}${marker}`);
+    }
+  } else {
+    lines.push("No versions installed.");
   }
   return lines.join("\n");
 }

--- a/packages/server-npm/src/schemas/index.ts
+++ b/packages/server-npm/src/schemas/index.ts
@@ -173,3 +173,12 @@ export const NpmSearchSchema = z.object({
 });
 
 export type NpmSearch = z.infer<typeof NpmSearchSchema>;
+
+/** Zod schema for structured nvm output with current version and installed versions list. */
+export const NvmResultSchema = z.object({
+  current: z.string().describe("Currently active Node.js version"),
+  versions: z.array(z.string()).describe("List of installed Node.js versions"),
+  default: z.string().optional().describe("Default Node.js version (alias default)"),
+});
+
+export type NvmResult = z.infer<typeof NvmResultSchema>;

--- a/packages/server-npm/src/tools/index.ts
+++ b/packages/server-npm/src/tools/index.ts
@@ -9,6 +9,7 @@ import { registerTestTool } from "./test.js";
 import { registerInitTool } from "./init.js";
 import { registerInfoTool } from "./info.js";
 import { registerSearchTool } from "./search.js";
+import { registerNvmTool } from "./nvm.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("npm", name);
@@ -21,4 +22,5 @@ export function registerAllTools(server: McpServer) {
   if (s("init")) registerInitTool(server);
   if (s("info")) registerInfoTool(server);
   if (s("search")) registerSearchTool(server);
+  if (s("nvm")) registerNvmTool(server);
 }

--- a/packages/server-npm/src/tools/nvm.ts
+++ b/packages/server-npm/src/tools/nvm.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, run } from "@paretools/shared";
+import { parseNvmOutput } from "../lib/parsers.js";
+import { formatNvm } from "../lib/formatters.js";
+import { NvmResultSchema } from "../schemas/index.js";
+
+export function registerNvmTool(server: McpServer) {
+  server.registerTool(
+    "nvm",
+    {
+      title: "Node Version Manager",
+      description:
+        "Lists installed Node.js versions and shows the current version via nvm. " +
+        "Supports both Unix nvm and nvm-windows. " +
+        "Use instead of running `nvm list` or `nvm current` in the terminal.",
+      inputSchema: {
+        action: z
+          .enum(["list", "current"])
+          .describe(
+            "Action to perform: 'list' shows all installed versions, 'current' shows the active version",
+          ),
+      },
+      outputSchema: NvmResultSchema,
+    },
+    async ({ action }) => {
+      if (action === "current") {
+        const result = await run("nvm", ["current"], { timeout: 15_000 });
+        if (result.exitCode !== 0 && !result.stdout) {
+          throw new Error(`nvm current failed: ${result.stderr}`);
+        }
+        const parsed = parseNvmOutput("", result.stdout);
+        return dualOutput(parsed, formatNvm);
+      }
+
+      // action === "list"
+      const listResult = await run("nvm", ["list"], { timeout: 15_000 });
+      if (listResult.exitCode !== 0 && !listResult.stdout) {
+        throw new Error(`nvm list failed: ${listResult.stderr}`);
+      }
+
+      // Also get current version as fallback
+      let currentStdout = "";
+      try {
+        const currentResult = await run("nvm", ["current"], { timeout: 15_000 });
+        currentStdout = currentResult.stdout;
+      } catch {
+        // nvm current may fail if no version is active; that's ok
+      }
+
+      const parsed = parseNvmOutput(listResult.stdout, currentStdout);
+      return dualOutput(parsed, formatNvm);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds an `nvm` tool to `@paretools/npm` that wraps Node.js version management commands
- Supports `action: "list"` (list all installed versions) and `action: "current"` (show active version)
- Parses both Unix nvm and nvm-windows output formats into structured JSON
- Returns current version, list of installed versions, and default version alias

Closes #277

## Changes
- `src/schemas/index.ts` — added `NvmResultSchema` with current, versions, default fields
- `src/lib/parsers.ts` — added `parseNvmOutput()` parser for nvm list/current output
- `src/lib/formatters.ts` — added `formatNvm()` human-readable formatter
- `src/tools/nvm.ts` — new tool registration file
- `src/tools/index.ts` — registered nvm tool
- `__tests__/nvm.test.ts` — 11 tests covering parser and formatter
- `__tests__/integration.test.ts` — updated tool count from 9 to 10

## Test plan
- [x] All 11 nvm-specific tests pass (parser + formatter)
- [x] All 249 tests in server-npm pass (no regressions)
- [ ] Manual verification with nvm installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)