### PR TITLE
feat(k8s): add kubectl tool (#286)

### DIFF
--- a/packages/server-k8s/__tests__/formatters.test.ts
+++ b/packages/server-k8s/__tests__/formatters.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatGet,
+  formatDescribe,
+  formatLogs,
+  formatApply,
+  compactGetMap,
+  formatGetCompact,
+  compactDescribeMap,
+  formatDescribeCompact,
+  compactLogsMap,
+  formatLogsCompact,
+  compactApplyMap,
+  formatApplyCompact,
+} from "../src/lib/formatters.js";
+import type {
+  KubectlGetResult,
+  KubectlDescribeResult,
+  KubectlLogsResult,
+  KubectlApplyResult,
+} from "../src/schemas/index.js";
+
+// ── Full formatters ──────────────────────────────────────────────────
+
+describe("formatGet", () => {
+  it("formats successful get with items", () => {
+    const data: KubectlGetResult = {
+      action: "get",
+      success: true,
+      resource: "pods",
+      namespace: "default",
+      items: [
+        { kind: "Pod", metadata: { name: "nginx-abc" } },
+        { kind: "Pod", metadata: { name: "redis-xyz" } },
+      ],
+      total: 2,
+      exitCode: 0,
+    };
+    const output = formatGet(data);
+    expect(output).toContain("kubectl get pods -n default: 2 item(s)");
+    expect(output).toContain("Pod nginx-abc");
+    expect(output).toContain("Pod redis-xyz");
+  });
+
+  it("formats failed get", () => {
+    const data: KubectlGetResult = {
+      action: "get",
+      success: false,
+      resource: "foos",
+      items: [],
+      total: 0,
+      exitCode: 1,
+      error: "resource type not found",
+    };
+    const output = formatGet(data);
+    expect(output).toContain("kubectl get foos: failed (exit 1)");
+    expect(output).toContain("resource type not found");
+  });
+
+  it("formats get without namespace", () => {
+    const data: KubectlGetResult = {
+      action: "get",
+      success: true,
+      resource: "nodes",
+      items: [{ kind: "Node", metadata: { name: "node-1" } }],
+      total: 1,
+      exitCode: 0,
+    };
+    const output = formatGet(data);
+    expect(output).toContain("kubectl get nodes: 1 item(s)");
+    expect(output).not.toContain("-n");
+  });
+});
+
+describe("formatDescribe", () => {
+  it("returns full output on success", () => {
+    const data: KubectlDescribeResult = {
+      action: "describe",
+      success: true,
+      resource: "pod",
+      name: "nginx-abc",
+      namespace: "default",
+      output: "Name: nginx-abc\nNamespace: default",
+      exitCode: 0,
+    };
+    expect(formatDescribe(data)).toBe("Name: nginx-abc\nNamespace: default");
+  });
+
+  it("formats failure", () => {
+    const data: KubectlDescribeResult = {
+      action: "describe",
+      success: false,
+      resource: "pod",
+      name: "missing",
+      output: "",
+      exitCode: 1,
+      error: "not found",
+    };
+    const output = formatDescribe(data);
+    expect(output).toContain("failed (exit 1)");
+    expect(output).toContain("not found");
+  });
+});
+
+describe("formatLogs", () => {
+  it("formats logs with content", () => {
+    const data: KubectlLogsResult = {
+      action: "logs",
+      success: true,
+      pod: "nginx-abc",
+      logs: "line 1\nline 2",
+      lineCount: 2,
+      exitCode: 0,
+    };
+    const output = formatLogs(data);
+    expect(output).toContain("kubectl logs nginx-abc: 2 line(s)");
+    expect(output).toContain("line 1\nline 2");
+  });
+
+  it("formats empty logs", () => {
+    const data: KubectlLogsResult = {
+      action: "logs",
+      success: true,
+      pod: "empty-pod",
+      logs: "",
+      lineCount: 0,
+      exitCode: 0,
+    };
+    expect(formatLogs(data)).toBe("kubectl logs empty-pod: 0 line(s)");
+  });
+
+  it("formats failed logs", () => {
+    const data: KubectlLogsResult = {
+      action: "logs",
+      success: false,
+      pod: "missing-pod",
+      logs: "",
+      lineCount: 0,
+      exitCode: 1,
+      error: "pod not found",
+    };
+    const output = formatLogs(data);
+    expect(output).toContain("failed (exit 1)");
+    expect(output).toContain("pod not found");
+  });
+});
+
+describe("formatApply", () => {
+  it("formats successful apply", () => {
+    const data: KubectlApplyResult = {
+      action: "apply",
+      success: true,
+      output: "service/my-svc created",
+      exitCode: 0,
+    };
+    const output = formatApply(data);
+    expect(output).toContain("kubectl apply: success");
+    expect(output).toContain("service/my-svc created");
+  });
+
+  it("formats failed apply", () => {
+    const data: KubectlApplyResult = {
+      action: "apply",
+      success: false,
+      output: "error details",
+      exitCode: 1,
+      error: "validation error",
+    };
+    const output = formatApply(data);
+    expect(output).toContain("kubectl apply: failed (exit 1)");
+    expect(output).toContain("validation error");
+  });
+});
+
+// ── Compact mappers and formatters ───────────────────────────────────
+
+describe("compactGetMap", () => {
+  it("keeps summary, drops full item details", () => {
+    const data: KubectlGetResult = {
+      action: "get",
+      success: true,
+      resource: "pods",
+      namespace: "default",
+      items: [
+        {
+          kind: "Pod",
+          metadata: { name: "nginx-abc" },
+          status: { phase: "Running" },
+          spec: { containers: [] },
+        },
+        {
+          kind: "Pod",
+          metadata: { name: "redis-xyz" },
+          status: { phase: "Pending" },
+          spec: { containers: [] },
+        },
+      ],
+      total: 2,
+      exitCode: 0,
+    };
+
+    const compact = compactGetMap(data);
+
+    expect(compact.action).toBe("get");
+    expect(compact.success).toBe(true);
+    expect(compact.total).toBe(2);
+    expect(compact.names).toEqual(["nginx-abc", "redis-xyz"]);
+    expect(compact).not.toHaveProperty("items");
+  });
+});
+
+describe("formatGetCompact", () => {
+  it("formats successful compact get", () => {
+    expect(
+      formatGetCompact({
+        action: "get",
+        success: true,
+        resource: "pods",
+        namespace: "default",
+        total: 3,
+        names: [],
+      }),
+    ).toBe("kubectl get pods -n default: 3 item(s)");
+  });
+
+  it("formats failed compact get", () => {
+    expect(
+      formatGetCompact({ action: "get", success: false, resource: "foos", total: 0, names: [] }),
+    ).toBe("kubectl get foos: failed");
+  });
+});
+
+describe("compactDescribeMap", () => {
+  it("keeps resource and name, drops output", () => {
+    const data: KubectlDescribeResult = {
+      action: "describe",
+      success: true,
+      resource: "pod",
+      name: "nginx-abc",
+      namespace: "default",
+      output: "very long describe output...",
+      exitCode: 0,
+    };
+
+    const compact = compactDescribeMap(data);
+
+    expect(compact.resource).toBe("pod");
+    expect(compact.name).toBe("nginx-abc");
+    expect(compact).not.toHaveProperty("output");
+  });
+});
+
+describe("formatDescribeCompact", () => {
+  it("formats success", () => {
+    expect(
+      formatDescribeCompact({ action: "describe", success: true, resource: "pod", name: "nginx" }),
+    ).toBe("kubectl describe pod nginx: success");
+  });
+
+  it("formats failure", () => {
+    expect(
+      formatDescribeCompact({
+        action: "describe",
+        success: false,
+        resource: "pod",
+        name: "missing",
+      }),
+    ).toBe("kubectl describe pod missing: failed");
+  });
+});
+
+describe("compactLogsMap", () => {
+  it("keeps line count, drops log content", () => {
+    const data: KubectlLogsResult = {
+      action: "logs",
+      success: true,
+      pod: "nginx-abc",
+      namespace: "default",
+      logs: "line 1\nline 2\nline 3",
+      lineCount: 3,
+      exitCode: 0,
+    };
+
+    const compact = compactLogsMap(data);
+
+    expect(compact.pod).toBe("nginx-abc");
+    expect(compact.lineCount).toBe(3);
+    expect(compact).not.toHaveProperty("logs");
+  });
+});
+
+describe("formatLogsCompact", () => {
+  it("formats success with line count", () => {
+    expect(formatLogsCompact({ action: "logs", success: true, pod: "nginx", lineCount: 42 })).toBe(
+      "kubectl logs nginx: 42 line(s)",
+    );
+  });
+
+  it("formats failure", () => {
+    expect(
+      formatLogsCompact({ action: "logs", success: false, pod: "missing", lineCount: 0 }),
+    ).toBe("kubectl logs missing: failed");
+  });
+});
+
+describe("compactApplyMap", () => {
+  it("keeps success and exit code, drops output", () => {
+    const data: KubectlApplyResult = {
+      action: "apply",
+      success: true,
+      output: "service/my-svc created",
+      exitCode: 0,
+    };
+
+    const compact = compactApplyMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact.exitCode).toBe(0);
+    expect(compact).not.toHaveProperty("output");
+  });
+});
+
+describe("formatApplyCompact", () => {
+  it("formats success", () => {
+    expect(formatApplyCompact({ action: "apply", success: true, exitCode: 0 })).toBe(
+      "kubectl apply: success",
+    );
+  });
+
+  it("formats failure", () => {
+    expect(formatApplyCompact({ action: "apply", success: false, exitCode: 1 })).toBe(
+      "kubectl apply: failed (exit 1)",
+    );
+  });
+});

--- a/packages/server-k8s/__tests__/parsers.test.ts
+++ b/packages/server-k8s/__tests__/parsers.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseGetOutput,
+  parseDescribeOutput,
+  parseLogsOutput,
+  parseApplyOutput,
+} from "../src/lib/parsers.js";
+
+describe("parseGetOutput", () => {
+  it("parses a list of resources from kubectl get -o json", () => {
+    const stdout = JSON.stringify({
+      kind: "List",
+      apiVersion: "v1",
+      items: [
+        {
+          apiVersion: "v1",
+          kind: "Pod",
+          metadata: {
+            name: "nginx-abc",
+            namespace: "default",
+            creationTimestamp: "2026-01-01T00:00:00Z",
+          },
+          status: { phase: "Running" },
+          spec: { containers: [{ name: "nginx" }] },
+        },
+        {
+          apiVersion: "v1",
+          kind: "Pod",
+          metadata: {
+            name: "redis-xyz",
+            namespace: "default",
+            creationTimestamp: "2026-01-02T00:00:00Z",
+          },
+          status: { phase: "Pending" },
+          spec: { containers: [{ name: "redis" }] },
+        },
+      ],
+    });
+
+    const result = parseGetOutput(stdout, "", 0, "pods", "default");
+
+    expect(result.action).toBe("get");
+    expect(result.success).toBe(true);
+    expect(result.resource).toBe("pods");
+    expect(result.namespace).toBe("default");
+    expect(result.total).toBe(2);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].kind).toBe("Pod");
+    expect(result.items[0].metadata?.name).toBe("nginx-abc");
+    expect(result.items[1].metadata?.name).toBe("redis-xyz");
+    expect(result.exitCode).toBe(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("parses a single resource", () => {
+    const stdout = JSON.stringify({
+      apiVersion: "v1",
+      kind: "Pod",
+      metadata: { name: "nginx-abc", namespace: "default" },
+      status: { phase: "Running" },
+    });
+
+    const result = parseGetOutput(stdout, "", 0, "pod", "default");
+
+    expect(result.success).toBe(true);
+    expect(result.total).toBe(1);
+    expect(result.items[0].kind).toBe("Pod");
+    expect(result.items[0].metadata?.name).toBe("nginx-abc");
+  });
+
+  it("handles empty list", () => {
+    const stdout = JSON.stringify({
+      kind: "List",
+      apiVersion: "v1",
+      items: [],
+    });
+
+    const result = parseGetOutput(stdout, "", 0, "pods");
+
+    expect(result.success).toBe(true);
+    expect(result.total).toBe(0);
+    expect(result.items).toEqual([]);
+  });
+
+  it("handles failure with stderr", () => {
+    const result = parseGetOutput(
+      "",
+      'error: the server doesn\'t have a resource type "foos"',
+      1,
+      "foos",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.total).toBe(0);
+    expect(result.items).toEqual([]);
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toContain("doesn't have a resource type");
+  });
+
+  it("handles invalid JSON output", () => {
+    const result = parseGetOutput("not-json{", "", 0, "pods");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to parse kubectl JSON output");
+  });
+
+  it("preserves namespace as undefined when not provided", () => {
+    const stdout = JSON.stringify({ kind: "List", apiVersion: "v1", items: [] });
+    const result = parseGetOutput(stdout, "", 0, "pods");
+
+    expect(result.namespace).toBeUndefined();
+  });
+});
+
+describe("parseDescribeOutput", () => {
+  it("parses successful describe output", () => {
+    const stdout = "Name:         nginx-abc\nNamespace:    default\nNode:         node-1\n";
+
+    const result = parseDescribeOutput(stdout, "", 0, "pod", "nginx-abc", "default");
+
+    expect(result.action).toBe("describe");
+    expect(result.success).toBe(true);
+    expect(result.resource).toBe("pod");
+    expect(result.name).toBe("nginx-abc");
+    expect(result.namespace).toBe("default");
+    expect(result.output).toContain("Name:         nginx-abc");
+    expect(result.exitCode).toBe(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("handles describe failure", () => {
+    const result = parseDescribeOutput(
+      "",
+      'Error from server (NotFound): pods "missing" not found',
+      1,
+      "pod",
+      "missing",
+      "default",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toContain("NotFound");
+  });
+
+  it("trims trailing whitespace from output", () => {
+    const result = parseDescribeOutput("Name: test\n\n  \n", "", 0, "svc", "test");
+
+    expect(result.output).toBe("Name: test");
+  });
+});
+
+describe("parseLogsOutput", () => {
+  it("parses successful log output", () => {
+    const stdout = "2026-01-01 INFO Starting\n2026-01-01 INFO Ready\n2026-01-01 INFO Serving\n";
+
+    const result = parseLogsOutput(stdout, "", 0, "nginx-abc", "default", "nginx");
+
+    expect(result.action).toBe("logs");
+    expect(result.success).toBe(true);
+    expect(result.pod).toBe("nginx-abc");
+    expect(result.namespace).toBe("default");
+    expect(result.container).toBe("nginx");
+    expect(result.lineCount).toBe(3);
+    expect(result.logs).toContain("Starting");
+    expect(result.exitCode).toBe(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("handles empty logs", () => {
+    const result = parseLogsOutput("", "", 0, "empty-pod");
+
+    expect(result.success).toBe(true);
+    expect(result.lineCount).toBe(0);
+    expect(result.logs).toBe("");
+  });
+
+  it("handles logs failure", () => {
+    const result = parseLogsOutput("", "Error from server: pod not found", 1, "missing-pod");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("pod not found");
+  });
+
+  it("leaves container undefined when not provided", () => {
+    const result = parseLogsOutput("log line\n", "", 0, "my-pod");
+
+    expect(result.container).toBeUndefined();
+  });
+});
+
+describe("parseApplyOutput", () => {
+  it("parses successful apply output", () => {
+    const stdout = '{"apiVersion":"v1","kind":"Service","metadata":{"name":"my-svc"}}';
+
+    const result = parseApplyOutput(stdout, "", 0);
+
+    expect(result.action).toBe("apply");
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("my-svc");
+    expect(result.exitCode).toBe(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("handles apply failure", () => {
+    const result = parseApplyOutput("", "error: no objects passed to apply", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toContain("no objects passed to apply");
+    expect(result.output).toContain("no objects passed to apply");
+  });
+
+  it("trims trailing whitespace", () => {
+    const result = parseApplyOutput("service/my-svc created\n\n", "", 0);
+
+    expect(result.output).toBe("service/my-svc created");
+  });
+});

--- a/packages/server-k8s/package.json
+++ b/packages/server-k8s/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@paretools/k8s",
+  "version": "0.8.1",
+  "mcpName": "io.github.Dave-London/pare-k8s",
+  "description": "MCP server for Kubernetes kubectl with structured, token-efficient output",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "structured-output",
+    "ai",
+    "ai-agent",
+    "claude",
+    "cursor",
+    "copilot",
+    "token-efficient",
+    "devtools",
+    "cli",
+    "kubernetes",
+    "kubectl",
+    "k8s",
+    "containers",
+    "orchestration"
+  ],
+  "homepage": "https://github.com/Dave-London/Pare/tree/main/packages/server-k8s",
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "bin": {
+    "pare-k8s": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/Pare.git",
+    "directory": "packages/server-k8s"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@paretools/shared": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@paretools/tsconfig": "workspace:*",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/server-k8s/src/index.ts
+++ b/packages/server-k8s/src/index.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerAllTools } from "./tools/index.js";
+
+const server = new McpServer(
+  { name: "@paretools/k8s", version: "0.8.1" },
+  {
+    instructions:
+      "Structured Kubernetes kubectl operations (get, describe, logs, apply). Returns typed JSON. Use instead of running kubectl in the terminal.",
+  },
+);
+
+registerAllTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/server-k8s/src/lib/formatters.ts
+++ b/packages/server-k8s/src/lib/formatters.ts
@@ -1,0 +1,165 @@
+import type {
+  KubectlGetResult,
+  KubectlDescribeResult,
+  KubectlLogsResult,
+  KubectlApplyResult,
+  KubectlResult,
+} from "../schemas/index.js";
+
+// ── Full formatters ──────────────────────────────────────────────────
+
+/** Formats a kubectl get result into human-readable text. */
+export function formatGet(data: KubectlGetResult): string {
+  if (!data.success) {
+    return `kubectl get ${data.resource}: failed (exit ${data.exitCode})${data.error ? `\n${data.error}` : ""}`;
+  }
+  const ns = data.namespace ? ` -n ${data.namespace}` : "";
+  const lines = [`kubectl get ${data.resource}${ns}: ${data.total} item(s)`];
+  for (const item of data.items) {
+    const name = item.metadata?.name ?? "unknown";
+    const kind = item.kind ?? "";
+    lines.push(`  ${kind} ${name}`);
+  }
+  return lines.join("\n");
+}
+
+/** Formats a kubectl describe result into human-readable text. */
+export function formatDescribe(data: KubectlDescribeResult): string {
+  if (!data.success) {
+    return `kubectl describe ${data.resource} ${data.name}: failed (exit ${data.exitCode})${data.error ? `\n${data.error}` : ""}`;
+  }
+  return data.output;
+}
+
+/** Formats a kubectl logs result into human-readable text. */
+export function formatLogs(data: KubectlLogsResult): string {
+  if (!data.success) {
+    return `kubectl logs ${data.pod}: failed (exit ${data.exitCode})${data.error ? `\n${data.error}` : ""}`;
+  }
+  const header = `kubectl logs ${data.pod}: ${data.lineCount} line(s)`;
+  if (!data.logs) return header;
+  return `${header}\n${data.logs}`;
+}
+
+/** Formats a kubectl apply result into human-readable text. */
+export function formatApply(data: KubectlApplyResult): string {
+  if (!data.success) {
+    return `kubectl apply: failed (exit ${data.exitCode})${data.error ? `\n${data.error}` : ""}`;
+  }
+  return `kubectl apply: success\n${data.output}`;
+}
+
+/** Dispatches formatting to the correct action formatter. */
+export function formatResult(data: KubectlResult): string {
+  switch (data.action) {
+    case "get":
+      return formatGet(data);
+    case "describe":
+      return formatDescribe(data);
+    case "logs":
+      return formatLogs(data);
+    case "apply":
+      return formatApply(data);
+  }
+}
+
+// ── Compact types, mappers, and formatters ───────────────────────────
+
+/** Compact get: summary without full resource details. */
+export interface KubectlGetCompact {
+  [key: string]: unknown;
+  action: "get";
+  success: boolean;
+  resource: string;
+  namespace?: string;
+  total: number;
+  names: string[];
+}
+
+export function compactGetMap(data: KubectlGetResult): KubectlGetCompact {
+  return {
+    action: "get",
+    success: data.success,
+    resource: data.resource,
+    namespace: data.namespace,
+    total: data.total,
+    names: data.items.map((i) => i.metadata?.name ?? "unknown"),
+  };
+}
+
+export function formatGetCompact(data: KubectlGetCompact): string {
+  if (!data.success) return `kubectl get ${data.resource}: failed`;
+  const ns = data.namespace ? ` -n ${data.namespace}` : "";
+  return `kubectl get ${data.resource}${ns}: ${data.total} item(s)`;
+}
+
+/** Compact describe: just success/failure, no full output. */
+export interface KubectlDescribeCompact {
+  [key: string]: unknown;
+  action: "describe";
+  success: boolean;
+  resource: string;
+  name: string;
+  namespace?: string;
+}
+
+export function compactDescribeMap(data: KubectlDescribeResult): KubectlDescribeCompact {
+  return {
+    action: "describe",
+    success: data.success,
+    resource: data.resource,
+    name: data.name,
+    namespace: data.namespace,
+  };
+}
+
+export function formatDescribeCompact(data: KubectlDescribeCompact): string {
+  if (!data.success) return `kubectl describe ${data.resource} ${data.name}: failed`;
+  return `kubectl describe ${data.resource} ${data.name}: success`;
+}
+
+/** Compact logs: line count, no full log content. */
+export interface KubectlLogsCompact {
+  [key: string]: unknown;
+  action: "logs";
+  success: boolean;
+  pod: string;
+  namespace?: string;
+  lineCount: number;
+}
+
+export function compactLogsMap(data: KubectlLogsResult): KubectlLogsCompact {
+  return {
+    action: "logs",
+    success: data.success,
+    pod: data.pod,
+    namespace: data.namespace,
+    lineCount: data.lineCount,
+  };
+}
+
+export function formatLogsCompact(data: KubectlLogsCompact): string {
+  if (!data.success) return `kubectl logs ${data.pod}: failed`;
+  return `kubectl logs ${data.pod}: ${data.lineCount} line(s)`;
+}
+
+/** Compact apply: just success/failure status. */
+export interface KubectlApplyCompact {
+  [key: string]: unknown;
+  action: "apply";
+  success: boolean;
+  exitCode: number;
+}
+
+export function compactApplyMap(data: KubectlApplyResult): KubectlApplyCompact {
+  return {
+    action: "apply",
+    success: data.success,
+    exitCode: data.exitCode,
+  };
+}
+
+export function formatApplyCompact(data: KubectlApplyCompact): string {
+  if (!data.success) return `kubectl apply: failed (exit ${data.exitCode})`;
+  return "kubectl apply: success";
+}

--- a/packages/server-k8s/src/lib/parsers.ts
+++ b/packages/server-k8s/src/lib/parsers.ts
@@ -1,0 +1,150 @@
+import type {
+  KubectlGetResult,
+  KubectlDescribeResult,
+  KubectlLogsResult,
+  KubectlApplyResult,
+  K8sResource,
+} from "../schemas/index.js";
+
+/**
+ * Parses `kubectl get -o json` output into a structured get result.
+ */
+export function parseGetOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  resource: string,
+  namespace?: string,
+): KubectlGetResult {
+  if (exitCode !== 0) {
+    return {
+      action: "get",
+      success: false,
+      resource,
+      namespace,
+      items: [],
+      total: 0,
+      exitCode,
+      error: stderr.trim() || undefined,
+    };
+  }
+
+  let items: K8sResource[] = [];
+  try {
+    const parsed = JSON.parse(stdout);
+    if (parsed.kind === "List" && Array.isArray(parsed.items)) {
+      items = parsed.items.map(extractResource);
+    } else {
+      // Single resource
+      items = [extractResource(parsed)];
+    }
+  } catch {
+    // If JSON parse fails, return raw output as error
+    return {
+      action: "get",
+      success: false,
+      resource,
+      namespace,
+      items: [],
+      total: 0,
+      exitCode,
+      error: `Failed to parse kubectl JSON output: ${stdout.slice(0, 200)}`,
+    };
+  }
+
+  return {
+    action: "get",
+    success: true,
+    resource,
+    namespace,
+    items,
+    total: items.length,
+    exitCode,
+  };
+}
+
+/**
+ * Extracts a minimal K8sResource from a raw kubectl JSON object.
+ */
+function extractResource(raw: Record<string, unknown>): K8sResource {
+  const result: K8sResource = {};
+  if (typeof raw.apiVersion === "string") result.apiVersion = raw.apiVersion;
+  if (typeof raw.kind === "string") result.kind = raw.kind;
+  if (raw.metadata && typeof raw.metadata === "object") {
+    result.metadata = raw.metadata as K8sResource["metadata"];
+  }
+  if (raw.status && typeof raw.status === "object") {
+    result.status = raw.status as Record<string, unknown>;
+  }
+  if (raw.spec && typeof raw.spec === "object") {
+    result.spec = raw.spec as Record<string, unknown>;
+  }
+  return result;
+}
+
+/**
+ * Parses `kubectl describe` output into a structured describe result.
+ */
+export function parseDescribeOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  resource: string,
+  name: string,
+  namespace?: string,
+): KubectlDescribeResult {
+  return {
+    action: "describe",
+    success: exitCode === 0,
+    resource,
+    name,
+    namespace,
+    output: stdout.trimEnd(),
+    exitCode,
+    error: exitCode !== 0 ? stderr.trim() || undefined : undefined,
+  };
+}
+
+/**
+ * Parses `kubectl logs` output into a structured logs result.
+ */
+export function parseLogsOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  pod: string,
+  namespace?: string,
+  container?: string,
+): KubectlLogsResult {
+  const logs = stdout.trimEnd();
+  const lineCount = logs ? logs.split("\n").length : 0;
+
+  return {
+    action: "logs",
+    success: exitCode === 0,
+    pod,
+    namespace,
+    container,
+    logs,
+    lineCount,
+    exitCode,
+    error: exitCode !== 0 ? stderr.trim() || undefined : undefined,
+  };
+}
+
+/**
+ * Parses `kubectl apply` output into a structured apply result.
+ */
+export function parseApplyOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): KubectlApplyResult {
+  return {
+    action: "apply",
+    success: exitCode === 0,
+    output: (exitCode === 0 ? stdout : stderr).trimEnd(),
+    exitCode,
+    error: exitCode !== 0 ? stderr.trim() || undefined : undefined,
+  };
+}

--- a/packages/server-k8s/src/schemas/index.ts
+++ b/packages/server-k8s/src/schemas/index.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+
+// ── Shared resource item schema ─────────────────────────────────────
+
+/** A single Kubernetes resource item from `kubectl get -o json`. */
+export const K8sResourceSchema = z.object({
+  apiVersion: z.string().optional(),
+  kind: z.string().optional(),
+  metadata: z
+    .object({
+      name: z.string().optional(),
+      namespace: z.string().optional(),
+      creationTimestamp: z.string().optional(),
+      labels: z.record(z.string(), z.string()).optional(),
+    })
+    .optional(),
+  status: z.record(z.string(), z.unknown()).optional(),
+  spec: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type K8sResource = z.infer<typeof K8sResourceSchema>;
+
+// ── Get result ──────────────────────────────────────────────────────
+
+/** Zod schema for structured `kubectl get` output. */
+export const KubectlGetResultSchema = z.object({
+  action: z.literal("get"),
+  success: z.boolean(),
+  resource: z.string(),
+  namespace: z.string().optional(),
+  items: z.array(K8sResourceSchema),
+  total: z.number(),
+  exitCode: z.number(),
+  error: z.string().optional(),
+});
+
+export type KubectlGetResult = z.infer<typeof KubectlGetResultSchema>;
+
+// ── Describe result ─────────────────────────────────────────────────
+
+/** Zod schema for structured `kubectl describe` output. */
+export const KubectlDescribeResultSchema = z.object({
+  action: z.literal("describe"),
+  success: z.boolean(),
+  resource: z.string(),
+  name: z.string(),
+  namespace: z.string().optional(),
+  output: z.string(),
+  exitCode: z.number(),
+  error: z.string().optional(),
+});
+
+export type KubectlDescribeResult = z.infer<typeof KubectlDescribeResultSchema>;
+
+// ── Logs result ─────────────────────────────────────────────────────
+
+/** Zod schema for structured `kubectl logs` output. */
+export const KubectlLogsResultSchema = z.object({
+  action: z.literal("logs"),
+  success: z.boolean(),
+  pod: z.string(),
+  namespace: z.string().optional(),
+  container: z.string().optional(),
+  logs: z.string(),
+  lineCount: z.number(),
+  exitCode: z.number(),
+  error: z.string().optional(),
+});
+
+export type KubectlLogsResult = z.infer<typeof KubectlLogsResultSchema>;
+
+// ── Apply result ────────────────────────────────────────────────────
+
+/** Zod schema for structured `kubectl apply` output. */
+export const KubectlApplyResultSchema = z.object({
+  action: z.literal("apply"),
+  success: z.boolean(),
+  output: z.string(),
+  exitCode: z.number(),
+  error: z.string().optional(),
+});
+
+export type KubectlApplyResult = z.infer<typeof KubectlApplyResultSchema>;
+
+// ── Union result ────────────────────────────────────────────────────
+
+/** Union of all kubectl result types. */
+export const KubectlResultSchema = z.discriminatedUnion("action", [
+  KubectlGetResultSchema,
+  KubectlDescribeResultSchema,
+  KubectlLogsResultSchema,
+  KubectlApplyResultSchema,
+]);
+
+export type KubectlResult = z.infer<typeof KubectlResultSchema>;

--- a/packages/server-k8s/src/tools/apply.ts
+++ b/packages/server-k8s/src/tools/apply.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, run, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { parseApplyOutput } from "../lib/parsers.js";
+import { formatApply, compactApplyMap, formatApplyCompact } from "../lib/formatters.js";
+import { KubectlApplyResultSchema } from "../schemas/index.js";
+
+export function registerApplyTool(server: McpServer) {
+  server.registerTool(
+    "apply",
+    {
+      title: "Kubectl Apply",
+      description:
+        "Applies a Kubernetes manifest file. Use instead of running `kubectl apply` in the terminal.",
+      inputSchema: {
+        file: z.string().max(INPUT_LIMITS.PATH_MAX).describe("Path to the manifest file to apply"),
+        namespace: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Kubernetes namespace (omit for default)"),
+        dryRun: z
+          .enum(["none", "client", "server"])
+          .optional()
+          .default("none")
+          .describe("Dry run mode: none, client, or server"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: KubectlApplyResultSchema,
+    },
+    async ({ file, namespace, dryRun, compact }) => {
+      const args = ["apply", "-f", file];
+      if (namespace) {
+        assertNoFlagInjection(namespace, "namespace");
+        args.push("-n", namespace);
+      }
+      if (dryRun && dryRun !== "none") {
+        args.push("--dry-run", dryRun);
+      }
+      args.push("-o", "json");
+
+      const result = await run("kubectl", args, { timeout: 60_000 });
+      const data = parseApplyOutput(result.stdout, result.stderr, result.exitCode);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatApply,
+        compactApplyMap,
+        formatApplyCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-k8s/src/tools/describe.ts
+++ b/packages/server-k8s/src/tools/describe.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, run, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { parseDescribeOutput } from "../lib/parsers.js";
+import { formatDescribe, compactDescribeMap, formatDescribeCompact } from "../lib/formatters.js";
+import { KubectlDescribeResultSchema } from "../schemas/index.js";
+
+export function registerDescribeTool(server: McpServer) {
+  server.registerTool(
+    "describe",
+    {
+      title: "Kubectl Describe",
+      description:
+        "Describes a Kubernetes resource with detailed information. Use instead of running `kubectl describe` in the terminal.",
+      inputSchema: {
+        resource: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .describe("Resource type (e.g., pod, service, deployment)"),
+        name: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Resource name"),
+        namespace: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Kubernetes namespace (omit for default)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: KubectlDescribeResultSchema,
+    },
+    async ({ resource, name, namespace, compact }) => {
+      assertNoFlagInjection(resource, "resource");
+      assertNoFlagInjection(name, "name");
+      if (namespace) assertNoFlagInjection(namespace, "namespace");
+
+      const args = ["describe", resource, name];
+      if (namespace) args.push("-n", namespace);
+
+      const result = await run("kubectl", args, { timeout: 60_000 });
+      const data = parseDescribeOutput(
+        result.stdout,
+        result.stderr,
+        result.exitCode,
+        resource,
+        name,
+        namespace,
+      );
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatDescribe,
+        compactDescribeMap,
+        formatDescribeCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-k8s/src/tools/get.ts
+++ b/packages/server-k8s/src/tools/get.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, run, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { parseGetOutput } from "../lib/parsers.js";
+import { formatGet, compactGetMap, formatGetCompact } from "../lib/formatters.js";
+import { KubectlGetResultSchema } from "../schemas/index.js";
+
+export function registerGetTool(server: McpServer) {
+  server.registerTool(
+    "get",
+    {
+      title: "Kubectl Get",
+      description:
+        "Gets Kubernetes resources and returns structured JSON output. Use instead of running `kubectl get` in the terminal.",
+      inputSchema: {
+        resource: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .describe("Resource type (e.g., pods, services, deployments, nodes)"),
+        name: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Resource name (omit to list all)"),
+        namespace: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Kubernetes namespace (omit for default)"),
+        allNamespaces: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Get resources from all namespaces (-A)"),
+        selector: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Label selector (e.g., app=nginx)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: KubectlGetResultSchema,
+    },
+    async ({ resource, name, namespace, allNamespaces, selector, compact }) => {
+      assertNoFlagInjection(resource, "resource");
+      if (name) assertNoFlagInjection(name, "name");
+      if (namespace) assertNoFlagInjection(namespace, "namespace");
+      if (selector) assertNoFlagInjection(selector, "selector");
+
+      const args = ["get", resource];
+      if (name) args.push(name);
+      if (allNamespaces) {
+        args.push("-A");
+      } else if (namespace) {
+        args.push("-n", namespace);
+      }
+      if (selector) args.push("-l", selector);
+      args.push("-o", "json");
+
+      const result = await run("kubectl", args, { timeout: 60_000 });
+      const data = parseGetOutput(
+        result.stdout,
+        result.stderr,
+        result.exitCode,
+        resource,
+        namespace,
+      );
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatGet,
+        compactGetMap,
+        formatGetCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-k8s/src/tools/index.ts
+++ b/packages/server-k8s/src/tools/index.ts
@@ -1,0 +1,14 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
+import { registerGetTool } from "./get.js";
+import { registerDescribeTool } from "./describe.js";
+import { registerLogsTool } from "./logs.js";
+import { registerApplyTool } from "./apply.js";
+
+export function registerAllTools(server: McpServer) {
+  const s = (name: string) => shouldRegisterTool("k8s", name);
+  if (s("get")) registerGetTool(server);
+  if (s("describe")) registerDescribeTool(server);
+  if (s("logs")) registerLogsTool(server);
+  if (s("apply")) registerApplyTool(server);
+}

--- a/packages/server-k8s/src/tools/logs.ts
+++ b/packages/server-k8s/src/tools/logs.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, run, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { parseLogsOutput } from "../lib/parsers.js";
+import { formatLogs, compactLogsMap, formatLogsCompact } from "../lib/formatters.js";
+import { KubectlLogsResultSchema } from "../schemas/index.js";
+
+export function registerLogsTool(server: McpServer) {
+  server.registerTool(
+    "logs",
+    {
+      title: "Kubectl Logs",
+      description:
+        "Gets logs from a Kubernetes pod. Use instead of running `kubectl logs` in the terminal.",
+      inputSchema: {
+        pod: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Pod name"),
+        namespace: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Kubernetes namespace (omit for default)"),
+        container: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Container name (for multi-container pods)"),
+        tail: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Number of recent lines to show (e.g., 100)"),
+        since: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Only return logs newer than duration (e.g., 1h, 5m, 30s)"),
+        previous: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Get logs from previous terminated container"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: KubectlLogsResultSchema,
+    },
+    async ({ pod, namespace, container, tail, since, previous, compact }) => {
+      assertNoFlagInjection(pod, "pod");
+      if (namespace) assertNoFlagInjection(namespace, "namespace");
+      if (container) assertNoFlagInjection(container, "container");
+      if (since) assertNoFlagInjection(since, "since");
+
+      const args = ["logs", pod];
+      if (namespace) args.push("-n", namespace);
+      if (container) args.push("-c", container);
+      if (tail !== undefined) args.push("--tail", String(tail));
+      if (since) args.push("--since", since);
+      if (previous) args.push("--previous");
+
+      const result = await run("kubectl", args, { timeout: 60_000 });
+      const data = parseLogsOutput(
+        result.stdout,
+        result.stderr,
+        result.exitCode,
+        pod,
+        namespace,
+        container,
+      );
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatLogs,
+        compactLogsMap,
+        formatLogsCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-k8s/tsconfig.json
+++ b/packages/server-k8s/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@paretools/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/server-k8s/vitest.config.ts
+++ b/packages/server-k8s/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 120_000,
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 70,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,31 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/server-k8s:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.26.0(zod@4.3.6)
+      '@paretools/shared':
+        specifier: workspace:*
+        version: link:../shared
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@paretools/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/server-lint:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary
- Adds new `@paretools/k8s` MCP server package with 4 kubectl tools: `get`, `describe`, `logs`, `apply`
- Each tool returns structured, token-efficient JSON via `dualOutput`/`compactDualOutput` with full/compact formatters
- Includes parsers for kubectl JSON and text output, Zod v4 output schemas, and `shouldRegisterTool` filtering

## Tools
| Tool | Description |
|------|-------------|
| `get` | Retrieve K8s resources as structured JSON (`kubectl get -o json`) |
| `describe` | Describe a resource with detailed info |
| `logs` | Get pod logs with tail/since/container/previous filtering |
| `apply` | Apply manifest files with dry-run and namespace support |

## Test plan
- [x] 38 unit tests covering all parsers and formatters (full + compact)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Integration test with a live cluster (manual)

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)