### PR TITLE
feat(github): add gist-create tool (#275)

### DIFF
--- a/packages/server-github/__tests__/gist-create.test.ts
+++ b/packages/server-github/__tests__/gist-create.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { parseGistCreate } from "../src/lib/parsers.js";
+import { formatGistCreate } from "../src/lib/formatters.js";
+import type { GistCreateResult } from "../src/schemas/index.js";
+
+// ── Parser tests ────────────────────────────────────────────────────
+
+describe("parseGistCreate", () => {
+  it("parses gist create output with URL and extracts ID", () => {
+    const stdout = "https://gist.github.com/abc123def456\n";
+
+    const result = parseGistCreate(stdout, false);
+
+    expect(result.id).toBe("abc123def456");
+    expect(result.url).toBe("https://gist.github.com/abc123def456");
+    expect(result.public).toBe(false);
+  });
+
+  it("parses public gist output", () => {
+    const stdout = "https://gist.github.com/deadbeef0123\n";
+
+    const result = parseGistCreate(stdout, true);
+
+    expect(result.id).toBe("deadbeef0123");
+    expect(result.url).toBe("https://gist.github.com/deadbeef0123");
+    expect(result.public).toBe(true);
+  });
+
+  it("trims whitespace from URL", () => {
+    const stdout = "  https://gist.github.com/abc123def456  \n";
+
+    const result = parseGistCreate(stdout, false);
+
+    expect(result.url).toBe("https://gist.github.com/abc123def456");
+    expect(result.id).toBe("abc123def456");
+  });
+
+  it("handles URL with no matching ID gracefully", () => {
+    const stdout = "https://gist.github.com/\n";
+
+    const result = parseGistCreate(stdout, false);
+
+    expect(result.id).toBe("");
+    expect(result.url).toBe("https://gist.github.com/");
+  });
+});
+
+// ── Formatter tests ─────────────────────────────────────────────────
+
+describe("formatGistCreate", () => {
+  it("formats a secret gist", () => {
+    const data: GistCreateResult = {
+      id: "abc123def456",
+      url: "https://gist.github.com/abc123def456",
+      public: false,
+    };
+    expect(formatGistCreate(data)).toBe(
+      "Created secret gist abc123def456: https://gist.github.com/abc123def456",
+    );
+  });
+
+  it("formats a public gist", () => {
+    const data: GistCreateResult = {
+      id: "deadbeef0123",
+      url: "https://gist.github.com/deadbeef0123",
+      public: true,
+    };
+    expect(formatGistCreate(data)).toBe(
+      "Created public gist deadbeef0123: https://gist.github.com/deadbeef0123",
+    );
+  });
+});

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -16,6 +16,7 @@ import type {
   RunListResult,
   RunRerunResult,
   ReleaseCreateResult,
+  GistCreateResult,
   ApiResult,
 } from "../schemas/index.js";
 
@@ -414,6 +415,14 @@ export function formatRunRerun(data: RunRerunResult): string {
   const mode = data.failedOnly ? "failed jobs only" : "all jobs";
   const urlPart = data.url ? `: ${data.url}` : "";
   return `Rerun requested for run #${data.runId} (${mode})${urlPart}`;
+}
+
+// ── Gist ────────────────────────────────────────────────────────────
+
+/** Formats structured gist create data into human-readable text. */
+export function formatGistCreate(data: GistCreateResult): string {
+  const visibility = data.public ? "public" : "secret";
+  return `Created ${visibility} gist ${data.id}: ${data.url}`;
 }
 
 // ── Release ─────────────────────────────────────────────────────────

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -16,6 +16,7 @@ import type {
   RunListResult,
   RunRerunResult,
   ReleaseCreateResult,
+  GistCreateResult,
   ApiResult,
 } from "../schemas/index.js";
 
@@ -377,6 +378,17 @@ export function parseApi(
   }
 
   return { status, body, endpoint, method };
+}
+
+/**
+ * Parses `gh gist create` output (URL on stdout) into structured data.
+ * The gh CLI prints the new gist URL to stdout. We extract the ID from it.
+ */
+export function parseGistCreate(stdout: string, isPublic: boolean): GistCreateResult {
+  const url = stdout.trim();
+  const match = url.match(/\/([a-f0-9]+)$/);
+  const id = match ? match[1] : "";
+  return { id, url, public: isPublic };
 }
 
 /**

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -270,6 +270,17 @@ export const ReleaseCreateResultSchema = z.object({
 
 export type ReleaseCreateResult = z.infer<typeof ReleaseCreateResultSchema>;
 
+// ── Gist schemas ────────────────────────────────────────────────────
+
+/** Zod schema for structured gist-create output. */
+export const GistCreateResultSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  public: z.boolean(),
+});
+
+export type GistCreateResult = z.infer<typeof GistCreateResultSchema>;
+
 // ── API schemas ─────────────────────────────────────────────────────
 
 /** Zod schema for structured gh api output. */

--- a/packages/server-github/src/tools/gist-create.ts
+++ b/packages/server-github/src/tools/gist-create.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseGistCreate } from "../lib/parsers.js";
+import { formatGistCreate } from "../lib/formatters.js";
+import { GistCreateResultSchema } from "../schemas/index.js";
+
+export function registerGistCreateTool(server: McpServer) {
+  server.registerTool(
+    "gist-create",
+    {
+      title: "Gist Create",
+      description:
+        "Creates a new GitHub gist from one or more files. Returns structured data with gist ID, URL, and visibility. Use instead of running `gh gist create` in the terminal.",
+      inputSchema: {
+        files: z
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .min(1)
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .describe("File paths to include in the gist"),
+        description: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Gist description"),
+        public: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Create as public gist (default: secret)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+      },
+      outputSchema: GistCreateResultSchema,
+    },
+    async ({ files, description, public: isPublic, path }) => {
+      const cwd = path || process.cwd();
+
+      const args = ["gist", "create"];
+      if (description) {
+        args.push("--desc", description);
+      }
+      if (isPublic) {
+        args.push("--public");
+      }
+      args.push(...files);
+
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh gist create failed: ${result.stderr}`);
+      }
+
+      const data = parseGistCreate(result.stdout, !!isPublic);
+      return dualOutput(data, formatGistCreate);
+    },
+  );
+}

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -20,6 +20,7 @@ import { registerRunListTool } from "./run-list.js";
 import { registerRunRerunTool } from "./run-rerun.js";
 import { registerApiTool } from "./api.js";
 import { registerReleaseCreateTool } from "./release-create.js";
+import { registerGistCreateTool } from "./gist-create.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("github", name);
@@ -42,5 +43,6 @@ export function registerAllTools(server: McpServer) {
   if (s("run-list")) registerRunListTool(server);
   if (s("run-rerun")) registerRunRerunTool(server);
   if (s("release-create")) registerReleaseCreateTool(server);
+  if (s("gist-create")) registerGistCreateTool(server);
   if (s("api")) registerApiTool(server);
 }


### PR DESCRIPTION
## Summary
- Adds a new `gist-create` tool to `@paretools/github` that wraps `gh gist create`
- Returns structured JSON with gist `id` (extracted from URL), `url`, and `public` visibility flag
- Accepts `files` (required, array of paths), `description` (optional), and `public` (boolean, default false) as inputs

## Test plan
- [x] 6 unit tests for parser and formatter (all passing)
- [x] Full github package test suite passes (143 tests)
- [x] TypeScript type-checks clean
- [ ] Manual verification: run `gh gist create` via the MCP tool

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)