### PR TITLE
feat(security): add gitleaks tool (#290)

### DIFF
--- a/packages/server-security/package.json
+++ b/packages/server-security/package.json
@@ -2,7 +2,7 @@
   "name": "@paretools/security",
   "version": "0.1.0",
   "mcpName": "io.github.Dave-London/pare-security",
-  "description": "MCP server for security scanning (Trivy, Semgrep) with structured, token-efficient output",
+  "description": "MCP server for security scanning (Trivy, Semgrep, Gitleaks) with structured, token-efficient output",
   "license": "MIT",
   "keywords": [
     "mcp",
@@ -25,7 +25,9 @@
     "iac",
     "semgrep",
     "static-analysis",
-    "sast"
+    "sast",
+    "gitleaks",
+    "secret-detection"
   ],
   "homepage": "https://github.com/Dave-London/Pare/tree/main/packages/server-security",
   "engines": {

--- a/packages/server-security/src/index.ts
+++ b/packages/server-security/src/index.ts
@@ -8,7 +8,7 @@ const server = new McpServer(
   { name: "@paretools/security", version: "0.1.0" },
   {
     instructions:
-      "Structured security scanning operations (trivy, semgrep). Returns typed JSON with vulnerability and finding data. Use instead of running trivy or semgrep in the terminal.",
+      "Structured security scanning operations (trivy, semgrep, gitleaks). Returns typed JSON with vulnerability and finding data. Use instead of running trivy, semgrep, or gitleaks in the terminal.",
   },
 );
 

--- a/packages/server-security/src/lib/formatters.ts
+++ b/packages/server-security/src/lib/formatters.ts
@@ -1,4 +1,4 @@
-import type { TrivyScanResult, SemgrepScanResult } from "../schemas/index.js";
+import type { TrivyScanResult, SemgrepScanResult, GitleaksScanResult } from "../schemas/index.js";
 
 // -- Full formatters ----------------------------------------------------------
 
@@ -113,4 +113,43 @@ export function formatSemgrepScanCompact(data: SemgrepScanCompact): string {
     `${data.totalFindings} findings ` +
     `(${data.summary.error}E/${data.summary.warning}W/${data.summary.info}I)`
   );
+}
+
+// -- Gitleaks formatters ------------------------------------------------------
+
+/** Formats a Gitleaks scan result into human-readable text. */
+export function formatGitleaksScan(data: GitleaksScanResult): string {
+  const lines: string[] = [];
+
+  lines.push(`Gitleaks secret detection scan`);
+  lines.push(`Found ${data.totalFindings} secret(s)`);
+
+  if (data.findings.length > 0) {
+    lines.push("");
+    for (const f of data.findings) {
+      const commit = f.commit ? ` (commit: ${f.commit.slice(0, 8)})` : "";
+      lines.push(`  [${f.ruleID}] ${f.file}:${f.startLine}-${f.endLine}${commit}`);
+      lines.push(`    ${f.description} -- secret: ${f.secret}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// -- Gitleaks compact types, mappers, and formatters --------------------------
+
+/** Compact scan result: summary and total only, no individual findings. */
+export interface GitleaksScanCompact {
+  [key: string]: unknown;
+  totalFindings: number;
+}
+
+export function compactGitleaksScanMap(data: GitleaksScanResult): GitleaksScanCompact {
+  return {
+    totalFindings: data.totalFindings,
+  };
+}
+
+export function formatGitleaksScanCompact(data: GitleaksScanCompact): string {
+  return `Gitleaks scan -- ${data.totalFindings} secret(s) detected`;
 }

--- a/packages/server-security/src/schemas/index.ts
+++ b/packages/server-security/src/schemas/index.ts
@@ -67,3 +67,37 @@ export const SemgrepScanResultSchema = z.object({
 });
 
 export type SemgrepScanResult = z.infer<typeof SemgrepScanResultSchema>;
+
+// -- Gitleaks schemas ---------------------------------------------------------
+
+/** Zod schema for a single Gitleaks finding. */
+export const GitleaksFindingSchema = z.object({
+  ruleID: z.string(),
+  description: z.string(),
+  match: z.string(),
+  secret: z.string(),
+  file: z.string(),
+  startLine: z.number(),
+  endLine: z.number(),
+  commit: z.string(),
+  author: z.string(),
+  date: z.string(),
+});
+
+export type GitleaksFinding = z.infer<typeof GitleaksFindingSchema>;
+
+/** Zod schema for Gitleaks summary. */
+export const GitleaksSummarySchema = z.object({
+  totalFindings: z.number(),
+});
+
+export type GitleaksSummary = z.infer<typeof GitleaksSummarySchema>;
+
+/** Zod schema for the structured Gitleaks scan result. */
+export const GitleaksScanResultSchema = z.object({
+  totalFindings: z.number(),
+  findings: z.array(GitleaksFindingSchema),
+  summary: GitleaksSummarySchema,
+});
+
+export type GitleaksScanResult = z.infer<typeof GitleaksScanResultSchema>;

--- a/packages/server-security/src/tools/gitleaks.ts
+++ b/packages/server-security/src/tools/gitleaks.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, run, INPUT_LIMITS } from "@paretools/shared";
+import { parseGitleaksJson } from "../lib/parsers.js";
+import {
+  formatGitleaksScan,
+  compactGitleaksScanMap,
+  formatGitleaksScanCompact,
+} from "../lib/formatters.js";
+import { GitleaksScanResultSchema } from "../schemas/index.js";
+
+export function registerGitleaksTool(server: McpServer) {
+  server.registerTool(
+    "gitleaks",
+    {
+      title: "Gitleaks Secret Detection",
+      description:
+        "Runs Gitleaks to detect hardcoded secrets in git repositories. Returns structured finding data with redacted secrets. Use instead of running `gitleaks` in the terminal.",
+      inputSchema: {
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Repository path to scan (default: cwd)"),
+        noGit: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Scan files without git history (--no-git). Useful for scanning non-git directories.",
+          ),
+        verbose: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Enable verbose output from gitleaks"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: GitleaksScanResultSchema,
+    },
+    async ({ path, noGit, verbose, compact }) => {
+      const cwd = path || process.cwd();
+
+      const args: string[] = ["detect", "--report-format", "json", "--report-path", "/dev/stdout"];
+
+      if (noGit) {
+        args.push("--no-git");
+      }
+
+      if (verbose) {
+        args.push("--verbose");
+      }
+
+      args.push("--source", cwd);
+
+      // gitleaks exits with code 1 when findings are detected, which is not an error
+      const result = await run("gitleaks", args, { cwd, timeout: 300_000 });
+
+      const data = parseGitleaksJson(result.stdout);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatGitleaksScan,
+        compactGitleaksScanMap,
+        formatGitleaksScanCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-security/src/tools/index.ts
+++ b/packages/server-security/src/tools/index.ts
@@ -2,9 +2,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { shouldRegisterTool } from "@paretools/shared";
 import { registerTrivyTool } from "./trivy.js";
 import { registerSemgrepTool } from "./semgrep.js";
+import { registerGitleaksTool } from "./gitleaks.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("security", name);
   if (s("trivy")) registerTrivyTool(server);
   if (s("semgrep")) registerSemgrepTool(server);
+  if (s("gitleaks")) registerGitleaksTool(server);
 }


### PR DESCRIPTION
## Summary
- Adds `gitleaks` tool to the `@paretools/security` MCP server package for detecting hardcoded secrets in git repositories
- Wraps `gitleaks detect` with JSON output, automatically redacting secrets in findings (first 3 + last 3 chars, rest masked)
- Follows existing trivy/semgrep patterns: Zod schemas, parser, full/compact formatters, `dualOutput()`, `shouldRegisterTool()` filtering
- Accepts `path` (repo path), `noGit` (scan without git history), `verbose`, and `compact` parameters

Closes #290

## Test plan
- [x] Parser tests: full output, empty array, invalid JSON, non-array JSON, missing fields, secret redaction (short, exact 8, and longer than 8 chars)
- [x] Formatter tests: full format with findings, no findings, compact mapper drops findings, compact format
- [x] All 40 tests pass (24 parser + 16 formatter)
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)