### PR TITLE
test: add missing formatter and integration tests

### DIFF
--- a/packages/server-docker/src/lib/formatters.ts
+++ b/packages/server-docker/src/lib/formatters.ts
@@ -12,7 +12,6 @@ import type {
   DockerNetworkLs,
   DockerVolumeLs,
   DockerComposePs,
-
   DockerComposeLogs,
   DockerComposeBuild,
   DockerStats,
@@ -436,7 +435,6 @@ export function formatVolumeLsCompact(data: DockerVolumeLsCompact): string {
   return lines.join("\n");
 }
 
-
 // ── Compose Build ────────────────────────────────────────────────────
 
 /** Formats structured Docker Compose build output into a human-readable summary. */
@@ -454,6 +452,10 @@ export function formatComposeBuild(data: DockerComposeBuild): string {
     const status = s.success ? "built" : "failed";
     const error = s.error ? ` — ${s.error}` : "";
     lines.push(`  ${s.service}: ${status}${error}`);
+  }
+  return lines.join("\n");
+}
+
 // ── Stats ────────────────────────────────────────────────────────────
 
 /** Formats structured Docker stats data into a human-readable listing with CPU, memory, and I/O. */
@@ -468,7 +470,6 @@ export function formatStats(data: DockerStats): string {
   }
   return lines.join("\n");
 }
-
 
 /** Compact compose build: success, built, failed, duration. Drop per-service details. */
 export interface DockerComposeBuildCompact {
@@ -493,6 +494,8 @@ export function formatComposeBuildCompact(data: DockerComposeBuildCompact): stri
     return `Compose build failed (${data.duration}s)`;
   }
   return `Compose build: ${data.built} built, ${data.failed} failed (${data.duration}s)`;
+}
+
 /** Compact stats: name, cpuPercent, memoryPercent, pids only. Drop I/O details. */
 export interface DockerStatsCompact {
   [key: string]: unknown;

--- a/packages/server-docker/src/lib/parsers.ts
+++ b/packages/server-docker/src/lib/parsers.ts
@@ -12,7 +12,6 @@ import type {
   DockerNetworkLs,
   DockerVolumeLs,
   DockerComposePs,
-
   DockerComposeLogs,
   DockerComposeBuild,
   DockerStats,
@@ -317,7 +316,6 @@ export function parseVolumeLsJson(stdout: string): DockerVolumeLs {
   return { volumes, total: volumes.length };
 }
 
-
 /** Parses `docker compose build` output into structured per-service build status. */
 export function parseComposeBuildOutput(
   stdout: string,
@@ -397,6 +395,8 @@ export function parseComposeBuildOutput(
     failed,
     duration,
   };
+}
+
 /** Parses percentage string like "1.23%" into a number. Returns 0 for unparseable values. */
 function parsePercent(value: string): number {
   const n = parseFloat(value.replace("%", ""));

--- a/packages/server-python/src/lib/formatters.ts
+++ b/packages/server-python/src/lib/formatters.ts
@@ -635,6 +635,8 @@ export function compactPyenvMap(data: PyenvResult): PyenvResultCompact {
 export function formatPyenvCompact(data: PyenvResultCompact): string {
   if (!data.success) return `pyenv ${data.action} failed.`;
   return `pyenv ${data.action}: success.`;
+}
+
 // ── poetry formatters ────────────────────────────────────────────────
 
 /** Formats structured poetry results into a human-readable summary. */


### PR DESCRIPTION
## Summary
- **server-npm**: Add formatter tests for `formatRun`, `formatTest`, `formatInit`, `formatInfo`, `formatSearch`, and `formatNvm` — these formatters had zero test coverage
- **server-docker**: Add formatter tests for `formatComposeBuild`, `formatComposeBuildCompact`, and `formatStatsCompact` — these were untested. Fix missing closing braces in `formatComposeLogs` test block
- **server-test**: Add playwright integration test that verifies the tool handles missing/present Playwright gracefully and returns proper structured output
- **server-build**: Verified all 7 tools (tsc, build, esbuild, vite-build, webpack, turbo, nx) already have integration tests — no changes needed
- **server-docker/server-python source fixes**: Fix missing closing braces in `formatComposeBuild`, `formatComposeBuildCompact` (formatters.ts), `parseComposeBuildOutput` (parsers.ts), and `formatPyenvCompact` (python formatters.ts) that caused TypeScript build failures

## Test plan
- [x] server-npm formatter tests: 22 tests passing
- [x] server-docker formatter tests: 34 tests passing (317 total in package)
- [x] server-test integration tests: 5 tests passing (including new playwright test)
- [x] server-build integration tests: 13 tests passing (verified, no changes needed)
- [x] Full monorepo build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)