### PR TITLE
docs(make): document tool schemas for 2 make tools (#350)

### DIFF
--- a/docs/tool-schemas/make/list.md
+++ b/docs/tool-schemas/make/list.md
@@ -6,11 +6,11 @@ Lists available make or just targets with optional descriptions. Auto-detects ma
 
 ## Input Parameters
 
-| Parameter | Type                                    | Default  | Description                                                |
-| --------- | --------------------------------------- | -------- | ---------------------------------------------------------- |
-| `path`    | string                                  | cwd      | Project root path                                          |
-| `tool`    | `"auto"` \| `"make"` \| `"just"`       | `"auto"` | Task runner to use; "auto" detects from files              |
-| `compact` | boolean                                 | `true`   | Auto-compact when structured output exceeds raw CLI tokens |
+| Parameter | Type                             | Default  | Description                                                |
+| --------- | -------------------------------- | -------- | ---------------------------------------------------------- |
+| `path`    | string                           | cwd      | Project root path                                          |
+| `tool`    | `"auto"` \| `"make"` \| `"just"` | `"auto"` | Task runner to use; "auto" detects from files              |
+| `compact` | boolean                          | `true`   | Auto-compact when structured output exceeds raw CLI tokens |
 
 ## Success — Just Targets with Descriptions
 
@@ -165,11 +165,11 @@ make: *** No targets specified and no makefile found. Stop.
 
 ## Token Savings
 
-| Scenario                    | CLI Tokens | Pare Full | Pare Compact | Savings   |
-| --------------------------- | ---------- | --------- | ------------ | --------- |
-| Just targets (5 with desc.) | ~55        | ~65       | ~10          | 82%*      |
-| Make targets (5 targets)    | ~800       | ~50       | ~10          | 94–99%    |
-| No targets found            | ~30        | ~15       | ~15          | 50%       |
+| Scenario                    | CLI Tokens | Pare Full | Pare Compact | Savings |
+| --------------------------- | ---------- | --------- | ------------ | ------- |
+| Just targets (5 with desc.) | ~55        | ~65       | ~10          | 82%\*   |
+| Make targets (5 targets)    | ~800       | ~50       | ~10          | 94–99%  |
+| No targets found            | ~30        | ~15       | ~15          | 50%     |
 
 \* Just list output is already concise; full Pare response is slightly larger due to JSON structure, but compact mode still provides significant savings. The real savings come from make, where `make -pRrq` outputs the entire internal database (often hundreds of lines) while Pare extracts just the target names.
 

--- a/docs/tool-schemas/make/run.md
+++ b/docs/tool-schemas/make/run.md
@@ -6,13 +6,13 @@ Runs a make or just target and returns structured output with stdout, stderr, ex
 
 ## Input Parameters
 
-| Parameter | Type                                    | Default  | Description                                                |
-| --------- | --------------------------------------- | -------- | ---------------------------------------------------------- |
-| `target`  | string                                  | —        | Target to run (required)                                   |
-| `args`    | string[]                                | `[]`     | Additional arguments to pass to the target                 |
-| `path`    | string                                  | cwd      | Project root path                                          |
-| `tool`    | `"auto"` \| `"make"` \| `"just"`       | `"auto"` | Task runner to use; "auto" detects from files              |
-| `compact` | boolean                                 | `true`   | Auto-compact when structured output exceeds raw CLI tokens |
+| Parameter | Type                             | Default  | Description                                                |
+| --------- | -------------------------------- | -------- | ---------------------------------------------------------- |
+| `target`  | string                           | —        | Target to run (required)                                   |
+| `args`    | string[]                         | `[]`     | Additional arguments to pass to the target                 |
+| `path`    | string                           | cwd      | Project root path                                          |
+| `tool`    | `"auto"` \| `"make"` \| `"just"` | `"auto"` | Task runner to use; "auto" detects from files              |
+| `compact` | boolean                          | `true`   | Auto-compact when structured output exceeds raw CLI tokens |
 
 ## Success — Target Completes
 


### PR DESCRIPTION
## Summary
- Add tool schema documentation for `@paretools/make` server (run, list)
- Each page follows the established format from `docs/tool-schemas/test/run.md`
- Includes input parameters, CLI vs Pare output comparisons, compact mode examples, error scenarios, and token savings tables

## Files Added
- `docs/tool-schemas/make/run.md` — run tool (execute make/just targets)
- `docs/tool-schemas/make/list.md` — list tool (enumerate available targets)

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm examples match actual schema definitions in `packages/server-make/src/schemas/index.ts`
- [ ] Check token estimates are reasonable (~4 chars/token)

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)