### PR TITLE
feat(git): add bisect tool (#271)

### DIFF
--- a/packages/server-git/__tests__/bisect.test.ts
+++ b/packages/server-git/__tests__/bisect.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { parseBisect } from "../src/lib/parsers.js";
+import { formatBisect } from "../src/lib/formatters.js";
+import type { GitBisect } from "../src/schemas/index.js";
+
+describe("parseBisect", () => {
+  it("parses bisecting step with remaining revisions", () => {
+    const stdout = `Bisecting: 5 revisions left to test after this (roughly 3 steps)
+[abc1234def5678901234567890abcdef12345678] Fix something`;
+
+    const result = parseBisect(stdout, "", "start");
+
+    expect(result.action).toBe("start");
+    expect(result.remaining).toBe(3);
+    expect(result.current).toBe("abc1234def5678901234567890abcdef12345678");
+    expect(result.result).toBeUndefined();
+  });
+
+  it("parses bisect finding the culprit commit", () => {
+    const stdout = `abc1234def5678901234567890abcdef12345678 is the first bad commit
+commit abc1234def5678901234567890abcdef12345678
+Author: John Doe <john@example.com>
+Date:   Mon Jan 1 12:00:00 2024 +0000
+
+    Introduce the bug`;
+
+    const result = parseBisect(stdout, "", "bad");
+
+    expect(result.action).toBe("bad");
+    expect(result.result).toBeDefined();
+    expect(result.result!.hash).toBe("abc1234def5678901234567890abcdef12345678");
+    expect(result.result!.message).toBe("Introduce the bug");
+    expect(result.result!.author).toBe("John Doe <john@example.com>");
+    expect(result.result!.date).toBe("Mon Jan 1 12:00:00 2024 +0000");
+  });
+
+  it("parses bisect good with remaining steps", () => {
+    const stdout = `Bisecting: 2 revisions left to test after this (roughly 1 steps)
+[def5678abc1234567890abcdef1234567890abcd] Another commit`;
+
+    const result = parseBisect(stdout, "", "good");
+
+    expect(result.action).toBe("good");
+    expect(result.remaining).toBe(1);
+    expect(result.current).toBe("def5678abc1234567890abcdef1234567890abcd");
+  });
+
+  it("parses bisect reset", () => {
+    const stdout = "Previous HEAD position was abc1234 Fix something\nSwitched to branch 'main'";
+
+    const result = parseBisect(stdout, "", "reset");
+
+    expect(result.action).toBe("reset");
+    expect(result.message).toContain("Switched to branch");
+  });
+
+  it("parses bisect status (log output)", () => {
+    const stdout = `git bisect start
+# bad: [abc1234] Bad commit
+git bisect bad abc1234
+# good: [def5678] Good commit
+git bisect good def5678`;
+
+    const result = parseBisect(stdout, "", "status");
+
+    expect(result.action).toBe("status");
+    expect(result.message).toContain("git bisect start");
+  });
+
+  it("handles single revision left", () => {
+    const stdout = `Bisecting: 0 revisions left to test after this (roughly 1 steps)
+[aaa1111bbb2222ccc3333ddd4444eee5555fff66] Last step`;
+
+    const result = parseBisect(stdout, "", "good");
+
+    expect(result.remaining).toBe(1);
+    expect(result.current).toBe("aaa1111bbb2222ccc3333ddd4444eee5555fff66");
+  });
+
+  it("handles empty output for reset", () => {
+    const result = parseBisect("", "", "reset");
+
+    expect(result.action).toBe("reset");
+    expect(result.message).toBe("Bisect reset completed");
+  });
+});
+
+describe("formatBisect", () => {
+  it("formats bisect step with remaining", () => {
+    const data: GitBisect = {
+      action: "start",
+      current: "abc1234",
+      remaining: 3,
+      message: "Bisecting: 5 revisions left",
+    };
+    const output = formatBisect(data);
+
+    expect(output).toContain("Bisect start");
+    expect(output).toContain("Current: abc1234");
+    expect(output).toContain("~3 step(s) remaining");
+  });
+
+  it("formats bisect result (culprit found)", () => {
+    const data: GitBisect = {
+      action: "bad",
+      result: {
+        hash: "abc1234def5678901234567890abcdef12345678",
+        message: "Introduce the bug",
+        author: "John Doe <john@example.com>",
+        date: "Mon Jan 1 12:00:00 2024 +0000",
+      },
+      message: "Found it",
+    };
+    const output = formatBisect(data);
+
+    expect(output).toContain("Bisect found culprit: abc1234d Introduce the bug");
+    expect(output).toContain("Author: John Doe <john@example.com>");
+    expect(output).toContain("Date: Mon Jan 1 12:00:00 2024 +0000");
+  });
+
+  it("formats bisect reset", () => {
+    const data: GitBisect = {
+      action: "reset",
+      message: "Bisect reset completed",
+    };
+    const output = formatBisect(data);
+
+    expect(output).toBe("Bisect reset");
+  });
+
+  it("formats bisect result without author/date", () => {
+    const data: GitBisect = {
+      action: "bad",
+      result: {
+        hash: "abc1234def5678901234567890abcdef12345678",
+        message: "Bug commit",
+      },
+      message: "Found it",
+    };
+    const output = formatBisect(data);
+
+    expect(output).toContain("Bisect found culprit: abc1234d Bug commit");
+    expect(output).not.toContain("Author:");
+  });
+});

--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -30,11 +30,12 @@ describe("@paretools/git integration", () => {
     await transport.close();
   });
 
-  it("lists all 22 tools", async () => {
+  it("lists all 23 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
       "add",
+      "bisect",
       "blame",
       "branch",
       "checkout",

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -21,6 +21,7 @@ import type {
   GitRebase,
   GitLogGraphFull,
   GitReflogFull,
+  GitBisect,
 } from "../schemas/index.js";
 
 /** Formats structured git status data into a human-readable summary string. */
@@ -515,4 +516,21 @@ export function compactReflogMap(r: GitReflogFull): GitReflogCompact {
 export function formatReflogCompact(r: GitReflogCompact): string {
   if (r.entries.length === 0) return "No reflog entries found";
   return r.entries.join("\n");
+}
+
+// ── Bisect formatters ─────────────────────────────────────────────────
+
+/** Formats structured git bisect data into a human-readable bisect summary. */
+export function formatBisect(b: GitBisect): string {
+  if (b.result) {
+    const parts = [`Bisect found culprit: ${b.result.hash.slice(0, 8)} ${b.result.message}`];
+    if (b.result.author) parts.push(`Author: ${b.result.author}`);
+    if (b.result.date) parts.push(`Date: ${b.result.date}`);
+    return parts.join("\n");
+  }
+
+  const parts = [`Bisect ${b.action}`];
+  if (b.current) parts.push(`Current: ${b.current}`);
+  if (b.remaining !== undefined) parts.push(`~${b.remaining} step(s) remaining`);
+  return parts.join(" — ");
 }

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -363,3 +363,21 @@ export type GitReflogFull = {
 };
 
 export type GitReflog = z.infer<typeof GitReflogSchema>;
+
+/** Zod schema for structured git bisect output with action, current commit, remaining steps, and result. */
+export const GitBisectSchema = z.object({
+  action: z.enum(["start", "good", "bad", "reset", "status"]),
+  current: z.string().optional(),
+  remaining: z.number().optional(),
+  result: z
+    .object({
+      hash: z.string(),
+      message: z.string(),
+      author: z.string().optional(),
+      date: z.string().optional(),
+    })
+    .optional(),
+  message: z.string(),
+});
+
+export type GitBisect = z.infer<typeof GitBisectSchema>;

--- a/packages/server-git/src/tools/bisect.ts
+++ b/packages/server-git/src/tools/bisect.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseBisect } from "../lib/parsers.js";
+import { formatBisect } from "../lib/formatters.js";
+import { GitBisectSchema } from "../schemas/index.js";
+
+export function registerBisectTool(server: McpServer) {
+  server.registerTool(
+    "bisect",
+    {
+      title: "Git Bisect",
+      description:
+        "Binary search for the commit that introduced a bug. Supports start, good, bad, reset, and status actions. Returns structured data with action taken, current commit, remaining steps estimate, and result when the culprit is found. Use instead of running `git bisect` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        action: z
+          .enum(["start", "good", "bad", "reset", "status"])
+          .describe("Bisect action to perform"),
+        bad: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Bad commit ref (used with start action)"),
+        good: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Good commit ref (used with start action)"),
+      },
+      outputSchema: GitBisectSchema,
+    },
+    async (params) => {
+      const cwd = params.path || process.cwd();
+      const action = params.action;
+
+      if (action === "start") {
+        const bad = params.bad;
+        const good = params.good;
+
+        if (!bad || !good) {
+          throw new Error("Both 'bad' and 'good' commit refs are required for bisect start");
+        }
+
+        assertNoFlagInjection(bad, "bad");
+        assertNoFlagInjection(good, "good");
+
+        // Start bisect session
+        const startResult = await git(["bisect", "start"], cwd);
+        if (startResult.exitCode !== 0) {
+          throw new Error(`git bisect start failed: ${startResult.stderr}`);
+        }
+
+        // Mark the bad commit
+        const badResult = await git(["bisect", "bad", bad], cwd);
+        if (badResult.exitCode !== 0) {
+          // Reset bisect on failure
+          await git(["bisect", "reset"], cwd);
+          throw new Error(`git bisect bad failed: ${badResult.stderr}`);
+        }
+
+        // Mark the good commit — this triggers the first bisect step
+        const goodResult = await git(["bisect", "good", good], cwd);
+        if (goodResult.exitCode !== 0) {
+          await git(["bisect", "reset"], cwd);
+          throw new Error(`git bisect good failed: ${goodResult.stderr}`);
+        }
+
+        const bisectResult = parseBisect(goodResult.stdout, goodResult.stderr, "start");
+        return dualOutput(bisectResult, formatBisect);
+      }
+
+      if (action === "good") {
+        const result = await git(["bisect", "good"], cwd);
+        if (result.exitCode !== 0) {
+          throw new Error(`git bisect good failed: ${result.stderr}`);
+        }
+
+        const bisectResult = parseBisect(result.stdout, result.stderr, "good");
+        return dualOutput(bisectResult, formatBisect);
+      }
+
+      if (action === "bad") {
+        const result = await git(["bisect", "bad"], cwd);
+        if (result.exitCode !== 0) {
+          throw new Error(`git bisect bad failed: ${result.stderr}`);
+        }
+
+        const bisectResult = parseBisect(result.stdout, result.stderr, "bad");
+        return dualOutput(bisectResult, formatBisect);
+      }
+
+      if (action === "reset") {
+        const result = await git(["bisect", "reset"], cwd);
+        if (result.exitCode !== 0) {
+          throw new Error(`git bisect reset failed: ${result.stderr}`);
+        }
+
+        const bisectResult = parseBisect(result.stdout, result.stderr, "reset");
+        return dualOutput(bisectResult, formatBisect);
+      }
+
+      // status
+      const result = await git(["bisect", "log"], cwd);
+      if (result.exitCode !== 0) {
+        throw new Error(`git bisect log failed: ${result.stderr}`);
+      }
+
+      const bisectResult = parseBisect(result.stdout, result.stderr, "status");
+      return dualOutput(bisectResult, formatBisect);
+    },
+  );
+}

--- a/packages/server-git/src/tools/index.ts
+++ b/packages/server-git/src/tools/index.ts
@@ -22,6 +22,7 @@ import { registerMergeTool } from "./merge.js";
 import { registerRebaseTool } from "./rebase.js";
 import { registerLogGraphTool } from "./log-graph.js";
 import { registerReflogTool } from "./reflog.js";
+import { registerBisectTool } from "./bisect.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("git", name);
@@ -47,4 +48,5 @@ export function registerAllTools(server: McpServer) {
   if (s("merge")) registerMergeTool(server);
   if (s("rebase")) registerRebaseTool(server);
   if (s("reflog")) registerReflogTool(server);
+  if (s("bisect")) registerBisectTool(server);
 }


### PR DESCRIPTION
## Summary
- Adds a new `bisect` tool to `@paretools/git` that wraps `git bisect` for binary search of bug-introducing commits
- Supports 5 actions: `start` (with bad/good refs), `good`, `bad`, `reset`, and `status`
- Returns structured data with action, current commit hash, remaining steps estimate, and culprit commit details when bisect completes
- Includes parser, formatter, Zod schema, 11 unit tests, and integration test update (22 -> 23 tools)

Closes #271

## Test plan
- [x] All 11 new bisect parser/formatter tests pass
- [x] Full git package test suite passes (442/442)
- [x] TypeScript build succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)