### PR TITLE
feat(process): add process-run tool (#294)

### DIFF
--- a/packages/server-process/__tests__/formatters.test.ts
+++ b/packages/server-process/__tests__/formatters.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import { formatRun, compactRunMap, formatRunCompact } from "../src/lib/formatters.js";
+import type { ProcessRunResult } from "../src/schemas/index.js";
+
+// ── Full formatters ──────────────────────────────────────────────────
+
+describe("formatRun", () => {
+  it("formats successful run", () => {
+    const data: ProcessRunResult = {
+      command: "echo",
+      success: true,
+      exitCode: 0,
+      stdout: "hello world",
+      duration: 50,
+      timedOut: false,
+    };
+    const output = formatRun(data);
+    expect(output).toContain("echo: success (50ms).");
+    expect(output).toContain("hello world");
+  });
+
+  it("formats failed run", () => {
+    const data: ProcessRunResult = {
+      command: "node",
+      success: false,
+      exitCode: 1,
+      stderr: "Error: cannot find module",
+      duration: 200,
+      timedOut: false,
+    };
+    const output = formatRun(data);
+    expect(output).toContain("node: exit code 1 (200ms).");
+    expect(output).toContain("Error: cannot find module");
+  });
+
+  it("formats timed-out run", () => {
+    const data: ProcessRunResult = {
+      command: "sleep",
+      success: false,
+      exitCode: 124,
+      duration: 60000,
+      timedOut: true,
+      signal: "SIGTERM",
+    };
+    const output = formatRun(data);
+    expect(output).toContain("sleep: timed out after 60000ms (SIGTERM).");
+  });
+
+  it("formats timed-out run without signal", () => {
+    const data: ProcessRunResult = {
+      command: "sleep",
+      success: false,
+      exitCode: 124,
+      duration: 60000,
+      timedOut: true,
+    };
+    const output = formatRun(data);
+    expect(output).toContain("sleep: timed out after 60000ms.");
+    expect(output).not.toContain("SIGTERM");
+  });
+
+  it("formats run with no output", () => {
+    const data: ProcessRunResult = {
+      command: "true",
+      success: true,
+      exitCode: 0,
+      duration: 10,
+      timedOut: false,
+    };
+    const output = formatRun(data);
+    expect(output).toBe("true: success (10ms).");
+  });
+});
+
+// ── Compact mappers and formatters ───────────────────────────────────
+
+describe("compactRunMap", () => {
+  it("keeps command, exitCode, success, duration, timedOut — drops stdout/stderr", () => {
+    const data: ProcessRunResult = {
+      command: "echo",
+      success: true,
+      exitCode: 0,
+      stdout: "lots of output...",
+      stderr: "some warnings",
+      duration: 50,
+      timedOut: false,
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.command).toBe("echo");
+    expect(compact.success).toBe(true);
+    expect(compact.exitCode).toBe(0);
+    expect(compact.duration).toBe(50);
+    expect(compact.timedOut).toBe(false);
+    expect(compact).not.toHaveProperty("stdout");
+    expect(compact).not.toHaveProperty("stderr");
+  });
+
+  it("preserves signal and timedOut", () => {
+    const data: ProcessRunResult = {
+      command: "sleep",
+      success: false,
+      exitCode: 124,
+      duration: 60000,
+      timedOut: true,
+      signal: "SIGTERM",
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.timedOut).toBe(true);
+    expect(compact.signal).toBe("SIGTERM");
+  });
+
+  it("preserves non-zero exit code", () => {
+    const data: ProcessRunResult = {
+      command: "node",
+      success: false,
+      exitCode: 2,
+      stderr: "error details",
+      duration: 567,
+      timedOut: false,
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.exitCode).toBe(2);
+    expect(compact.success).toBe(false);
+  });
+});
+
+describe("formatRunCompact", () => {
+  it("formats successful run", () => {
+    expect(
+      formatRunCompact({
+        command: "echo",
+        exitCode: 0,
+        success: true,
+        duration: 50,
+        timedOut: false,
+      }),
+    ).toBe("echo: success (50ms).");
+  });
+
+  it("formats failed run with exit code", () => {
+    expect(
+      formatRunCompact({
+        command: "node",
+        exitCode: 1,
+        success: false,
+        duration: 200,
+        timedOut: false,
+      }),
+    ).toBe("node: exit code 1 (200ms).");
+  });
+
+  it("formats timed-out run", () => {
+    expect(
+      formatRunCompact({
+        command: "sleep",
+        exitCode: 124,
+        success: false,
+        duration: 60000,
+        timedOut: true,
+        signal: "SIGTERM",
+      }),
+    ).toBe("sleep: timed out after 60000ms (SIGTERM).");
+  });
+
+  it("formats timed-out run without signal", () => {
+    expect(
+      formatRunCompact({
+        command: "sleep",
+        exitCode: 124,
+        success: false,
+        duration: 60000,
+        timedOut: true,
+      }),
+    ).toBe("sleep: timed out after 60000ms.");
+  });
+});

--- a/packages/server-process/__tests__/parsers.test.ts
+++ b/packages/server-process/__tests__/parsers.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { parseRunOutput } from "../src/lib/parsers.js";
+
+describe("parseRunOutput", () => {
+  it("parses successful run", () => {
+    const result = parseRunOutput("echo", "hello world\n", "", 0, 50, false);
+
+    expect(result.command).toBe("echo");
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("hello world");
+    expect(result.stderr).toBeUndefined();
+    expect(result.duration).toBe(50);
+    expect(result.timedOut).toBe(false);
+    expect(result.signal).toBeUndefined();
+  });
+
+  it("parses failed run", () => {
+    const result = parseRunOutput("node", "", "Error: module not found\n", 1, 200, false);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBeUndefined();
+    expect(result.stderr).toBe("Error: module not found");
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("parses run with both stdout and stderr", () => {
+    const result = parseRunOutput(
+      "python",
+      "Processing...\nDone.",
+      "DeprecationWarning: ...",
+      0,
+      3000,
+      false,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.stdout).toBe("Processing...\nDone.");
+    expect(result.stderr).toBe("DeprecationWarning: ...");
+  });
+
+  it("handles empty stdout and stderr", () => {
+    const result = parseRunOutput("true", "", "", 0, 10, false);
+
+    expect(result.success).toBe(true);
+    expect(result.stdout).toBeUndefined();
+    expect(result.stderr).toBeUndefined();
+  });
+
+  it("parses timed-out run", () => {
+    const result = parseRunOutput("sleep", "", "timed out", 124, 60000, true, "SIGTERM");
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(124);
+    expect(result.timedOut).toBe(true);
+    expect(result.signal).toBe("SIGTERM");
+    expect(result.duration).toBe(60000);
+  });
+
+  it("timed-out run is never success even with exit code 0", () => {
+    const result = parseRunOutput("cmd", "partial output", "", 0, 5000, true, "SIGTERM");
+
+    expect(result.success).toBe(false);
+    expect(result.timedOut).toBe(true);
+  });
+
+  it("handles empty signal string as undefined", () => {
+    const result = parseRunOutput("test", "", "", 1, 100, false, "");
+
+    expect(result.signal).toBeUndefined();
+  });
+});

--- a/packages/server-process/__tests__/security.test.ts
+++ b/packages/server-process/__tests__/security.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Security tests: verify that Zod input constraints are properly enforced
+ * on user-supplied parameters in the process run tool.
+ */
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { INPUT_LIMITS } from "@paretools/shared";
+
+// ---------------------------------------------------------------------------
+// Zod .max() input-limit constraints — Process tool schemas
+// ---------------------------------------------------------------------------
+
+describe("Zod .max() constraints — Process tool schemas", () => {
+  describe("command parameter (SHORT_STRING_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.SHORT_STRING_MAX);
+
+    it("accepts a command within the limit", () => {
+      expect(schema.safeParse("node").success).toBe(true);
+    });
+
+    it("rejects a command exceeding SHORT_STRING_MAX", () => {
+      const oversized = "c".repeat(INPUT_LIMITS.SHORT_STRING_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("args array (ARRAY_MAX + STRING_MAX)", () => {
+    const schema = z.array(z.string().max(INPUT_LIMITS.STRING_MAX)).max(INPUT_LIMITS.ARRAY_MAX);
+
+    it("rejects array exceeding ARRAY_MAX", () => {
+      const oversized = Array.from({ length: INPUT_LIMITS.ARRAY_MAX + 1 }, (_, i) => `arg${i}`);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+
+    it("rejects arg exceeding STRING_MAX", () => {
+      const oversized = ["x".repeat(INPUT_LIMITS.STRING_MAX + 1)];
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+
+    it("accepts normal args", () => {
+      expect(schema.safeParse(["--version", "-e", "console.log('hi')"]).success).toBe(true);
+    });
+  });
+
+  describe("cwd parameter (PATH_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.PATH_MAX);
+
+    it("accepts a path within the limit", () => {
+      expect(schema.safeParse("/home/user/project").success).toBe(true);
+    });
+
+    it("rejects a path exceeding PATH_MAX", () => {
+      const oversized = "p".repeat(INPUT_LIMITS.PATH_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("timeout parameter", () => {
+    const schema = z.number().int().min(1).max(600_000);
+
+    it("accepts valid timeout", () => {
+      expect(schema.safeParse(30_000).success).toBe(true);
+    });
+
+    it("rejects timeout below minimum", () => {
+      expect(schema.safeParse(0).success).toBe(false);
+    });
+
+    it("rejects timeout above maximum", () => {
+      expect(schema.safeParse(600_001).success).toBe(false);
+    });
+
+    it("rejects non-integer timeout", () => {
+      expect(schema.safeParse(1.5).success).toBe(false);
+    });
+  });
+
+  describe("env parameter (record of strings)", () => {
+    const schema = z.record(z.string(), z.string().max(INPUT_LIMITS.STRING_MAX));
+
+    it("accepts valid env vars", () => {
+      expect(schema.safeParse({ NODE_ENV: "production", PORT: "3000" }).success).toBe(true);
+    });
+
+    it("rejects value exceeding STRING_MAX", () => {
+      const oversized = { KEY: "v".repeat(INPUT_LIMITS.STRING_MAX + 1) };
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+});

--- a/packages/server-process/package.json
+++ b/packages/server-process/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@paretools/process",
+  "version": "0.8.1",
+  "mcpName": "io.github.Dave-London/pare-process",
+  "description": "MCP server for running commands with structured output, timeout, and signal support",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "structured-output",
+    "ai",
+    "ai-agent",
+    "claude",
+    "cursor",
+    "copilot",
+    "token-efficient",
+    "devtools",
+    "cli",
+    "process",
+    "command",
+    "exec",
+    "spawn",
+    "shell"
+  ],
+  "homepage": "https://github.com/Dave-London/Pare/tree/main/packages/server-process",
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "bin": {
+    "pare-process": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/Pare.git",
+    "directory": "packages/server-process"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@paretools/shared": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@paretools/tsconfig": "workspace:*",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/server-process/server.json
+++ b/packages/server-process/server.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Dave-London/pare-process",
+  "description": "Pare Process — Run commands with structured output, timeout, and signal support as typed JSON.",
+  "repository": {
+    "url": "https://github.com/Dave-London/Pare",
+    "source": "github"
+  },
+  "version": "0.8.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@paretools/process",
+      "version": "0.8.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/server-process/src/index.ts
+++ b/packages/server-process/src/index.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerAllTools } from "./tools/index.js";
+
+const server = new McpServer(
+  { name: "@paretools/process", version: "0.8.1" },
+  {
+    instructions:
+      "Structured process execution (run). Runs commands with timeout, environment, and signal support. Returns typed JSON with exit code, stdout, stderr, duration, and timeout status. Use instead of running arbitrary commands in the terminal.",
+  },
+);
+
+registerAllTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/server-process/src/lib/formatters.ts
+++ b/packages/server-process/src/lib/formatters.ts
@@ -1,0 +1,54 @@
+import type { ProcessRunResult } from "../schemas/index.js";
+
+// ── Full formatters ──────────────────────────────────────────────────
+
+/** Formats structured run results into a human-readable output summary. */
+export function formatRun(data: ProcessRunResult): string {
+  const lines: string[] = [];
+
+  if (data.timedOut) {
+    lines.push(
+      `${data.command}: timed out after ${data.duration}ms${data.signal ? ` (${data.signal})` : ""}.`,
+    );
+  } else if (data.success) {
+    lines.push(`${data.command}: success (${data.duration}ms).`);
+  } else {
+    lines.push(`${data.command}: exit code ${data.exitCode} (${data.duration}ms).`);
+  }
+
+  if (data.stdout) lines.push(data.stdout);
+  if (data.stderr) lines.push(data.stderr);
+  return lines.join("\n");
+}
+
+// ── Compact types, mappers, and formatters ───────────────────────────
+
+/** Compact run: command, exitCode, success, duration, timedOut, signal. Drop stdout/stderr. */
+export interface ProcessRunCompact {
+  [key: string]: unknown;
+  command: string;
+  success: boolean;
+  exitCode: number;
+  duration: number;
+  timedOut: boolean;
+  signal?: string;
+}
+
+export function compactRunMap(data: ProcessRunResult): ProcessRunCompact {
+  return {
+    command: data.command,
+    success: data.success,
+    exitCode: data.exitCode,
+    duration: data.duration,
+    timedOut: data.timedOut,
+    signal: data.signal,
+  };
+}
+
+export function formatRunCompact(data: ProcessRunCompact): string {
+  if (data.timedOut) {
+    return `${data.command}: timed out after ${data.duration}ms${data.signal ? ` (${data.signal})` : ""}.`;
+  }
+  if (data.success) return `${data.command}: success (${data.duration}ms).`;
+  return `${data.command}: exit code ${data.exitCode} (${data.duration}ms).`;
+}

--- a/packages/server-process/src/lib/parsers.ts
+++ b/packages/server-process/src/lib/parsers.ts
@@ -1,0 +1,25 @@
+import type { ProcessRunResult } from "../schemas/index.js";
+
+/**
+ * Parses the output of a process run into structured result data.
+ */
+export function parseRunOutput(
+  command: string,
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  duration: number,
+  timedOut: boolean,
+  signal?: string,
+): ProcessRunResult {
+  return {
+    command,
+    success: exitCode === 0 && !timedOut,
+    exitCode,
+    stdout: stdout.trimEnd() || undefined,
+    stderr: stderr.trimEnd() || undefined,
+    duration,
+    timedOut,
+    signal: signal || undefined,
+  };
+}

--- a/packages/server-process/src/schemas/index.ts
+++ b/packages/server-process/src/schemas/index.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+/** Zod schema for structured process run output with stdout, stderr, exit code, duration, and timeout/signal info. */
+export const ProcessRunResultSchema = z.object({
+  command: z.string(),
+  exitCode: z.number(),
+  success: z.boolean(),
+  stdout: z.string().optional(),
+  stderr: z.string().optional(),
+  duration: z.number(),
+  timedOut: z.boolean(),
+  signal: z.string().optional(),
+});
+
+export type ProcessRunResult = z.infer<typeof ProcessRunResultSchema>;

--- a/packages/server-process/src/tools/index.ts
+++ b/packages/server-process/src/tools/index.ts
@@ -1,0 +1,8 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
+import { registerRunTool } from "./run.js";
+
+export function registerAllTools(server: McpServer) {
+  const s = (name: string) => shouldRegisterTool("process", name);
+  if (s("run")) registerRunTool(server);
+}

--- a/packages/server-process/src/tools/run.ts
+++ b/packages/server-process/src/tools/run.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, INPUT_LIMITS, run } from "@paretools/shared";
+import { parseRunOutput } from "../lib/parsers.js";
+import { formatRun, compactRunMap, formatRunCompact } from "../lib/formatters.js";
+import { ProcessRunResultSchema } from "../schemas/index.js";
+
+export function registerRunTool(server: McpServer) {
+  server.registerTool(
+    "run",
+    {
+      title: "Process Run",
+      description:
+        "Runs a command and returns structured output (stdout, stderr, exit code, duration, timeout status). Use instead of running commands directly in the terminal.",
+      inputSchema: {
+        command: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .describe("Command to run (e.g., 'node', 'python', 'echo')"),
+        args: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .default([])
+          .describe("Arguments to pass to the command"),
+        cwd: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd)"),
+        timeout: z
+          .number()
+          .int()
+          .min(1)
+          .max(600_000)
+          .optional()
+          .default(60_000)
+          .describe("Timeout in milliseconds (default: 60000, max: 600000)"),
+        env: z
+          .record(z.string(), z.string().max(INPUT_LIMITS.STRING_MAX))
+          .optional()
+          .describe("Additional environment variables as key-value pairs"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: ProcessRunResultSchema,
+    },
+    async ({ command, args, cwd, timeout, env, compact }) => {
+      const workDir = cwd || process.cwd();
+      const timeoutMs = timeout ?? 60_000;
+
+      const start = Date.now();
+      let timedOut = false;
+      let signal: string | undefined;
+      let result: { exitCode: number; stdout: string; stderr: string };
+
+      try {
+        result = await run(command, args ?? [], {
+          cwd: workDir,
+          timeout: timeoutMs,
+          env: env ? ({ ...process.env, ...env } as Record<string, string>) : undefined,
+        });
+      } catch (err: unknown) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+
+        // Detect timeout errors from the shared runner
+        if (errMsg.includes("timed out")) {
+          timedOut = true;
+          // Extract signal from message like "...was killed (SIGTERM)."
+          const sigMatch = errMsg.match(/\((\w+)\)/);
+          signal = sigMatch?.[1];
+          result = {
+            exitCode: 124, // Standard timeout exit code
+            stdout: "",
+            stderr: errMsg,
+          };
+        } else {
+          // Re-throw non-timeout errors (command not found, permission denied, etc.)
+          throw err;
+        }
+      }
+      const duration = Date.now() - start;
+
+      const data = parseRunOutput(
+        command,
+        result.stdout,
+        result.stderr,
+        result.exitCode,
+        duration,
+        timedOut,
+        signal,
+      );
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatRun,
+        compactRunMap,
+        formatRunCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-process/tsconfig.json
+++ b/packages/server-process/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@paretools/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/server-process/vitest.config.ts
+++ b/packages/server-process/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 120_000,
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 70,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,31 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/server-process:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.26.0(zod@4.3.6)
+      '@paretools/shared':
+        specifier: workspace:*
+        version: link:../shared
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@paretools/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/server-python:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary

- Adds new `@paretools/process` MCP server package with a `run` tool
- Executes commands and returns structured JSON output: exit code, stdout, stderr, duration, timeout status, and signal
- Follows the same patterns as `server-make`: schemas, parsers, formatters, compact variants, `dualOutput()`, `shouldRegisterTool()`
- Includes 32 tests covering parsers, formatters, compact mappers, and Zod input validation

Closes #294

## Test plan

- [x] 32 unit tests pass (parsers, formatters, security/input validation)
- [x] TypeScript compiles cleanly with `tsc --noEmit`
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)