### PR TITLE
docs(lint): document tool schemas for 9 lint tools (#347)

### DIFF
--- a/docs/tool-schemas/lint/biome-check.md
+++ b/docs/tool-schemas/lint/biome-check.md
@@ -175,11 +175,11 @@ sh: biome: command not found
 
 ## Token Savings
 
-| Scenario           | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ------------------ | ---------- | --------- | ------------ | ------- |
-| No issues          | ~50        | ~25       | ~25          | 50%     |
-| 3 diagnostics      | ~300       | ~100      | ~20          | 67-93%  |
-| Biome not found    | ~30        | ~25       | ~25          | 17%     |
+| Scenario        | CLI Tokens | Pare Full | Pare Compact | Savings |
+| --------------- | ---------- | --------- | ------------ | ------- |
+| No issues       | ~50        | ~25       | ~25          | 50%     |
+| 3 diagnostics   | ~300       | ~100      | ~20          | 67-93%  |
+| Biome not found | ~30        | ~25       | ~25          | 17%     |
 
 ## Notes
 

--- a/docs/tool-schemas/lint/biome-format.md
+++ b/docs/tool-schemas/lint/biome-format.md
@@ -77,11 +77,7 @@ Formatted 10 files in 60ms. Fixed 3 files.
 ```json
 {
   "filesChanged": 3,
-  "files": [
-    "src/index.ts",
-    "src/utils.ts",
-    "src/components/App.tsx"
-  ],
+  "files": ["src/index.ts", "src/utils.ts", "src/components/App.tsx"],
   "success": true
 }
 ```
@@ -139,11 +135,11 @@ sh: biome: command not found
 
 ## Token Savings
 
-| Scenario             | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------------- | ---------- | --------- | ------------ | ------- |
-| Already formatted    | ~40        | ~15       | ~15          | 63%     |
-| 3 files formatted    | ~80        | ~30       | ~10          | 63-88%  |
-| Biome not found      | ~30        | ~15       | ~15          | 50%     |
+| Scenario          | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ----------------- | ---------- | --------- | ------------ | ------- |
+| Already formatted | ~40        | ~15       | ~15          | 63%     |
+| 3 files formatted | ~80        | ~30       | ~10          | 63-88%  |
+| Biome not found   | ~30        | ~15       | ~15          | 50%     |
 
 ## Notes
 

--- a/docs/tool-schemas/lint/format-check.md
+++ b/docs/tool-schemas/lint/format-check.md
@@ -80,12 +80,7 @@ Checking formatting...
 ```json
 {
   "formatted": false,
-  "files": [
-    "src/index.ts",
-    "src/utils.ts",
-    "src/components/App.tsx",
-    "tests/helpers.ts"
-  ],
+  "files": ["src/index.ts", "src/utils.ts", "src/components/App.tsx", "tests/helpers.ts"],
   "total": 4
 }
 ```
@@ -143,11 +138,11 @@ sh: prettier: command not found
 
 ## Token Savings
 
-| Scenario               | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ---------------------- | ---------- | --------- | ------------ | ------- |
-| All formatted          | ~40        | ~15       | ~15          | 63%     |
-| 4 files need formatting | ~120      | ~40       | ~10          | 67-92%  |
-| Prettier not found     | ~30        | ~15       | ~15          | 50%     |
+| Scenario                | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ----------------------- | ---------- | --------- | ------------ | ------- |
+| All formatted           | ~40        | ~15       | ~15          | 63%     |
+| 4 files need formatting | ~120       | ~40       | ~10          | 67-92%  |
+| Prettier not found      | ~30        | ~15       | ~15          | 50%     |
 
 ## Notes
 

--- a/docs/tool-schemas/lint/hadolint.md
+++ b/docs/tool-schemas/lint/hadolint.md
@@ -6,13 +6,13 @@ Runs Hadolint (Dockerfile linter) and returns structured diagnostics (file, line
 
 ## Input Parameters
 
-| Parameter           | Type     | Default          | Description                                                |
-| ------------------- | -------- | ---------------- | ---------------------------------------------------------- |
-| `path`              | string   | cwd              | Project root path                                          |
-| `patterns`          | string[] | `["Dockerfile"]` | Dockerfile paths to check                                  |
+| Parameter           | Type     | Default          | Description                                                  |
+| ------------------- | -------- | ---------------- | ------------------------------------------------------------ |
+| `path`              | string   | cwd              | Project root path                                            |
+| `patterns`          | string[] | `["Dockerfile"]` | Dockerfile paths to check                                    |
 | `trustedRegistries` | string[] | --               | Trusted Docker registries (e.g., `["docker.io", "ghcr.io"]`) |
-| `ignoreRules`       | string[] | --               | Rule codes to ignore (e.g., `["DL3008", "DL3013"]`)       |
-| `compact`           | boolean  | `true`           | Auto-compact when structured output exceeds raw CLI tokens |
+| `ignoreRules`       | string[] | --               | Rule codes to ignore (e.g., `["DL3008", "DL3013"]`)          |
+| `compact`           | boolean  | `true`           | Auto-compact when structured output exceeds raw CLI tokens   |
 
 ## Success — No Issues
 
@@ -177,11 +177,11 @@ sh: hadolint: command not found
 
 ## Token Savings
 
-| Scenario            | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ------------------- | ---------- | --------- | ------------ | ------- |
-| No issues           | ~15        | ~25       | ~25          | 0%      |
-| 3 diagnostics       | ~250       | ~100      | ~20          | 60-92%  |
-| Hadolint not found  | ~30        | ~25       | ~25          | 17%     |
+| Scenario           | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------------ | ---------- | --------- | ------------ | ------- |
+| No issues          | ~15        | ~25       | ~25          | 0%      |
+| 3 diagnostics      | ~250       | ~100      | ~20          | 60-92%  |
+| Hadolint not found | ~30        | ~25       | ~25          | 17%     |
 
 ## Notes
 

--- a/docs/tool-schemas/lint/lint.md
+++ b/docs/tool-schemas/lint/lint.md
@@ -190,11 +190,11 @@ sh: eslint: command not found
 
 ## Token Savings
 
-| Scenario          | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ----------------- | ---------- | --------- | ------------ | ------- |
-| No issues (12 files) | ~50    | ~25       | ~25          | 50%     |
-| 5 diagnostics     | ~350       | ~130      | ~20          | 63-94%  |
-| ESLint not found  | ~30        | ~25       | ~25          | 17%     |
+| Scenario             | CLI Tokens | Pare Full | Pare Compact | Savings |
+| -------------------- | ---------- | --------- | ------------ | ------- |
+| No issues (12 files) | ~50        | ~25       | ~25          | 50%     |
+| 5 diagnostics        | ~350       | ~130      | ~20          | 63-94%  |
+| ESLint not found     | ~30        | ~25       | ~25          | 17%     |
 
 ## Notes
 

--- a/docs/tool-schemas/lint/oxlint.md
+++ b/docs/tool-schemas/lint/oxlint.md
@@ -184,11 +184,11 @@ sh: oxlint: command not found
 
 ## Token Savings
 
-| Scenario           | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ------------------ | ---------- | --------- | ------------ | ------- |
-| No issues          | ~40        | ~25       | ~25          | 38%     |
-| 3 diagnostics      | ~280       | ~100      | ~20          | 64-93%  |
-| Oxlint not found   | ~30        | ~25       | ~25          | 17%     |
+| Scenario         | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ---------------- | ---------- | --------- | ------------ | ------- |
+| No issues        | ~40        | ~25       | ~25          | 38%     |
+| 3 diagnostics    | ~280       | ~100      | ~20          | 64-93%  |
+| Oxlint not found | ~30        | ~25       | ~25          | 17%     |
 
 ## Notes
 

--- a/docs/tool-schemas/lint/prettier-format.md
+++ b/docs/tool-schemas/lint/prettier-format.md
@@ -76,11 +76,7 @@ src/components/App.tsx 23ms
 ```json
 {
   "filesChanged": 3,
-  "files": [
-    "src/index.ts",
-    "src/utils.ts",
-    "src/components/App.tsx"
-  ],
+  "files": ["src/index.ts", "src/utils.ts", "src/components/App.tsx"],
   "success": true
 }
 ```
@@ -138,11 +134,11 @@ sh: prettier: command not found
 
 ## Token Savings
 
-| Scenario             | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------------- | ---------- | --------- | ------------ | ------- |
-| Already formatted    | ~30        | ~15       | ~15          | 50%     |
-| 3 files formatted    | ~80        | ~30       | ~10          | 63-88%  |
-| Prettier not found   | ~30        | ~15       | ~15          | 50%     |
+| Scenario           | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------------ | ---------- | --------- | ------------ | ------- |
+| Already formatted  | ~30        | ~15       | ~15          | 50%     |
+| 3 files formatted  | ~80        | ~30       | ~10          | 63-88%  |
+| Prettier not found | ~30        | ~15       | ~15          | 50%     |
 
 ## Notes
 

--- a/docs/tool-schemas/lint/shellcheck.md
+++ b/docs/tool-schemas/lint/shellcheck.md
@@ -6,12 +6,12 @@ Runs ShellCheck (shell script linter) and returns structured diagnostics (file, 
 
 ## Input Parameters
 
-| Parameter  | Type                                               | Default | Description                                                |
-| ---------- | -------------------------------------------------- | ------- | ---------------------------------------------------------- |
-| `path`     | string                                             | cwd     | Project root path                                          |
-| `patterns` | string[]                                           | `["."]` | File patterns to check                                     |
+| Parameter  | Type                                              | Default | Description                                                |
+| ---------- | ------------------------------------------------- | ------- | ---------------------------------------------------------- |
+| `path`     | string                                            | cwd     | Project root path                                          |
+| `patterns` | string[]                                          | `["."]` | File patterns to check                                     |
 | `severity` | `"error"` \| `"warning"` \| `"info"` \| `"style"` | --      | Minimum severity level to report (default: style)          |
-| `compact`  | boolean                                            | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
+| `compact`  | boolean                                           | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
 
 ## Success — No Issues
 
@@ -190,11 +190,11 @@ sh: shellcheck: command not found
 
 ## Token Savings
 
-| Scenario              | CLI Tokens | Pare Full | Pare Compact | Savings |
-| --------------------- | ---------- | --------- | ------------ | ------- |
-| No issues             | ~20        | ~25       | ~25          | 0%      |
-| 4 diagnostics         | ~300       | ~120      | ~20          | 60-93%  |
-| ShellCheck not found  | ~30        | ~25       | ~25          | 17%     |
+| Scenario             | CLI Tokens | Pare Full | Pare Compact | Savings |
+| -------------------- | ---------- | --------- | ------------ | ------- |
+| No issues            | ~20        | ~25       | ~25          | 0%      |
+| 4 diagnostics        | ~300       | ~120      | ~20          | 60-93%  |
+| ShellCheck not found | ~30        | ~25       | ~25          | 17%     |
 
 ## Notes
 

--- a/docs/tool-schemas/lint/stylelint.md
+++ b/docs/tool-schemas/lint/stylelint.md
@@ -174,11 +174,11 @@ sh: stylelint: command not found
 
 ## Token Savings
 
-| Scenario           | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ------------------ | ---------- | --------- | ------------ | ------- |
-| No issues (6 files) | ~30       | ~25       | ~25          | 17%     |
-| 3 diagnostics      | ~250       | ~100      | ~20          | 60-92%  |
-| Stylelint not found | ~30       | ~25       | ~25          | 17%     |
+| Scenario            | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------------- | ---------- | --------- | ------------ | ------- |
+| No issues (6 files) | ~30        | ~25       | ~25          | 17%     |
+| 3 diagnostics       | ~250       | ~100      | ~20          | 60-92%  |
+| Stylelint not found | ~30        | ~25       | ~25          | 17%     |
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Add tool schema documentation for all 9 `@paretools/lint` tools under `docs/tool-schemas/lint/`
- Each page follows the established template from `docs/tool-schemas/test/run.md`
- Covers: `lint`, `format-check`, `prettier-format`, `biome-check`, `biome-format`, `stylelint`, `oxlint`, `shellcheck`, `hadolint`

Each documentation page includes:
- Tool description and underlying CLI command
- Input parameters table with types, defaults, and descriptions
- Side-by-side CLI vs Pare structured JSON output comparisons with token estimates
- Compact mode response examples
- Error scenario handling
- Token savings summary table
- Implementation notes (parsing behavior, severity mapping, compact mode behavior)

## Test plan

- [ ] Verify all 9 `.md` files render correctly on GitHub
- [ ] Confirm JSON examples match the Zod schemas in `packages/server-lint/src/schemas/index.ts`
- [ ] Confirm input parameters match tool definitions in `packages/server-lint/src/tools/`
- [ ] Verify formatting follows the template in `docs/tool-schemas/test/run.md`

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)