### PR TITLE
docs(go): document tool schemas for 11 go tools (#354)

### DIFF
--- a/docs/tool-schemas/go/build.md
+++ b/docs/tool-schemas/go/build.md
@@ -6,11 +6,11 @@ Runs go build and returns structured error list (file, line, column, message). U
 
 ## Input Parameters
 
-| Parameter  | Type     | Default  | Description                                                |
-| ---------- | -------- | -------- | ---------------------------------------------------------- |
-| `path`     | string   | cwd      | Project root path                                          |
-| `packages` | string[] | `[./...]` | Packages to build                                         |
-| `compact`  | boolean  | `true`   | Auto-compact when structured output exceeds raw CLI tokens |
+| Parameter  | Type     | Default   | Description                                                |
+| ---------- | -------- | --------- | ---------------------------------------------------------- |
+| `path`     | string   | cwd       | Project root path                                          |
+| `packages` | string[] | `[./...]` | Packages to build                                          |
+| `compact`  | boolean  | `true`    | Auto-compact when structured output exceeds raw CLI tokens |
 
 ## Success — Build Passes
 
@@ -123,10 +123,10 @@ Same as full (no reduction when build succeeds).
 
 ## Token Savings
 
-| Scenario          | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ----------------- | ---------- | --------- | ------------ | ------- |
-| Build passes      | ~5         | ~15       | ~15          | 0%      |
-| 3 build errors    | ~120       | ~80       | ~10          | 33-92%  |
+| Scenario       | CLI Tokens | Pare Full | Pare Compact | Savings |
+| -------------- | ---------- | --------- | ------------ | ------- |
+| Build passes   | ~5         | ~15       | ~15          | 0%      |
+| 3 build errors | ~120       | ~80       | ~10          | 33-92%  |
 
 ## Notes
 

--- a/docs/tool-schemas/go/env.md
+++ b/docs/tool-schemas/go/env.md
@@ -6,11 +6,11 @@ Returns Go environment variables as structured JSON. Optionally request specific
 
 ## Input Parameters
 
-| Parameter | Type     | Default | Description                                                          |
-| --------- | -------- | ------- | -------------------------------------------------------------------- |
-| `path`    | string   | cwd     | Project root path                                                    |
+| Parameter | Type     | Default | Description                                                            |
+| --------- | -------- | ------- | ---------------------------------------------------------------------- |
+| `path`    | string   | cwd     | Project root path                                                      |
 | `vars`    | string[] | --      | Specific environment variables to query (e.g., `['GOROOT', 'GOPATH']`) |
-| `compact` | boolean  | `true`  | Auto-compact when structured output exceeds raw CLI tokens           |
+| `compact` | boolean  | `true`  | Auto-compact when structured output exceeds raw CLI tokens             |
 
 ## Success — Full Environment
 
@@ -89,9 +89,9 @@ GOVERSION="go1.22.2"
 
 ## Token Savings
 
-| Scenario           | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ------------------ | ---------- | --------- | ------------ | ------- |
-| Full environment   | ~400       | ~250      | ~30          | 38-93%  |
+| Scenario         | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ---------------- | ---------- | --------- | ------------ | ------- |
+| Full environment | ~400       | ~250      | ~30          | 38-93%  |
 
 ## Notes
 

--- a/docs/tool-schemas/go/fmt.md
+++ b/docs/tool-schemas/go/fmt.md
@@ -78,11 +78,7 @@ internal/utils.go
 {
   "success": false,
   "filesChanged": 3,
-  "files": [
-    "server/handler.go",
-    "server/middleware.go",
-    "internal/utils.go"
-  ]
+  "files": ["server/handler.go", "server/middleware.go", "internal/utils.go"]
 }
 ```
 
@@ -108,10 +104,10 @@ internal/utils.go
 
 ## Token Savings
 
-| Scenario             | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------------- | ---------- | --------- | ------------ | ------- |
-| All formatted        | ~5         | ~15       | ~15          | 0%      |
-| 3 unformatted files  | ~30        | ~25       | ~10          | 17-67%  |
+| Scenario            | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------------- | ---------- | --------- | ------------ | ------- |
+| All formatted       | ~5         | ~15       | ~15          | 0%      |
+| 3 unformatted files | ~30        | ~25       | ~10          | 17-67%  |
 
 ## Notes
 

--- a/docs/tool-schemas/go/generate.md
+++ b/docs/tool-schemas/go/generate.md
@@ -105,10 +105,10 @@ main.go:3: running "mockgen": exec: "mockgen": executable file not found in $PAT
 
 ## Token Savings
 
-| Scenario         | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ---------------- | ---------- | --------- | ------------ | ------- |
-| Generate succeeds | ~20       | ~20       | ~5           | 0-75%   |
-| Generate fails   | ~40        | ~20       | ~5           | 50-88%  |
+| Scenario          | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ----------------- | ---------- | --------- | ------------ | ------- |
+| Generate succeeds | ~20        | ~20       | ~5           | 0-75%   |
+| Generate fails    | ~40        | ~20       | ~5           | 50-88%  |
 
 ## Notes
 

--- a/docs/tool-schemas/go/get.md
+++ b/docs/tool-schemas/go/get.md
@@ -6,11 +6,11 @@ Downloads and installs Go packages and their dependencies. Use instead of runnin
 
 ## Input Parameters
 
-| Parameter  | Type     | Default | Description                                                        |
-| ---------- | -------- | ------- | ------------------------------------------------------------------ |
+| Parameter  | Type     | Default | Description                                                               |
+| ---------- | -------- | ------- | ------------------------------------------------------------------------- |
 | `packages` | string[] | --      | Packages to install (e.g., `['github.com/pkg/errors@latest']`) (required) |
-| `path`     | string   | cwd     | Project root path                                                  |
-| `compact`  | boolean  | `true`  | Auto-compact when structured output exceeds raw CLI tokens         |
+| `path`     | string   | cwd     | Project root path                                                         |
+| `compact`  | boolean  | `true`  | Auto-compact when structured output exceeds raw CLI tokens                |
 
 ## Success — Package Installed
 
@@ -105,10 +105,10 @@ go: module github.com/example/nonexistent: no matching versions for query "lates
 
 ## Token Savings
 
-| Scenario            | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ------------------- | ---------- | --------- | ------------ | ------- |
-| Package installed   | ~30        | ~20       | ~5           | 33-83%  |
-| Package not found   | ~40        | ~20       | ~5           | 50-88%  |
+| Scenario          | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ----------------- | ---------- | --------- | ------------ | ------- |
+| Package installed | ~30        | ~20       | ~5           | 33-83%  |
+| Package not found | ~40        | ~20       | ~5           | 50-88%  |
 
 ## Notes
 

--- a/docs/tool-schemas/go/golangci-lint.md
+++ b/docs/tool-schemas/go/golangci-lint.md
@@ -149,10 +149,10 @@ server/router.go:18:4: error returned from external package is unwrapped (wrapch
 
 ## Token Savings
 
-| Scenario       | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------- | ---------- | --------- | ------------ | ------- |
-| No issues      | ~5         | ~20       | ~20          | 0%      |
-| 4 lint issues  | ~200       | ~150      | ~15          | 25-93%  |
+| Scenario      | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------- | ---------- | --------- | ------------ | ------- |
+| No issues     | ~5         | ~20       | ~20          | 0%      |
+| 4 lint issues | ~200       | ~150      | ~15          | 25-93%  |
 
 ## Notes
 

--- a/docs/tool-schemas/go/list.md
+++ b/docs/tool-schemas/go/list.md
@@ -87,9 +87,9 @@ Lists Go packages and returns structured package information (dir, importPath, n
 
 ## Token Savings
 
-| Scenario       | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------- | ---------- | --------- | ------------ | ------- |
-| 2 packages     | ~250       | ~80       | ~5           | 68-98%  |
+| Scenario   | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ---------- | ---------- | --------- | ------------ | ------- |
+| 2 packages | ~250       | ~80       | ~5           | 68-98%  |
 
 ## Notes
 

--- a/docs/tool-schemas/go/mod-tidy.md
+++ b/docs/tool-schemas/go/mod-tidy.md
@@ -105,10 +105,10 @@ go: myapp imports
 
 ## Token Savings
 
-| Scenario       | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------- | ---------- | --------- | ------------ | ------- |
-| Already tidy   | ~5         | ~15       | ~5           | 0%      |
-| Tidy fails     | ~40        | ~30       | ~5           | 25-88%  |
+| Scenario     | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------ | ---------- | --------- | ------------ | ------- |
+| Already tidy | ~5         | ~15       | ~5           | 0%      |
+| Tidy fails   | ~40        | ~30       | ~5           | 25-88%  |
 
 ## Notes
 

--- a/docs/tool-schemas/go/run.md
+++ b/docs/tool-schemas/go/run.md
@@ -119,10 +119,10 @@ exit status 2
 
 ## Token Savings
 
-| Scenario       | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------- | ---------- | --------- | ------------ | ------- |
-| Program runs   | ~30        | ~30       | ~10          | 0-67%   |
-| Program fails  | ~50        | ~40       | ~10          | 20-80%  |
+| Scenario      | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------- | ---------- | --------- | ------------ | ------- |
+| Program runs  | ~30        | ~30       | ~10          | 0-67%   |
+| Program fails | ~50        | ~40       | ~10          | 20-80%  |
 
 ## Notes
 

--- a/docs/tool-schemas/go/test.md
+++ b/docs/tool-schemas/go/test.md
@@ -147,10 +147,10 @@ FAIL	myapp/server   0.08s
 
 ## Token Savings
 
-| Scenario             | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------------- | ---------- | --------- | ------------ | ------- |
-| 4 tests passing      | ~150       | ~100      | ~25          | 33-83%  |
-| 5 tests, 2 failures  | ~300       | ~120      | ~25          | 60-92%  |
+| Scenario            | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------------- | ---------- | --------- | ------------ | ------- |
+| 4 tests passing     | ~150       | ~100      | ~25          | 33-83%  |
+| 5 tests, 2 failures | ~300       | ~120      | ~25          | 60-92%  |
 
 ## Notes
 

--- a/docs/tool-schemas/go/vet.md
+++ b/docs/tool-schemas/go/vet.md
@@ -120,10 +120,10 @@ Same as full (no reduction when there are no issues).
 
 ## Token Savings
 
-| Scenario       | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------- | ---------- | --------- | ------------ | ------- |
-| No issues      | ~5         | ~10       | ~10          | 0%      |
-| 3 diagnostics  | ~100       | ~70       | ~5           | 30-95%  |
+| Scenario      | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------- | ---------- | --------- | ------------ | ------- |
+| No issues     | ~5         | ~10       | ~10          | 0%      |
+| 3 diagnostics | ~100       | ~70       | ~5           | 30-95%  |
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Add schema documentation pages under `docs/tool-schemas/go/` for all 11 `@paretools/go` tools: build, test, vet, run, mod-tidy, fmt, generate, env, list, get, golangci-lint
- Each page follows the established template format (matching `docs/tool-schemas/test/run.md`) with input parameters table, CLI vs Pare output comparison with token estimates, compact mode examples, error scenarios, token savings summary, and notes
- Closes #354

## Test plan
- [x] Verified all 11 `.md` files created under `docs/tool-schemas/go/`
- [ ] Review each page for accuracy against source schemas and parsers
- [ ] Confirm markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)