### PR TITLE
docs(http): document tool schemas for 4 http tools (#349)

### DIFF
--- a/docs/tool-schemas/http/get.md
+++ b/docs/tool-schemas/http/get.md
@@ -119,10 +119,10 @@ curl: (28) Operation timed out after 30001 milliseconds
 
 ## Token Savings
 
-| Scenario     | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ------------ | ---------- | --------- | ------------ | ------- |
-| HTML page    | ~200       | ~110      | ~30          | 45–85%  |
-| Timeout      | ~25        | ~30       | ~30          | 0%      |
+| Scenario  | CLI Tokens | Pare Full | Pare Compact | Savings |
+| --------- | ---------- | --------- | ------------ | ------- |
+| HTML page | ~200       | ~110      | ~30          | 45–85%  |
+| Timeout   | ~25        | ~30       | ~30          | 0%      |
 
 ## Notes
 

--- a/docs/tool-schemas/http/head.md
+++ b/docs/tool-schemas/http/head.md
@@ -137,10 +137,10 @@ content-length: 0
 
 ## Token Savings
 
-| Scenario              | CLI Tokens | Pare Full | Pare Compact | Savings |
-| --------------------- | ---------- | --------- | ------------ | ------- |
-| Resource headers      | ~150       | ~80       | ~20          | 47–87%  |
-| 301 Redirect          | ~80        | ~55       | ~15          | 31–81%  |
+| Scenario         | CLI Tokens | Pare Full | Pare Compact | Savings |
+| ---------------- | ---------- | --------- | ------------ | ------- |
+| Resource headers | ~150       | ~80       | ~20          | 47–87%  |
+| 301 Redirect     | ~80        | ~55       | ~15          | 31–81%  |
 
 ## Notes
 

--- a/docs/tool-schemas/http/post.md
+++ b/docs/tool-schemas/http/post.md
@@ -147,10 +147,10 @@ content-length: 74
 
 ## Token Savings
 
-| Scenario         | CLI Tokens | Pare Full | Pare Compact | Savings |
-| ---------------- | ---------- | --------- | ------------ | ------- |
-| 201 Created      | ~180       | ~100      | ~30          | 44–83%  |
-| 422 Validation   | ~140       | ~80       | ~25          | 43–82%  |
+| Scenario       | CLI Tokens | Pare Full | Pare Compact | Savings |
+| -------------- | ---------- | --------- | ------------ | ------- |
+| 201 Created    | ~180       | ~100      | ~30          | 44–83%  |
+| 422 Validation | ~140       | ~80       | ~25          | 43–82%  |
 
 ## Notes
 

--- a/docs/tool-schemas/http/request.md
+++ b/docs/tool-schemas/http/request.md
@@ -6,16 +6,16 @@ Makes an HTTP request via curl and returns structured response data (status, hea
 
 ## Input Parameters
 
-| Parameter         | Type                                                                          | Default             | Description                                                |
-| ----------------- | ----------------------------------------------------------------------------- | ------------------- | ---------------------------------------------------------- |
-| `url`             | string                                                                        | (required)          | The URL to request (http:// or https:// only)              |
-| `method`          | `"GET"` \| `"POST"` \| `"PUT"` \| `"PATCH"` \| `"DELETE"` \| `"HEAD"` \| `"OPTIONS"` | `"GET"`             | HTTP method                                                |
-| `headers`         | Record\<string, string\>                                                      | —                   | Request headers as key-value pairs                         |
-| `body`            | string                                                                        | —                   | Request body (for POST, PUT, PATCH)                        |
-| `timeout`         | number (1–300)                                                                | `30`                | Request timeout in seconds                                 |
-| `followRedirects` | boolean                                                                       | `true`              | Follow HTTP redirects                                      |
-| `compact`         | boolean                                                                       | `true`              | Auto-compact when structured output exceeds raw CLI tokens |
-| `path`            | string                                                                        | cwd                 | Working directory                                          |
+| Parameter         | Type                                                                                 | Default    | Description                                                |
+| ----------------- | ------------------------------------------------------------------------------------ | ---------- | ---------------------------------------------------------- |
+| `url`             | string                                                                               | (required) | The URL to request (http:// or https:// only)              |
+| `method`          | `"GET"` \| `"POST"` \| `"PUT"` \| `"PATCH"` \| `"DELETE"` \| `"HEAD"` \| `"OPTIONS"` | `"GET"`    | HTTP method                                                |
+| `headers`         | Record\<string, string\>                                                             | —          | Request headers as key-value pairs                         |
+| `body`            | string                                                                               | —          | Request body (for POST, PUT, PATCH)                        |
+| `timeout`         | number (1–300)                                                                       | `30`       | Request timeout in seconds                                 |
+| `followRedirects` | boolean                                                                              | `true`     | Follow HTTP redirects                                      |
+| `compact`         | boolean                                                                              | `true`     | Auto-compact when structured output exceeds raw CLI tokens |
+| `path`            | string                                                                               | cwd        | Working directory                                          |
 
 ## Success — JSON API Response
 


### PR DESCRIPTION
## Summary
- Add schema documentation for all 4 `@paretools/http` tools: `request`, `get`, `post`, `head`
- Each page follows the established template from `docs/tool-schemas/test/run.md`
- Includes input parameter tables, CLI vs Pare output comparisons with token estimates, compact mode examples, error scenarios, and notes

## Files Added
- `docs/tool-schemas/http/request.md` — general-purpose HTTP request (all methods)
- `docs/tool-schemas/http/get.md` — convenience GET wrapper
- `docs/tool-schemas/http/post.md` — convenience POST wrapper with required body and Content-Type
- `docs/tool-schemas/http/head.md` — HEAD request for header inspection without body download

## Test plan
- [x] Verified schema fields match `packages/server-http/src/schemas/index.ts`
- [x] Verified input parameters match tool definitions in `packages/server-http/src/tools/*.ts`
- [x] Verified compact mode behavior matches formatter logic in `packages/server-http/src/lib/formatters.ts`
- [x] Followed exact format of existing `docs/tool-schemas/test/run.md` template

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)