### PR TITLE
feat(security): add trivy tool (#288)

### DIFF
--- a/packages/server-security/__tests__/formatters.test.ts
+++ b/packages/server-security/__tests__/formatters.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatTrivyScan,
+  compactTrivyScanMap,
+  formatTrivyScanCompact,
+} from "../src/lib/formatters.js";
+import type { TrivyScanResult } from "../src/schemas/index.js";
+
+// -- Full formatters ----------------------------------------------------------
+
+describe("formatTrivyScan", () => {
+  it("formats scan with vulnerabilities", () => {
+    const data: TrivyScanResult = {
+      target: "alpine:3.18",
+      scanType: "image",
+      vulnerabilities: [
+        {
+          id: "CVE-2024-0001",
+          severity: "CRITICAL",
+          package: "libcrypto3",
+          installedVersion: "3.1.4-r1",
+          fixedVersion: "3.1.4-r5",
+          title: "Buffer overflow",
+        },
+        {
+          id: "CVE-2024-0002",
+          severity: "HIGH",
+          package: "libssl3",
+          installedVersion: "3.1.4-r1",
+        },
+      ],
+      summary: { critical: 1, high: 1, medium: 0, low: 0, unknown: 0 },
+      totalVulnerabilities: 2,
+    };
+
+    const output = formatTrivyScan(data);
+
+    expect(output).toContain("Trivy image scan: alpine:3.18");
+    expect(output).toContain("Found 2 vulnerabilities");
+    expect(output).toContain("1 critical");
+    expect(output).toContain("1 high");
+    expect(output).toContain(
+      "[CRITICAL] CVE-2024-0001: libcrypto3@3.1.4-r1 -> 3.1.4-r5 - Buffer overflow",
+    );
+    expect(output).toContain("[HIGH] CVE-2024-0002: libssl3@3.1.4-r1");
+    // No fixed version or title for second vuln
+    expect(output).not.toContain("CVE-2024-0002: libssl3@3.1.4-r1 ->");
+  });
+
+  it("formats scan with no vulnerabilities", () => {
+    const data: TrivyScanResult = {
+      target: "clean-image:latest",
+      scanType: "image",
+      vulnerabilities: [],
+      summary: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
+      totalVulnerabilities: 0,
+    };
+
+    const output = formatTrivyScan(data);
+
+    expect(output).toContain("Trivy image scan: clean-image:latest");
+    expect(output).toContain("Found 0 vulnerabilities");
+    // Should NOT have individual vulnerability lines
+    expect(output).not.toContain("[");
+  });
+
+  it("formats filesystem scan", () => {
+    const data: TrivyScanResult = {
+      target: "/app",
+      scanType: "fs",
+      vulnerabilities: [
+        {
+          id: "CVE-2024-1234",
+          severity: "MEDIUM",
+          package: "lodash",
+          installedVersion: "4.17.20",
+          fixedVersion: "4.17.21",
+          title: "Prototype pollution",
+        },
+      ],
+      summary: { critical: 0, high: 0, medium: 1, low: 0, unknown: 0 },
+      totalVulnerabilities: 1,
+    };
+
+    const output = formatTrivyScan(data);
+
+    expect(output).toContain("Trivy fs scan: /app");
+    expect(output).toContain("1 medium");
+  });
+});
+
+// -- Compact mappers and formatters -------------------------------------------
+
+describe("compactTrivyScanMap", () => {
+  it("keeps summary and total, drops individual vulnerabilities", () => {
+    const data: TrivyScanResult = {
+      target: "alpine:3.18",
+      scanType: "image",
+      vulnerabilities: [
+        {
+          id: "CVE-2024-0001",
+          severity: "CRITICAL",
+          package: "libcrypto3",
+          installedVersion: "3.1.4-r1",
+          fixedVersion: "3.1.4-r5",
+          title: "Buffer overflow",
+        },
+      ],
+      summary: { critical: 1, high: 0, medium: 0, low: 0, unknown: 0 },
+      totalVulnerabilities: 1,
+    };
+
+    const compact = compactTrivyScanMap(data);
+
+    expect(compact.target).toBe("alpine:3.18");
+    expect(compact.scanType).toBe("image");
+    expect(compact.totalVulnerabilities).toBe(1);
+    expect(compact.summary.critical).toBe(1);
+    expect(compact).not.toHaveProperty("vulnerabilities");
+  });
+});
+
+describe("formatTrivyScanCompact", () => {
+  it("formats compact summary", () => {
+    const output = formatTrivyScanCompact({
+      target: "alpine:3.18",
+      scanType: "image",
+      totalVulnerabilities: 5,
+      summary: { critical: 1, high: 2, medium: 1, low: 1, unknown: 0 },
+    });
+
+    expect(output).toBe("Trivy image scan: alpine:3.18 -- 5 vulnerabilities (1C/2H/1M/1L)");
+  });
+
+  it("formats compact with zero vulnerabilities", () => {
+    const output = formatTrivyScanCompact({
+      target: "clean:latest",
+      scanType: "fs",
+      totalVulnerabilities: 0,
+      summary: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
+    });
+
+    expect(output).toBe("Trivy fs scan: clean:latest -- 0 vulnerabilities (0C/0H/0M/0L)");
+  });
+});

--- a/packages/server-security/__tests__/parsers.test.ts
+++ b/packages/server-security/__tests__/parsers.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "vitest";
+import { parseTrivyJson } from "../src/lib/parsers.js";
+
+describe("parseTrivyJson", () => {
+  it("parses a full Trivy JSON output with vulnerabilities", () => {
+    const json = JSON.stringify({
+      Results: [
+        {
+          Target: "alpine:3.18 (alpine 3.18.6)",
+          Vulnerabilities: [
+            {
+              VulnerabilityID: "CVE-2024-0001",
+              Severity: "CRITICAL",
+              PkgName: "libcrypto3",
+              InstalledVersion: "3.1.4-r1",
+              FixedVersion: "3.1.4-r5",
+              Title: "OpenSSL buffer overflow",
+            },
+            {
+              VulnerabilityID: "CVE-2024-0002",
+              Severity: "HIGH",
+              PkgName: "libssl3",
+              InstalledVersion: "3.1.4-r1",
+              FixedVersion: "3.1.4-r5",
+              Title: "OpenSSL denial of service",
+            },
+            {
+              VulnerabilityID: "CVE-2024-0003",
+              Severity: "LOW",
+              PkgName: "busybox",
+              InstalledVersion: "1.36.1-r2",
+              Title: "Minor issue",
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parseTrivyJson(json, "alpine:3.18", "image");
+
+    expect(result.target).toBe("alpine:3.18");
+    expect(result.scanType).toBe("image");
+    expect(result.totalVulnerabilities).toBe(3);
+    expect(result.vulnerabilities).toHaveLength(3);
+
+    expect(result.vulnerabilities[0]).toEqual({
+      id: "CVE-2024-0001",
+      severity: "CRITICAL",
+      package: "libcrypto3",
+      installedVersion: "3.1.4-r1",
+      fixedVersion: "3.1.4-r5",
+      title: "OpenSSL buffer overflow",
+    });
+
+    expect(result.vulnerabilities[2].fixedVersion).toBeUndefined();
+
+    expect(result.summary).toEqual({
+      critical: 1,
+      high: 1,
+      medium: 0,
+      low: 1,
+      unknown: 0,
+    });
+  });
+
+  it("handles empty Results array", () => {
+    const json = JSON.stringify({ Results: [] });
+    const result = parseTrivyJson(json, "clean-image:latest", "image");
+
+    expect(result.target).toBe("clean-image:latest");
+    expect(result.totalVulnerabilities).toBe(0);
+    expect(result.vulnerabilities).toEqual([]);
+    expect(result.summary).toEqual({
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      unknown: 0,
+    });
+  });
+
+  it("handles null Vulnerabilities in a result", () => {
+    const json = JSON.stringify({
+      Results: [
+        {
+          Target: "node:18",
+          Vulnerabilities: null,
+        },
+      ],
+    });
+
+    const result = parseTrivyJson(json, "node:18", "image");
+    expect(result.totalVulnerabilities).toBe(0);
+    expect(result.vulnerabilities).toEqual([]);
+  });
+
+  it("handles invalid JSON gracefully", () => {
+    const result = parseTrivyJson("not valid json", "target", "fs");
+
+    expect(result.target).toBe("target");
+    expect(result.scanType).toBe("fs");
+    expect(result.totalVulnerabilities).toBe(0);
+    expect(result.vulnerabilities).toEqual([]);
+  });
+
+  it("handles null Results", () => {
+    const json = JSON.stringify({ Results: null });
+    const result = parseTrivyJson(json, "myimage", "image");
+
+    expect(result.totalVulnerabilities).toBe(0);
+  });
+
+  it("flattens vulnerabilities from multiple results", () => {
+    const json = JSON.stringify({
+      Results: [
+        {
+          Target: "layer1",
+          Vulnerabilities: [
+            {
+              VulnerabilityID: "CVE-2024-1111",
+              Severity: "HIGH",
+              PkgName: "pkg1",
+              InstalledVersion: "1.0",
+            },
+          ],
+        },
+        {
+          Target: "layer2",
+          Vulnerabilities: [
+            {
+              VulnerabilityID: "CVE-2024-2222",
+              Severity: "MEDIUM",
+              PkgName: "pkg2",
+              InstalledVersion: "2.0",
+              FixedVersion: "2.1",
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parseTrivyJson(json, "multi-layer:latest", "image");
+
+    expect(result.totalVulnerabilities).toBe(2);
+    expect(result.summary.high).toBe(1);
+    expect(result.summary.medium).toBe(1);
+  });
+
+  it("normalizes severity strings to uppercase", () => {
+    const json = JSON.stringify({
+      Results: [
+        {
+          Target: "test",
+          Vulnerabilities: [
+            {
+              VulnerabilityID: "CVE-2024-0001",
+              Severity: "critical",
+              PkgName: "pkg",
+              InstalledVersion: "1.0",
+            },
+            {
+              VulnerabilityID: "CVE-2024-0002",
+              Severity: "High",
+              PkgName: "pkg2",
+              InstalledVersion: "2.0",
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parseTrivyJson(json, "test", "fs");
+
+    expect(result.vulnerabilities[0].severity).toBe("CRITICAL");
+    expect(result.vulnerabilities[1].severity).toBe("HIGH");
+    expect(result.summary.critical).toBe(1);
+    expect(result.summary.high).toBe(1);
+  });
+
+  it("handles missing fields with defaults", () => {
+    const json = JSON.stringify({
+      Results: [
+        {
+          Target: "test",
+          Vulnerabilities: [
+            {
+              // Minimal: no VulnerabilityID, no PkgName, no InstalledVersion
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parseTrivyJson(json, "test", "image");
+
+    expect(result.vulnerabilities[0]).toEqual({
+      id: "UNKNOWN",
+      severity: "UNKNOWN",
+      package: "unknown",
+      installedVersion: "unknown",
+      fixedVersion: undefined,
+      title: undefined,
+    });
+    expect(result.summary.unknown).toBe(1);
+  });
+
+  it("parses misconfigurations from config scans", () => {
+    const json = JSON.stringify({
+      Results: [
+        {
+          Target: "Dockerfile",
+          Misconfigurations: [
+            {
+              ID: "DS001",
+              Severity: "HIGH",
+              Type: "dockerfile",
+              Title: "Running as root",
+              Message: "Specify a non-root user",
+            },
+            {
+              ID: "DS002",
+              Severity: "MEDIUM",
+              Type: "dockerfile",
+              Title: "COPY with ADD",
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parseTrivyJson(json, "./", "config");
+
+    expect(result.scanType).toBe("config");
+    expect(result.totalVulnerabilities).toBe(2);
+    expect(result.vulnerabilities[0]).toEqual({
+      id: "DS001",
+      severity: "HIGH",
+      package: "dockerfile",
+      installedVersion: "N/A",
+      fixedVersion: undefined,
+      title: "Running as root",
+    });
+    expect(result.summary.high).toBe(1);
+    expect(result.summary.medium).toBe(1);
+  });
+});

--- a/packages/server-security/package.json
+++ b/packages/server-security/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@paretools/security",
+  "version": "0.1.0",
+  "mcpName": "io.github.Dave-London/pare-security",
+  "description": "MCP server for security scanning (Trivy) with structured, token-efficient output",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "structured-output",
+    "ai",
+    "ai-agent",
+    "claude",
+    "cursor",
+    "copilot",
+    "token-efficient",
+    "devtools",
+    "cli",
+    "trivy",
+    "security",
+    "vulnerability",
+    "scanner",
+    "container",
+    "iac"
+  ],
+  "homepage": "https://github.com/Dave-London/Pare/tree/main/packages/server-security",
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "bin": {
+    "pare-security": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/Pare.git",
+    "directory": "packages/server-security"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@paretools/shared": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@paretools/tsconfig": "workspace:*",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/server-security/server.json
+++ b/packages/server-security/server.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Dave-London/pare-security",
+  "description": "Pare Security -- Structured security scanning (Trivy) as typed JSON.",
+  "repository": {
+    "url": "https://github.com/Dave-London/Pare",
+    "source": "github"
+  },
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@paretools/security",
+      "version": "0.1.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/server-security/src/index.ts
+++ b/packages/server-security/src/index.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerAllTools } from "./tools/index.js";
+
+const server = new McpServer(
+  { name: "@paretools/security", version: "0.1.0" },
+  {
+    instructions:
+      "Structured security scanning operations (trivy). Returns typed JSON with vulnerability data. Use instead of running trivy in the terminal.",
+  },
+);
+
+registerAllTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/server-security/src/lib/formatters.ts
+++ b/packages/server-security/src/lib/formatters.ts
@@ -1,0 +1,61 @@
+import type { TrivyScanResult } from "../schemas/index.js";
+
+// -- Full formatters ----------------------------------------------------------
+
+/** Formats a Trivy scan result into human-readable text. */
+export function formatTrivyScan(data: TrivyScanResult): string {
+  const lines: string[] = [];
+
+  lines.push(`Trivy ${data.scanType} scan: ${data.target}`);
+  lines.push(
+    `Found ${data.totalVulnerabilities} vulnerabilities: ` +
+      `${data.summary.critical} critical, ${data.summary.high} high, ` +
+      `${data.summary.medium} medium, ${data.summary.low} low, ` +
+      `${data.summary.unknown} unknown`,
+  );
+
+  if (data.vulnerabilities.length > 0) {
+    lines.push("");
+    for (const v of data.vulnerabilities) {
+      const fixed = v.fixedVersion ? ` -> ${v.fixedVersion}` : "";
+      const title = v.title ? ` - ${v.title}` : "";
+      lines.push(`  [${v.severity}] ${v.id}: ${v.package}@${v.installedVersion}${fixed}${title}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// -- Compact types, mappers, and formatters -----------------------------------
+
+/** Compact scan result: summary and total only, no individual vulnerabilities. */
+export interface TrivyScanCompact {
+  [key: string]: unknown;
+  target: string;
+  scanType: "image" | "fs" | "config";
+  totalVulnerabilities: number;
+  summary: {
+    critical: number;
+    high: number;
+    medium: number;
+    low: number;
+    unknown: number;
+  };
+}
+
+export function compactTrivyScanMap(data: TrivyScanResult): TrivyScanCompact {
+  return {
+    target: data.target,
+    scanType: data.scanType,
+    totalVulnerabilities: data.totalVulnerabilities,
+    summary: data.summary,
+  };
+}
+
+export function formatTrivyScanCompact(data: TrivyScanCompact): string {
+  return (
+    `Trivy ${data.scanType} scan: ${data.target} -- ` +
+    `${data.totalVulnerabilities} vulnerabilities ` +
+    `(${data.summary.critical}C/${data.summary.high}H/${data.summary.medium}M/${data.summary.low}L)`
+  );
+}

--- a/packages/server-security/src/lib/parsers.ts
+++ b/packages/server-security/src/lib/parsers.ts
@@ -1,0 +1,139 @@
+import type {
+  TrivyScanResult,
+  TrivyVulnerability,
+  TrivySeveritySummary,
+} from "../schemas/index.js";
+
+/** Raw Trivy JSON vulnerability shape (from `trivy --format json`). */
+interface TrivyJsonVuln {
+  VulnerabilityID?: string;
+  Severity?: string;
+  PkgName?: string;
+  InstalledVersion?: string;
+  FixedVersion?: string;
+  Title?: string;
+}
+
+/** Raw Trivy JSON result shape (one per target/layer). */
+interface TrivyJsonResult {
+  Target?: string;
+  Vulnerabilities?: TrivyJsonVuln[] | null;
+  Misconfigurations?: TrivyJsonMisconfig[] | null;
+}
+
+/** Raw Trivy JSON misconfiguration shape (from config scans). */
+interface TrivyJsonMisconfig {
+  ID?: string;
+  Severity?: string;
+  Type?: string;
+  Title?: string;
+  Message?: string;
+}
+
+/** Top-level Trivy JSON output. */
+interface TrivyJsonOutput {
+  Results?: TrivyJsonResult[] | null;
+}
+
+/**
+ * Parses raw Trivy JSON output into a structured TrivyScanResult.
+ *
+ * Trivy's JSON output has a `Results` array, each entry containing
+ * a `Target` and `Vulnerabilities` array. We flatten all vulnerabilities
+ * across all results into a single list.
+ */
+export function parseTrivyJson(
+  jsonStr: string,
+  target: string,
+  scanType: "image" | "fs" | "config",
+): TrivyScanResult {
+  let parsed: TrivyJsonOutput;
+  try {
+    parsed = JSON.parse(jsonStr) as TrivyJsonOutput;
+  } catch {
+    return {
+      target,
+      scanType,
+      vulnerabilities: [],
+      summary: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
+      totalVulnerabilities: 0,
+    };
+  }
+
+  const vulnerabilities: TrivyVulnerability[] = [];
+
+  if (parsed.Results) {
+    for (const result of parsed.Results) {
+      // Handle regular vulnerabilities
+      if (result.Vulnerabilities) {
+        for (const v of result.Vulnerabilities) {
+          vulnerabilities.push({
+            id: v.VulnerabilityID || "UNKNOWN",
+            severity: normalizeSeverity(v.Severity),
+            package: v.PkgName || "unknown",
+            installedVersion: v.InstalledVersion || "unknown",
+            fixedVersion: v.FixedVersion || undefined,
+            title: v.Title || undefined,
+          });
+        }
+      }
+
+      // Handle misconfigurations (config scans)
+      if (result.Misconfigurations) {
+        for (const m of result.Misconfigurations) {
+          vulnerabilities.push({
+            id: m.ID || "UNKNOWN",
+            severity: normalizeSeverity(m.Severity),
+            package: m.Type || "config",
+            installedVersion: "N/A",
+            fixedVersion: undefined,
+            title: m.Title || m.Message || undefined,
+          });
+        }
+      }
+    }
+  }
+
+  const summary = computeSummary(vulnerabilities);
+
+  return {
+    target,
+    scanType,
+    vulnerabilities,
+    summary,
+    totalVulnerabilities: vulnerabilities.length,
+  };
+}
+
+/** Normalizes Trivy severity strings to a consistent uppercase form. */
+function normalizeSeverity(severity: string | undefined): string {
+  if (!severity) return "UNKNOWN";
+  const upper = severity.toUpperCase();
+  if (["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"].includes(upper)) return upper;
+  return upper;
+}
+
+/** Computes severity summary counts from a list of vulnerabilities. */
+function computeSummary(vulnerabilities: TrivyVulnerability[]): TrivySeveritySummary {
+  const summary: TrivySeveritySummary = { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 };
+  for (const v of vulnerabilities) {
+    switch (v.severity) {
+      case "CRITICAL":
+        summary.critical++;
+        break;
+      case "HIGH":
+        summary.high++;
+        break;
+      case "MEDIUM":
+        summary.medium++;
+        break;
+      case "LOW":
+        summary.low++;
+        break;
+      default:
+        summary.unknown++;
+        break;
+    }
+  }
+  return summary;
+}

--- a/packages/server-security/src/schemas/index.ts
+++ b/packages/server-security/src/schemas/index.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+/** Zod schema for a single vulnerability entry from Trivy output. */
+export const TrivyVulnerabilitySchema = z.object({
+  id: z.string(),
+  severity: z.string(),
+  package: z.string(),
+  installedVersion: z.string(),
+  fixedVersion: z.string().optional(),
+  title: z.string().optional(),
+});
+
+export type TrivyVulnerability = z.infer<typeof TrivyVulnerabilitySchema>;
+
+/** Zod schema for severity summary counts. */
+export const TrivySeveritySummarySchema = z.object({
+  critical: z.number(),
+  high: z.number(),
+  medium: z.number(),
+  low: z.number(),
+  unknown: z.number(),
+});
+
+export type TrivySeveritySummary = z.infer<typeof TrivySeveritySummarySchema>;
+
+/** Zod schema for the structured Trivy scan result. */
+export const TrivyScanResultSchema = z.object({
+  target: z.string(),
+  scanType: z.enum(["image", "fs", "config"]),
+  vulnerabilities: z.array(TrivyVulnerabilitySchema),
+  summary: TrivySeveritySummarySchema,
+  totalVulnerabilities: z.number(),
+});
+
+export type TrivyScanResult = z.infer<typeof TrivyScanResultSchema>;

--- a/packages/server-security/src/tools/index.ts
+++ b/packages/server-security/src/tools/index.ts
@@ -1,0 +1,8 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
+import { registerTrivyTool } from "./trivy.js";
+
+export function registerAllTools(server: McpServer) {
+  const s = (name: string) => shouldRegisterTool("security", name);
+  if (s("trivy")) registerTrivyTool(server);
+}

--- a/packages/server-security/src/tools/trivy.ts
+++ b/packages/server-security/src/tools/trivy.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, run, INPUT_LIMITS } from "@paretools/shared";
+import { parseTrivyJson } from "../lib/parsers.js";
+import { formatTrivyScan, compactTrivyScanMap, formatTrivyScanCompact } from "../lib/formatters.js";
+import { TrivyScanResultSchema } from "../schemas/index.js";
+
+export function registerTrivyTool(server: McpServer) {
+  server.registerTool(
+    "trivy",
+    {
+      title: "Trivy Security Scanner",
+      description:
+        "Runs Trivy vulnerability/misconfiguration scanner on container images, filesystems, or IaC configs. Returns structured vulnerability data with severity summary. Use instead of running `trivy` in the terminal.",
+      inputSchema: {
+        target: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .describe("Scan target: image name (e.g. 'alpine:3.18') or filesystem path"),
+        scanType: z
+          .enum(["image", "fs", "config"])
+          .optional()
+          .default("image")
+          .describe(
+            'Scan type: "image" for container images, "fs" for filesystem, "config" for IaC misconfigurations',
+          ),
+        severity: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "Comma-separated severity filter (e.g. 'CRITICAL,HIGH'). Default: all severities",
+          ),
+        ignoreUnfixed: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Only show vulnerabilities with known fixes"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: TrivyScanResultSchema,
+    },
+    async ({ target, scanType, severity, ignoreUnfixed, path, compact }) => {
+      const cwd = path || process.cwd();
+
+      const args: string[] = [scanType, "--format", "json", "--quiet"];
+
+      if (severity) {
+        args.push("--severity", severity);
+      }
+
+      if (ignoreUnfixed) {
+        args.push("--ignore-unfixed");
+      }
+
+      args.push(target);
+
+      const result = await run("trivy", args, { cwd, timeout: 300_000 });
+
+      const data = parseTrivyJson(result.stdout, target, scanType);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatTrivyScan,
+        compactTrivyScanMap,
+        formatTrivyScanCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-security/tsconfig.json
+++ b/packages/server-security/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@paretools/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/server-security/vitest.config.ts
+++ b/packages/server-security/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 120_000,
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 70,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,31 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/server-security:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.26.0(zod@4.3.6)
+      '@paretools/shared':
+        specifier: workspace:*
+        version: link:../shared
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@paretools/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/server-test:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary
- Add new `@paretools/security` MCP server package with a `trivy` tool
- Wraps Trivy (container image, filesystem, and IaC config vulnerability scanner) with structured JSON output
- Supports scan types: `image`, `fs`, `config`; severity filtering; ignore-unfixed option
- Returns structured vulnerability data with severity summary counts, plus compact mode for token efficiency
- Includes 15 unit tests covering parsers and formatters

Closes #288

## Test plan
- [x] All 15 unit tests pass (parsers: 8, formatters: 5, compact: 2)
- [ ] Manual test with `trivy image alpine:3.18` to verify end-to-end output
- [ ] Verify build succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)