### PR TITLE
feat(lint): add hadolint tool (#292)

### DIFF
--- a/packages/server-lint/__tests__/integration.test.ts
+++ b/packages/server-lint/__tests__/integration.test.ts
@@ -36,13 +36,14 @@ describe("@paretools/lint integration", () => {
     await transport.close();
   });
 
-  it("lists all 8 tools", async () => {
+  it("lists all 9 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
       "biome-check",
       "biome-format",
       "format-check",
+      "hadolint",
       "lint",
       "oxlint",
       "prettier-format",

--- a/packages/server-lint/src/lib/lint-runner.ts
+++ b/packages/server-lint/src/lib/lint-runner.ts
@@ -23,3 +23,7 @@ export async function oxlintCmd(args: string[], cwd?: string): Promise<RunResult
 export async function shellcheckCmd(args: string[], cwd?: string): Promise<RunResult> {
   return run("shellcheck", args, { cwd, timeout: 120_000 });
 }
+
+export async function hadolintCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("hadolint", args, { cwd, timeout: 120_000 });
+}

--- a/packages/server-lint/src/tools/hadolint.ts
+++ b/packages/server-lint/src/tools/hadolint.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { hadolintCmd } from "../lib/lint-runner.js";
+import { parseHadolintJson } from "../lib/parsers.js";
+import { formatLint, compactLintMap, formatLintCompact } from "../lib/formatters.js";
+import { LintResultSchema } from "../schemas/index.js";
+
+export function registerHadolintTool(server: McpServer) {
+  server.registerTool(
+    "hadolint",
+    {
+      title: "Hadolint",
+      description:
+        "Runs Hadolint (Dockerfile linter) and returns structured diagnostics (file, line, rule, severity, message). Use instead of running `hadolint` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        patterns: z
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default(["Dockerfile"])
+          .describe("Dockerfile paths to check (default: ['Dockerfile'])"),
+        trustedRegistries: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Trusted Docker registries (e.g., ['docker.io', 'ghcr.io'])"),
+        ignoreRules: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Rule codes to ignore (e.g., ['DL3008', 'DL3013'])"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: LintResultSchema,
+    },
+    async ({ path, patterns, trustedRegistries, ignoreRules, compact }) => {
+      const cwd = path || process.cwd();
+      for (const p of patterns ?? []) {
+        assertNoFlagInjection(p, "patterns");
+      }
+      const args = ["--format=json"];
+
+      if (trustedRegistries) {
+        for (const reg of trustedRegistries) {
+          assertNoFlagInjection(reg, "trustedRegistries");
+          args.push(`--trusted-registry=${reg}`);
+        }
+      }
+
+      if (ignoreRules) {
+        for (const rule of ignoreRules) {
+          assertNoFlagInjection(rule, "ignoreRules");
+          args.push(`--ignore=${rule}`);
+        }
+      }
+
+      args.push(...(patterns || ["Dockerfile"]));
+
+      const result = await hadolintCmd(args, cwd);
+      const data = parseHadolintJson(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatLint,
+        compactLintMap,
+        formatLintCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-lint/src/tools/index.ts
+++ b/packages/server-lint/src/tools/index.ts
@@ -8,6 +8,7 @@ import { registerBiomeFormatTool } from "./biome-format.js";
 import { registerStylelintTool } from "./stylelint.js";
 import { registerOxlintTool } from "./oxlint.js";
 import { registerShellcheckTool } from "./shellcheck.js";
+import { registerHadolintTool } from "./hadolint.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("lint", name);
@@ -19,4 +20,5 @@ export function registerAllTools(server: McpServer) {
   if (s("stylelint")) registerStylelintTool(server);
   if (s("oxlint")) registerOxlintTool(server);
   if (s("shellcheck")) registerShellcheckTool(server);
+  if (s("hadolint")) registerHadolintTool(server);
 }


### PR DESCRIPTION
## Summary
- Add `hadolint` tool to `@paretools/lint` that wraps the Hadolint Dockerfile linter with `--format json` output
- Accepts `patterns` (Dockerfile paths), `trustedRegistries`, and `ignoreRules` input parameters
- Returns structured `LintResult` diagnostics with file, line, rule (DL/SC codes), severity, and message
- Includes parser for hadolint JSON output, command runner, tool registration, and 8 parser unit tests

## Test plan
- [x] Parser tests: 8 new tests covering errors/warnings/info, empty output, invalid JSON, style mapping, missing code, non-array JSON, SC-prefixed codes
- [x] Formatter tests: existing formatters pass (hadolint reuses LintResult schema and formatLint formatter)
- [x] Integration tests: updated tool count from 8 to 9, all 26 integration tests pass
- [x] Full lint package test suite: 195 tests pass

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)