### PR TITLE
docs(search): document tool schemas for 3 search tools (#348)

### DIFF
--- a/docs/tool-schemas/search/count.md
+++ b/docs/tool-schemas/search/count.md
@@ -10,7 +10,7 @@ Counts pattern matches per file using ripgrep. Returns per-file match counts and
 | --------------- | ------- | ------- | ---------------------------------------------------------- |
 | `pattern`       | string  | —       | Regular expression pattern to count matches for            |
 | `path`          | string  | cwd     | Directory or file to search in                             |
-| `glob`          | string  | —       | Glob pattern to filter files (e.g., `*.ts`, `*.{js,jsx}`) |
+| `glob`          | string  | —       | Glob pattern to filter files (e.g., `*.ts`, `*.{js,jsx}`)  |
 | `caseSensitive` | boolean | `true`  | Case-sensitive search                                      |
 | `compact`       | boolean | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
 
@@ -145,11 +145,11 @@ error: unclosed character class
 
 ## Token Savings
 
-| Scenario       | CLI Tokens | Pare Full | Pare Compact | Savings  |
-| -------------- | ---------- | --------- | ------------ | -------- |
-| 7 files matched| ~65        | ~85       | ~15          | —/77%    |
-| No matches     | ~10        | ~18       | ~15          | —        |
-| Invalid regex  | ~25        | ~18       | ~15          | 28-40%   |
+| Scenario        | CLI Tokens | Pare Full | Pare Compact | Savings |
+| --------------- | ---------- | --------- | ------------ | ------- |
+| 7 files matched | ~65        | ~85       | ~15          | —/77%   |
+| No matches      | ~10        | ~18       | ~15          | —       |
+| Invalid regex   | ~25        | ~18       | ~15          | 28-40%  |
 
 ## Notes
 

--- a/docs/tool-schemas/search/find.md
+++ b/docs/tool-schemas/search/find.md
@@ -6,14 +6,14 @@ Finds files and directories using fd with structured output. Returns file paths,
 
 ## Input Parameters
 
-| Parameter    | Type                                         | Default | Description                                                |
-| ------------ | -------------------------------------------- | ------- | ---------------------------------------------------------- |
-| `pattern`    | string                                       | —       | Regex pattern to match file/directory names                |
-| `path`       | string                                       | cwd     | Directory to search in                                     |
-| `type`       | `"file"` \| `"directory"` \| `"symlink"`     | —       | Filter by entry type                                       |
-| `extension`  | string                                       | —       | Filter by file extension (e.g., `ts`, `js`)                |
-| `maxResults` | number                                       | `1000`  | Maximum number of results to return                        |
-| `compact`    | boolean                                      | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
+| Parameter    | Type                                     | Default | Description                                                |
+| ------------ | ---------------------------------------- | ------- | ---------------------------------------------------------- |
+| `pattern`    | string                                   | —       | Regex pattern to match file/directory names                |
+| `path`       | string                                   | cwd     | Directory to search in                                     |
+| `type`       | `"file"` \| `"directory"` \| `"symlink"` | —       | Filter by entry type                                       |
+| `extension`  | string                                   | —       | Filter by file extension (e.g., `ts`, `js`)                |
+| `maxResults` | number                                   | `1000`  | Maximum number of results to return                        |
+| `compact`    | boolean                                  | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
 
 ## Success — Files Found
 
@@ -142,11 +142,11 @@ error: unclosed character class
 
 ## Token Savings
 
-| Scenario       | CLI Tokens | Pare Full | Pare Compact | Savings  |
-| -------------- | ---------- | --------- | ------------ | -------- |
-| 7 files found  | ~80        | ~130      | ~8           | —/90%    |
-| No files found | ~5         | ~12       | ~8           | —        |
-| Invalid pattern| ~30        | ~12       | ~8           | 60-73%   |
+| Scenario        | CLI Tokens | Pare Full | Pare Compact | Savings |
+| --------------- | ---------- | --------- | ------------ | ------- |
+| 7 files found   | ~80        | ~130      | ~8           | —/90%   |
+| No files found  | ~5         | ~12       | ~8           | —       |
+| Invalid pattern | ~30        | ~12       | ~8           | 60-73%  |
 
 ## Notes
 

--- a/docs/tool-schemas/search/search.md
+++ b/docs/tool-schemas/search/search.md
@@ -10,7 +10,7 @@ Searches file contents using ripgrep with structured JSON output. Returns match 
 | --------------- | ------- | ------- | ---------------------------------------------------------- |
 | `pattern`       | string  | —       | Regular expression pattern to search for                   |
 | `path`          | string  | cwd     | Directory or file to search in                             |
-| `glob`          | string  | —       | Glob pattern to filter files (e.g., `*.ts`, `*.{js,jsx}`) |
+| `glob`          | string  | —       | Glob pattern to filter files (e.g., `*.ts`, `*.{js,jsx}`)  |
 | `caseSensitive` | boolean | `true`  | Case-sensitive search                                      |
 | `maxResults`    | number  | `1000`  | Maximum number of matches to return                        |
 | `compact`       | boolean | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
@@ -172,11 +172,11 @@ error: unclosed character class
 
 ## Token Savings
 
-| Scenario       | CLI Tokens | Pare Full | Pare Compact | Savings |
-| -------------- | ---------- | --------- | ------------ | ------- |
-| 5 matches      | ~220       | ~120      | ~15          | 45-93%  |
-| No matches     | ~10        | ~20       | ~15          | —       |
-| Invalid regex  | ~25        | ~20       | ~15          | 20-40%  |
+| Scenario      | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ------------- | ---------- | --------- | ------------ | ------- |
+| 5 matches     | ~220       | ~120      | ~15          | 45-93%  |
+| No matches    | ~10        | ~20       | ~15          | —       |
+| Invalid regex | ~25        | ~20       | ~15          | 20-40%  |
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Add tool schema documentation for all 3 `@paretools/search` tools: `search`, `find`, and `count`
- Each page follows the established template format from `docs/tool-schemas/test/run.md`
- Includes input parameters, CLI vs Pare output comparisons (full + compact), error scenarios, token savings tables, and notes

## Files Added
- `docs/tool-schemas/search/search.md` — ripgrep content search with match locations
- `docs/tool-schemas/search/find.md` — fd file finder with path/name/extension metadata
- `docs/tool-schemas/search/count.md` — ripgrep per-file match counting

## Test plan
- [ ] Verify each doc page renders correctly on GitHub
- [ ] Confirm examples match actual schema shapes from `packages/server-search/src/schemas/index.ts`
- [ ] Confirm compact mode descriptions match `formatters.ts` compact mappers

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)