### PR TITLE
docs(cargo): document tool schemas for 11 cargo tools (#353)

### DIFF
--- a/docs/tool-schemas/cargo/add.md
+++ b/docs/tool-schemas/cargo/add.md
@@ -9,7 +9,7 @@ Adds dependencies to a Rust project and returns structured output with added pac
 | Parameter  | Type     | Default | Description                                                |
 | ---------- | -------- | ------- | ---------------------------------------------------------- |
 | `path`     | string   | cwd     | Project root path                                          |
-| `packages` | string[] | --      | Packages to add (e.g. `["serde", "tokio@1.0"]`)           |
+| `packages` | string[] | --      | Packages to add (e.g. `["serde", "tokio@1.0"]`)            |
 | `dev`      | boolean  | `false` | Add as dev dependency (--dev)                              |
 | `features` | string[] | --      | Features to enable (e.g. `["derive", "full"]`)             |
 | `dryRun`   | boolean  | `false` | Preview without modifying Cargo.toml (--dry-run)           |
@@ -112,10 +112,10 @@ error: could not find `nonexistent-crate` in registry `crates-io`
 
 ## Token Savings
 
-| Scenario           | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ------------------ | ---------- | --------- | ------------ | ------- |
-| Adding 2 packages  | ~150       | ~45       | ~20          | 70-87%  |
-| Package not found  | ~60        | ~15       | ~15          | 75%     |
+| Scenario          | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ----------------- | ---------- | --------- | ------------ | ------- |
+| Adding 2 packages | ~150       | ~45       | ~20          | 70-87%  |
+| Package not found | ~60        | ~15       | ~15          | 75%     |
 
 ## Notes
 

--- a/docs/tool-schemas/cargo/build.md
+++ b/docs/tool-schemas/cargo/build.md
@@ -195,11 +195,11 @@ error: aborting due to 1 previous error
 
 ## Token Savings
 
-| Scenario             | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------------- | ---------- | --------- | ------------ | ------- |
-| Clean build          | ~120       | ~30       | ~30          | 75%     |
+| Scenario              | CLI Tokens | Pare Full | Pare Compact | Savings |
+| --------------------- | ---------- | --------- | ------------ | ------- |
+| Clean build           | ~120       | ~30       | ~30          | 75%     |
 | Build with 2 warnings | ~350       | ~100      | ~25          | 71-93%  |
-| Compilation error    | ~250       | ~65       | ~25          | 74-90%  |
+| Compilation error     | ~250       | ~65       | ~25          | 74-90%  |
 
 ## Notes
 

--- a/docs/tool-schemas/cargo/check.md
+++ b/docs/tool-schemas/cargo/check.md
@@ -143,10 +143,10 @@ error: aborting due to 2 previous errors
 
 ## Token Savings
 
-| Scenario        | CLI Tokens | Pare Full | Pare Compact | Savings |
-| --------------- | ---------- | --------- | ------------ | ------- |
-| Clean check     | ~80        | ~30       | ~30          | 63%     |
-| 2 type errors   | ~350       | ~100      | ~25          | 71-93%  |
+| Scenario      | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------- | ---------- | --------- | ------------ | ------- |
+| Clean check   | ~80        | ~30       | ~30          | 63%     |
+| 2 type errors | ~350       | ~100      | ~25          | 71-93%  |
 
 ## Notes
 

--- a/docs/tool-schemas/cargo/clippy.md
+++ b/docs/tool-schemas/cargo/clippy.md
@@ -140,10 +140,10 @@ warning: `my-app` (bin "my-app") generated 2 warnings
 
 ## Token Savings
 
-| Scenario          | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ----------------- | ---------- | --------- | ------------ | ------- |
-| No warnings       | ~80        | ~20       | ~20          | 75%     |
-| 2 lint warnings   | ~400       | ~100      | ~20          | 75-95%  |
+| Scenario        | CLI Tokens | Pare Full | Pare Compact | Savings |
+| --------------- | ---------- | --------- | ------------ | ------- |
+| No warnings     | ~80        | ~20       | ~20          | 75%     |
+| 2 lint warnings | ~400       | ~100      | ~20          | 75-95%  |
 
 ## Notes
 

--- a/docs/tool-schemas/cargo/doc.md
+++ b/docs/tool-schemas/cargo/doc.md
@@ -109,10 +109,10 @@ Same as full (output is already minimal).
 
 ## Token Savings
 
-| Scenario           | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ------------------ | ---------- | --------- | ------------ | ------- |
-| Clean docs         | ~100       | ~10       | ~10          | 90%     |
-| 2 doc warnings     | ~300       | ~10       | ~10          | 97%     |
+| Scenario       | CLI Tokens | Pare Full | Pare Compact | Savings |
+| -------------- | ---------- | --------- | ------------ | ------- |
+| Clean docs     | ~100       | ~10       | ~10          | 90%     |
+| 2 doc warnings | ~300       | ~10       | ~10          | 97%     |
 
 ## Notes
 

--- a/docs/tool-schemas/cargo/fmt.md
+++ b/docs/tool-schemas/cargo/fmt.md
@@ -88,10 +88,7 @@ Diff in /home/user/my-app/src/lib.rs at line 12:
 {
   "success": false,
   "filesChanged": 2,
-  "files": [
-    "src/main.rs",
-    "src/lib.rs"
-  ]
+  "files": ["src/main.rs", "src/lib.rs"]
 }
 ```
 
@@ -117,9 +114,9 @@ Diff in /home/user/my-app/src/lib.rs at line 12:
 
 ## Token Savings
 
-| Scenario               | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ---------------------- | ---------- | --------- | ------------ | ------- |
-| All formatted          | ~10        | ~15       | ~10          | 0%      |
+| Scenario                | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ----------------------- | ---------- | --------- | ------------ | ------- |
+| All formatted           | ~10        | ~15       | ~10          | 0%      |
 | 2 files need formatting | ~250       | ~30       | ~10          | 88-96%  |
 
 ## Notes

--- a/docs/tool-schemas/cargo/remove.md
+++ b/docs/tool-schemas/cargo/remove.md
@@ -87,10 +87,10 @@ error: the dependency `nonexistent` could not be found in `dependencies`
 
 ## Token Savings
 
-| Scenario             | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------------- | ---------- | --------- | ------------ | ------- |
-| Removing 2 packages  | ~80        | ~25       | ~25          | 69%     |
-| Package not found    | ~60        | ~15       | ~15          | 75%     |
+| Scenario            | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------------- | ---------- | --------- | ------------ | ------- |
+| Removing 2 packages | ~80        | ~25       | ~25          | 69%     |
+| Package not found   | ~60        | ~15       | ~15          | 75%     |
 
 ## Notes
 

--- a/docs/tool-schemas/cargo/run.md
+++ b/docs/tool-schemas/cargo/run.md
@@ -106,10 +106,10 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 ## Token Savings
 
-| Scenario       | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------- | ---------- | --------- | ------------ | ------- |
-| Normal run     | ~100       | ~40       | ~10          | 60-90%  |
-| Runtime panic  | ~200       | ~50       | ~10          | 75-95%  |
+| Scenario      | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------- | ---------- | --------- | ------------ | ------- |
+| Normal run    | ~100       | ~40       | ~10          | 60-90%  |
+| Runtime panic | ~200       | ~50       | ~10          | 75-95%  |
 
 ## Notes
 

--- a/docs/tool-schemas/cargo/test.md
+++ b/docs/tool-schemas/cargo/test.md
@@ -6,11 +6,11 @@ Runs cargo test and returns structured test results (name, status, pass/fail cou
 
 ## Input Parameters
 
-| Parameter | Type   | Default | Description                                                |
-| --------- | ------ | ------- | ---------------------------------------------------------- |
-| `path`    | string | cwd     | Project root path                                          |
-| `filter`  | string | --      | Test name filter pattern                                   |
-| `compact` | boolean | `true` | Auto-compact when structured output exceeds raw CLI tokens |
+| Parameter | Type    | Default | Description                                                |
+| --------- | ------- | ------- | ---------------------------------------------------------- |
+| `path`    | string  | cwd     | Project root path                                          |
+| `filter`  | string  | --      | Test name filter pattern                                   |
+| `compact` | boolean | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
 
 ## Success — All Tests Passing
 
@@ -165,10 +165,10 @@ test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; 
 
 ## Token Savings
 
-| Scenario              | CLI Tokens | Pare Full | Pare Compact | Savings |
-| --------------------- | ---------- | --------- | ------------ | ------- |
-| 4 tests passing       | ~200       | ~70       | ~25          | 65-88%  |
-| 4 tests, 2 failures   | ~400       | ~75       | ~25          | 81-94%  |
+| Scenario            | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------------- | ---------- | --------- | ------------ | ------- |
+| 4 tests passing     | ~200       | ~70       | ~25          | 65-88%  |
+| 4 tests, 2 failures | ~400       | ~75       | ~25          | 81-94%  |
 
 ## Notes
 

--- a/docs/tool-schemas/cargo/tree.md
+++ b/docs/tool-schemas/cargo/tree.md
@@ -9,8 +9,8 @@ Displays the dependency tree for a Rust project with unique package count.
 | Parameter | Type    | Default | Description                                                |
 | --------- | ------- | ------- | ---------------------------------------------------------- |
 | `path`    | string  | cwd     | Project root path                                          |
-| `depth`   | number  | --      | Maximum depth of the dependency tree to display             |
-| `package` | string  | --      | Focus on a specific package in the tree                     |
+| `depth`   | number  | --      | Maximum depth of the dependency tree to display            |
+| `package` | string  | --      | Focus on a specific package in the tree                    |
 | `compact` | boolean | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
 
 ## Success — Dependency Tree
@@ -106,8 +106,8 @@ my-app v0.1.0 (/home/user/my-app)
 
 ## Token Savings
 
-| Scenario           | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ------------------ | ---------- | --------- | ------------ | ------- |
+| Scenario            | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------------- | ---------- | --------- | ------------ | ------- |
 | Full tree (12 deps) | ~200       | ~220      | ~5           | 0-98%   |
 | Depth-limited tree  | ~80        | ~50       | ~5           | 38-94%  |
 

--- a/docs/tool-schemas/cargo/update.md
+++ b/docs/tool-schemas/cargo/update.md
@@ -6,11 +6,11 @@ Updates dependencies in the lock file and returns structured output.
 
 ## Input Parameters
 
-| Parameter | Type    | Default | Description                                                |
-| --------- | ------- | ------- | ---------------------------------------------------------- |
-| `path`    | string  | cwd     | Project root path                                          |
+| Parameter | Type    | Default | Description                                                    |
+| --------- | ------- | ------- | -------------------------------------------------------------- |
+| `path`    | string  | cwd     | Project root path                                              |
 | `package` | string  | --      | Specific package to update (e.g. `serde`). Omit to update all. |
-| `compact` | boolean | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
+| `compact` | boolean | `true`  | Auto-compact when structured output exceeds raw CLI tokens     |
 
 ## Success — Updating All Dependencies
 


### PR DESCRIPTION
## Summary
- Add schema documentation pages for all 11 `@paretools/cargo` tools under `docs/tool-schemas/cargo/`
- Tools documented: `build`, `test`, `clippy`, `run`, `add`, `remove`, `fmt`, `doc`, `check`, `update`, `tree`
- Each page follows the standard format established in `docs/tool-schemas/test/run.md`

## What each page includes
- Tool name, description, and command
- Input parameters table with types and defaults
- CLI vs Pare structured JSON comparison tables with token estimates
- Compact mode response examples
- Error scenarios where relevant
- Token savings summary table
- Notes on behavior and implementation details

## Test plan
- [ ] Verify all 11 markdown files render correctly on GitHub
- [ ] Confirm input parameters match tool definitions in `packages/server-cargo/src/tools/*.ts`
- [ ] Confirm output schemas match `packages/server-cargo/src/schemas/index.ts`
- [ ] Confirm compact mode examples match formatters in `packages/server-cargo/src/lib/formatters.ts`

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)