### PR TITLE
feat(git): add reflog tool (#270)

### DIFF
--- a/packages/server-git/__tests__/compact.test.ts
+++ b/packages/server-git/__tests__/compact.test.ts
@@ -18,6 +18,8 @@ import {
   formatBlameCompact,
   compactLogGraphMap,
   formatLogGraphCompact,
+  compactReflogMap,
+  formatReflogCompact,
 } from "../src/lib/formatters.js";
 import type { GitLog, GitDiff, GitShow } from "../src/schemas/index.js";
 import type {
@@ -27,6 +29,7 @@ import type {
   GitRemoteFull,
   GitBlameFull,
   GitLogGraphFull,
+  GitReflogFull,
 } from "../src/schemas/index.js";
 
 describe("compactLogMap", () => {
@@ -456,5 +459,61 @@ describe("formatLogGraphCompact", () => {
   it("formats empty log-graph", () => {
     const compact = { commits: [], total: 0 };
     expect(formatLogGraphCompact(compact)).toBe("No commits found");
+  });
+});
+
+describe("compactReflogMap", () => {
+  it("reduces entries to string array with shortHash, selector, and action", () => {
+    const reflog: GitReflogFull = {
+      entries: [
+        {
+          hash: "abc123full",
+          shortHash: "abc1234",
+          selector: "HEAD@{0}",
+          action: "checkout",
+          description: "moving from main to feature",
+          date: "2024-01-15 10:30:00 +0000",
+        },
+        {
+          hash: "def456full",
+          shortHash: "def5678",
+          selector: "HEAD@{1}",
+          action: "commit",
+          description: "fix the bug",
+          date: "2024-01-14 09:00:00 +0000",
+        },
+      ],
+      total: 2,
+    };
+
+    const compact = compactReflogMap(reflog);
+
+    expect(compact.total).toBe(2);
+    expect(compact.entries).toEqual([
+      "abc1234 HEAD@{0} checkout: moving from main to feature",
+      "def5678 HEAD@{1} commit: fix the bug",
+    ]);
+  });
+});
+
+describe("formatReflogCompact", () => {
+  it("formats compact reflog entries", () => {
+    const compact = {
+      entries: [
+        "abc1234 HEAD@{0} checkout: moving from main to feature",
+        "def5678 HEAD@{1} commit: fix the bug",
+      ],
+      total: 2,
+    };
+    const output = formatReflogCompact(compact);
+
+    expect(output).toBe(
+      "abc1234 HEAD@{0} checkout: moving from main to feature\ndef5678 HEAD@{1} commit: fix the bug",
+    );
+  });
+
+  it("formats empty reflog", () => {
+    const compact = { entries: [], total: 0 };
+    expect(formatReflogCompact(compact)).toBe("No reflog entries found");
   });
 });

--- a/packages/server-git/__tests__/formatters.test.ts
+++ b/packages/server-git/__tests__/formatters.test.ts
@@ -17,6 +17,7 @@ import {
   formatBlame,
   formatReset,
   formatLogGraph,
+  formatReflog,
 } from "../src/lib/formatters.js";
 import type {
   GitStatus,
@@ -36,6 +37,7 @@ import type {
   GitBlameFull,
   GitReset,
   GitLogGraphFull,
+  GitReflogFull,
 } from "../src/schemas/index.js";
 
 describe("formatStatus", () => {
@@ -756,5 +758,61 @@ describe("formatLogGraph", () => {
   it("formats empty graph", () => {
     const data: GitLogGraphFull = { commits: [], total: 0 };
     expect(formatLogGraph(data)).toBe("No commits found");
+  });
+});
+
+describe("formatReflog", () => {
+  it("formats reflog entries", () => {
+    const reflog: GitReflogFull = {
+      entries: [
+        {
+          hash: "abc123full",
+          shortHash: "abc1234",
+          selector: "HEAD@{0}",
+          action: "checkout",
+          description: "moving from main to feature",
+          date: "2024-01-15 10:30:00 +0000",
+        },
+        {
+          hash: "def456full",
+          shortHash: "def5678",
+          selector: "HEAD@{1}",
+          action: "commit",
+          description: "fix the bug",
+          date: "2024-01-14 09:00:00 +0000",
+        },
+      ],
+      total: 2,
+    };
+    const output = formatReflog(reflog);
+
+    expect(output).toContain("abc1234 HEAD@{0} checkout: moving from main to feature");
+    expect(output).toContain("def5678 HEAD@{1} commit: fix the bug");
+    expect(output).toContain("2024-01-15 10:30:00 +0000");
+  });
+
+  it("formats empty reflog", () => {
+    const reflog: GitReflogFull = { entries: [], total: 0 };
+    expect(formatReflog(reflog)).toBe("No reflog entries found");
+  });
+
+  it("formats reflog entry without description", () => {
+    const reflog: GitReflogFull = {
+      entries: [
+        {
+          hash: "aaa111full",
+          shortHash: "aaa1111",
+          selector: "HEAD@{0}",
+          action: "reset",
+          description: "",
+          date: "2024-01-01 00:00:00 +0000",
+        },
+      ],
+      total: 1,
+    };
+    const output = formatReflog(reflog);
+
+    expect(output).toContain("aaa1111 HEAD@{0} reset");
+    expect(output).not.toContain(": (");
   });
 });

--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -30,7 +30,7 @@ describe("@paretools/git integration", () => {
     await transport.close();
   });
 
-  it("lists all 21 tools", async () => {
+  it("lists all 22 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
@@ -47,6 +47,7 @@ describe("@paretools/git integration", () => {
       "pull",
       "push",
       "rebase",
+      "reflog",
       "remote",
       "reset",
       "restore",

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -20,6 +20,7 @@ import type {
   GitMerge,
   GitRebase,
   GitLogGraphFull,
+  GitReflogFull,
 } from "../schemas/index.js";
 
 /** Formats structured git status data into a human-readable summary string. */
@@ -479,4 +480,39 @@ export function compactLogGraphMap(lg: GitLogGraphFull): GitLogGraphCompact {
 export function formatLogGraphCompact(lg: GitLogGraphCompact): string {
   if (lg.total === 0) return "No commits found";
   return lg.commits.map((c) => `${c.g} ${c.h} ${c.m}${c.r ? ` (${c.r})` : ""}`).join("\n");
+}
+
+// ── Reflog formatters ─────────────────────────────────────────────────
+
+/** Formats structured git reflog data into a human-readable reflog listing. */
+export function formatReflog(r: GitReflogFull): string {
+  if (r.entries.length === 0) return "No reflog entries found";
+  return r.entries
+    .map((e) => {
+      const desc = e.description ? `: ${e.description}` : "";
+      return `${e.shortHash} ${e.selector} ${e.action}${desc} (${e.date})`;
+    })
+    .join("\n");
+}
+
+/** Compact reflog: selector + action as string array + total. */
+export interface GitReflogCompact {
+  [key: string]: unknown;
+  entries: string[];
+  total: number;
+}
+
+export function compactReflogMap(r: GitReflogFull): GitReflogCompact {
+  return {
+    entries: r.entries.map((e) => {
+      const desc = e.description ? `: ${e.description}` : "";
+      return `${e.shortHash} ${e.selector} ${e.action}${desc}`;
+    }),
+    total: r.total,
+  };
+}
+
+export function formatReflogCompact(r: GitReflogCompact): string {
+  if (r.entries.length === 0) return "No reflog entries found";
+  return r.entries.join("\n");
 }

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -332,3 +332,34 @@ export type GitLogGraphFull = {
 };
 
 export type GitLogGraph = z.infer<typeof GitLogGraphSchema>;
+
+/** Zod schema for a single reflog entry with hash, selector, action, description, and date. */
+export const GitReflogEntrySchema = z.object({
+  hash: z.string(),
+  shortHash: z.string(),
+  selector: z.string(),
+  action: z.string(),
+  description: z.string(),
+  date: z.string(),
+});
+
+/** Zod schema for structured git reflog output with entries array and total count. */
+export const GitReflogSchema = z.object({
+  entries: z.union([z.array(GitReflogEntrySchema), z.array(z.string())]),
+  total: z.number(),
+});
+
+/** Full reflog data (always returned by parser, before compact projection). */
+export type GitReflogFull = {
+  entries: Array<{
+    hash: string;
+    shortHash: string;
+    selector: string;
+    action: string;
+    description: string;
+    date: string;
+  }>;
+  total: number;
+};
+
+export type GitReflog = z.infer<typeof GitReflogSchema>;

--- a/packages/server-git/src/tools/index.ts
+++ b/packages/server-git/src/tools/index.ts
@@ -21,6 +21,7 @@ import { registerCherryPickTool } from "./cherry-pick.js";
 import { registerMergeTool } from "./merge.js";
 import { registerRebaseTool } from "./rebase.js";
 import { registerLogGraphTool } from "./log-graph.js";
+import { registerReflogTool } from "./reflog.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("git", name);
@@ -45,4 +46,5 @@ export function registerAllTools(server: McpServer) {
   if (s("cherry-pick")) registerCherryPickTool(server);
   if (s("merge")) registerMergeTool(server);
   if (s("rebase")) registerRebaseTool(server);
+  if (s("reflog")) registerReflogTool(server);
 }

--- a/packages/server-git/src/tools/reflog.ts
+++ b/packages/server-git/src/tools/reflog.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { assertNoFlagInjection } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseReflogOutput } from "../lib/parsers.js";
+import { formatReflog, compactReflogMap, formatReflogCompact } from "../lib/formatters.js";
+import { GitReflogSchema } from "../schemas/index.js";
+
+const REFLOG_FORMAT = "%H\t%h\t%gd\t%gs\t%ci";
+
+export function registerReflogTool(server: McpServer) {
+  server.registerTool(
+    "reflog",
+    {
+      title: "Git Reflog",
+      description:
+        "Returns reference log entries as structured data, useful for recovery operations. Use instead of running `git reflog` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        maxCount: z
+          .number()
+          .optional()
+          .default(20)
+          .describe("Number of entries to return (default: 20)"),
+        ref: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Which ref to show (default: HEAD)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: GitReflogSchema,
+    },
+    async ({ path, maxCount, ref, compact }) => {
+      const cwd = path || process.cwd();
+      const args = ["reflog", "show", `--format=${REFLOG_FORMAT}`, `--max-count=${maxCount ?? 20}`];
+
+      if (ref) {
+        assertNoFlagInjection(ref, "ref");
+        args.push(ref);
+      }
+
+      const result = await git(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`git reflog failed: ${result.stderr}`);
+      }
+
+      const reflog = parseReflogOutput(result.stdout);
+      return compactDualOutput(
+        reflog,
+        result.stdout,
+        formatReflog,
+        compactReflogMap,
+        formatReflogCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a `reflog` tool to `@paretools/git` that wraps `git reflog` and returns reference log entries as structured JSON data
- Returns entries with: `hash`, `shortHash`, `selector` (e.g. `HEAD@{0}`), `action` (checkout, commit, merge, etc.), `description`, and `date`
- Supports `maxCount` (default 20), `ref` (default HEAD), and `compact` parameters
- Includes full test coverage: parser tests, formatter tests, compact formatter tests, and integration test update

Closes #270

## Test plan

- [x] Parser tests pass (61 total, including 4 new reflog tests)
- [x] Formatter tests pass (49 total, including 3 new reflog tests)
- [x] Compact tests pass (28 total, including 2 new reflog tests)
- [x] Integration tests pass (33 total, tool count updated from 21 to 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)