### PR TITLE
feat(security): add semgrep tool (#289)

### DIFF
--- a/packages/server-security/package.json
+++ b/packages/server-security/package.json
@@ -2,7 +2,7 @@
   "name": "@paretools/security",
   "version": "0.1.0",
   "mcpName": "io.github.Dave-London/pare-security",
-  "description": "MCP server for security scanning (Trivy) with structured, token-efficient output",
+  "description": "MCP server for security scanning (Trivy, Semgrep) with structured, token-efficient output",
   "license": "MIT",
   "keywords": [
     "mcp",
@@ -22,7 +22,10 @@
     "vulnerability",
     "scanner",
     "container",
-    "iac"
+    "iac",
+    "semgrep",
+    "static-analysis",
+    "sast"
   ],
   "homepage": "https://github.com/Dave-London/Pare/tree/main/packages/server-security",
   "engines": {

--- a/packages/server-security/src/index.ts
+++ b/packages/server-security/src/index.ts
@@ -8,7 +8,7 @@ const server = new McpServer(
   { name: "@paretools/security", version: "0.1.0" },
   {
     instructions:
-      "Structured security scanning operations (trivy). Returns typed JSON with vulnerability data. Use instead of running trivy in the terminal.",
+      "Structured security scanning operations (trivy, semgrep). Returns typed JSON with vulnerability and finding data. Use instead of running trivy or semgrep in the terminal.",
   },
 );
 

--- a/packages/server-security/src/schemas/index.ts
+++ b/packages/server-security/src/schemas/index.ts
@@ -33,3 +33,37 @@ export const TrivyScanResultSchema = z.object({
 });
 
 export type TrivyScanResult = z.infer<typeof TrivyScanResultSchema>;
+
+// -- Semgrep schemas ----------------------------------------------------------
+
+/** Zod schema for a single Semgrep finding. */
+export const SemgrepFindingSchema = z.object({
+  ruleId: z.string(),
+  path: z.string(),
+  startLine: z.number(),
+  endLine: z.number(),
+  message: z.string(),
+  severity: z.string(),
+  category: z.string().optional(),
+});
+
+export type SemgrepFinding = z.infer<typeof SemgrepFindingSchema>;
+
+/** Zod schema for Semgrep severity summary counts. */
+export const SemgrepSeveritySummarySchema = z.object({
+  error: z.number(),
+  warning: z.number(),
+  info: z.number(),
+});
+
+export type SemgrepSeveritySummary = z.infer<typeof SemgrepSeveritySummarySchema>;
+
+/** Zod schema for the structured Semgrep scan result. */
+export const SemgrepScanResultSchema = z.object({
+  totalFindings: z.number(),
+  findings: z.array(SemgrepFindingSchema),
+  summary: SemgrepSeveritySummarySchema,
+  config: z.string(),
+});
+
+export type SemgrepScanResult = z.infer<typeof SemgrepScanResultSchema>;

--- a/packages/server-security/src/tools/index.ts
+++ b/packages/server-security/src/tools/index.ts
@@ -1,8 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { shouldRegisterTool } from "@paretools/shared";
 import { registerTrivyTool } from "./trivy.js";
+import { registerSemgrepTool } from "./semgrep.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("security", name);
   if (s("trivy")) registerTrivyTool(server);
+  if (s("semgrep")) registerSemgrepTool(server);
 }

--- a/packages/server-security/src/tools/semgrep.ts
+++ b/packages/server-security/src/tools/semgrep.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, run, INPUT_LIMITS } from "@paretools/shared";
+import { parseSemgrepJson } from "../lib/parsers.js";
+import {
+  formatSemgrepScan,
+  compactSemgrepScanMap,
+  formatSemgrepScanCompact,
+} from "../lib/formatters.js";
+import { SemgrepScanResultSchema } from "../schemas/index.js";
+
+export function registerSemgrepTool(server: McpServer) {
+  server.registerTool(
+    "semgrep",
+    {
+      title: "Semgrep Static Analysis",
+      description:
+        "Runs Semgrep static analysis with structured rules and findings. Returns structured finding data with severity summary. Use instead of running `semgrep` in the terminal.",
+      inputSchema: {
+        patterns: z
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default(["."])
+          .describe("File patterns or paths to scan (default: ['.'])"),
+        config: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .default("auto")
+          .describe(
+            'Semgrep config/ruleset (e.g. "auto", "p/security-audit", "p/owasp-top-ten"). Default: "auto"',
+          ),
+        severity: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "Comma-separated severity filter (e.g. 'ERROR,WARNING'). Default: all severities",
+          ),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: SemgrepScanResultSchema,
+    },
+    async ({ patterns, config, severity, path, compact }) => {
+      const cwd = path || process.cwd();
+
+      const args: string[] = ["scan", "--json", "--quiet"];
+
+      if (config) {
+        args.push("--config", config);
+      }
+
+      if (severity) {
+        args.push("--severity", severity);
+      }
+
+      args.push(...patterns);
+
+      const result = await run("semgrep", args, { cwd, timeout: 300_000 });
+
+      const data = parseSemgrepJson(result.stdout, config);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatSemgrepScan,
+        compactSemgrepScanMap,
+        formatSemgrepScanCompact,
+        compact === false,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `semgrep` tool to the existing `@paretools/security` MCP server package
- Wraps `semgrep scan --json` with structured output: findings array (ruleId, path, startLine, endLine, message, severity, category) and severity summary counts (error/warning/info)
- Accepts `patterns` (paths to scan), `config` (ruleset, e.g. "auto", "p/security-audit"), and `severity` (filter) inputs
- Follows existing trivy tool patterns: dual output, compact mode, Zod schemas, `run()` command runner

## Test plan
- [x] Parser tests: full output, empty results, null results, invalid JSON, severity normalization, missing fields
- [x] Formatter tests: full format, empty format, compact mapper, compact format
- [x] All 27 tests passing (17 existing trivy + 10 new semgrep)
- [x] TypeScript build passes

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)