### PR TITLE
docs(npm): document tool schemas for 10 npm tools (#344)

### DIFF
--- a/docs/tool-schemas/npm/audit.md
+++ b/docs/tool-schemas/npm/audit.md
@@ -6,9 +6,9 @@ Runs npm/pnpm/yarn audit and returns structured vulnerability data with severity
 
 ## Input Parameters
 
-| Parameter        | Type                             | Default     | Description                                                            |
-| ---------------- | -------------------------------- | ----------- | ---------------------------------------------------------------------- |
-| `path`           | string                           | cwd         | Project root path                                                      |
+| Parameter        | Type                            | Default     | Description                                                            |
+| ---------------- | ------------------------------- | ----------- | ---------------------------------------------------------------------- |
+| `path`           | string                          | cwd         | Project root path                                                      |
 | `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"` | auto-detect | Package manager to use. Auto-detected from lock files if not specified |
 
 ## Success — No Vulnerabilities
@@ -140,10 +140,10 @@ minimatch  <3.0.5
 
 ## Token Savings
 
-| Scenario              | CLI Tokens | Pare Full | Savings |
-| --------------------- | ---------- | --------- | ------- |
-| No vulnerabilities    | ~30        | ~25       | 17%     |
-| 3 vulnerabilities     | ~250       | ~100      | 60%     |
+| Scenario           | CLI Tokens | Pare Full | Savings |
+| ------------------ | ---------- | --------- | ------- |
+| No vulnerabilities | ~30        | ~25       | 17%     |
+| 3 vulnerabilities  | ~250       | ~100      | 60%     |
 
 ## Notes
 

--- a/docs/tool-schemas/npm/info.md
+++ b/docs/tool-schemas/npm/info.md
@@ -6,12 +6,12 @@ Shows detailed package metadata from the npm registry. Returns structured data w
 
 ## Input Parameters
 
-| Parameter        | Type                             | Default     | Description                                                                          |
-| ---------------- | -------------------------------- | ----------- | ------------------------------------------------------------------------------------ |
-| `package`        | string                           | *(required)* | Package name to look up (e.g., `express`, `lodash@4.17.21`)                         |
-| `path`           | string                           | cwd         | Project root path                                                                    |
-| `compact`        | boolean                          | `true`      | Auto-compact when structured output exceeds raw CLI tokens. Set false for full schema |
-| `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"` | auto-detect | Package manager to use. Auto-detected from lock files if not specified                |
+| Parameter        | Type                            | Default      | Description                                                                           |
+| ---------------- | ------------------------------- | ------------ | ------------------------------------------------------------------------------------- |
+| `package`        | string                          | _(required)_ | Package name to look up (e.g., `express`, `lodash@4.17.21`)                           |
+| `path`           | string                          | cwd          | Project root path                                                                     |
+| `compact`        | boolean                         | `true`       | Auto-compact when structured output exceeds raw CLI tokens. Set false for full schema |
+| `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"` | auto-detect  | Package manager to use. Auto-detected from lock files if not specified                |
 
 ## Success — Package Found
 
@@ -122,10 +122,10 @@ npm info failed: 404 Not Found - 'nonexistent-pkg-xyz' is not in this registry.
 
 ## Token Savings
 
-| Scenario          | CLI Tokens | Pare Full | Pare Compact | Savings    |
-| ----------------- | ---------- | --------- | ------------ | ---------- |
-| Package found     | ~350       | ~120      | ~35          | 66–90%     |
-| Package not found | ~40        | error     | error        | n/a        |
+| Scenario          | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ----------------- | ---------- | --------- | ------------ | ------- |
+| Package found     | ~350       | ~120      | ~35          | 66–90%  |
+| Package not found | ~40        | error     | error        | n/a     |
 
 ## Notes
 

--- a/docs/tool-schemas/npm/init.md
+++ b/docs/tool-schemas/npm/init.md
@@ -6,11 +6,11 @@ Initializes a new package.json in the target directory. Returns structured outpu
 
 ## Input Parameters
 
-| Parameter        | Type                             | Default     | Description                                                            |
-| ---------------- | -------------------------------- | ----------- | ---------------------------------------------------------------------- |
-| `path`           | string                           | cwd         | Directory to initialize                                                |
-| `yes`            | boolean                          | `true`      | Use `-y` flag for non-interactive init with defaults                   |
-| `scope`          | string                           | —           | npm scope for the package (e.g., `@myorg`)                             |
+| Parameter        | Type                            | Default     | Description                                                            |
+| ---------------- | ------------------------------- | ----------- | ---------------------------------------------------------------------- |
+| `path`           | string                          | cwd         | Directory to initialize                                                |
+| `yes`            | boolean                         | `true`      | Use `-y` flag for non-interactive init with defaults                   |
+| `scope`          | string                          | —           | npm scope for the package (e.g., `@myorg`)                             |
 | `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"` | auto-detect | Package manager to use. Auto-detected from lock files if not specified |
 
 ## Success — Package Initialized

--- a/docs/tool-schemas/npm/install.md
+++ b/docs/tool-schemas/npm/install.md
@@ -6,13 +6,13 @@ Runs npm/pnpm/yarn install and returns a structured summary of added/removed pac
 
 ## Input Parameters
 
-| Parameter        | Type                                  | Default     | Description                                                                                                             |
-| ---------------- | ------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `path`           | string                                | cwd         | Project root path                                                                                                       |
-| `args`           | string[]                              | `[]`        | Additional arguments (e.g., package names to install)                                                                   |
-| `ignoreScripts`  | boolean                               | `true`      | Skip lifecycle scripts (preinstall/postinstall). Set to false if packages need postinstall scripts (e.g., esbuild, sharp) |
-| `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"`      | auto-detect | Package manager to use. Auto-detected from lock files if not specified                                                  |
-| `filter`         | string                                | —           | pnpm workspace filter pattern (e.g., `@scope/pkg`). Only used with pnpm                                                |
+| Parameter        | Type                            | Default     | Description                                                                                                               |
+| ---------------- | ------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `path`           | string                          | cwd         | Project root path                                                                                                         |
+| `args`           | string[]                        | `[]`        | Additional arguments (e.g., package names to install)                                                                     |
+| `ignoreScripts`  | boolean                         | `true`      | Skip lifecycle scripts (preinstall/postinstall). Set to false if packages need postinstall scripts (e.g., esbuild, sharp) |
+| `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"` | auto-detect | Package manager to use. Auto-detected from lock files if not specified                                                    |
+| `filter`         | string                          | —           | pnpm workspace filter pattern (e.g., `@scope/pkg`). Only used with pnpm                                                   |
 
 ## Success — Clean Install
 

--- a/docs/tool-schemas/npm/list.md
+++ b/docs/tool-schemas/npm/list.md
@@ -6,13 +6,13 @@ Lists installed packages as structured dependency data with version information.
 
 ## Input Parameters
 
-| Parameter        | Type                             | Default     | Description                                                                          |
-| ---------------- | -------------------------------- | ----------- | ------------------------------------------------------------------------------------ |
-| `path`           | string                           | cwd         | Project root path                                                                    |
-| `depth`          | number                           | `0`         | Dependency tree depth (0 = top-level only)                                           |
-| `compact`        | boolean                          | `true`      | Auto-compact when structured output exceeds raw CLI tokens. Set false for full schema |
+| Parameter        | Type                            | Default     | Description                                                                           |
+| ---------------- | ------------------------------- | ----------- | ------------------------------------------------------------------------------------- |
+| `path`           | string                          | cwd         | Project root path                                                                     |
+| `depth`          | number                          | `0`         | Dependency tree depth (0 = top-level only)                                            |
+| `compact`        | boolean                         | `true`      | Auto-compact when structured output exceeds raw CLI tokens. Set false for full schema |
 | `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"` | auto-detect | Package manager to use. Auto-detected from lock files if not specified                |
-| `filter`         | string                           | —           | pnpm workspace filter pattern (e.g., `@scope/pkg`). Only used with pnpm              |
+| `filter`         | string                          | —           | pnpm workspace filter pattern (e.g., `@scope/pkg`). Only used with pnpm               |
 
 ## Success — Top-Level Dependencies
 
@@ -166,10 +166,10 @@ my-app@1.0.0 /home/user/my-app
 
 ## Token Savings
 
-| Scenario                | CLI Tokens | Pare Full | Pare Compact | Savings    |
-| ----------------------- | ---------- | --------- | ------------ | ---------- |
-| 4 top-level deps        | ~100       | ~60       | ~45          | 40–55%     |
-| 8 deps (depth=1)        | ~250       | ~100      | ~70          | 60–72%     |
+| Scenario         | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ---------------- | ---------- | --------- | ------------ | ------- |
+| 4 top-level deps | ~100       | ~60       | ~45          | 40–55%  |
+| 8 deps (depth=1) | ~250       | ~100      | ~70          | 60–72%  |
 
 ## Notes
 

--- a/docs/tool-schemas/npm/nvm.md
+++ b/docs/tool-schemas/npm/nvm.md
@@ -6,9 +6,9 @@ Lists installed Node.js versions and shows the current version via nvm. Supports
 
 ## Input Parameters
 
-| Parameter | Type                       | Default | Description                                                                                  |
-| --------- | -------------------------- | ------- | -------------------------------------------------------------------------------------------- |
-| `action`  | `"list"` \| `"current"`   | *(required)* | Action to perform: `list` shows all installed versions, `current` shows the active version |
+| Parameter | Type                    | Default      | Description                                                                                |
+| --------- | ----------------------- | ------------ | ------------------------------------------------------------------------------------------ |
+| `action`  | `"list"` \| `"current"` | _(required)_ | Action to perform: `list` shows all installed versions, `current` shows the active version |
 
 ## Success — List Versions
 
@@ -34,11 +34,7 @@ Lists installed Node.js versions and shows the current version via nvm. Supports
 ```json
 {
   "current": "v20.11.1",
-  "versions": [
-    "v20.11.1",
-    "v18.19.0",
-    "v16.20.2"
-  ]
+  "versions": ["v20.11.1", "v18.19.0", "v16.20.2"]
 }
 ```
 
@@ -112,11 +108,7 @@ lts/* -> lts/iron (-> v20.11.1)
 ```json
 {
   "current": "v20.11.1",
-  "versions": [
-    "v20.11.1",
-    "v18.19.0",
-    "v16.20.2"
-  ],
+  "versions": ["v20.11.1", "v18.19.0", "v16.20.2"],
   "default": "v20.11.1"
 }
 ```
@@ -154,12 +146,12 @@ nvm list failed: nvm: command not found
 
 ## Token Savings
 
-| Scenario               | CLI Tokens | Pare Full | Savings |
-| ---------------------- | ---------- | --------- | ------- |
-| 3 versions (Windows)   | ~60        | ~25       | 58%     |
-| Current version only   | ~10        | ~15       | -50%    |
-| 3 versions (Unix)      | ~80        | ~30       | 63%     |
-| nvm not installed      | ~15        | error     | n/a     |
+| Scenario             | CLI Tokens | Pare Full | Savings |
+| -------------------- | ---------- | --------- | ------- |
+| 3 versions (Windows) | ~60        | ~25       | 58%     |
+| Current version only | ~10        | ~15       | -50%    |
+| 3 versions (Unix)    | ~80        | ~30       | 63%     |
+| nvm not installed    | ~15        | error     | n/a     |
 
 ## Notes
 

--- a/docs/tool-schemas/npm/outdated.md
+++ b/docs/tool-schemas/npm/outdated.md
@@ -6,11 +6,11 @@ Checks for outdated packages and returns structured update information with curr
 
 ## Input Parameters
 
-| Parameter        | Type                             | Default     | Description                                                            |
-| ---------------- | -------------------------------- | ----------- | ---------------------------------------------------------------------- |
-| `path`           | string                           | cwd         | Project root path                                                      |
-| `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"` | auto-detect | Package manager to use. Auto-detected from lock files if not specified |
-| `filter`         | string                           | —           | pnpm workspace filter pattern (e.g., `@scope/pkg`). Only used with pnpm |
+| Parameter        | Type                            | Default     | Description                                                             |
+| ---------------- | ------------------------------- | ----------- | ----------------------------------------------------------------------- |
+| `path`           | string                          | cwd         | Project root path                                                       |
+| `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"` | auto-detect | Package manager to use. Auto-detected from lock files if not specified  |
+| `filter`         | string                          | —           | pnpm workspace filter pattern (e.g., `@scope/pkg`). Only used with pnpm |
 
 ## Success — All Up To Date
 

--- a/docs/tool-schemas/npm/run.md
+++ b/docs/tool-schemas/npm/run.md
@@ -6,13 +6,13 @@ Runs a package.json script and returns structured output with exit code, stdout,
 
 ## Input Parameters
 
-| Parameter        | Type                             | Default     | Description                                                            |
-| ---------------- | -------------------------------- | ----------- | ---------------------------------------------------------------------- |
-| `path`           | string                           | cwd         | Project root path                                                      |
-| `script`         | string                           | *(required)* | The package.json script name to run                                   |
-| `args`           | string[]                         | `[]`        | Additional arguments passed after `--` to the script                   |
-| `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"` | auto-detect | Package manager to use. Auto-detected from lock files if not specified |
-| `filter`         | string                           | —           | pnpm workspace filter pattern (e.g., `@scope/pkg`). Only used with pnpm |
+| Parameter        | Type                            | Default      | Description                                                             |
+| ---------------- | ------------------------------- | ------------ | ----------------------------------------------------------------------- |
+| `path`           | string                          | cwd          | Project root path                                                       |
+| `script`         | string                          | _(required)_ | The package.json script name to run                                     |
+| `args`           | string[]                        | `[]`         | Additional arguments passed after `--` to the script                    |
+| `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"` | auto-detect  | Package manager to use. Auto-detected from lock files if not specified  |
+| `filter`         | string                          | —            | pnpm workspace filter pattern (e.g., `@scope/pkg`). Only used with pnpm |
 
 ## Success — Script Completes
 

--- a/docs/tool-schemas/npm/search.md
+++ b/docs/tool-schemas/npm/search.md
@@ -6,12 +6,12 @@ Searches the npm registry for packages matching a query. Always uses npm (pnpm a
 
 ## Input Parameters
 
-| Parameter | Type    | Default     | Description                                                                          |
-| --------- | ------- | ----------- | ------------------------------------------------------------------------------------ |
-| `query`   | string  | *(required)* | Search query string                                                                 |
-| `path`    | string  | cwd         | Project root path                                                                    |
-| `limit`   | number  | `20`        | Maximum number of results to return                                                  |
-| `compact` | boolean | `true`      | Auto-compact when structured output exceeds raw CLI tokens. Set false for full schema |
+| Parameter | Type    | Default      | Description                                                                           |
+| --------- | ------- | ------------ | ------------------------------------------------------------------------------------- |
+| `query`   | string  | _(required)_ | Search query string                                                                   |
+| `path`    | string  | cwd          | Project root path                                                                     |
+| `limit`   | number  | `20`         | Maximum number of results to return                                                   |
+| `compact` | boolean | `true`       | Auto-compact when structured output exceeds raw CLI tokens. Set false for full schema |
 
 ## Success — Packages Found
 
@@ -160,10 +160,10 @@ No matches found for "xyznonexistentpackage123"
 
 ## Token Savings
 
-| Scenario          | CLI Tokens | Pare Full | Pare Compact | Savings    |
-| ----------------- | ---------- | --------- | ------------ | ---------- |
-| 5 results         | ~200       | ~100      | ~75          | 50–63%     |
-| No results        | ~10        | ~10       | ~10          | 0%         |
+| Scenario   | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ---------- | ---------- | --------- | ------------ | ------- |
+| 5 results  | ~200       | ~100      | ~75          | 50–63%  |
+| No results | ~10        | ~10       | ~10          | 0%      |
 
 ## Notes
 

--- a/docs/tool-schemas/npm/test.md
+++ b/docs/tool-schemas/npm/test.md
@@ -6,12 +6,12 @@ Runs `npm test` / `pnpm test` / `yarn test` and returns structured output with e
 
 ## Input Parameters
 
-| Parameter        | Type                             | Default     | Description                                                            |
-| ---------------- | -------------------------------- | ----------- | ---------------------------------------------------------------------- |
-| `path`           | string                           | cwd         | Project root path                                                      |
-| `args`           | string[]                         | `[]`        | Additional arguments passed after `--` to the test script              |
-| `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"` | auto-detect | Package manager to use. Auto-detected from lock files if not specified |
-| `filter`         | string                           | —           | pnpm workspace filter pattern (e.g., `@scope/pkg`). Only used with pnpm |
+| Parameter        | Type                            | Default     | Description                                                             |
+| ---------------- | ------------------------------- | ----------- | ----------------------------------------------------------------------- |
+| `path`           | string                          | cwd         | Project root path                                                       |
+| `args`           | string[]                        | `[]`        | Additional arguments passed after `--` to the test script               |
+| `packageManager` | `"npm"` \| `"pnpm"` \| `"yarn"` | auto-detect | Package manager to use. Auto-detected from lock files if not specified  |
+| `filter`         | string                          | —           | pnpm workspace filter pattern (e.g., `@scope/pkg`). Only used with pnpm |
 
 ## Success — Tests Pass
 
@@ -111,10 +111,10 @@ npm ERR! Test failed.  See above for more details.
 
 ## Token Savings
 
-| Scenario    | CLI Tokens | Pare Full | Savings |
-| ----------- | ---------- | --------- | ------- |
-| Tests pass  | ~100       | ~40       | 60%     |
-| Tests fail  | ~150       | ~55       | 63%     |
+| Scenario   | CLI Tokens | Pare Full | Savings |
+| ---------- | ---------- | --------- | ------- |
+| Tests pass | ~100       | ~40       | 60%     |
+| Tests fail | ~150       | ~55       | 63%     |
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Add schema documentation pages under `docs/tool-schemas/npm/` for all 10 `@paretools/npm` tools
- Each page follows the established template from `docs/tool-schemas/test/run.md`
- Covers: install, audit, outdated, list, run, test, init, info, search, nvm

Each documentation page includes:
- Tool description and CLI command
- Input parameters table
- CLI output vs Pare structured JSON comparison with approximate token counts
- Compact mode response (where applicable)
- Error scenarios
- Token savings summary table
- Notes on behavior and edge cases

## Test plan

- [x] Verified all 10 `.md` files created under `docs/tool-schemas/npm/`
- [x] Confirmed each file matches the template format from `test/run.md`
- [x] Cross-referenced input parameters against tool source in `packages/server-npm/src/tools/*.ts`
- [x] Cross-referenced output schemas against `packages/server-npm/src/schemas/index.ts`
- [x] Verified compact mode documented for tools that support it (list, info, search)
- [ ] Visual review of rendered markdown

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)