### PR TITLE
feat(git): add worktree tool (#272)

### DIFF
--- a/packages/server-git/__tests__/formatters.test.ts
+++ b/packages/server-git/__tests__/formatters.test.ts
@@ -18,6 +18,8 @@ import {
   formatReset,
   formatLogGraph,
   formatReflog,
+  formatWorktreeList,
+  formatWorktree,
 } from "../src/lib/formatters.js";
 import type {
   GitStatus,
@@ -38,6 +40,8 @@ import type {
   GitReset,
   GitLogGraphFull,
   GitReflogFull,
+  GitWorktreeListFull,
+  GitWorktree,
 } from "../src/schemas/index.js";
 
 describe("formatStatus", () => {
@@ -814,5 +818,62 @@ describe("formatReflog", () => {
 
     expect(output).toContain("aaa1111 HEAD@{0} reset");
     expect(output).not.toContain(": (");
+  });
+});
+
+describe("formatWorktreeList", () => {
+  it("formats worktree list with multiple entries", () => {
+    const data: GitWorktreeListFull = {
+      worktrees: [
+        { path: "/home/user/repo", head: "abc1234567890abcdef", branch: "main", bare: false },
+        {
+          path: "/home/user/repo-feature",
+          head: "def5678901234567890",
+          branch: "feature",
+          bare: false,
+        },
+      ],
+      total: 2,
+    };
+    const output = formatWorktreeList(data);
+
+    expect(output).toContain("/home/user/repo");
+    expect(output).toContain("abc12345");
+    expect(output).toContain("(main)");
+    expect(output).toContain("/home/user/repo-feature");
+    expect(output).toContain("(feature)");
+  });
+
+  it("formats bare worktree", () => {
+    const data: GitWorktreeListFull = {
+      worktrees: [
+        { path: "/home/user/repo.git", head: "abc1234567890abcdef", branch: "", bare: true },
+      ],
+      total: 1,
+    };
+    const output = formatWorktreeList(data);
+
+    expect(output).toContain("[bare]");
+  });
+
+  it("formats empty worktree list", () => {
+    const data: GitWorktreeListFull = { worktrees: [], total: 0 };
+    expect(formatWorktreeList(data)).toBe("No worktrees found");
+  });
+});
+
+describe("formatWorktree", () => {
+  it("formats worktree add result with branch", () => {
+    const data: GitWorktree = { success: true, path: "/tmp/wt", branch: "feature" };
+    const output = formatWorktree(data);
+
+    expect(output).toBe("Worktree at '/tmp/wt' on branch 'feature'");
+  });
+
+  it("formats worktree remove result without branch", () => {
+    const data: GitWorktree = { success: true, path: "/tmp/wt", branch: "" };
+    const output = formatWorktree(data);
+
+    expect(output).toBe("Worktree at '/tmp/wt'");
   });
 });

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -22,6 +22,8 @@ import type {
   GitLogGraphFull,
   GitReflogFull,
   GitBisect,
+  GitWorktreeListFull,
+  GitWorktree,
 } from "../schemas/index.js";
 
 /** Formats structured git status data into a human-readable summary string. */
@@ -533,4 +535,46 @@ export function formatBisect(b: GitBisect): string {
   if (b.current) parts.push(`Current: ${b.current}`);
   if (b.remaining !== undefined) parts.push(`~${b.remaining} step(s) remaining`);
   return parts.join(" — ");
+}
+
+// ── Worktree formatters ────────────────────────────────────────────────
+
+/** Formats structured git worktree list data into a human-readable worktree listing. */
+export function formatWorktreeList(w: GitWorktreeListFull): string {
+  if (w.worktrees.length === 0) return "No worktrees found";
+  return w.worktrees
+    .map((wt) => {
+      const bare = wt.bare ? " [bare]" : "";
+      const branch = wt.branch ? ` (${wt.branch})` : "";
+      return `${wt.path}  ${wt.head.slice(0, 8)}${branch}${bare}`;
+    })
+    .join("\n");
+}
+
+/** Compact worktree list: path + branch as string array + total. */
+export interface GitWorktreeListCompact {
+  [key: string]: unknown;
+  worktrees: string[];
+  total: number;
+}
+
+export function compactWorktreeListMap(w: GitWorktreeListFull): GitWorktreeListCompact {
+  return {
+    worktrees: w.worktrees.map((wt) => {
+      const branch = wt.branch ? ` (${wt.branch})` : "";
+      return `${wt.path}${branch}`;
+    }),
+    total: w.total,
+  };
+}
+
+export function formatWorktreeListCompact(w: GitWorktreeListCompact): string {
+  if (w.worktrees.length === 0) return "No worktrees found";
+  return w.worktrees.join("\n");
+}
+
+/** Formats structured git worktree add/remove result into a human-readable summary. */
+export function formatWorktree(w: GitWorktree): string {
+  const branch = w.branch ? ` on branch '${w.branch}'` : "";
+  return `Worktree at '${w.path}'${branch}`;
 }

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -381,3 +381,34 @@ export const GitBisectSchema = z.object({
 });
 
 export type GitBisect = z.infer<typeof GitBisectSchema>;
+
+/** Zod schema for a single worktree entry with path, HEAD commit, branch, and bare flag. */
+export const GitWorktreeEntrySchema = z.object({
+  path: z.string(),
+  head: z.string(),
+  branch: z.string(),
+  bare: z.boolean(),
+});
+
+/** Zod schema for structured git worktree list output. */
+export const GitWorktreeListSchema = z.object({
+  worktrees: z.union([z.array(GitWorktreeEntrySchema), z.array(z.string())]),
+  total: z.number(),
+});
+
+/** Full worktree list data (always returned by parser, before compact projection). */
+export type GitWorktreeListFull = {
+  worktrees: Array<{ path: string; head: string; branch: string; bare: boolean }>;
+  total: number;
+};
+
+export type GitWorktreeList = z.infer<typeof GitWorktreeListSchema>;
+
+/** Zod schema for structured git worktree add/remove output. */
+export const GitWorktreeSchema = z.object({
+  success: z.boolean(),
+  path: z.string(),
+  branch: z.string(),
+});
+
+export type GitWorktree = z.infer<typeof GitWorktreeSchema>;

--- a/packages/server-git/src/tools/index.ts
+++ b/packages/server-git/src/tools/index.ts
@@ -23,6 +23,7 @@ import { registerRebaseTool } from "./rebase.js";
 import { registerLogGraphTool } from "./log-graph.js";
 import { registerReflogTool } from "./reflog.js";
 import { registerBisectTool } from "./bisect.js";
+import { registerWorktreeTool } from "./worktree.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("git", name);
@@ -49,4 +50,5 @@ export function registerAllTools(server: McpServer) {
   if (s("rebase")) registerRebaseTool(server);
   if (s("reflog")) registerReflogTool(server);
   if (s("bisect")) registerBisectTool(server);
+  if (s("worktree")) registerWorktreeTool(server);
 }

--- a/packages/server-git/src/tools/worktree.ts
+++ b/packages/server-git/src/tools/worktree.ts
@@ -1,0 +1,161 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  dualOutput,
+  compactDualOutput,
+  assertNoFlagInjection,
+  INPUT_LIMITS,
+} from "@paretools/shared";
+import { git } from "../lib/git-runner.js";
+import { parseWorktreeList, parseWorktreeResult } from "../lib/parsers.js";
+import {
+  formatWorktreeList,
+  compactWorktreeListMap,
+  formatWorktreeListCompact,
+  formatWorktree,
+} from "../lib/formatters.js";
+import { GitWorktreeListSchema, GitWorktreeSchema } from "../schemas/index.js";
+
+export function registerWorktreeTool(server: McpServer) {
+  server.registerTool(
+    "worktree",
+    {
+      title: "Git Worktree",
+      description:
+        "Lists, adds, or removes git worktrees for managing multiple working trees. Returns structured data with worktree paths, branches, and HEAD commits. Use instead of running `git worktree` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path (default: cwd)"),
+        action: z
+          .enum(["list", "add", "remove"])
+          .optional()
+          .default("list")
+          .describe("Worktree action to perform (default: list)"),
+        worktreePath: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path for the new or existing worktree (required for add/remove)"),
+        branch: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Branch to checkout in the new worktree (used with add action)"),
+        createBranch: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Create a new branch when adding a worktree (used with add action)"),
+        base: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Base ref for the new branch (used with add + createBranch)"),
+        force: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Force removal even if worktree is dirty (used with remove action)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: z.union([GitWorktreeListSchema, GitWorktreeSchema]),
+    },
+    async (params) => {
+      const cwd = params.path || process.cwd();
+      const action = params.action || "list";
+
+      if (action === "list") {
+        const result = await git(["worktree", "list", "--porcelain"], cwd);
+
+        if (result.exitCode !== 0) {
+          throw new Error(`git worktree list failed: ${result.stderr}`);
+        }
+
+        const worktreeList = parseWorktreeList(result.stdout);
+        return compactDualOutput(
+          worktreeList,
+          result.stdout,
+          formatWorktreeList,
+          compactWorktreeListMap,
+          formatWorktreeListCompact,
+          params.compact === false,
+        );
+      }
+
+      if (action === "add") {
+        const worktreePath = params.worktreePath;
+        if (!worktreePath) {
+          throw new Error("'worktreePath' is required for worktree add");
+        }
+
+        assertNoFlagInjection(worktreePath, "worktreePath");
+
+        const args = ["worktree", "add"];
+
+        if (params.createBranch && params.branch) {
+          assertNoFlagInjection(params.branch, "branch");
+          args.push("-b", params.branch);
+        }
+
+        args.push(worktreePath);
+
+        if (!params.createBranch && params.branch) {
+          assertNoFlagInjection(params.branch, "branch");
+          args.push(params.branch);
+        }
+
+        if (params.base) {
+          assertNoFlagInjection(params.base, "base");
+          args.push(params.base);
+        }
+
+        const result = await git(args, cwd);
+
+        if (result.exitCode !== 0) {
+          throw new Error(`git worktree add failed: ${result.stderr}`);
+        }
+
+        const branch = params.branch || "";
+        const worktreeResult = parseWorktreeResult(
+          result.stdout,
+          result.stderr,
+          worktreePath,
+          branch,
+        );
+        return dualOutput(worktreeResult, formatWorktree);
+      }
+
+      // remove
+      const worktreePath = params.worktreePath;
+      if (!worktreePath) {
+        throw new Error("'worktreePath' is required for worktree remove");
+      }
+
+      assertNoFlagInjection(worktreePath, "worktreePath");
+
+      const args = ["worktree", "remove"];
+      if (params.force) {
+        args.push("--force");
+      }
+      args.push(worktreePath);
+
+      const result = await git(args, cwd);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`git worktree remove failed: ${result.stderr}`);
+      }
+
+      const worktreeResult = parseWorktreeResult(result.stdout, result.stderr, worktreePath, "");
+      return dualOutput(worktreeResult, formatWorktree);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a `worktree` tool to `@paretools/git` that wraps `git worktree` commands with structured JSON output
- Supports three actions: **list** (default, parses porcelain output), **add** (create new worktree with optional branch creation), and **remove** (with optional force flag)
- Includes compact output mode for token-efficient list responses
- Closes #272

## Changes

| File | Change |
|---|---|
| `src/schemas/index.ts` | `GitWorktreeListSchema`, `GitWorktreeSchema` Zod schemas |
| `src/lib/parsers.ts` | `parseWorktreeList` (porcelain format), `parseWorktreeResult` |
| `src/lib/formatters.ts` | `formatWorktreeList`, compact variant, `formatWorktree` |
| `src/tools/worktree.ts` | Tool registration with action-based dispatch |
| `src/tools/index.ts` | Register worktree tool |
| `__tests__/parsers.test.ts` | Parser tests (single/multiple/bare/detached/empty) |
| `__tests__/formatters.test.ts` | Formatter tests (list/bare/empty/add/remove) |

## Test plan

- [x] Parser tests pass (68 total including new worktree tests)
- [x] Formatter tests pass (54 total including new worktree tests)
- [x] TypeScript build succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)