### PR TITLE
feat(github): add release-list tool (#274)

### DIFF
--- a/packages/server-github/__tests__/release-list.test.ts
+++ b/packages/server-github/__tests__/release-list.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import { parseReleaseList } from "../src/lib/parsers.js";
+import {
+  formatReleaseList,
+  compactReleaseListMap,
+  formatReleaseListCompact,
+} from "../src/lib/formatters.js";
+import type { ReleaseListResult } from "../src/schemas/index.js";
+
+// ── Parser tests ────────────────────────────────────────────────────
+
+describe("parseReleaseList", () => {
+  it("parses release list JSON", () => {
+    const json = JSON.stringify([
+      {
+        tagName: "v1.0.0",
+        name: "Version 1.0.0",
+        isDraft: false,
+        isPrerelease: false,
+        publishedAt: "2024-01-15T10:00:00Z",
+        url: "https://github.com/owner/repo/releases/tag/v1.0.0",
+      },
+      {
+        tagName: "v0.9.0-beta",
+        name: "Beta Release",
+        isDraft: false,
+        isPrerelease: true,
+        publishedAt: "2024-01-10T08:00:00Z",
+        url: "https://github.com/owner/repo/releases/tag/v0.9.0-beta",
+      },
+    ]);
+
+    const result = parseReleaseList(json);
+
+    expect(result.total).toBe(2);
+    expect(result.releases[0]).toEqual({
+      tag: "v1.0.0",
+      name: "Version 1.0.0",
+      draft: false,
+      prerelease: false,
+      publishedAt: "2024-01-15T10:00:00Z",
+      url: "https://github.com/owner/repo/releases/tag/v1.0.0",
+    });
+    expect(result.releases[1].tag).toBe("v0.9.0-beta");
+    expect(result.releases[1].prerelease).toBe(true);
+  });
+
+  it("handles empty list", () => {
+    const result = parseReleaseList("[]");
+    expect(result.total).toBe(0);
+    expect(result.releases).toEqual([]);
+  });
+
+  it("handles draft releases", () => {
+    const json = JSON.stringify([
+      {
+        tagName: "v2.0.0",
+        name: "Draft Release",
+        isDraft: true,
+        isPrerelease: false,
+        publishedAt: "",
+        url: "https://github.com/owner/repo/releases/tag/v2.0.0",
+      },
+    ]);
+
+    const result = parseReleaseList(json);
+
+    expect(result.releases[0].draft).toBe(true);
+    expect(result.releases[0].prerelease).toBe(false);
+  });
+
+  it("handles missing optional fields with defaults", () => {
+    const json = JSON.stringify([{ tagName: "v1.0.0" }]);
+
+    const result = parseReleaseList(json);
+
+    expect(result.releases[0]).toEqual({
+      tag: "v1.0.0",
+      name: "",
+      draft: false,
+      prerelease: false,
+      publishedAt: "",
+      url: "",
+    });
+  });
+});
+
+// ── Formatter tests ─────────────────────────────────────────────────
+
+describe("formatReleaseList", () => {
+  it("formats a release list", () => {
+    const data: ReleaseListResult = {
+      releases: [
+        {
+          tag: "v1.0.0",
+          name: "Version 1.0.0",
+          draft: false,
+          prerelease: false,
+          publishedAt: "2024-01-15T10:00:00Z",
+          url: "https://github.com/owner/repo/releases/tag/v1.0.0",
+        },
+      ],
+      total: 1,
+    };
+    const output = formatReleaseList(data);
+    expect(output).toContain("1 releases:");
+    expect(output).toContain("v1.0.0 Version 1.0.0 — 2024-01-15T10:00:00Z");
+  });
+
+  it("formats empty list", () => {
+    const data: ReleaseListResult = { releases: [], total: 0 };
+    expect(formatReleaseList(data)).toBe("No releases found.");
+  });
+
+  it("shows draft and prerelease flags", () => {
+    const data: ReleaseListResult = {
+      releases: [
+        {
+          tag: "v2.0.0-alpha",
+          name: "Alpha",
+          draft: true,
+          prerelease: true,
+          publishedAt: "2024-02-01T00:00:00Z",
+          url: "https://github.com/owner/repo/releases/tag/v2.0.0-alpha",
+        },
+      ],
+      total: 1,
+    };
+    const output = formatReleaseList(data);
+    expect(output).toContain("(draft, prerelease)");
+  });
+
+  it("shows only draft flag when not prerelease", () => {
+    const data: ReleaseListResult = {
+      releases: [
+        {
+          tag: "v2.0.0",
+          name: "Draft",
+          draft: true,
+          prerelease: false,
+          publishedAt: "",
+          url: "https://url",
+        },
+      ],
+      total: 1,
+    };
+    const output = formatReleaseList(data);
+    expect(output).toContain("(draft)");
+    expect(output).not.toContain("prerelease");
+  });
+});
+
+// ── Compact formatter tests ─────────────────────────────────────────
+
+describe("compactReleaseList", () => {
+  it("maps to compact format", () => {
+    const data: ReleaseListResult = {
+      releases: [
+        {
+          tag: "v1.0.0",
+          name: "Version 1.0.0",
+          draft: false,
+          prerelease: false,
+          publishedAt: "2024-01-15T10:00:00Z",
+          url: "https://github.com/owner/repo/releases/tag/v1.0.0",
+        },
+      ],
+      total: 1,
+    };
+    const compact = compactReleaseListMap(data);
+    expect(compact.releases[0]).not.toHaveProperty("url");
+    expect(compact.releases[0]).not.toHaveProperty("publishedAt");
+    expect(compact.releases[0].tag).toBe("v1.0.0");
+    expect(compact.total).toBe(1);
+
+    const text = formatReleaseListCompact(compact);
+    expect(text).toContain("1 releases:");
+    expect(text).toContain("v1.0.0 Version 1.0.0");
+  });
+
+  it("formats empty compact list", () => {
+    const compact = compactReleaseListMap({ releases: [], total: 0 });
+    expect(formatReleaseListCompact(compact)).toBe("No releases found.");
+  });
+});

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -17,6 +17,7 @@ import type {
   RunRerunResult,
   ReleaseCreateResult,
   GistCreateResult,
+  ReleaseListResult,
   ApiResult,
 } from "../schemas/index.js";
 
@@ -434,6 +435,53 @@ export function formatReleaseCreate(data: ReleaseCreateResult): string {
     .join(", ");
   const suffix = flags ? ` (${flags})` : "";
   return `Created release ${data.tag}${suffix}: ${data.url}`;
+}
+
+/** Formats structured release list data into human-readable text. */
+export function formatReleaseList(data: ReleaseListResult): string {
+  if (data.total === 0) return "No releases found.";
+
+  const lines = [`${data.total} releases:`];
+  for (const r of data.releases) {
+    const flags = [r.draft ? "draft" : "", r.prerelease ? "prerelease" : ""]
+      .filter(Boolean)
+      .join(", ");
+    const suffix = flags ? ` (${flags})` : "";
+    lines.push(`  ${r.tag} ${r.name}${suffix} — ${r.publishedAt}`);
+  }
+  return lines.join("\n");
+}
+
+/** Compact release list: tag, name, and flags only. */
+export interface ReleaseListCompact {
+  [key: string]: unknown;
+  releases: { tag: string; name: string; draft: boolean; prerelease: boolean }[];
+  total: number;
+}
+
+export function compactReleaseListMap(data: ReleaseListResult): ReleaseListCompact {
+  return {
+    releases: data.releases.map((r) => ({
+      tag: r.tag,
+      name: r.name,
+      draft: r.draft,
+      prerelease: r.prerelease,
+    })),
+    total: data.total,
+  };
+}
+
+export function formatReleaseListCompact(data: ReleaseListCompact): string {
+  if (data.total === 0) return "No releases found.";
+  const lines = [`${data.total} releases:`];
+  for (const r of data.releases) {
+    const flags = [r.draft ? "draft" : "", r.prerelease ? "prerelease" : ""]
+      .filter(Boolean)
+      .join(", ");
+    const suffix = flags ? ` (${flags})` : "";
+    lines.push(`  ${r.tag} ${r.name}${suffix}`);
+  }
+  return lines.join("\n");
 }
 
 // ── API ─────────────────────────────────────────────────────────────

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -17,6 +17,7 @@ import type {
   RunRerunResult,
   ReleaseCreateResult,
   GistCreateResult,
+  ReleaseListResult,
   ApiResult,
 } from "../schemas/index.js";
 
@@ -355,6 +356,34 @@ export function parseReleaseCreate(
 ): ReleaseCreateResult {
   const url = stdout.trim();
   return { tag, url, draft, prerelease };
+}
+
+/**
+ * Parses `gh release list --json ...` output into structured release list data.
+ */
+export function parseReleaseList(json: string): ReleaseListResult {
+  const raw = JSON.parse(json);
+  const items = Array.isArray(raw) ? raw : [];
+
+  const releases = items.map(
+    (r: {
+      tagName: string;
+      name: string;
+      isDraft: boolean;
+      isPrerelease: boolean;
+      publishedAt: string;
+      url: string;
+    }) => ({
+      tag: r.tagName ?? "",
+      name: r.name ?? "",
+      draft: r.isDraft ?? false,
+      prerelease: r.isPrerelease ?? false,
+      publishedAt: r.publishedAt ?? "",
+      url: r.url ?? "",
+    }),
+  );
+
+  return { releases, total: releases.length };
 }
 
 /**

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -280,6 +280,23 @@ export const GistCreateResultSchema = z.object({
 });
 
 export type GistCreateResult = z.infer<typeof GistCreateResultSchema>;
+/** Zod schema for a single release in list output. */
+export const ReleaseListItemSchema = z.object({
+  tag: z.string(),
+  name: z.string(),
+  draft: z.boolean(),
+  prerelease: z.boolean(),
+  publishedAt: z.string(),
+  url: z.string(),
+});
+
+/** Zod schema for structured release-list output. */
+export const ReleaseListResultSchema = z.object({
+  releases: z.array(ReleaseListItemSchema),
+  total: z.number(),
+});
+
+export type ReleaseListResult = z.infer<typeof ReleaseListResultSchema>;
 
 // ── API schemas ─────────────────────────────────────────────────────
 

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -21,6 +21,7 @@ import { registerRunRerunTool } from "./run-rerun.js";
 import { registerApiTool } from "./api.js";
 import { registerReleaseCreateTool } from "./release-create.js";
 import { registerGistCreateTool } from "./gist-create.js";
+import { registerReleaseListTool } from "./release-list.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("github", name);
@@ -44,5 +45,6 @@ export function registerAllTools(server: McpServer) {
   if (s("run-rerun")) registerRunRerunTool(server);
   if (s("release-create")) registerReleaseCreateTool(server);
   if (s("gist-create")) registerGistCreateTool(server);
+  if (s("release-list")) registerReleaseListTool(server);
   if (s("api")) registerApiTool(server);
 }

--- a/packages/server-github/src/tools/release-list.ts
+++ b/packages/server-github/src/tools/release-list.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import { parseReleaseList } from "../lib/parsers.js";
+import {
+  formatReleaseList,
+  compactReleaseListMap,
+  formatReleaseListCompact,
+} from "../lib/formatters.js";
+import { ReleaseListResultSchema } from "../schemas/index.js";
+
+const RELEASE_LIST_FIELDS = "tagName,name,isDraft,isPrerelease,publishedAt,url";
+
+export function registerReleaseListTool(server: McpServer) {
+  server.registerTool(
+    "release-list",
+    {
+      title: "Release List",
+      description:
+        "Lists GitHub releases for a repository. Returns structured list with tag, name, draft/prerelease status, publish date, and URL. Use instead of running `gh release list` in the terminal.",
+      inputSchema: {
+        limit: z
+          .number()
+          .optional()
+          .default(10)
+          .describe("Maximum number of releases to return (default: 10)"),
+        repo: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Repository in owner/repo format (default: current repo)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: ReleaseListResultSchema,
+    },
+    async ({ limit, repo, path, compact }) => {
+      const cwd = path || process.cwd();
+
+      if (repo) assertNoFlagInjection(repo, "repo");
+
+      const args = ["release", "list", "--json", RELEASE_LIST_FIELDS, "--limit", String(limit)];
+      if (repo) args.push("--repo", repo);
+
+      const result = await ghCmd(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`gh release list failed: ${result.stderr}`);
+      }
+
+      const data = parseReleaseList(result.stdout);
+      return compactDualOutput(
+        data,
+        result.stdout,
+        formatReleaseList,
+        compactReleaseListMap,
+        formatReleaseListCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add `release-list` tool to `server-github` that wraps `gh release list --json` and returns structured data
- Returns releases array with tag, name, draft/prerelease status, publishedAt, and URL, plus total count
- Supports `limit` (default 10), `repo`, `path`, and `compact` input parameters
- Includes full formatter, compact formatter, parser, Zod schema, and 10 unit tests

Closes #274

## Test plan
- [x] All 10 new unit tests pass (parser, formatter, compact formatter)
- [x] All 147 existing tests continue to pass
- [ ] Manual verification: `gh release list --json tagName,name,isDraft,isPrerelease,publishedAt,url --limit 10` on a repo with releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)