### PR TITLE
test(python): add missing formatter tests for conda, pyenv, and poetry

### DIFF
--- a/packages/server-python/__tests__/integration.test.ts
+++ b/packages/server-python/__tests__/integration.test.ts
@@ -40,8 +40,8 @@ describe("@paretools/python integration", () => {
       "pip-install",
       "pip-list",
       "pip-show",
-      "pyenv",
       "poetry",
+      "pyenv",
       "pytest",
       "ruff-check",
       "ruff-format",
@@ -368,10 +368,6 @@ describe("@paretools/python integration", () => {
     it("returns structured data or a command-not-found error", async () => {
       const result = await client.callTool(
         { name: "pyenv", arguments: { action: "version" } },
-  describe("poetry", () => {
-    it("returns structured data or a command-not-found error", async () => {
-      const result = await client.callTool(
-        { name: "poetry", arguments: { action: "show" } },
         undefined,
         CALL_TIMEOUT,
       );
@@ -384,6 +380,20 @@ describe("@paretools/python integration", () => {
         expect(sc).toBeDefined();
         expect(sc.action).toBe("version");
         expect(typeof sc.success).toBe("boolean");
+      }
+    });
+  });
+
+  describe("poetry", () => {
+    it("returns structured data or a command-not-found error", async () => {
+      const result = await client.callTool(
+        { name: "poetry", arguments: { action: "show" } },
+        undefined,
+        CALL_TIMEOUT,
+      );
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
         expect(content[0].text).toMatch(/poetry|command|not found/i);
       } else {
         const sc = result.structuredContent as Record<string, unknown>;

--- a/packages/server-python/__tests__/parsers.test.ts
+++ b/packages/server-python/__tests__/parsers.test.ts
@@ -712,6 +712,9 @@ describe("parseCondaEnvListJson", () => {
     const result = parseCondaEnvListJson(json);
 
     expect(result.environments[0].active).toBe(false);
+  });
+});
+
 // ─── poetry parser tests ────────────────────────────────────────────────────
 
 describe("parsePoetryOutput — show", () => {

--- a/packages/server-python/src/lib/formatters.ts
+++ b/packages/server-python/src/lib/formatters.ts
@@ -635,6 +635,8 @@ export function compactPyenvMap(data: PyenvResult): PyenvResultCompact {
 export function formatPyenvCompact(data: PyenvResultCompact): string {
   if (!data.success) return `pyenv ${data.action} failed.`;
   return `pyenv ${data.action}: success.`;
+}
+
 // ── poetry formatters ────────────────────────────────────────────────
 
 /** Formats structured poetry results into a human-readable summary. */


### PR DESCRIPTION
## Summary
- Add missing formatter tests for conda compact variants (`formatCondaListCompact`, `formatCondaInfoCompact`, `formatCondaEnvListCompact`, `formatCondaResultCompact`), conda result dispatcher (`formatCondaResult`), pyenv formatters (`formatPyenv` with all 5 actions, `formatPyenvCompact`), and poetry compact formatter (`formatPoetryCompact` with all 5 actions)
- Fix syntax errors: missing closing brace in `formatPyenvCompact` (source code bug), missing `});` in `formatCondaEnvList` and `parseCondaEnvListJson` describe blocks, and merged/overlapping pyenv+poetry integration tests
- Fix tool list alphabetical ordering in integration test (`poetry` before `pyenv`)

## Test plan
- [x] All 78 formatter tests pass (was 42 before, +36 new tests)
- [x] All 74 parser tests pass (was broken due to missing closing braces)
- [x] All 18 integration tests pass (pyenv and poetry now properly separated)
- [x] Full suite: 336 tests across 11 files, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)