### PR TITLE
feat(test): add playwright tool (#293)

### DIFF
--- a/packages/server-test/__tests__/fixtures/playwright-json.json
+++ b/packages/server-test/__tests__/fixtures/playwright-json.json
@@ -1,0 +1,137 @@
+{
+  "config": {
+    "rootDir": "/home/user/project"
+  },
+  "suites": [
+    {
+      "title": "auth.spec.ts",
+      "file": "tests/auth.spec.ts",
+      "specs": [
+        {
+          "title": "should login with valid credentials",
+          "file": "tests/auth.spec.ts",
+          "line": 5,
+          "tests": [
+            {
+              "projectName": "chromium",
+              "results": [
+                {
+                  "status": "passed",
+                  "duration": 1200,
+                  "retry": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "should show error for invalid password",
+          "file": "tests/auth.spec.ts",
+          "line": 15,
+          "tests": [
+            {
+              "projectName": "chromium",
+              "results": [
+                {
+                  "status": "failed",
+                  "duration": 3500,
+                  "retry": 0,
+                  "error": {
+                    "message": "Expected element to be visible",
+                    "stack": "Error: Expected element to be visible\n    at tests/auth.spec.ts:20:15"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "should redirect after login",
+          "file": "tests/auth.spec.ts",
+          "line": 25,
+          "tests": [
+            {
+              "projectName": "chromium",
+              "results": [
+                {
+                  "status": "passed",
+                  "duration": 800,
+                  "retry": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "dashboard.spec.ts",
+      "file": "tests/dashboard.spec.ts",
+      "specs": [
+        {
+          "title": "should display user name",
+          "file": "tests/dashboard.spec.ts",
+          "line": 3,
+          "tests": [
+            {
+              "projectName": "chromium",
+              "results": [
+                {
+                  "status": "passed",
+                  "duration": 600,
+                  "retry": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "should load dashboard widgets",
+          "file": "tests/dashboard.spec.ts",
+          "line": 12,
+          "tests": [
+            {
+              "projectName": "chromium",
+              "results": [
+                {
+                  "status": "skipped",
+                  "duration": 0,
+                  "retry": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "should handle slow network",
+          "file": "tests/dashboard.spec.ts",
+          "line": 20,
+          "tests": [
+            {
+              "projectName": "chromium",
+              "results": [
+                {
+                  "status": "timedOut",
+                  "duration": 30000,
+                  "retry": 0,
+                  "error": {
+                    "message": "Test timeout of 30000ms exceeded"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "stats": {
+    "startTime": "2024-01-15T10:00:00.000Z",
+    "duration": 36100,
+    "expected": 3,
+    "unexpected": 1,
+    "flaky": 0,
+    "skipped": 1,
+    "interrupted": 0
+  }
+}

--- a/packages/server-test/__tests__/integration.test.ts
+++ b/packages/server-test/__tests__/integration.test.ts
@@ -29,10 +29,10 @@ describe("@paretools/test integration", () => {
     await transport.close();
   });
 
-  it("lists all 2 tools", async () => {
+  it("lists all 3 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
-    expect(names).toEqual(["coverage", "run"]);
+    expect(names).toEqual(["coverage", "playwright", "run"]);
   });
 
   describe("run", () => {

--- a/packages/server-test/__tests__/playwright-parser.test.ts
+++ b/packages/server-test/__tests__/playwright-parser.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parsePlaywrightJson } from "../src/lib/parsers/playwright.js";
+
+const fixture = (name: string) => readFileSync(join(__dirname, "fixtures", name), "utf-8");
+
+describe("parsePlaywrightJson", () => {
+  it("parses JSON output with mixed results", () => {
+    const result = parsePlaywrightJson(fixture("playwright-json.json"));
+
+    expect(result.summary.total).toBe(6);
+    expect(result.summary.passed).toBe(3);
+    expect(result.summary.failed).toBe(1);
+    expect(result.summary.skipped).toBe(1);
+    expect(result.summary.timedOut).toBe(1);
+    expect(result.summary.interrupted).toBe(0);
+    expect(result.summary.duration).toBe(36.1);
+
+    expect(result.suites).toHaveLength(2);
+    expect(result.suites[0].title).toBe("auth.spec.ts");
+    expect(result.suites[0].tests).toHaveLength(3);
+    expect(result.suites[1].title).toBe("dashboard.spec.ts");
+    expect(result.suites[1].tests).toHaveLength(3);
+
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures[0].title).toBe("should show error for invalid password");
+    expect(result.failures[0].file).toBe("tests/auth.spec.ts");
+    expect(result.failures[0].line).toBe(15);
+    expect(result.failures[0].error).toBe("Expected element to be visible");
+
+    expect(result.failures[1].title).toBe("should handle slow network");
+    expect(result.failures[1].error).toBe("Test timeout of 30000ms exceeded");
+  });
+
+  it("parses all-passing results", () => {
+    const json = JSON.stringify({
+      config: { rootDir: "/project" },
+      suites: [
+        {
+          title: "basic.spec.ts",
+          file: "tests/basic.spec.ts",
+          specs: [
+            {
+              title: "test 1",
+              file: "tests/basic.spec.ts",
+              line: 3,
+              tests: [
+                {
+                  projectName: "chromium",
+                  results: [{ status: "passed", duration: 100, retry: 0 }],
+                },
+              ],
+            },
+            {
+              title: "test 2",
+              file: "tests/basic.spec.ts",
+              line: 10,
+              tests: [
+                {
+                  projectName: "chromium",
+                  results: [{ status: "passed", duration: 200, retry: 0 }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parsePlaywrightJson(json);
+
+    expect(result.summary.total).toBe(2);
+    expect(result.summary.passed).toBe(2);
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.skipped).toBe(0);
+    expect(result.summary.timedOut).toBe(0);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("uses last retry result", () => {
+    const json = JSON.stringify({
+      config: { rootDir: "/project" },
+      suites: [
+        {
+          title: "flaky.spec.ts",
+          file: "tests/flaky.spec.ts",
+          specs: [
+            {
+              title: "flaky test",
+              file: "tests/flaky.spec.ts",
+              line: 5,
+              tests: [
+                {
+                  projectName: "chromium",
+                  results: [
+                    {
+                      status: "failed",
+                      duration: 500,
+                      retry: 0,
+                      error: { message: "First attempt failed" },
+                    },
+                    { status: "passed", duration: 600, retry: 1 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parsePlaywrightJson(json);
+
+    expect(result.summary.total).toBe(1);
+    expect(result.summary.passed).toBe(1);
+    expect(result.summary.failed).toBe(0);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("handles nested suites", () => {
+    const json = JSON.stringify({
+      config: { rootDir: "/project" },
+      suites: [
+        {
+          title: "outer.spec.ts",
+          file: "tests/outer.spec.ts",
+          specs: [],
+          suites: [
+            {
+              title: "inner group",
+              specs: [
+                {
+                  title: "nested test",
+                  file: "tests/outer.spec.ts",
+                  line: 10,
+                  tests: [
+                    {
+                      projectName: "chromium",
+                      results: [{ status: "passed", duration: 300, retry: 0 }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parsePlaywrightJson(json);
+
+    expect(result.summary.total).toBe(1);
+    expect(result.summary.passed).toBe(1);
+    // Nested tests are flattened into parent suite
+    expect(result.suites[0].tests).toHaveLength(1);
+    expect(result.suites[0].tests[0].title).toBe("nested test");
+  });
+
+  it("handles errors array in results", () => {
+    const json = JSON.stringify({
+      config: { rootDir: "/project" },
+      suites: [
+        {
+          title: "multi-error.spec.ts",
+          file: "tests/multi-error.spec.ts",
+          specs: [
+            {
+              title: "test with multiple errors",
+              file: "tests/multi-error.spec.ts",
+              line: 3,
+              tests: [
+                {
+                  projectName: "chromium",
+                  results: [
+                    {
+                      status: "failed",
+                      duration: 400,
+                      retry: 0,
+                      errors: [{ message: "Error one" }, { message: "Error two" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parsePlaywrightJson(json);
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].error).toBe("Error one\nError two");
+  });
+
+  it("handles empty suites", () => {
+    const json = JSON.stringify({
+      config: { rootDir: "/project" },
+      suites: [],
+    });
+
+    const result = parsePlaywrightJson(json);
+
+    expect(result.summary.total).toBe(0);
+    expect(result.summary.passed).toBe(0);
+    expect(result.summary.failed).toBe(0);
+    expect(result.suites).toHaveLength(0);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("records retry count on test results", () => {
+    const json = JSON.stringify({
+      config: { rootDir: "/project" },
+      suites: [
+        {
+          title: "retry.spec.ts",
+          file: "tests/retry.spec.ts",
+          specs: [
+            {
+              title: "retried test",
+              file: "tests/retry.spec.ts",
+              line: 1,
+              tests: [
+                {
+                  projectName: "chromium",
+                  results: [
+                    { status: "failed", duration: 100, retry: 0, error: { message: "fail" } },
+                    { status: "failed", duration: 200, retry: 1, error: { message: "fail again" } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parsePlaywrightJson(json);
+
+    expect(result.summary.failed).toBe(1);
+    expect(result.suites[0].tests[0].retry).toBe(1);
+  });
+});

--- a/packages/server-test/src/lib/parsers/index.ts
+++ b/packages/server-test/src/lib/parsers/index.ts
@@ -1,3 +1,4 @@
 export { parsePytestOutput, parsePytestCoverage } from "./pytest.js";
 export { parseJestJson, parseJestCoverage } from "./jest.js";
 export { parseVitestJson, parseVitestCoverage } from "./vitest.js";
+export { parsePlaywrightJson } from "./playwright.js";

--- a/packages/server-test/src/lib/parsers/playwright.ts
+++ b/packages/server-test/src/lib/parsers/playwright.ts
@@ -1,0 +1,170 @@
+import type {
+  PlaywrightResult,
+  PlaywrightSuite,
+  PlaywrightTestResult,
+} from "../../schemas/index.js";
+
+/**
+ * Playwright JSON reporter output structure (from `--reporter=json`).
+ * See: https://playwright.dev/docs/test-reporters#json-reporter
+ */
+interface PlaywrightJsonOutput {
+  config: { rootDir?: string };
+  suites: PlaywrightJsonSuite[];
+  errors?: Array<{ message?: string }>;
+  stats?: {
+    startTime?: string;
+    duration?: number;
+    expected?: number;
+    unexpected?: number;
+    flaky?: number;
+    skipped?: number;
+    interrupted?: number;
+  };
+}
+
+interface PlaywrightJsonSuite {
+  title: string;
+  file?: string;
+  line?: number;
+  suites?: PlaywrightJsonSuite[];
+  specs?: PlaywrightJsonSpec[];
+}
+
+interface PlaywrightJsonSpec {
+  title: string;
+  file?: string;
+  line?: number;
+  tests: Array<{
+    projectName?: string;
+    results: Array<{
+      status: "passed" | "failed" | "timedOut" | "skipped" | "interrupted";
+      duration: number;
+      retry: number;
+      error?: { message?: string; stack?: string };
+      errors?: Array<{ message?: string; stack?: string }>;
+    }>;
+  }>;
+}
+
+/**
+ * Parses Playwright JSON reporter output into structured data.
+ */
+export function parsePlaywrightJson(jsonStr: string): PlaywrightResult {
+  const data = JSON.parse(jsonStr) as PlaywrightJsonOutput;
+
+  const suites: PlaywrightSuite[] = [];
+  const failures: PlaywrightResult["failures"] = [];
+  let total = 0;
+  let passed = 0;
+  let failed = 0;
+  let skipped = 0;
+  let timedOut = 0;
+  let interrupted = 0;
+  let totalDuration = 0;
+
+  function processSuite(suite: PlaywrightJsonSuite, parentFile?: string): PlaywrightSuite {
+    const suiteFile = suite.file || parentFile;
+    const tests: PlaywrightTestResult[] = [];
+
+    // Process specs in this suite
+    for (const spec of suite.specs ?? []) {
+      for (const test of spec.tests) {
+        // Use the last result (final retry)
+        const lastResult = test.results[test.results.length - 1];
+        if (!lastResult) continue;
+
+        total++;
+        const status = lastResult.status;
+        const duration = lastResult.duration;
+        totalDuration += duration;
+
+        switch (status) {
+          case "passed":
+            passed++;
+            break;
+          case "failed":
+            failed++;
+            break;
+          case "skipped":
+            skipped++;
+            break;
+          case "timedOut":
+            timedOut++;
+            break;
+          case "interrupted":
+            interrupted++;
+            break;
+        }
+
+        // Extract error message
+        let errorMsg: string | undefined;
+        if (lastResult.error?.message) {
+          errorMsg = lastResult.error.message;
+        } else if (lastResult.errors && lastResult.errors.length > 0) {
+          errorMsg = lastResult.errors
+            .map((e) => e.message)
+            .filter(Boolean)
+            .join("\n");
+        }
+
+        const testResult: PlaywrightTestResult = {
+          title: spec.title,
+          file: spec.file || suiteFile,
+          line: spec.line,
+          status,
+          duration,
+          ...(errorMsg ? { error: errorMsg } : {}),
+          ...(lastResult.retry > 0 ? { retry: lastResult.retry } : {}),
+        };
+
+        tests.push(testResult);
+
+        // Track failures
+        if (status === "failed" || status === "timedOut") {
+          failures.push({
+            title: spec.title,
+            file: spec.file || suiteFile,
+            line: spec.line,
+            ...(errorMsg ? { error: errorMsg } : {}),
+          });
+        }
+      }
+    }
+
+    // Process nested suites
+    for (const child of suite.suites ?? []) {
+      const childSuite = processSuite(child, suiteFile);
+      // Flatten nested suite tests into the parent
+      tests.push(...childSuite.tests);
+    }
+
+    return {
+      title: suite.title,
+      file: suiteFile,
+      tests,
+    };
+  }
+
+  for (const suite of data.suites) {
+    suites.push(processSuite(suite));
+  }
+
+  // If stats are provided by Playwright, use the duration from there
+  const durationMs = data.stats?.duration ?? totalDuration;
+  const durationSec = Math.round((durationMs / 1000) * 100) / 100;
+
+  return {
+    summary: {
+      total,
+      passed,
+      failed,
+      skipped,
+      timedOut,
+      interrupted,
+      duration: durationSec,
+    },
+    suites,
+    failures,
+  };
+}

--- a/packages/server-test/src/schemas/index.ts
+++ b/packages/server-test/src/schemas/index.ts
@@ -50,3 +50,47 @@ export const CoverageSchema = z.object({
 });
 
 export type Coverage = z.infer<typeof CoverageSchema>;
+
+/** Zod schema for a single Playwright test result with title, status, duration, and optional error. */
+export const PlaywrightTestResultSchema = z.object({
+  title: z.string(),
+  file: z.string().optional(),
+  line: z.number().optional(),
+  status: z.enum(["passed", "failed", "timedOut", "skipped", "interrupted"]),
+  duration: z.number(),
+  error: z.string().optional(),
+  retry: z.number().optional(),
+});
+
+/** Zod schema for a Playwright suite containing specs. */
+export const PlaywrightSuiteSchema = z.object({
+  title: z.string(),
+  file: z.string().optional(),
+  tests: z.array(PlaywrightTestResultSchema),
+});
+
+/** Zod schema for structured Playwright test run output. */
+export const PlaywrightResultSchema = z.object({
+  summary: z.object({
+    total: z.number(),
+    passed: z.number(),
+    failed: z.number(),
+    skipped: z.number(),
+    timedOut: z.number(),
+    interrupted: z.number(),
+    duration: z.number(),
+  }),
+  suites: z.array(PlaywrightSuiteSchema),
+  failures: z.array(
+    z.object({
+      title: z.string(),
+      file: z.string().optional(),
+      line: z.number().optional(),
+      error: z.string().optional(),
+    }),
+  ),
+});
+
+export type PlaywrightTestResult = z.infer<typeof PlaywrightTestResultSchema>;
+export type PlaywrightSuite = z.infer<typeof PlaywrightSuiteSchema>;
+export type PlaywrightResult = z.infer<typeof PlaywrightResultSchema>;

--- a/packages/server-test/src/tools/index.ts
+++ b/packages/server-test/src/tools/index.ts
@@ -2,9 +2,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { shouldRegisterTool } from "@paretools/shared";
 import { registerRunTool } from "./run.js";
 import { registerCoverageTool } from "./coverage.js";
+import { registerPlaywrightTool } from "./playwright.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("test", name);
   if (s("run")) registerRunTool(server);
   if (s("coverage")) registerCoverageTool(server);
+  if (s("playwright")) registerPlaywrightTool(server);
 }

--- a/packages/server-test/src/tools/playwright.ts
+++ b/packages/server-test/src/tools/playwright.ts
@@ -1,0 +1,133 @@
+import { z } from "zod";
+import { readFile, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, run, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { parsePlaywrightJson } from "../lib/parsers/playwright.js";
+import {
+  formatPlaywrightResult,
+  compactPlaywrightResultMap,
+  formatPlaywrightResultCompact,
+} from "../lib/formatters.js";
+import { PlaywrightResultSchema } from "../schemas/index.js";
+
+export function registerPlaywrightTool(server: McpServer) {
+  server.registerTool(
+    "playwright",
+    {
+      title: "Playwright Tests",
+      description:
+        "Runs Playwright tests with JSON reporter and returns structured results with pass/fail status, duration, and error messages. Use instead of running `npx playwright test` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Project root path (default: cwd)"),
+        filter: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Test filter pattern (file path or test name grep pattern)"),
+        project: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Playwright project name (e.g., 'chromium', 'firefox', 'webkit')"),
+        headed: z.boolean().optional().default(false).describe("Run tests in headed browser mode"),
+        updateSnapshots: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Update snapshots (adds --update-snapshots flag)"),
+        args: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default([])
+          .describe("Additional arguments to pass to Playwright test runner"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: PlaywrightResultSchema,
+    },
+    async ({ path, filter, project, headed, updateSnapshots, args, compact }) => {
+      for (const a of args ?? []) {
+        assertNoFlagInjection(a, "args");
+      }
+
+      const cwd = path || process.cwd();
+      const extraArgs: string[] = [...(args || [])];
+
+      if (filter) {
+        assertNoFlagInjection(filter, "filter");
+        extraArgs.push(filter);
+      }
+
+      if (project) {
+        assertNoFlagInjection(project, "project");
+        extraArgs.push("--project", project);
+      }
+
+      if (headed) {
+        extraArgs.push("--headed");
+      }
+
+      if (updateSnapshots) {
+        extraArgs.push("--update-snapshots");
+      }
+
+      // Write JSON output to a temp file to avoid stdout parsing issues on Windows
+      const tempPath = join(tmpdir(), `pare-playwright-${randomUUID()}.json`);
+
+      const cmdArgs = ["playwright", "test", `--reporter=json`, ...extraArgs];
+
+      // Set PLAYWRIGHT_JSON_OUTPUT_NAME env var to direct JSON to temp file
+      const result = await run("npx", cmdArgs, {
+        cwd,
+        timeout: 120_000,
+        env: { PLAYWRIGHT_JSON_OUTPUT_NAME: tempPath },
+      });
+
+      let jsonStr: string;
+      try {
+        jsonStr = await readFile(tempPath, "utf-8");
+      } catch {
+        // Temp file wasn't created — fall back to stdout extraction
+        const output = result.stdout + "\n" + result.stderr;
+        const start = output.indexOf("{");
+        const end = output.lastIndexOf("}");
+        if (start === -1 || end === -1 || end <= start) {
+          throw new Error(
+            "No JSON output found from Playwright. Ensure Playwright is installed and configured in the project.",
+          );
+        }
+        jsonStr = output.slice(start, end + 1);
+      } finally {
+        try {
+          await unlink(tempPath);
+        } catch {
+          /* ignore cleanup errors */
+        }
+      }
+
+      const playwrightResult = parsePlaywrightJson(jsonStr);
+
+      return compactDualOutput(
+        playwrightResult,
+        result.stdout,
+        formatPlaywrightResult,
+        compactPlaywrightResultMap,
+        formatPlaywrightResultCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a `playwright` tool to `@paretools/test` that wraps Playwright's JSON reporter and returns structured test results
- Parses Playwright JSON output into typed schema with summary counts (passed, failed, skipped, timedOut, interrupted), suites with per-test details, and failure list
- Supports `filter`, `project`, `headed`, `updateSnapshots`, and `args` parameters
- Uses `PLAYWRIGHT_JSON_OUTPUT_NAME` env var for reliable JSON capture (avoids stdout parsing issues on Windows)

## Changes
- `packages/server-test/src/schemas/index.ts` — Added `PlaywrightResultSchema`, `PlaywrightSuiteSchema`, `PlaywrightTestResultSchema`
- `packages/server-test/src/lib/parsers/playwright.ts` — New parser for Playwright JSON reporter output (handles nested suites, retries, multiple error formats)
- `packages/server-test/src/lib/formatters.ts` — Added `formatPlaywrightResult`, `compactPlaywrightResultMap`, `formatPlaywrightResultCompact`
- `packages/server-test/src/tools/playwright.ts` — Tool registration with full input validation
- `packages/server-test/__tests__/playwright-parser.test.ts` — 7 parser tests
- `packages/server-test/__tests__/formatters.test.ts` — 10 new formatter tests for Playwright variants

Closes #293

## Test plan
- [x] All 7 playwright parser tests pass (mixed results, all-passing, retries, nested suites, errors array, empty suites, retry count)
- [x] All 10 playwright formatter tests pass (full format, compact format, compact map)
- [x] Integration test updated and passes (tool listing now shows 3 tools)
- [x] All existing tests continue to pass (77 total in server-test unit tests)
- [x] TypeScript build succeeds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)