### PR TITLE
feat(k8s): add helm tool (#287)

### DIFF
--- a/packages/server-k8s/src/index.ts
+++ b/packages/server-k8s/src/index.ts
@@ -8,7 +8,7 @@ const server = new McpServer(
   { name: "@paretools/k8s", version: "0.8.1" },
   {
     instructions:
-      "Structured Kubernetes kubectl operations (get, describe, logs, apply). Returns typed JSON. Use instead of running kubectl in the terminal.",
+      "Structured Kubernetes kubectl and Helm operations (get, describe, logs, apply, helm). Returns typed JSON. Use instead of running kubectl/helm in the terminal.",
   },
 );
 

--- a/packages/server-k8s/src/schemas/index.ts
+++ b/packages/server-k8s/src/schemas/index.ts
@@ -93,3 +93,83 @@ export const KubectlResultSchema = z.discriminatedUnion("action", [
 ]);
 
 export type KubectlResult = z.infer<typeof KubectlResultSchema>;
+
+// ── Helm schemas ───────────────────────────────────────────────────
+
+/** A single Helm release from `helm list -o json`. */
+export const HelmReleaseSchema = z.object({
+  name: z.string(),
+  namespace: z.string(),
+  revision: z.string(),
+  status: z.string(),
+  chart: z.string(),
+  app_version: z.string().optional(),
+});
+
+export type HelmRelease = z.infer<typeof HelmReleaseSchema>;
+
+/** Helm list result. */
+export const HelmListResultSchema = z.object({
+  action: z.literal("list"),
+  success: z.boolean(),
+  namespace: z.string().optional(),
+  releases: z.array(HelmReleaseSchema),
+  total: z.number(),
+  exitCode: z.number(),
+  error: z.string().optional(),
+});
+
+export type HelmListResult = z.infer<typeof HelmListResultSchema>;
+
+/** Helm status result. */
+export const HelmStatusResultSchema = z.object({
+  action: z.literal("status"),
+  success: z.boolean(),
+  name: z.string(),
+  namespace: z.string().optional(),
+  revision: z.string().optional(),
+  status: z.string().optional(),
+  description: z.string().optional(),
+  notes: z.string().optional(),
+  exitCode: z.number(),
+  error: z.string().optional(),
+});
+
+export type HelmStatusResult = z.infer<typeof HelmStatusResultSchema>;
+
+/** Helm install/upgrade result. */
+export const HelmInstallResultSchema = z.object({
+  action: z.literal("install"),
+  success: z.boolean(),
+  name: z.string(),
+  namespace: z.string().optional(),
+  revision: z.string().optional(),
+  status: z.string().optional(),
+  exitCode: z.number(),
+  error: z.string().optional(),
+});
+
+export type HelmInstallResult = z.infer<typeof HelmInstallResultSchema>;
+
+export const HelmUpgradeResultSchema = z.object({
+  action: z.literal("upgrade"),
+  success: z.boolean(),
+  name: z.string(),
+  namespace: z.string().optional(),
+  revision: z.string().optional(),
+  status: z.string().optional(),
+  exitCode: z.number(),
+  error: z.string().optional(),
+});
+
+export type HelmUpgradeResult = z.infer<typeof HelmUpgradeResultSchema>;
+
+/** Union of all helm result types. */
+export const HelmResultSchema = z.discriminatedUnion("action", [
+  HelmListResultSchema,
+  HelmStatusResultSchema,
+  HelmInstallResultSchema,
+  HelmUpgradeResultSchema,
+]);
+
+export type HelmResult = z.infer<typeof HelmResultSchema>;

--- a/packages/server-k8s/src/tools/helm.ts
+++ b/packages/server-k8s/src/tools/helm.ts
@@ -1,0 +1,205 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { compactDualOutput, run, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import {
+  parseHelmListOutput,
+  parseHelmStatusOutput,
+  parseHelmInstallOutput,
+  parseHelmUpgradeOutput,
+} from "../lib/parsers.js";
+import {
+  formatHelmList,
+  formatHelmStatus,
+  formatHelmInstall,
+  formatHelmUpgrade,
+  compactHelmListMap,
+  formatHelmListCompact,
+  compactHelmStatusMap,
+  formatHelmStatusCompact,
+  compactHelmInstallMap,
+  formatHelmInstallCompact,
+  compactHelmUpgradeMap,
+  formatHelmUpgradeCompact,
+} from "../lib/formatters.js";
+import {
+  HelmListResultSchema,
+  HelmStatusResultSchema,
+  HelmInstallResultSchema,
+  HelmUpgradeResultSchema,
+} from "../schemas/index.js";
+
+export function registerHelmTool(server: McpServer) {
+  server.registerTool(
+    "helm",
+    {
+      title: "Helm",
+      description:
+        "Manages Helm releases (install, upgrade, list, status). Returns structured JSON output. Use instead of running `helm` in the terminal.",
+      inputSchema: {
+        action: z.enum(["list", "status", "install", "upgrade"]).describe("Helm action to perform"),
+        release: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Release name (required for status, install, upgrade)"),
+        chart: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Chart reference (required for install, upgrade; e.g., bitnami/nginx)"),
+        namespace: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Kubernetes namespace (omit for default)"),
+        setValues: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .optional()
+          .describe("Values to set via --set (e.g., ['key1=val1', 'key2=val2'])"),
+        values: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to a values YAML file (--values)"),
+        compact: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
+          ),
+      },
+      outputSchema: z.union([
+        HelmListResultSchema,
+        HelmStatusResultSchema,
+        HelmInstallResultSchema,
+        HelmUpgradeResultSchema,
+      ]),
+    },
+    async ({ action, release, chart, namespace, setValues, values, compact }) => {
+      if (release) assertNoFlagInjection(release, "release");
+      if (chart) assertNoFlagInjection(chart, "chart");
+      if (namespace) assertNoFlagInjection(namespace, "namespace");
+      if (values) assertNoFlagInjection(values, "values");
+
+      switch (action) {
+        case "list": {
+          const args = ["list", "-o", "json"];
+          if (namespace) args.push("-n", namespace);
+
+          const result = await run("helm", args, { timeout: 60_000 });
+          const data = parseHelmListOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            namespace,
+          );
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatHelmList,
+            compactHelmListMap,
+            formatHelmListCompact,
+            compact === false,
+          );
+        }
+
+        case "status": {
+          if (!release) throw new Error("release is required for status action");
+
+          const args = ["status", release, "-o", "json"];
+          if (namespace) args.push("-n", namespace);
+
+          const result = await run("helm", args, { timeout: 60_000 });
+          const data = parseHelmStatusOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            release,
+            namespace,
+          );
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatHelmStatus,
+            compactHelmStatusMap,
+            formatHelmStatusCompact,
+            compact === false,
+          );
+        }
+
+        case "install": {
+          if (!release) throw new Error("release is required for install action");
+          if (!chart) throw new Error("chart is required for install action");
+
+          const args = ["install", release, chart, "-o", "json"];
+          if (namespace) args.push("-n", namespace);
+          if (values) args.push("--values", values);
+          if (setValues) {
+            for (const sv of setValues) {
+              assertNoFlagInjection(sv, "setValues");
+              args.push("--set", sv);
+            }
+          }
+
+          const result = await run("helm", args, { timeout: 120_000 });
+          const data = parseHelmInstallOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            release,
+            namespace,
+          );
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatHelmInstall,
+            compactHelmInstallMap,
+            formatHelmInstallCompact,
+            compact === false,
+          );
+        }
+
+        case "upgrade": {
+          if (!release) throw new Error("release is required for upgrade action");
+          if (!chart) throw new Error("chart is required for upgrade action");
+
+          const args = ["upgrade", release, chart, "-o", "json"];
+          if (namespace) args.push("-n", namespace);
+          if (values) args.push("--values", values);
+          if (setValues) {
+            for (const sv of setValues) {
+              assertNoFlagInjection(sv, "setValues");
+              args.push("--set", sv);
+            }
+          }
+
+          const result = await run("helm", args, { timeout: 120_000 });
+          const data = parseHelmUpgradeOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            release,
+            namespace,
+          );
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatHelmUpgrade,
+            compactHelmUpgradeMap,
+            formatHelmUpgradeCompact,
+            compact === false,
+          );
+        }
+      }
+    },
+  );
+}

--- a/packages/server-k8s/src/tools/index.ts
+++ b/packages/server-k8s/src/tools/index.ts
@@ -4,6 +4,7 @@ import { registerGetTool } from "./get.js";
 import { registerDescribeTool } from "./describe.js";
 import { registerLogsTool } from "./logs.js";
 import { registerApplyTool } from "./apply.js";
+import { registerHelmTool } from "./helm.js";
 
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("k8s", name);
@@ -11,4 +12,5 @@ export function registerAllTools(server: McpServer) {
   if (s("describe")) registerDescribeTool(server);
   if (s("logs")) registerLogsTool(server);
   if (s("apply")) registerApplyTool(server);
+  if (s("helm")) registerHelmTool(server);
 }


### PR DESCRIPTION
## Summary
- Adds a `helm` tool to the existing `@paretools/k8s` package wrapping Helm CLI commands with structured JSON output
- Supports four actions: `list`, `status`, `install`, and `upgrade` with namespace filtering, `--set` values, and `--values` file support
- Follows existing package patterns: Zod schemas, parser/formatter pairs, compact dual output, flag injection protection

## Changes
- `src/schemas/index.ts` — Added `HelmRelease`, `HelmListResult`, `HelmStatusResult`, `HelmInstallResult`, `HelmUpgradeResult` schemas
- `src/lib/parsers.ts` — Added `parseHelmListOutput`, `parseHelmStatusOutput`, `parseHelmInstallOutput`, `parseHelmUpgradeOutput`
- `src/lib/formatters.ts` — Added full + compact formatters and mappers for all four helm actions
- `src/tools/helm.ts` — New tool registration with input validation and `compactDualOutput`
- `src/tools/index.ts` — Registered helm tool alongside existing kubectl tools
- `__tests__/parsers.test.ts` — 17 new parser tests covering success, failure, empty, and invalid JSON cases
- `__tests__/formatters.test.ts` — 22 new formatter tests covering full + compact variants

Closes #287

## Test plan
- [x] All 29 parser tests pass (12 existing + 17 new)
- [x] All 42 formatter tests pass (20 existing + 22 new)
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)