### PR TITLE
feat(github): add release-create tool (#273)

### DIFF
--- a/packages/server-github/__tests__/release-create.test.ts
+++ b/packages/server-github/__tests__/release-create.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { parseReleaseCreate } from "../src/lib/parsers.js";
+import { formatReleaseCreate } from "../src/lib/formatters.js";
+import type { ReleaseCreateResult } from "../src/schemas/index.js";
+
+// ── Parser tests ────────────────────────────────────────────────────
+
+describe("parseReleaseCreate", () => {
+  it("parses release create output with URL", () => {
+    const stdout = "https://github.com/owner/repo/releases/tag/v1.0.0\n";
+
+    const result = parseReleaseCreate(stdout, "v1.0.0", false, false);
+
+    expect(result.tag).toBe("v1.0.0");
+    expect(result.url).toBe("https://github.com/owner/repo/releases/tag/v1.0.0");
+    expect(result.draft).toBe(false);
+    expect(result.prerelease).toBe(false);
+  });
+
+  it("parses draft release output", () => {
+    const stdout = "https://github.com/owner/repo/releases/tag/v2.0.0-beta\n";
+
+    const result = parseReleaseCreate(stdout, "v2.0.0-beta", true, false);
+
+    expect(result.tag).toBe("v2.0.0-beta");
+    expect(result.url).toBe("https://github.com/owner/repo/releases/tag/v2.0.0-beta");
+    expect(result.draft).toBe(true);
+    expect(result.prerelease).toBe(false);
+  });
+
+  it("parses prerelease output", () => {
+    const stdout = "https://github.com/owner/repo/releases/tag/v3.0.0-rc.1\n";
+
+    const result = parseReleaseCreate(stdout, "v3.0.0-rc.1", false, true);
+
+    expect(result.tag).toBe("v3.0.0-rc.1");
+    expect(result.url).toBe("https://github.com/owner/repo/releases/tag/v3.0.0-rc.1");
+    expect(result.draft).toBe(false);
+    expect(result.prerelease).toBe(true);
+  });
+
+  it("parses draft prerelease output", () => {
+    const stdout = "https://github.com/owner/repo/releases/tag/v4.0.0-alpha\n";
+
+    const result = parseReleaseCreate(stdout, "v4.0.0-alpha", true, true);
+
+    expect(result.tag).toBe("v4.0.0-alpha");
+    expect(result.draft).toBe(true);
+    expect(result.prerelease).toBe(true);
+  });
+
+  it("trims whitespace from URL", () => {
+    const stdout = "  https://github.com/owner/repo/releases/tag/v1.0.0  \n";
+
+    const result = parseReleaseCreate(stdout, "v1.0.0", false, false);
+
+    expect(result.url).toBe("https://github.com/owner/repo/releases/tag/v1.0.0");
+  });
+});
+
+// ── Formatter tests ─────────────────────────────────────────────────
+
+describe("formatReleaseCreate", () => {
+  it("formats a standard release", () => {
+    const data: ReleaseCreateResult = {
+      tag: "v1.0.0",
+      url: "https://github.com/owner/repo/releases/tag/v1.0.0",
+      draft: false,
+      prerelease: false,
+    };
+    expect(formatReleaseCreate(data)).toBe(
+      "Created release v1.0.0: https://github.com/owner/repo/releases/tag/v1.0.0",
+    );
+  });
+
+  it("formats a draft release", () => {
+    const data: ReleaseCreateResult = {
+      tag: "v2.0.0",
+      url: "https://github.com/owner/repo/releases/tag/v2.0.0",
+      draft: true,
+      prerelease: false,
+    };
+    expect(formatReleaseCreate(data)).toBe(
+      "Created release v2.0.0 (draft): https://github.com/owner/repo/releases/tag/v2.0.0",
+    );
+  });
+
+  it("formats a prerelease", () => {
+    const data: ReleaseCreateResult = {
+      tag: "v3.0.0-rc.1",
+      url: "https://github.com/owner/repo/releases/tag/v3.0.0-rc.1",
+      draft: false,
+      prerelease: true,
+    };
+    expect(formatReleaseCreate(data)).toBe(
+      "Created release v3.0.0-rc.1 (prerelease): https://github.com/owner/repo/releases/tag/v3.0.0-rc.1",
+    );
+  });
+
+  it("formats a draft prerelease", () => {
+    const data: ReleaseCreateResult = {
+      tag: "v4.0.0-alpha",
+      url: "https://github.com/owner/repo/releases/tag/v4.0.0-alpha",
+      draft: true,
+      prerelease: true,
+    };
+    expect(formatReleaseCreate(data)).toBe(
+      "Created release v4.0.0-alpha (draft, prerelease): https://github.com/owner/repo/releases/tag/v4.0.0-alpha",
+    );
+  });
+});

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -15,6 +15,7 @@ import type {
   RunViewResult,
   RunListResult,
   RunRerunResult,
+  ReleaseCreateResult,
   ApiResult,
 } from "../schemas/index.js";
 
@@ -413,6 +414,17 @@ export function formatRunRerun(data: RunRerunResult): string {
   const mode = data.failedOnly ? "failed jobs only" : "all jobs";
   const urlPart = data.url ? `: ${data.url}` : "";
   return `Rerun requested for run #${data.runId} (${mode})${urlPart}`;
+}
+
+// ── Release ─────────────────────────────────────────────────────────
+
+/** Formats structured release create data into human-readable text. */
+export function formatReleaseCreate(data: ReleaseCreateResult): string {
+  const flags = [data.draft ? "draft" : "", data.prerelease ? "prerelease" : ""]
+    .filter(Boolean)
+    .join(", ");
+  const suffix = flags ? ` (${flags})` : "";
+  return `Created release ${data.tag}${suffix}: ${data.url}`;
 }
 
 // ── API ─────────────────────────────────────────────────────────────

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -15,6 +15,7 @@ import type {
   RunViewResult,
   RunListResult,
   RunRerunResult,
+  ReleaseCreateResult,
   ApiResult,
 } from "../schemas/index.js";
 
@@ -339,6 +340,20 @@ export function parseRunRerun(
     failedOnly,
     url,
   };
+}
+
+/**
+ * Parses `gh release create` output (URL on stdout) into structured data.
+ * The gh CLI prints the new release URL to stdout.
+ */
+export function parseReleaseCreate(
+  stdout: string,
+  tag: string,
+  draft: boolean,
+  prerelease: boolean,
+): ReleaseCreateResult {
+  const url = stdout.trim();
+  return { tag, url, draft, prerelease };
 }
 
 /**

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -258,6 +258,18 @@ export const RunRerunResultSchema = z.object({
 
 export type RunRerunResult = z.infer<typeof RunRerunResultSchema>;
 
+// ── Release schemas ─────────────────────────────────────────────────
+
+/** Zod schema for structured release-create output. */
+export const ReleaseCreateResultSchema = z.object({
+  tag: z.string(),
+  url: z.string(),
+  draft: z.boolean(),
+  prerelease: z.boolean(),
+});
+
+export type ReleaseCreateResult = z.infer<typeof ReleaseCreateResultSchema>;
+
 // ── API schemas ─────────────────────────────────────────────────────
 
 /** Zod schema for structured gh api output. */

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -19,6 +19,7 @@ import { registerRunViewTool } from "./run-view.js";
 import { registerRunListTool } from "./run-list.js";
 import { registerRunRerunTool } from "./run-rerun.js";
 import { registerApiTool } from "./api.js";
+import { registerReleaseCreateTool } from "./release-create.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("github", name);
@@ -40,5 +41,6 @@ export function registerAllTools(server: McpServer) {
   if (s("run-view")) registerRunViewTool(server);
   if (s("run-list")) registerRunListTool(server);
   if (s("run-rerun")) registerRunRerunTool(server);
+  if (s("release-create")) registerReleaseCreateTool(server);
   if (s("api")) registerApiTool(server);
 }

--- a/packages/server-github/src/tools/release-create.ts
+++ b/packages/server-github/src/tools/release-create.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseReleaseCreate } from "../lib/parsers.js";
+import { formatReleaseCreate } from "../lib/formatters.js";
+import { ReleaseCreateResultSchema } from "../schemas/index.js";
+
+export function registerReleaseCreateTool(server: McpServer) {
+  server.registerTool(
+    "release-create",
+    {
+      title: "Release Create",
+      description:
+        "Creates a new GitHub release. Returns structured data with tag, URL, draft, and prerelease status. Use instead of running `gh release create` in the terminal.",
+      inputSchema: {
+        tag: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Tag name for the release"),
+        title: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Release title (default: tag name)"),
+        notes: z.string().max(INPUT_LIMITS.STRING_MAX).optional().describe("Release notes/body"),
+        draft: z.boolean().optional().default(false).describe("Create as draft release"),
+        prerelease: z.boolean().optional().default(false).describe("Mark as prerelease"),
+        target: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Target commitish (branch or commit SHA)"),
+        repo: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Repository in owner/repo format (default: current repo)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+      },
+      outputSchema: ReleaseCreateResultSchema,
+    },
+    async ({ tag, title, notes, draft, prerelease, target, repo, path }) => {
+      const cwd = path || process.cwd();
+
+      assertNoFlagInjection(tag, "tag");
+      if (title) assertNoFlagInjection(title, "title");
+      if (target) assertNoFlagInjection(target, "target");
+      if (repo) assertNoFlagInjection(repo, "repo");
+
+      const args = ["release", "create", tag];
+      if (title) args.push("--title", title);
+      if (notes !== undefined) args.push("--notes", notes);
+      if (draft) args.push("--draft");
+      if (prerelease) args.push("--prerelease");
+      if (target) args.push("--target", target);
+      if (repo) args.push("--repo", repo);
+
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh release create failed: ${result.stderr}`);
+      }
+
+      const data = parseReleaseCreate(result.stdout, tag, !!draft, !!prerelease);
+      return dualOutput(data, formatReleaseCreate);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a new `release-create` tool to `@paretools/github` that wraps `gh release create`
- Returns structured JSON with tag, URL, draft, and prerelease status
- Supports optional title, notes, draft, prerelease, target commitish, and repo parameters

Closes #273

## Changes
- `src/schemas/index.ts` — added `ReleaseCreateResultSchema` and `ReleaseCreateResult` type
- `src/lib/parsers.ts` — added `parseReleaseCreate()` parser
- `src/lib/formatters.ts` — added `formatReleaseCreate()` formatter
- `src/tools/release-create.ts` — new tool registration file
- `src/tools/index.ts` — registered the new tool with `shouldRegisterTool` guard
- `__tests__/release-create.test.ts` — parser and formatter unit tests

## Test plan
- [x] All 183 existing github package tests pass
- [x] New release-create parser tests pass (5 cases)
- [x] New release-create formatter tests pass (4 cases)
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)