### PR TITLE
docs: add JSDoc to all register*Tool functions

### DIFF
--- a/packages/server-build/src/tools/build.ts
+++ b/packages/server-build/src/tools/build.ts
@@ -12,6 +12,7 @@ import { parseBuildCommandOutput } from "../lib/parsers.js";
 import { formatBuildCommand, compactBuildMap, formatBuildCompact } from "../lib/formatters.js";
 import { BuildResultSchema } from "../schemas/index.js";
 
+/** Registers the `build` tool on the given MCP server. */
 export function registerBuildTool(server: McpServer) {
   server.registerTool(
     "build",

--- a/packages/server-build/src/tools/esbuild.ts
+++ b/packages/server-build/src/tools/esbuild.ts
@@ -6,6 +6,7 @@ import { parseEsbuildOutput } from "../lib/parsers.js";
 import { formatEsbuild, compactEsbuildMap, formatEsbuildCompact } from "../lib/formatters.js";
 import { EsbuildResultSchema } from "../schemas/index.js";
 
+/** Registers the `esbuild` tool on the given MCP server. */
 export function registerEsbuildTool(server: McpServer) {
   server.registerTool(
     "esbuild",

--- a/packages/server-build/src/tools/index.ts
+++ b/packages/server-build/src/tools/index.ts
@@ -8,6 +8,7 @@ import { registerWebpackTool } from "./webpack.js";
 import { registerTurboTool } from "./turbo.js";
 import { registerNxTool } from "./nx.js";
 
+/** Registers all build tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("build", name);
   if (s("tsc")) registerTscTool(server);

--- a/packages/server-build/src/tools/nx.ts
+++ b/packages/server-build/src/tools/nx.ts
@@ -6,6 +6,7 @@ import { parseNxOutput } from "../lib/parsers.js";
 import { formatNx, compactNxMap, formatNxCompact } from "../lib/formatters.js";
 import { NxResultSchema } from "../schemas/index.js";
 
+/** Registers the `nx` tool on the given MCP server. */
 export function registerNxTool(server: McpServer) {
   server.registerTool(
     "nx",

--- a/packages/server-build/src/tools/tsc.ts
+++ b/packages/server-build/src/tools/tsc.ts
@@ -6,6 +6,7 @@ import { parseTscOutput } from "../lib/parsers.js";
 import { formatTsc, compactTscMap, formatTscCompact } from "../lib/formatters.js";
 import { TscResultSchema } from "../schemas/index.js";
 
+/** Registers the `tsc` tool on the given MCP server. */
 export function registerTscTool(server: McpServer) {
   server.registerTool(
     "tsc",

--- a/packages/server-build/src/tools/turbo.ts
+++ b/packages/server-build/src/tools/turbo.ts
@@ -6,6 +6,7 @@ import { parseTurboOutput } from "../lib/parsers.js";
 import { formatTurbo, compactTurboMap, formatTurboCompact } from "../lib/formatters.js";
 import { TurboResultSchema } from "../schemas/index.js";
 
+/** Registers the `turbo` tool on the given MCP server. */
 export function registerTurboTool(server: McpServer) {
   server.registerTool(
     "turbo",

--- a/packages/server-build/src/tools/vite-build.ts
+++ b/packages/server-build/src/tools/vite-build.ts
@@ -6,6 +6,7 @@ import { parseViteBuildOutput } from "../lib/parsers.js";
 import { formatViteBuild, compactViteBuildMap, formatViteBuildCompact } from "../lib/formatters.js";
 import { ViteBuildResultSchema } from "../schemas/index.js";
 
+/** Registers the `vite-build` tool on the given MCP server. */
 export function registerViteBuildTool(server: McpServer) {
   server.registerTool(
     "vite-build",

--- a/packages/server-build/src/tools/webpack.ts
+++ b/packages/server-build/src/tools/webpack.ts
@@ -6,6 +6,7 @@ import { parseWebpackOutput } from "../lib/parsers.js";
 import { formatWebpack, compactWebpackMap, formatWebpackCompact } from "../lib/formatters.js";
 import { WebpackResultSchema } from "../schemas/index.js";
 
+/** Registers the `webpack` tool on the given MCP server. */
 export function registerWebpackTool(server: McpServer) {
   server.registerTool(
     "webpack",

--- a/packages/server-cargo/src/tools/add.ts
+++ b/packages/server-cargo/src/tools/add.ts
@@ -6,6 +6,7 @@ import { parseCargoAddOutput } from "../lib/parsers.js";
 import { formatCargoAdd, compactAddMap, formatAddCompact } from "../lib/formatters.js";
 import { CargoAddResultSchema } from "../schemas/index.js";
 
+/** Registers the `add` tool on the given MCP server. */
 export function registerAddTool(server: McpServer) {
   server.registerTool(
     "add",

--- a/packages/server-cargo/src/tools/audit.ts
+++ b/packages/server-cargo/src/tools/audit.ts
@@ -6,6 +6,7 @@ import { parseCargoAuditJson } from "../lib/parsers.js";
 import { formatCargoAudit, compactAuditMap, formatAuditCompact } from "../lib/formatters.js";
 import { CargoAuditResultSchema } from "../schemas/index.js";
 
+/** Registers the `audit` tool on the given MCP server. */
 export function registerAuditTool(server: McpServer) {
   server.registerTool(
     "audit",

--- a/packages/server-cargo/src/tools/build.ts
+++ b/packages/server-cargo/src/tools/build.ts
@@ -6,6 +6,7 @@ import { parseCargoBuildJson } from "../lib/parsers.js";
 import { formatCargoBuild, compactBuildMap, formatBuildCompact } from "../lib/formatters.js";
 import { CargoBuildResultSchema } from "../schemas/index.js";
 
+/** Registers the `build` tool on the given MCP server. */
 export function registerBuildTool(server: McpServer) {
   server.registerTool(
     "build",

--- a/packages/server-cargo/src/tools/check.ts
+++ b/packages/server-cargo/src/tools/check.ts
@@ -6,6 +6,7 @@ import { parseCargoBuildJson } from "../lib/parsers.js";
 import { formatCargoBuild, compactBuildMap, formatBuildCompact } from "../lib/formatters.js";
 import { CargoBuildResultSchema } from "../schemas/index.js";
 
+/** Registers the `check` tool on the given MCP server. */
 export function registerCheckTool(server: McpServer) {
   server.registerTool(
     "check",

--- a/packages/server-cargo/src/tools/clippy.ts
+++ b/packages/server-cargo/src/tools/clippy.ts
@@ -6,6 +6,7 @@ import { parseCargoClippyJson } from "../lib/parsers.js";
 import { formatCargoClippy, compactClippyMap, formatClippyCompact } from "../lib/formatters.js";
 import { CargoClippyResultSchema } from "../schemas/index.js";
 
+/** Registers the `clippy` tool on the given MCP server. */
 export function registerClippyTool(server: McpServer) {
   server.registerTool(
     "clippy",

--- a/packages/server-cargo/src/tools/doc.ts
+++ b/packages/server-cargo/src/tools/doc.ts
@@ -6,6 +6,7 @@ import { parseCargoDocOutput } from "../lib/parsers.js";
 import { formatCargoDoc, compactDocMap, formatDocCompact } from "../lib/formatters.js";
 import { CargoDocResultSchema } from "../schemas/index.js";
 
+/** Registers the `doc` tool on the given MCP server. */
 export function registerDocTool(server: McpServer) {
   server.registerTool(
     "doc",

--- a/packages/server-cargo/src/tools/fmt.ts
+++ b/packages/server-cargo/src/tools/fmt.ts
@@ -6,6 +6,7 @@ import { parseCargoFmtOutput } from "../lib/parsers.js";
 import { formatCargoFmt, compactFmtMap, formatFmtCompact } from "../lib/formatters.js";
 import { CargoFmtResultSchema } from "../schemas/index.js";
 
+/** Registers the `fmt` tool on the given MCP server. */
 export function registerFmtTool(server: McpServer) {
   server.registerTool(
     "fmt",

--- a/packages/server-cargo/src/tools/index.ts
+++ b/packages/server-cargo/src/tools/index.ts
@@ -13,6 +13,7 @@ import { registerUpdateTool } from "./update.js";
 import { registerTreeTool } from "./tree.js";
 import { registerAuditTool } from "./audit.js";
 
+/** Registers all Cargo tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("cargo", name);
   if (s("build")) registerBuildTool(server);

--- a/packages/server-cargo/src/tools/remove.ts
+++ b/packages/server-cargo/src/tools/remove.ts
@@ -6,6 +6,7 @@ import { parseCargoRemoveOutput } from "../lib/parsers.js";
 import { formatCargoRemove, compactRemoveMap, formatRemoveCompact } from "../lib/formatters.js";
 import { CargoRemoveResultSchema } from "../schemas/index.js";
 
+/** Registers the `remove` tool on the given MCP server. */
 export function registerRemoveTool(server: McpServer) {
   server.registerTool(
     "remove",

--- a/packages/server-cargo/src/tools/run.ts
+++ b/packages/server-cargo/src/tools/run.ts
@@ -6,6 +6,7 @@ import { parseCargoRunOutput } from "../lib/parsers.js";
 import { formatCargoRun, compactRunMap, formatRunCompact } from "../lib/formatters.js";
 import { CargoRunResultSchema } from "../schemas/index.js";
 
+/** Registers the `run` tool on the given MCP server. */
 export function registerRunTool(server: McpServer) {
   server.registerTool(
     "run",

--- a/packages/server-cargo/src/tools/test.ts
+++ b/packages/server-cargo/src/tools/test.ts
@@ -6,6 +6,7 @@ import { parseCargoTestOutput } from "../lib/parsers.js";
 import { formatCargoTest, compactTestMap, formatTestCompact } from "../lib/formatters.js";
 import { CargoTestResultSchema } from "../schemas/index.js";
 
+/** Registers the `test` tool on the given MCP server. */
 export function registerTestTool(server: McpServer) {
   server.registerTool(
     "test",

--- a/packages/server-cargo/src/tools/tree.ts
+++ b/packages/server-cargo/src/tools/tree.ts
@@ -6,6 +6,7 @@ import { parseCargoTreeOutput } from "../lib/parsers.js";
 import { formatCargoTree, compactTreeMap, formatTreeCompact } from "../lib/formatters.js";
 import { CargoTreeResultSchema } from "../schemas/index.js";
 
+/** Registers the `tree` tool on the given MCP server. */
 export function registerTreeTool(server: McpServer) {
   server.registerTool(
     "tree",

--- a/packages/server-cargo/src/tools/update.ts
+++ b/packages/server-cargo/src/tools/update.ts
@@ -6,6 +6,7 @@ import { parseCargoUpdateOutput } from "../lib/parsers.js";
 import { formatCargoUpdate, compactUpdateMap, formatUpdateCompact } from "../lib/formatters.js";
 import { CargoUpdateResultSchema } from "../schemas/index.js";
 
+/** Registers the `update` tool on the given MCP server. */
 export function registerUpdateTool(server: McpServer) {
   server.registerTool(
     "update",

--- a/packages/server-docker/src/tools/build.ts
+++ b/packages/server-docker/src/tools/build.ts
@@ -6,6 +6,7 @@ import { parseBuildOutput } from "../lib/parsers.js";
 import { formatBuild, compactBuildMap, formatBuildCompact } from "../lib/formatters.js";
 import { DockerBuildSchema } from "../schemas/index.js";
 
+/** Registers the `build` tool on the given MCP server. */
 export function registerBuildTool(server: McpServer) {
   server.registerTool(
     "build",

--- a/packages/server-docker/src/tools/compose-build.ts
+++ b/packages/server-docker/src/tools/compose-build.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/formatters.js";
 import { DockerComposeBuildSchema } from "../schemas/index.js";
 
+/** Registers the `compose-build` tool on the given MCP server. */
 export function registerComposeBuildTool(server: McpServer) {
   server.registerTool(
     "compose-build",

--- a/packages/server-docker/src/tools/compose-down.ts
+++ b/packages/server-docker/src/tools/compose-down.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/formatters.js";
 import { DockerComposeDownSchema } from "../schemas/index.js";
 
+/** Registers the `compose-down` tool on the given MCP server. */
 export function registerComposeDownTool(server: McpServer) {
   server.registerTool(
     "compose-down",

--- a/packages/server-docker/src/tools/compose-logs.ts
+++ b/packages/server-docker/src/tools/compose-logs.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/formatters.js";
 import { DockerComposeLogsSchema } from "../schemas/index.js";
 
+/** Registers the `compose-logs` tool on the given MCP server. */
 export function registerComposeLogsTool(server: McpServer) {
   server.registerTool(
     "compose-logs",

--- a/packages/server-docker/src/tools/compose-ps.ts
+++ b/packages/server-docker/src/tools/compose-ps.ts
@@ -6,6 +6,7 @@ import { parseComposePsJson } from "../lib/parsers.js";
 import { formatComposePs, compactComposePsMap, formatComposePsCompact } from "../lib/formatters.js";
 import { DockerComposePsSchema } from "../schemas/index.js";
 
+/** Registers the `compose-ps` tool on the given MCP server. */
 export function registerComposePsTool(server: McpServer) {
   server.registerTool(
     "compose-ps",

--- a/packages/server-docker/src/tools/compose-up.ts
+++ b/packages/server-docker/src/tools/compose-up.ts
@@ -6,6 +6,7 @@ import { parseComposeUpOutput } from "../lib/parsers.js";
 import { formatComposeUp, compactComposeUpMap, formatComposeUpCompact } from "../lib/formatters.js";
 import { DockerComposeUpSchema } from "../schemas/index.js";
 
+/** Registers the `compose-up` tool on the given MCP server. */
 export function registerComposeUpTool(server: McpServer) {
   server.registerTool(
     "compose-up",

--- a/packages/server-docker/src/tools/exec.ts
+++ b/packages/server-docker/src/tools/exec.ts
@@ -6,6 +6,7 @@ import { parseExecOutput } from "../lib/parsers.js";
 import { formatExec, compactExecMap, formatExecCompact } from "../lib/formatters.js";
 import { DockerExecSchema } from "../schemas/index.js";
 
+/** Registers the `exec` tool on the given MCP server. */
 export function registerExecTool(server: McpServer) {
   server.registerTool(
     "exec",

--- a/packages/server-docker/src/tools/images.ts
+++ b/packages/server-docker/src/tools/images.ts
@@ -6,6 +6,7 @@ import { parseImagesJson } from "../lib/parsers.js";
 import { formatImages, compactImagesMap, formatImagesCompact } from "../lib/formatters.js";
 import { DockerImagesSchema } from "../schemas/index.js";
 
+/** Registers the `images` tool on the given MCP server. */
 export function registerImagesTool(server: McpServer) {
   server.registerTool(
     "images",

--- a/packages/server-docker/src/tools/index.ts
+++ b/packages/server-docker/src/tools/index.ts
@@ -18,6 +18,7 @@ import { registerComposeLogsTool } from "./compose-logs.js";
 import { registerComposeBuildTool } from "./compose-build.js";
 import { registerStatsTool } from "./stats.js";
 
+/** Registers all Docker tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("docker", name);
   if (s("ps")) registerPsTool(server);

--- a/packages/server-docker/src/tools/inspect.ts
+++ b/packages/server-docker/src/tools/inspect.ts
@@ -6,6 +6,7 @@ import { parseInspectJson } from "../lib/parsers.js";
 import { formatInspect, compactInspectMap, formatInspectCompact } from "../lib/formatters.js";
 import { DockerInspectSchema } from "../schemas/index.js";
 
+/** Registers the `inspect` tool on the given MCP server. */
 export function registerInspectTool(server: McpServer) {
   server.registerTool(
     "inspect",

--- a/packages/server-docker/src/tools/logs.ts
+++ b/packages/server-docker/src/tools/logs.ts
@@ -6,6 +6,7 @@ import { parseLogsOutput } from "../lib/parsers.js";
 import { formatLogs, compactLogsMap, formatLogsCompact } from "../lib/formatters.js";
 import { DockerLogsSchema } from "../schemas/index.js";
 
+/** Registers the `logs` tool on the given MCP server. */
 export function registerLogsTool(server: McpServer) {
   server.registerTool(
     "logs",

--- a/packages/server-docker/src/tools/network-ls.ts
+++ b/packages/server-docker/src/tools/network-ls.ts
@@ -6,6 +6,7 @@ import { parseNetworkLsJson } from "../lib/parsers.js";
 import { formatNetworkLs, compactNetworkLsMap, formatNetworkLsCompact } from "../lib/formatters.js";
 import { DockerNetworkLsSchema } from "../schemas/index.js";
 
+/** Registers the `network-ls` tool on the given MCP server. */
 export function registerNetworkLsTool(server: McpServer) {
   server.registerTool(
     "network-ls",

--- a/packages/server-docker/src/tools/ps.ts
+++ b/packages/server-docker/src/tools/ps.ts
@@ -6,6 +6,7 @@ import { parsePsJson } from "../lib/parsers.js";
 import { formatPs, compactPsMap, formatPsCompact } from "../lib/formatters.js";
 import { DockerPsSchema } from "../schemas/index.js";
 
+/** Registers the `ps` tool on the given MCP server. */
 export function registerPsTool(server: McpServer) {
   server.registerTool(
     "ps",

--- a/packages/server-docker/src/tools/pull.ts
+++ b/packages/server-docker/src/tools/pull.ts
@@ -6,6 +6,7 @@ import { parsePullOutput } from "../lib/parsers.js";
 import { formatPull, compactPullMap, formatPullCompact } from "../lib/formatters.js";
 import { DockerPullSchema } from "../schemas/index.js";
 
+/** Registers the `pull` tool on the given MCP server. */
 export function registerPullTool(server: McpServer) {
   server.registerTool(
     "pull",

--- a/packages/server-docker/src/tools/run.ts
+++ b/packages/server-docker/src/tools/run.ts
@@ -7,6 +7,7 @@ import { formatRun, compactRunMap, formatRunCompact } from "../lib/formatters.js
 import { DockerRunSchema } from "../schemas/index.js";
 import { assertValidPortMapping, assertSafeVolumeMount } from "../lib/validation.js";
 
+/** Registers the `run` tool on the given MCP server. */
 export function registerRunTool(server: McpServer) {
   server.registerTool(
     "run",

--- a/packages/server-docker/src/tools/stats.ts
+++ b/packages/server-docker/src/tools/stats.ts
@@ -6,6 +6,7 @@ import { parseStatsJson } from "../lib/parsers.js";
 import { formatStats, compactStatsMap, formatStatsCompact } from "../lib/formatters.js";
 import { DockerStatsSchema } from "../schemas/index.js";
 
+/** Registers the `stats` tool on the given MCP server. */
 export function registerStatsTool(server: McpServer) {
   server.registerTool(
     "stats",

--- a/packages/server-docker/src/tools/volume-ls.ts
+++ b/packages/server-docker/src/tools/volume-ls.ts
@@ -6,6 +6,7 @@ import { parseVolumeLsJson } from "../lib/parsers.js";
 import { formatVolumeLs, compactVolumeLsMap, formatVolumeLsCompact } from "../lib/formatters.js";
 import { DockerVolumeLsSchema } from "../schemas/index.js";
 
+/** Registers the `volume-ls` tool on the given MCP server. */
 export function registerVolumeLsTool(server: McpServer) {
   server.registerTool(
     "volume-ls",

--- a/packages/server-git/src/tools/add.ts
+++ b/packages/server-git/src/tools/add.ts
@@ -6,6 +6,7 @@ import { parseAdd } from "../lib/parsers.js";
 import { formatAdd } from "../lib/formatters.js";
 import { GitAddSchema } from "../schemas/index.js";
 
+/** Registers the `add` tool on the given MCP server. */
 export function registerAddTool(server: McpServer) {
   server.registerTool(
     "add",

--- a/packages/server-git/src/tools/bisect.ts
+++ b/packages/server-git/src/tools/bisect.ts
@@ -6,6 +6,7 @@ import { parseBisect } from "../lib/parsers.js";
 import { formatBisect } from "../lib/formatters.js";
 import { GitBisectSchema } from "../schemas/index.js";
 
+/** Registers the `bisect` tool on the given MCP server. */
 export function registerBisectTool(server: McpServer) {
   server.registerTool(
     "bisect",

--- a/packages/server-git/src/tools/blame.ts
+++ b/packages/server-git/src/tools/blame.ts
@@ -6,6 +6,7 @@ import { parseBlameOutput } from "../lib/parsers.js";
 import { formatBlame, compactBlameMap, formatBlameCompact } from "../lib/formatters.js";
 import { GitBlameSchema } from "../schemas/index.js";
 
+/** Registers the `blame` tool on the given MCP server. */
 export function registerBlameTool(server: McpServer) {
   server.registerTool(
     "blame",

--- a/packages/server-git/src/tools/branch.ts
+++ b/packages/server-git/src/tools/branch.ts
@@ -7,6 +7,7 @@ import { parseBranch } from "../lib/parsers.js";
 import { formatBranch, compactBranchMap, formatBranchCompact } from "../lib/formatters.js";
 import { GitBranchSchema } from "../schemas/index.js";
 
+/** Registers the `branch` tool on the given MCP server. */
 export function registerBranchTool(server: McpServer) {
   server.registerTool(
     "branch",

--- a/packages/server-git/src/tools/checkout.ts
+++ b/packages/server-git/src/tools/checkout.ts
@@ -6,6 +6,7 @@ import { parseCheckout } from "../lib/parsers.js";
 import { formatCheckout } from "../lib/formatters.js";
 import { GitCheckoutSchema } from "../schemas/index.js";
 
+/** Registers the `checkout` tool on the given MCP server. */
 export function registerCheckoutTool(server: McpServer) {
   server.registerTool(
     "checkout",

--- a/packages/server-git/src/tools/cherry-pick.ts
+++ b/packages/server-git/src/tools/cherry-pick.ts
@@ -6,6 +6,7 @@ import { parseCherryPick } from "../lib/parsers.js";
 import { formatCherryPick } from "../lib/formatters.js";
 import { GitCherryPickSchema } from "../schemas/index.js";
 
+/** Registers the `cherry-pick` tool on the given MCP server. */
 export function registerCherryPickTool(server: McpServer) {
   server.registerTool(
     "cherry-pick",

--- a/packages/server-git/src/tools/commit.ts
+++ b/packages/server-git/src/tools/commit.ts
@@ -6,6 +6,7 @@ import { parseCommit } from "../lib/parsers.js";
 import { formatCommit } from "../lib/formatters.js";
 import { GitCommitSchema } from "../schemas/index.js";
 
+/** Registers the `commit` tool on the given MCP server. */
 export function registerCommitTool(server: McpServer) {
   server.registerTool(
     "commit",

--- a/packages/server-git/src/tools/diff.ts
+++ b/packages/server-git/src/tools/diff.ts
@@ -7,6 +7,7 @@ import { parseDiffStat } from "../lib/parsers.js";
 import { formatDiff, compactDiffMap, formatDiffCompact } from "../lib/formatters.js";
 import { GitDiffSchema } from "../schemas/index.js";
 
+/** Registers the `diff` tool on the given MCP server. */
 export function registerDiffTool(server: McpServer) {
   server.registerTool(
     "diff",

--- a/packages/server-git/src/tools/index.ts
+++ b/packages/server-git/src/tools/index.ts
@@ -25,6 +25,7 @@ import { registerReflogTool } from "./reflog.js";
 import { registerBisectTool } from "./bisect.js";
 import { registerWorktreeTool } from "./worktree.js";
 
+/** Registers all git tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("git", name);
   if (s("status")) registerStatusTool(server);

--- a/packages/server-git/src/tools/log-graph.ts
+++ b/packages/server-git/src/tools/log-graph.ts
@@ -7,6 +7,7 @@ import { parseLogGraph } from "../lib/parsers.js";
 import { formatLogGraph, compactLogGraphMap, formatLogGraphCompact } from "../lib/formatters.js";
 import { GitLogGraphSchema } from "../schemas/index.js";
 
+/** Registers the `log-graph` tool on the given MCP server. */
 export function registerLogGraphTool(server: McpServer) {
   server.registerTool(
     "log-graph",

--- a/packages/server-git/src/tools/log.ts
+++ b/packages/server-git/src/tools/log.ts
@@ -10,6 +10,7 @@ import { GitLogSchema } from "../schemas/index.js";
 const DELIMITER = "@@";
 const LOG_FORMAT = `%H${DELIMITER}%h${DELIMITER}%an <%ae>${DELIMITER}%ar${DELIMITER}%D${DELIMITER}%s`;
 
+/** Registers the `log` tool on the given MCP server. */
 export function registerLogTool(server: McpServer) {
   server.registerTool(
     "log",

--- a/packages/server-git/src/tools/merge.ts
+++ b/packages/server-git/src/tools/merge.ts
@@ -6,6 +6,7 @@ import { parseMerge, parseMergeAbort } from "../lib/parsers.js";
 import { formatMerge } from "../lib/formatters.js";
 import { GitMergeSchema } from "../schemas/index.js";
 
+/** Registers the `merge` tool on the given MCP server. */
 export function registerMergeTool(server: McpServer) {
   server.registerTool(
     "merge",

--- a/packages/server-git/src/tools/pull.ts
+++ b/packages/server-git/src/tools/pull.ts
@@ -6,6 +6,7 @@ import { parsePull } from "../lib/parsers.js";
 import { formatPull } from "../lib/formatters.js";
 import { GitPullSchema } from "../schemas/index.js";
 
+/** Registers the `pull` tool on the given MCP server. */
 export function registerPullTool(server: McpServer) {
   server.registerTool(
     "pull",

--- a/packages/server-git/src/tools/push.ts
+++ b/packages/server-git/src/tools/push.ts
@@ -6,6 +6,7 @@ import { parsePush } from "../lib/parsers.js";
 import { formatPush } from "../lib/formatters.js";
 import { GitPushSchema } from "../schemas/index.js";
 
+/** Registers the `push` tool on the given MCP server. */
 export function registerPushTool(server: McpServer) {
   server.registerTool(
     "push",

--- a/packages/server-git/src/tools/rebase.ts
+++ b/packages/server-git/src/tools/rebase.ts
@@ -6,6 +6,7 @@ import { parseRebase } from "../lib/parsers.js";
 import { formatRebase } from "../lib/formatters.js";
 import { GitRebaseSchema } from "../schemas/index.js";
 
+/** Registers the `rebase` tool on the given MCP server. */
 export function registerRebaseTool(server: McpServer) {
   server.registerTool(
     "rebase",

--- a/packages/server-git/src/tools/reflog.ts
+++ b/packages/server-git/src/tools/reflog.ts
@@ -9,6 +9,7 @@ import { GitReflogSchema } from "../schemas/index.js";
 
 const REFLOG_FORMAT = "%H\t%h\t%gd\t%gs\t%ci";
 
+/** Registers the `reflog` tool on the given MCP server. */
 export function registerReflogTool(server: McpServer) {
   server.registerTool(
     "reflog",

--- a/packages/server-git/src/tools/remote.ts
+++ b/packages/server-git/src/tools/remote.ts
@@ -6,6 +6,7 @@ import { parseRemoteOutput } from "../lib/parsers.js";
 import { formatRemote, compactRemoteMap, formatRemoteCompact } from "../lib/formatters.js";
 import { GitRemoteSchema } from "../schemas/index.js";
 
+/** Registers the `remote` tool on the given MCP server. */
 export function registerRemoteTool(server: McpServer) {
   server.registerTool(
     "remote",

--- a/packages/server-git/src/tools/reset.ts
+++ b/packages/server-git/src/tools/reset.ts
@@ -6,6 +6,7 @@ import { parseReset } from "../lib/parsers.js";
 import { formatReset } from "../lib/formatters.js";
 import { GitResetSchema } from "../schemas/index.js";
 
+/** Registers the `reset` tool on the given MCP server. */
 export function registerResetTool(server: McpServer) {
   server.registerTool(
     "reset",

--- a/packages/server-git/src/tools/restore.ts
+++ b/packages/server-git/src/tools/restore.ts
@@ -6,6 +6,7 @@ import { parseRestore } from "../lib/parsers.js";
 import { formatRestore } from "../lib/formatters.js";
 import { GitRestoreSchema } from "../schemas/index.js";
 
+/** Registers the `restore` tool on the given MCP server. */
 export function registerRestoreTool(server: McpServer) {
   server.registerTool(
     "restore",

--- a/packages/server-git/src/tools/show.ts
+++ b/packages/server-git/src/tools/show.ts
@@ -10,6 +10,7 @@ import { GitShowSchema } from "../schemas/index.js";
 const DELIMITER = "@@";
 const SHOW_FORMAT = `%H${DELIMITER}%an <%ae>${DELIMITER}%ar${DELIMITER}%B`;
 
+/** Registers the `show` tool on the given MCP server. */
 export function registerShowTool(server: McpServer) {
   server.registerTool(
     "show",

--- a/packages/server-git/src/tools/stash-list.ts
+++ b/packages/server-git/src/tools/stash-list.ts
@@ -6,6 +6,7 @@ import { parseStashListOutput } from "../lib/parsers.js";
 import { formatStashList, compactStashListMap, formatStashListCompact } from "../lib/formatters.js";
 import { GitStashListSchema } from "../schemas/index.js";
 
+/** Registers the `stash-list` tool on the given MCP server. */
 export function registerStashListTool(server: McpServer) {
   server.registerTool(
     "stash-list",

--- a/packages/server-git/src/tools/stash.ts
+++ b/packages/server-git/src/tools/stash.ts
@@ -6,6 +6,7 @@ import { parseStashOutput } from "../lib/parsers.js";
 import { formatStash } from "../lib/formatters.js";
 import { GitStashSchema } from "../schemas/index.js";
 
+/** Registers the `stash` tool on the given MCP server. */
 export function registerStashTool(server: McpServer) {
   server.registerTool(
     "stash",

--- a/packages/server-git/src/tools/status.ts
+++ b/packages/server-git/src/tools/status.ts
@@ -6,6 +6,7 @@ import { parseStatus } from "../lib/parsers.js";
 import { formatStatus } from "../lib/formatters.js";
 import { GitStatusSchema } from "../schemas/index.js";
 
+/** Registers the `status` tool on the given MCP server. */
 export function registerStatusTool(server: McpServer) {
   server.registerTool(
     "status",

--- a/packages/server-git/src/tools/tag.ts
+++ b/packages/server-git/src/tools/tag.ts
@@ -6,6 +6,7 @@ import { parseTagOutput } from "../lib/parsers.js";
 import { formatTag, compactTagMap, formatTagCompact } from "../lib/formatters.js";
 import { GitTagSchema } from "../schemas/index.js";
 
+/** Registers the `tag` tool on the given MCP server. */
 export function registerTagTool(server: McpServer) {
   server.registerTool(
     "tag",

--- a/packages/server-git/src/tools/worktree.ts
+++ b/packages/server-git/src/tools/worktree.ts
@@ -16,6 +16,7 @@ import {
 } from "../lib/formatters.js";
 import { GitWorktreeListSchema, GitWorktreeSchema } from "../schemas/index.js";
 
+/** Registers the `worktree` tool on the given MCP server. */
 export function registerWorktreeTool(server: McpServer) {
   server.registerTool(
     "worktree",

--- a/packages/server-github/src/tools/api.ts
+++ b/packages/server-github/src/tools/api.ts
@@ -6,6 +6,7 @@ import { parseApi } from "../lib/parsers.js";
 import { formatApi } from "../lib/formatters.js";
 import { ApiResultSchema } from "../schemas/index.js";
 
+/** Registers the `api` tool on the given MCP server. */
 export function registerApiTool(server: McpServer) {
   server.registerTool(
     "api",

--- a/packages/server-github/src/tools/gist-create.ts
+++ b/packages/server-github/src/tools/gist-create.ts
@@ -6,6 +6,7 @@ import { parseGistCreate } from "../lib/parsers.js";
 import { formatGistCreate } from "../lib/formatters.js";
 import { GistCreateResultSchema } from "../schemas/index.js";
 
+/** Registers the `gist-create` tool on the given MCP server. */
 export function registerGistCreateTool(server: McpServer) {
   server.registerTool(
     "gist-create",

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -23,6 +23,7 @@ import { registerReleaseCreateTool } from "./release-create.js";
 import { registerGistCreateTool } from "./gist-create.js";
 import { registerReleaseListTool } from "./release-list.js";
 
+/** Registers all GitHub tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("github", name);
   if (s("pr-view")) registerPrViewTool(server);

--- a/packages/server-github/src/tools/issue-close.ts
+++ b/packages/server-github/src/tools/issue-close.ts
@@ -6,6 +6,7 @@ import { parseIssueClose } from "../lib/parsers.js";
 import { formatIssueClose } from "../lib/formatters.js";
 import { IssueCloseResultSchema } from "../schemas/index.js";
 
+/** Registers the `issue-close` tool on the given MCP server. */
 export function registerIssueCloseTool(server: McpServer) {
   server.registerTool(
     "issue-close",

--- a/packages/server-github/src/tools/issue-comment.ts
+++ b/packages/server-github/src/tools/issue-comment.ts
@@ -6,6 +6,7 @@ import { parseComment } from "../lib/parsers.js";
 import { formatComment } from "../lib/formatters.js";
 import { CommentResultSchema } from "../schemas/index.js";
 
+/** Registers the `issue-comment` tool on the given MCP server. */
 export function registerIssueCommentTool(server: McpServer) {
   server.registerTool(
     "issue-comment",

--- a/packages/server-github/src/tools/issue-create.ts
+++ b/packages/server-github/src/tools/issue-create.ts
@@ -6,6 +6,7 @@ import { parseIssueCreate } from "../lib/parsers.js";
 import { formatIssueCreate } from "../lib/formatters.js";
 import { IssueCreateResultSchema } from "../schemas/index.js";
 
+/** Registers the `issue-create` tool on the given MCP server. */
 export function registerIssueCreateTool(server: McpServer) {
   server.registerTool(
     "issue-create",

--- a/packages/server-github/src/tools/issue-list.ts
+++ b/packages/server-github/src/tools/issue-list.ts
@@ -8,6 +8,7 @@ import { IssueListResultSchema } from "../schemas/index.js";
 
 const ISSUE_LIST_FIELDS = "number,state,title,url,labels,assignees";
 
+/** Registers the `issue-list` tool on the given MCP server. */
 export function registerIssueListTool(server: McpServer) {
   server.registerTool(
     "issue-list",

--- a/packages/server-github/src/tools/issue-update.ts
+++ b/packages/server-github/src/tools/issue-update.ts
@@ -6,6 +6,7 @@ import { parseIssueUpdate } from "../lib/parsers.js";
 import { formatIssueUpdate } from "../lib/formatters.js";
 import { EditResultSchema } from "../schemas/index.js";
 
+/** Registers the `issue-update` tool on the given MCP server. */
 export function registerIssueUpdateTool(server: McpServer) {
   server.registerTool(
     "issue-update",

--- a/packages/server-github/src/tools/issue-view.ts
+++ b/packages/server-github/src/tools/issue-view.ts
@@ -8,6 +8,7 @@ import { IssueViewResultSchema } from "../schemas/index.js";
 
 const ISSUE_VIEW_FIELDS = "number,state,title,body,labels,assignees,url,createdAt";
 
+/** Registers the `issue-view` tool on the given MCP server. */
 export function registerIssueViewTool(server: McpServer) {
   server.registerTool(
     "issue-view",

--- a/packages/server-github/src/tools/pr-checks.ts
+++ b/packages/server-github/src/tools/pr-checks.ts
@@ -8,6 +8,7 @@ import { PrChecksResultSchema } from "../schemas/index.js";
 
 const PR_CHECKS_FIELDS = "name,state,bucket,description,event,workflow,link,startedAt,completedAt";
 
+/** Registers the `pr-checks` tool on the given MCP server. */
 export function registerPrChecksTool(server: McpServer) {
   server.registerTool(
     "pr-checks",

--- a/packages/server-github/src/tools/pr-comment.ts
+++ b/packages/server-github/src/tools/pr-comment.ts
@@ -6,6 +6,7 @@ import { parseComment } from "../lib/parsers.js";
 import { formatComment } from "../lib/formatters.js";
 import { CommentResultSchema } from "../schemas/index.js";
 
+/** Registers the `pr-comment` tool on the given MCP server. */
 export function registerPrCommentTool(server: McpServer) {
   server.registerTool(
     "pr-comment",

--- a/packages/server-github/src/tools/pr-create.ts
+++ b/packages/server-github/src/tools/pr-create.ts
@@ -6,6 +6,7 @@ import { parsePrCreate } from "../lib/parsers.js";
 import { formatPrCreate } from "../lib/formatters.js";
 import { PrCreateResultSchema } from "../schemas/index.js";
 
+/** Registers the `pr-create` tool on the given MCP server. */
 export function registerPrCreateTool(server: McpServer) {
   server.registerTool(
     "pr-create",

--- a/packages/server-github/src/tools/pr-diff.ts
+++ b/packages/server-github/src/tools/pr-diff.ts
@@ -7,6 +7,7 @@ import { parsePrDiffNumstat } from "../lib/parsers.js";
 import { formatPrDiff, compactPrDiffMap, formatPrDiffCompact } from "../lib/formatters.js";
 import { PrDiffResultSchema } from "../schemas/index.js";
 
+/** Registers the `pr-diff` tool on the given MCP server. */
 export function registerPrDiffTool(server: McpServer) {
   server.registerTool(
     "pr-diff",

--- a/packages/server-github/src/tools/pr-list.ts
+++ b/packages/server-github/src/tools/pr-list.ts
@@ -8,6 +8,7 @@ import { PrListResultSchema } from "../schemas/index.js";
 
 const PR_LIST_FIELDS = "number,state,title,url,headRefName,author";
 
+/** Registers the `pr-list` tool on the given MCP server. */
 export function registerPrListTool(server: McpServer) {
   server.registerTool(
     "pr-list",

--- a/packages/server-github/src/tools/pr-merge.ts
+++ b/packages/server-github/src/tools/pr-merge.ts
@@ -6,6 +6,7 @@ import { parsePrMerge } from "../lib/parsers.js";
 import { formatPrMerge } from "../lib/formatters.js";
 import { PrMergeResultSchema } from "../schemas/index.js";
 
+/** Registers the `pr-merge` tool on the given MCP server. */
 export function registerPrMergeTool(server: McpServer) {
   server.registerTool(
     "pr-merge",

--- a/packages/server-github/src/tools/pr-review.ts
+++ b/packages/server-github/src/tools/pr-review.ts
@@ -6,6 +6,7 @@ import { parsePrReview } from "../lib/parsers.js";
 import { formatPrReview } from "../lib/formatters.js";
 import { PrReviewResultSchema } from "../schemas/index.js";
 
+/** Registers the `pr-review` tool on the given MCP server. */
 export function registerPrReviewTool(server: McpServer) {
   server.registerTool(
     "pr-review",

--- a/packages/server-github/src/tools/pr-update.ts
+++ b/packages/server-github/src/tools/pr-update.ts
@@ -6,6 +6,7 @@ import { parsePrUpdate } from "../lib/parsers.js";
 import { formatPrUpdate } from "../lib/formatters.js";
 import { EditResultSchema } from "../schemas/index.js";
 
+/** Registers the `pr-update` tool on the given MCP server. */
 export function registerPrUpdateTool(server: McpServer) {
   server.registerTool(
     "pr-update",

--- a/packages/server-github/src/tools/pr-view.ts
+++ b/packages/server-github/src/tools/pr-view.ts
@@ -9,6 +9,7 @@ import { PrViewResultSchema } from "../schemas/index.js";
 const PR_VIEW_FIELDS =
   "number,state,title,body,mergeable,reviewDecision,statusCheckRollup,url,headRefName,baseRefName,additions,deletions,changedFiles";
 
+/** Registers the `pr-view` tool on the given MCP server. */
 export function registerPrViewTool(server: McpServer) {
   server.registerTool(
     "pr-view",

--- a/packages/server-github/src/tools/release-create.ts
+++ b/packages/server-github/src/tools/release-create.ts
@@ -6,6 +6,7 @@ import { parseReleaseCreate } from "../lib/parsers.js";
 import { formatReleaseCreate } from "../lib/formatters.js";
 import { ReleaseCreateResultSchema } from "../schemas/index.js";
 
+/** Registers the `release-create` tool on the given MCP server. */
 export function registerReleaseCreateTool(server: McpServer) {
   server.registerTool(
     "release-create",

--- a/packages/server-github/src/tools/release-list.ts
+++ b/packages/server-github/src/tools/release-list.ts
@@ -12,6 +12,7 @@ import { ReleaseListResultSchema } from "../schemas/index.js";
 
 const RELEASE_LIST_FIELDS = "tagName,name,isDraft,isPrerelease,publishedAt,url";
 
+/** Registers the `release-list` tool on the given MCP server. */
 export function registerReleaseListTool(server: McpServer) {
   server.registerTool(
     "release-list",

--- a/packages/server-github/src/tools/run-list.ts
+++ b/packages/server-github/src/tools/run-list.ts
@@ -8,6 +8,7 @@ import { RunListResultSchema } from "../schemas/index.js";
 
 const RUN_LIST_FIELDS = "databaseId,status,conclusion,name,workflowName,headBranch,url,createdAt";
 
+/** Registers the `run-list` tool on the given MCP server. */
 export function registerRunListTool(server: McpServer) {
   server.registerTool(
     "run-list",

--- a/packages/server-github/src/tools/run-rerun.ts
+++ b/packages/server-github/src/tools/run-rerun.ts
@@ -6,6 +6,7 @@ import { parseRunRerun } from "../lib/parsers.js";
 import { formatRunRerun } from "../lib/formatters.js";
 import { RunRerunResultSchema } from "../schemas/index.js";
 
+/** Registers the `run-rerun` tool on the given MCP server. */
 export function registerRunRerunTool(server: McpServer) {
   server.registerTool(
     "run-rerun",

--- a/packages/server-github/src/tools/run-view.ts
+++ b/packages/server-github/src/tools/run-view.ts
@@ -9,6 +9,7 @@ import { RunViewResultSchema } from "../schemas/index.js";
 const RUN_VIEW_FIELDS =
   "databaseId,status,conclusion,name,workflowName,headBranch,jobs,url,createdAt";
 
+/** Registers the `run-view` tool on the given MCP server. */
 export function registerRunViewTool(server: McpServer) {
   server.registerTool(
     "run-view",

--- a/packages/server-go/src/tools/build.ts
+++ b/packages/server-go/src/tools/build.ts
@@ -6,6 +6,7 @@ import { parseGoBuildOutput } from "../lib/parsers.js";
 import { formatGoBuild, compactBuildMap, formatBuildCompact } from "../lib/formatters.js";
 import { GoBuildResultSchema } from "../schemas/index.js";
 
+/** Registers the `build` tool on the given MCP server. */
 export function registerBuildTool(server: McpServer) {
   server.registerTool(
     "build",

--- a/packages/server-go/src/tools/env.ts
+++ b/packages/server-go/src/tools/env.ts
@@ -6,6 +6,7 @@ import { parseGoEnvOutput } from "../lib/parsers.js";
 import { formatGoEnv, compactEnvMap, formatEnvCompact } from "../lib/formatters.js";
 import { GoEnvResultSchema } from "../schemas/index.js";
 
+/** Registers the `env` tool on the given MCP server. */
 export function registerEnvTool(server: McpServer) {
   server.registerTool(
     "env",

--- a/packages/server-go/src/tools/fmt.ts
+++ b/packages/server-go/src/tools/fmt.ts
@@ -6,6 +6,7 @@ import { parseGoFmtOutput } from "../lib/parsers.js";
 import { formatGoFmt, compactFmtMap, formatFmtCompact } from "../lib/formatters.js";
 import { GoFmtResultSchema } from "../schemas/index.js";
 
+/** Registers the `fmt` tool on the given MCP server. */
 export function registerFmtTool(server: McpServer) {
   server.registerTool(
     "fmt",

--- a/packages/server-go/src/tools/generate.ts
+++ b/packages/server-go/src/tools/generate.ts
@@ -6,6 +6,7 @@ import { parseGoGenerateOutput } from "../lib/parsers.js";
 import { formatGoGenerate, compactGenerateMap, formatGenerateCompact } from "../lib/formatters.js";
 import { GoGenerateResultSchema } from "../schemas/index.js";
 
+/** Registers the `generate` tool on the given MCP server. */
 export function registerGenerateTool(server: McpServer) {
   server.registerTool(
     "generate",

--- a/packages/server-go/src/tools/get.ts
+++ b/packages/server-go/src/tools/get.ts
@@ -6,6 +6,7 @@ import { parseGoGetOutput } from "../lib/parsers.js";
 import { formatGoGet, compactGetMap, formatGetCompact } from "../lib/formatters.js";
 import { GoGetResultSchema } from "../schemas/index.js";
 
+/** Registers the `get` tool on the given MCP server. */
 export function registerGetTool(server: McpServer) {
   server.registerTool(
     "get",

--- a/packages/server-go/src/tools/golangci-lint.ts
+++ b/packages/server-go/src/tools/golangci-lint.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/formatters.js";
 import { GolangciLintResultSchema } from "../schemas/index.js";
 
+/** Registers the `golangci-lint` tool on the given MCP server. */
 export function registerGolangciLintTool(server: McpServer) {
   server.registerTool(
     "golangci-lint",

--- a/packages/server-go/src/tools/index.ts
+++ b/packages/server-go/src/tools/index.ts
@@ -12,6 +12,7 @@ import { registerListTool } from "./list.js";
 import { registerGetTool } from "./get.js";
 import { registerGolangciLintTool } from "./golangci-lint.js";
 
+/** Registers all Go tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("go", name);
   if (s("build")) registerBuildTool(server);

--- a/packages/server-go/src/tools/list.ts
+++ b/packages/server-go/src/tools/list.ts
@@ -6,6 +6,7 @@ import { parseGoListOutput } from "../lib/parsers.js";
 import { formatGoList, compactListMap, formatListCompact } from "../lib/formatters.js";
 import { GoListResultSchema } from "../schemas/index.js";
 
+/** Registers the `list` tool on the given MCP server. */
 export function registerListTool(server: McpServer) {
   server.registerTool(
     "list",

--- a/packages/server-go/src/tools/mod-tidy.ts
+++ b/packages/server-go/src/tools/mod-tidy.ts
@@ -6,6 +6,7 @@ import { parseGoModTidyOutput } from "../lib/parsers.js";
 import { formatGoModTidy, compactModTidyMap, formatModTidyCompact } from "../lib/formatters.js";
 import { GoModTidyResultSchema } from "../schemas/index.js";
 
+/** Registers the `mod-tidy` tool on the given MCP server. */
 export function registerModTidyTool(server: McpServer) {
   server.registerTool(
     "mod-tidy",

--- a/packages/server-go/src/tools/run.ts
+++ b/packages/server-go/src/tools/run.ts
@@ -6,6 +6,7 @@ import { parseGoRunOutput } from "../lib/parsers.js";
 import { formatGoRun, compactRunMap, formatRunCompact } from "../lib/formatters.js";
 import { GoRunResultSchema } from "../schemas/index.js";
 
+/** Registers the `run` tool on the given MCP server. */
 export function registerRunTool(server: McpServer) {
   server.registerTool(
     "run",

--- a/packages/server-go/src/tools/test.ts
+++ b/packages/server-go/src/tools/test.ts
@@ -6,6 +6,7 @@ import { parseGoTestJson } from "../lib/parsers.js";
 import { formatGoTest, compactTestMap, formatTestCompact } from "../lib/formatters.js";
 import { GoTestResultSchema } from "../schemas/index.js";
 
+/** Registers the `test` tool on the given MCP server. */
 export function registerTestTool(server: McpServer) {
   server.registerTool(
     "test",

--- a/packages/server-go/src/tools/vet.ts
+++ b/packages/server-go/src/tools/vet.ts
@@ -6,6 +6,7 @@ import { parseGoVetOutput } from "../lib/parsers.js";
 import { formatGoVet, compactVetMap, formatVetCompact } from "../lib/formatters.js";
 import { GoVetResultSchema } from "../schemas/index.js";
 
+/** Registers the `vet` tool on the given MCP server. */
 export function registerVetTool(server: McpServer) {
   server.registerTool(
     "vet",

--- a/packages/server-http/src/tools/get.ts
+++ b/packages/server-http/src/tools/get.ts
@@ -12,6 +12,7 @@ import { HttpResponseSchema } from "../schemas/index.js";
 import { assertSafeUrl } from "../lib/url-validation.js";
 import { buildCurlArgs } from "./request.js";
 
+/** Registers the `get` tool on the given MCP server. */
 export function registerGetTool(server: McpServer) {
   server.registerTool(
     "get",

--- a/packages/server-http/src/tools/head.ts
+++ b/packages/server-http/src/tools/head.ts
@@ -12,6 +12,7 @@ import { HttpHeadResponseSchema } from "../schemas/index.js";
 import { assertSafeUrl } from "../lib/url-validation.js";
 import { buildCurlArgs } from "./request.js";
 
+/** Registers the `head` tool on the given MCP server. */
 export function registerHeadTool(server: McpServer) {
   server.registerTool(
     "head",

--- a/packages/server-http/src/tools/index.ts
+++ b/packages/server-http/src/tools/index.ts
@@ -5,6 +5,7 @@ import { registerGetTool } from "./get.js";
 import { registerPostTool } from "./post.js";
 import { registerHeadTool } from "./head.js";
 
+/** Registers all HTTP tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("http", name);
   if (s("request")) registerRequestTool(server);

--- a/packages/server-http/src/tools/post.ts
+++ b/packages/server-http/src/tools/post.ts
@@ -12,6 +12,7 @@ import { HttpResponseSchema } from "../schemas/index.js";
 import { assertSafeUrl } from "../lib/url-validation.js";
 import { buildCurlArgs } from "./request.js";
 
+/** Registers the `post` tool on the given MCP server. */
 export function registerPostTool(server: McpServer) {
   server.registerTool(
     "post",

--- a/packages/server-http/src/tools/request.ts
+++ b/packages/server-http/src/tools/request.ts
@@ -13,6 +13,7 @@ import { assertSafeUrl, assertSafeHeader } from "../lib/url-validation.js";
 
 const METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"] as const;
 
+/** Registers the `request` tool on the given MCP server. */
 export function registerRequestTool(server: McpServer) {
   server.registerTool(
     "request",

--- a/packages/server-k8s/src/tools/apply.ts
+++ b/packages/server-k8s/src/tools/apply.ts
@@ -5,6 +5,7 @@ import { parseApplyOutput } from "../lib/parsers.js";
 import { formatApply, compactApplyMap, formatApplyCompact } from "../lib/formatters.js";
 import { KubectlApplyResultSchema } from "../schemas/index.js";
 
+/** Registers the `apply` tool on the given MCP server. */
 export function registerApplyTool(server: McpServer) {
   server.registerTool(
     "apply",

--- a/packages/server-k8s/src/tools/describe.ts
+++ b/packages/server-k8s/src/tools/describe.ts
@@ -5,6 +5,7 @@ import { parseDescribeOutput } from "../lib/parsers.js";
 import { formatDescribe, compactDescribeMap, formatDescribeCompact } from "../lib/formatters.js";
 import { KubectlDescribeResultSchema } from "../schemas/index.js";
 
+/** Registers the `describe` tool on the given MCP server. */
 export function registerDescribeTool(server: McpServer) {
   server.registerTool(
     "describe",

--- a/packages/server-k8s/src/tools/get.ts
+++ b/packages/server-k8s/src/tools/get.ts
@@ -5,6 +5,7 @@ import { parseGetOutput } from "../lib/parsers.js";
 import { formatGet, compactGetMap, formatGetCompact } from "../lib/formatters.js";
 import { KubectlGetResultSchema } from "../schemas/index.js";
 
+/** Registers the `get` tool on the given MCP server. */
 export function registerGetTool(server: McpServer) {
   server.registerTool(
     "get",

--- a/packages/server-k8s/src/tools/helm.ts
+++ b/packages/server-k8s/src/tools/helm.ts
@@ -28,6 +28,7 @@ import {
   HelmUpgradeResultSchema,
 } from "../schemas/index.js";
 
+/** Registers the `helm` tool on the given MCP server. */
 export function registerHelmTool(server: McpServer) {
   server.registerTool(
     "helm",

--- a/packages/server-k8s/src/tools/index.ts
+++ b/packages/server-k8s/src/tools/index.ts
@@ -6,6 +6,7 @@ import { registerLogsTool } from "./logs.js";
 import { registerApplyTool } from "./apply.js";
 import { registerHelmTool } from "./helm.js";
 
+/** Registers all Kubernetes tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("k8s", name);
   if (s("get")) registerGetTool(server);

--- a/packages/server-k8s/src/tools/logs.ts
+++ b/packages/server-k8s/src/tools/logs.ts
@@ -5,6 +5,7 @@ import { parseLogsOutput } from "../lib/parsers.js";
 import { formatLogs, compactLogsMap, formatLogsCompact } from "../lib/formatters.js";
 import { KubectlLogsResultSchema } from "../schemas/index.js";
 
+/** Registers the `logs` tool on the given MCP server. */
 export function registerLogsTool(server: McpServer) {
   server.registerTool(
     "logs",

--- a/packages/server-lint/src/tools/biome-check.ts
+++ b/packages/server-lint/src/tools/biome-check.ts
@@ -6,6 +6,7 @@ import { parseBiomeJson } from "../lib/parsers.js";
 import { formatLint, compactLintMap, formatLintCompact } from "../lib/formatters.js";
 import { LintResultSchema } from "../schemas/index.js";
 
+/** Registers the `biome-check` tool on the given MCP server. */
 export function registerBiomeCheckTool(server: McpServer) {
   server.registerTool(
     "biome-check",

--- a/packages/server-lint/src/tools/biome-format.ts
+++ b/packages/server-lint/src/tools/biome-format.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/formatters.js";
 import { FormatWriteResultSchema } from "../schemas/index.js";
 
+/** Registers the `biome-format` tool on the given MCP server. */
 export function registerBiomeFormatTool(server: McpServer) {
   server.registerTool(
     "biome-format",

--- a/packages/server-lint/src/tools/format-check.ts
+++ b/packages/server-lint/src/tools/format-check.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/formatters.js";
 import { FormatCheckResultSchema } from "../schemas/index.js";
 
+/** Registers the `format-check` tool on the given MCP server. */
 export function registerFormatCheckTool(server: McpServer) {
   server.registerTool(
     "format-check",

--- a/packages/server-lint/src/tools/hadolint.ts
+++ b/packages/server-lint/src/tools/hadolint.ts
@@ -6,6 +6,7 @@ import { parseHadolintJson } from "../lib/parsers.js";
 import { formatLint, compactLintMap, formatLintCompact } from "../lib/formatters.js";
 import { LintResultSchema } from "../schemas/index.js";
 
+/** Registers the `hadolint` tool on the given MCP server. */
 export function registerHadolintTool(server: McpServer) {
   server.registerTool(
     "hadolint",

--- a/packages/server-lint/src/tools/index.ts
+++ b/packages/server-lint/src/tools/index.ts
@@ -10,6 +10,7 @@ import { registerOxlintTool } from "./oxlint.js";
 import { registerShellcheckTool } from "./shellcheck.js";
 import { registerHadolintTool } from "./hadolint.js";
 
+/** Registers all lint tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("lint", name);
   if (s("lint")) registerLintTool(server);

--- a/packages/server-lint/src/tools/lint.ts
+++ b/packages/server-lint/src/tools/lint.ts
@@ -6,6 +6,7 @@ import { parseEslintJson } from "../lib/parsers.js";
 import { formatLint, compactLintMap, formatLintCompact } from "../lib/formatters.js";
 import { LintResultSchema } from "../schemas/index.js";
 
+/** Registers the `lint` tool on the given MCP server. */
 export function registerLintTool(server: McpServer) {
   server.registerTool(
     "lint",

--- a/packages/server-lint/src/tools/oxlint.ts
+++ b/packages/server-lint/src/tools/oxlint.ts
@@ -6,6 +6,7 @@ import { parseOxlintJson } from "../lib/parsers.js";
 import { formatLint, compactLintMap, formatLintCompact } from "../lib/formatters.js";
 import { LintResultSchema } from "../schemas/index.js";
 
+/** Registers the `oxlint` tool on the given MCP server. */
 export function registerOxlintTool(server: McpServer) {
   server.registerTool(
     "oxlint",

--- a/packages/server-lint/src/tools/prettier-format.ts
+++ b/packages/server-lint/src/tools/prettier-format.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/formatters.js";
 import { FormatWriteResultSchema } from "../schemas/index.js";
 
+/** Registers the `prettier-format` tool on the given MCP server. */
 export function registerPrettierFormatTool(server: McpServer) {
   server.registerTool(
     "prettier-format",

--- a/packages/server-lint/src/tools/shellcheck.ts
+++ b/packages/server-lint/src/tools/shellcheck.ts
@@ -6,6 +6,7 @@ import { parseShellcheckJson } from "../lib/parsers.js";
 import { formatLint, compactLintMap, formatLintCompact } from "../lib/formatters.js";
 import { LintResultSchema } from "../schemas/index.js";
 
+/** Registers the `shellcheck` tool on the given MCP server. */
 export function registerShellcheckTool(server: McpServer) {
   server.registerTool(
     "shellcheck",

--- a/packages/server-lint/src/tools/stylelint.ts
+++ b/packages/server-lint/src/tools/stylelint.ts
@@ -6,6 +6,7 @@ import { parseStylelintJson } from "../lib/parsers.js";
 import { formatLint, compactLintMap, formatLintCompact } from "../lib/formatters.js";
 import { LintResultSchema } from "../schemas/index.js";
 
+/** Registers the `stylelint` tool on the given MCP server. */
 export function registerStylelintTool(server: McpServer) {
   server.registerTool(
     "stylelint",

--- a/packages/server-make/src/tools/index.ts
+++ b/packages/server-make/src/tools/index.ts
@@ -3,6 +3,7 @@ import { shouldRegisterTool } from "@paretools/shared";
 import { registerRunTool } from "./run.js";
 import { registerListTool } from "./list.js";
 
+/** Registers all Make tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("make", name);
   if (s("run")) registerRunTool(server);

--- a/packages/server-make/src/tools/list.ts
+++ b/packages/server-make/src/tools/list.ts
@@ -6,6 +6,7 @@ import { parseJustList, parseMakeTargets, buildListResult } from "../lib/parsers
 import { formatList, compactListMap, formatListCompact } from "../lib/formatters.js";
 import { MakeListResultSchema } from "../schemas/index.js";
 
+/** Registers the `list` tool on the given MCP server. */
 export function registerListTool(server: McpServer) {
   server.registerTool(
     "list",

--- a/packages/server-make/src/tools/run.ts
+++ b/packages/server-make/src/tools/run.ts
@@ -6,6 +6,7 @@ import { parseRunOutput } from "../lib/parsers.js";
 import { formatRun, compactRunMap, formatRunCompact } from "../lib/formatters.js";
 import { MakeRunResultSchema } from "../schemas/index.js";
 
+/** Registers the `run` tool on the given MCP server. */
 export function registerRunTool(server: McpServer) {
   server.registerTool(
     "run",

--- a/packages/server-npm/src/tools/audit.ts
+++ b/packages/server-npm/src/tools/audit.ts
@@ -8,6 +8,7 @@ import { formatAudit } from "../lib/formatters.js";
 import { NpmAuditSchema } from "../schemas/index.js";
 import { packageManagerInput } from "../lib/pm-input.js";
 
+/** Registers the `audit` tool on the given MCP server. */
 export function registerAuditTool(server: McpServer) {
   server.registerTool(
     "audit",

--- a/packages/server-npm/src/tools/index.ts
+++ b/packages/server-npm/src/tools/index.ts
@@ -11,6 +11,7 @@ import { registerInfoTool } from "./info.js";
 import { registerSearchTool } from "./search.js";
 import { registerNvmTool } from "./nvm.js";
 
+/** Registers all npm tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("npm", name);
   if (s("install")) registerInstallTool(server);

--- a/packages/server-npm/src/tools/info.ts
+++ b/packages/server-npm/src/tools/info.ts
@@ -8,6 +8,7 @@ import { formatInfo, compactInfoMap, formatInfoCompact } from "../lib/formatters
 import { NpmInfoSchema } from "../schemas/index.js";
 import { packageManagerInput } from "../lib/pm-input.js";
 
+/** Registers the `info` tool on the given MCP server. */
 export function registerInfoTool(server: McpServer) {
   server.registerTool(
     "info",

--- a/packages/server-npm/src/tools/init.ts
+++ b/packages/server-npm/src/tools/init.ts
@@ -10,6 +10,7 @@ import { packageManagerInput } from "../lib/pm-input.js";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
+/** Registers the `init` tool on the given MCP server. */
 export function registerInitTool(server: McpServer) {
   server.registerTool(
     "init",

--- a/packages/server-npm/src/tools/install.ts
+++ b/packages/server-npm/src/tools/install.ts
@@ -8,6 +8,7 @@ import { formatInstall } from "../lib/formatters.js";
 import { NpmInstallSchema } from "../schemas/index.js";
 import { packageManagerInput, filterInput } from "../lib/pm-input.js";
 
+/** Registers the `install` tool on the given MCP server. */
 export function registerInstallTool(server: McpServer) {
   server.registerTool(
     "install",

--- a/packages/server-npm/src/tools/list.ts
+++ b/packages/server-npm/src/tools/list.ts
@@ -8,6 +8,7 @@ import { formatList, compactListMap, formatListCompact } from "../lib/formatters
 import { NpmListSchema } from "../schemas/index.js";
 import { packageManagerInput, filterInput } from "../lib/pm-input.js";
 
+/** Registers the `list` tool on the given MCP server. */
 export function registerListTool(server: McpServer) {
   server.registerTool(
     "list",

--- a/packages/server-npm/src/tools/nvm.ts
+++ b/packages/server-npm/src/tools/nvm.ts
@@ -5,6 +5,7 @@ import { parseNvmOutput } from "../lib/parsers.js";
 import { formatNvm } from "../lib/formatters.js";
 import { NvmResultSchema } from "../schemas/index.js";
 
+/** Registers the `nvm` tool on the given MCP server. */
 export function registerNvmTool(server: McpServer) {
   server.registerTool(
     "nvm",

--- a/packages/server-npm/src/tools/outdated.ts
+++ b/packages/server-npm/src/tools/outdated.ts
@@ -8,6 +8,7 @@ import { formatOutdated } from "../lib/formatters.js";
 import { NpmOutdatedSchema } from "../schemas/index.js";
 import { packageManagerInput, filterInput } from "../lib/pm-input.js";
 
+/** Registers the `outdated` tool on the given MCP server. */
 export function registerOutdatedTool(server: McpServer) {
   server.registerTool(
     "outdated",

--- a/packages/server-npm/src/tools/run.ts
+++ b/packages/server-npm/src/tools/run.ts
@@ -8,6 +8,7 @@ import { formatRun } from "../lib/formatters.js";
 import { NpmRunSchema } from "../schemas/index.js";
 import { packageManagerInput, filterInput } from "../lib/pm-input.js";
 
+/** Registers the `run` tool on the given MCP server. */
 export function registerRunTool(server: McpServer) {
   server.registerTool(
     "run",

--- a/packages/server-npm/src/tools/search.ts
+++ b/packages/server-npm/src/tools/search.ts
@@ -6,6 +6,7 @@ import { parseSearchJson } from "../lib/parsers.js";
 import { formatSearch, compactSearchMap, formatSearchCompact } from "../lib/formatters.js";
 import { NpmSearchSchema } from "../schemas/index.js";
 
+/** Registers the `search` tool on the given MCP server. */
 export function registerSearchTool(server: McpServer) {
   server.registerTool(
     "search",

--- a/packages/server-npm/src/tools/test.ts
+++ b/packages/server-npm/src/tools/test.ts
@@ -8,6 +8,7 @@ import { formatTest } from "../lib/formatters.js";
 import { NpmTestSchema } from "../schemas/index.js";
 import { packageManagerInput, filterInput } from "../lib/pm-input.js";
 
+/** Registers the `test` tool on the given MCP server. */
 export function registerTestTool(server: McpServer) {
   server.registerTool(
     "test",

--- a/packages/server-process/src/tools/index.ts
+++ b/packages/server-process/src/tools/index.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { shouldRegisterTool } from "@paretools/shared";
 import { registerRunTool } from "./run.js";
 
+/** Registers all process tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("process", name);
   if (s("run")) registerRunTool(server);

--- a/packages/server-process/src/tools/run.ts
+++ b/packages/server-process/src/tools/run.ts
@@ -11,6 +11,7 @@ import { parseRunOutput } from "../lib/parsers.js";
 import { formatRun, compactRunMap, formatRunCompact } from "../lib/formatters.js";
 import { ProcessRunResultSchema } from "../schemas/index.js";
 
+/** Registers the `run` tool on the given MCP server. */
 export function registerRunTool(server: McpServer) {
   server.registerTool(
     "run",

--- a/packages/server-python/src/tools/black.ts
+++ b/packages/server-python/src/tools/black.ts
@@ -6,6 +6,7 @@ import { parseBlackOutput } from "../lib/parsers.js";
 import { formatBlack, compactBlackMap, formatBlackCompact } from "../lib/formatters.js";
 import { BlackResultSchema } from "../schemas/index.js";
 
+/** Registers the `black` tool on the given MCP server. */
 export function registerBlackTool(server: McpServer) {
   server.registerTool(
     "black",

--- a/packages/server-python/src/tools/conda.ts
+++ b/packages/server-python/src/tools/conda.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/formatters.js";
 import { CondaResultSchema } from "../schemas/index.js";
 
+/** Registers the `conda` tool on the given MCP server. */
 export function registerCondaTool(server: McpServer) {
   server.registerTool(
     "conda",

--- a/packages/server-python/src/tools/index.ts
+++ b/packages/server-python/src/tools/index.ts
@@ -15,6 +15,7 @@ import { registerCondaTool } from "./conda.js";
 import { registerPyenvTool } from "./pyenv.js";
 import { registerPoetryTool } from "./poetry.js";
 
+/** Registers all Python tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("python", name);
   if (s("pip-install")) registerPipInstallTool(server);

--- a/packages/server-python/src/tools/mypy.ts
+++ b/packages/server-python/src/tools/mypy.ts
@@ -6,6 +6,7 @@ import { parseMypyOutput } from "../lib/parsers.js";
 import { formatMypy, compactMypyMap, formatMypyCompact } from "../lib/formatters.js";
 import { MypyResultSchema } from "../schemas/index.js";
 
+/** Registers the `mypy` tool on the given MCP server. */
 export function registerMypyTool(server: McpServer) {
   server.registerTool(
     "mypy",

--- a/packages/server-python/src/tools/pip-audit.ts
+++ b/packages/server-python/src/tools/pip-audit.ts
@@ -5,6 +5,7 @@ import { parsePipAuditJson } from "../lib/parsers.js";
 import { formatPipAudit, compactPipAuditMap, formatPipAuditCompact } from "../lib/formatters.js";
 import { PipAuditResultSchema } from "../schemas/index.js";
 
+/** Registers the `pip-audit` tool on the given MCP server. */
 export function registerPipAuditTool(server: McpServer) {
   server.registerTool(
     "pip-audit",

--- a/packages/server-python/src/tools/pip-install.ts
+++ b/packages/server-python/src/tools/pip-install.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/formatters.js";
 import { PipInstallSchema } from "../schemas/index.js";
 
+/** Registers the `pip-install` tool on the given MCP server. */
 export function registerPipInstallTool(server: McpServer) {
   server.registerTool(
     "pip-install",

--- a/packages/server-python/src/tools/pip-list.ts
+++ b/packages/server-python/src/tools/pip-list.ts
@@ -6,6 +6,7 @@ import { parsePipListJson } from "../lib/parsers.js";
 import { formatPipList, compactPipListMap, formatPipListCompact } from "../lib/formatters.js";
 import { PipListSchema } from "../schemas/index.js";
 
+/** Registers the `pip-list` tool on the given MCP server. */
 export function registerPipListTool(server: McpServer) {
   server.registerTool(
     "pip-list",

--- a/packages/server-python/src/tools/pip-show.ts
+++ b/packages/server-python/src/tools/pip-show.ts
@@ -6,6 +6,7 @@ import { parsePipShowOutput } from "../lib/parsers.js";
 import { formatPipShow, compactPipShowMap, formatPipShowCompact } from "../lib/formatters.js";
 import { PipShowSchema } from "../schemas/index.js";
 
+/** Registers the `pip-show` tool on the given MCP server. */
 export function registerPipShowTool(server: McpServer) {
   server.registerTool(
     "pip-show",

--- a/packages/server-python/src/tools/poetry.ts
+++ b/packages/server-python/src/tools/poetry.ts
@@ -6,6 +6,7 @@ import { parsePoetryOutput } from "../lib/parsers.js";
 import { formatPoetry, compactPoetryMap, formatPoetryCompact } from "../lib/formatters.js";
 import { PoetryResultSchema } from "../schemas/index.js";
 
+/** Registers the `poetry` tool on the given MCP server. */
 export function registerPoetryTool(server: McpServer) {
   server.registerTool(
     "poetry",

--- a/packages/server-python/src/tools/pyenv.ts
+++ b/packages/server-python/src/tools/pyenv.ts
@@ -8,6 +8,7 @@ import { PyenvResultSchema } from "../schemas/index.js";
 
 const ACTIONS = ["versions", "version", "install", "local", "global"] as const;
 
+/** Registers the `pyenv` tool on the given MCP server. */
 export function registerPyenvTool(server: McpServer) {
   server.registerTool(
     "pyenv",

--- a/packages/server-python/src/tools/pytest.ts
+++ b/packages/server-python/src/tools/pytest.ts
@@ -6,6 +6,7 @@ import { parsePytestOutput } from "../lib/parsers.js";
 import { formatPytest, compactPytestMap, formatPytestCompact } from "../lib/formatters.js";
 import { PytestResultSchema } from "../schemas/index.js";
 
+/** Registers the `pytest` tool on the given MCP server. */
 export function registerPytestTool(server: McpServer) {
   server.registerTool(
     "pytest",

--- a/packages/server-python/src/tools/ruff-format.ts
+++ b/packages/server-python/src/tools/ruff-format.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/formatters.js";
 import { RuffFormatResultSchema } from "../schemas/index.js";
 
+/** Registers the `ruff-format` tool on the given MCP server. */
 export function registerRuffFormatTool(server: McpServer) {
   server.registerTool(
     "ruff-format",

--- a/packages/server-python/src/tools/ruff.ts
+++ b/packages/server-python/src/tools/ruff.ts
@@ -6,6 +6,7 @@ import { parseRuffJson } from "../lib/parsers.js";
 import { formatRuff, compactRuffMap, formatRuffCompact } from "../lib/formatters.js";
 import { RuffResultSchema } from "../schemas/index.js";
 
+/** Registers the `ruff-check` tool on the given MCP server. */
 export function registerRuffTool(server: McpServer) {
   server.registerTool(
     "ruff-check",

--- a/packages/server-python/src/tools/uv-install.ts
+++ b/packages/server-python/src/tools/uv-install.ts
@@ -6,6 +6,7 @@ import { parseUvInstall } from "../lib/parsers.js";
 import { formatUvInstall, compactUvInstallMap, formatUvInstallCompact } from "../lib/formatters.js";
 import { UvInstallSchema } from "../schemas/index.js";
 
+/** Registers the `uv-install` tool on the given MCP server. */
 export function registerUvInstallTool(server: McpServer) {
   server.registerTool(
     "uv-install",

--- a/packages/server-python/src/tools/uv-run.ts
+++ b/packages/server-python/src/tools/uv-run.ts
@@ -6,6 +6,7 @@ import { parseUvRun } from "../lib/parsers.js";
 import { formatUvRun, compactUvRunMap, formatUvRunCompact } from "../lib/formatters.js";
 import { UvRunSchema } from "../schemas/index.js";
 
+/** Registers the `uv-run` tool on the given MCP server. */
 export function registerUvRunTool(server: McpServer) {
   server.registerTool(
     "uv-run",

--- a/packages/server-search/src/tools/count.ts
+++ b/packages/server-search/src/tools/count.ts
@@ -6,6 +6,7 @@ import { parseRgCountOutput } from "../lib/parsers.js";
 import { formatCount, compactCountMap, formatCountCompact } from "../lib/formatters.js";
 import { CountResultSchema } from "../schemas/index.js";
 
+/** Registers the `count` tool on the given MCP server. */
 export function registerCountTool(server: McpServer) {
   server.registerTool(
     "count",

--- a/packages/server-search/src/tools/find.ts
+++ b/packages/server-search/src/tools/find.ts
@@ -6,6 +6,7 @@ import { parseFdOutput } from "../lib/parsers.js";
 import { formatFind, compactFindMap, formatFindCompact } from "../lib/formatters.js";
 import { FindResultSchema } from "../schemas/index.js";
 
+/** Registers the `find` tool on the given MCP server. */
 export function registerFindTool(server: McpServer) {
   server.registerTool(
     "find",

--- a/packages/server-search/src/tools/index.ts
+++ b/packages/server-search/src/tools/index.ts
@@ -5,6 +5,7 @@ import { registerFindTool } from "./find.js";
 import { registerCountTool } from "./count.js";
 import { registerJqTool } from "./jq.js";
 
+/** Registers all search tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("search", name);
   if (s("search")) registerSearchTool(server);

--- a/packages/server-search/src/tools/jq.ts
+++ b/packages/server-search/src/tools/jq.ts
@@ -6,6 +6,7 @@ import { parseJqOutput } from "../lib/parsers.js";
 import { formatJq, compactJqMap, formatJqCompact } from "../lib/formatters.js";
 import { JqResultSchema } from "../schemas/index.js";
 
+/** Registers the `jq` tool on the given MCP server. */
 export function registerJqTool(server: McpServer) {
   server.registerTool(
     "jq",

--- a/packages/server-search/src/tools/search.ts
+++ b/packages/server-search/src/tools/search.ts
@@ -6,6 +6,7 @@ import { parseRgJsonOutput } from "../lib/parsers.js";
 import { formatSearch, compactSearchMap, formatSearchCompact } from "../lib/formatters.js";
 import { SearchResultSchema } from "../schemas/index.js";
 
+/** Registers the `search` tool on the given MCP server. */
 export function registerSearchTool(server: McpServer) {
   server.registerTool(
     "search",

--- a/packages/server-security/src/tools/gitleaks.ts
+++ b/packages/server-security/src/tools/gitleaks.ts
@@ -9,6 +9,7 @@ import {
 } from "../lib/formatters.js";
 import { GitleaksScanResultSchema } from "../schemas/index.js";
 
+/** Registers the `gitleaks` tool on the given MCP server. */
 export function registerGitleaksTool(server: McpServer) {
   server.registerTool(
     "gitleaks",

--- a/packages/server-security/src/tools/index.ts
+++ b/packages/server-security/src/tools/index.ts
@@ -4,6 +4,7 @@ import { registerTrivyTool } from "./trivy.js";
 import { registerSemgrepTool } from "./semgrep.js";
 import { registerGitleaksTool } from "./gitleaks.js";
 
+/** Registers all security tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("security", name);
   if (s("trivy")) registerTrivyTool(server);

--- a/packages/server-security/src/tools/semgrep.ts
+++ b/packages/server-security/src/tools/semgrep.ts
@@ -15,6 +15,7 @@ import {
 } from "../lib/formatters.js";
 import { SemgrepScanResultSchema } from "../schemas/index.js";
 
+/** Registers the `semgrep` tool on the given MCP server. */
 export function registerSemgrepTool(server: McpServer) {
   server.registerTool(
     "semgrep",

--- a/packages/server-security/src/tools/trivy.ts
+++ b/packages/server-security/src/tools/trivy.ts
@@ -5,6 +5,7 @@ import { parseTrivyJson } from "../lib/parsers.js";
 import { formatTrivyScan, compactTrivyScanMap, formatTrivyScanCompact } from "../lib/formatters.js";
 import { TrivyScanResultSchema } from "../schemas/index.js";
 
+/** Registers the `trivy` tool on the given MCP server. */
 export function registerTrivyTool(server: McpServer) {
   server.registerTool(
     "trivy",

--- a/packages/server-test/src/tools/coverage.ts
+++ b/packages/server-test/src/tools/coverage.ts
@@ -26,6 +26,7 @@ export function getCoverageCommand(framework: Framework): { cmd: string; cmdArgs
   }
 }
 
+/** Registers the `coverage` tool on the given MCP server. */
 export function registerCoverageTool(server: McpServer) {
   server.registerTool(
     "coverage",

--- a/packages/server-test/src/tools/index.ts
+++ b/packages/server-test/src/tools/index.ts
@@ -4,6 +4,7 @@ import { registerRunTool } from "./run.js";
 import { registerCoverageTool } from "./coverage.js";
 import { registerPlaywrightTool } from "./playwright.js";
 
+/** Registers all test tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
   const s = (name: string) => shouldRegisterTool("test", name);
   if (s("run")) registerRunTool(server);

--- a/packages/server-test/src/tools/playwright.ts
+++ b/packages/server-test/src/tools/playwright.ts
@@ -13,6 +13,7 @@ import {
 } from "../lib/formatters.js";
 import { PlaywrightResultSchema } from "../schemas/index.js";
 
+/** Registers the `playwright` tool on the given MCP server. */
 export function registerPlaywrightTool(server: McpServer) {
   server.registerTool(
     "playwright",

--- a/packages/server-test/src/tools/run.ts
+++ b/packages/server-test/src/tools/run.ts
@@ -30,6 +30,7 @@ export function getRunCommand(
   }
 }
 
+/** Registers the `run` tool on the given MCP server. */
 export function registerRunTool(server: McpServer) {
   server.registerTool(
     "run",


### PR DESCRIPTION
## Summary
- Adds single-line JSDoc comments to all 163 `register*Tool` functions across 16 server packages
- Closes #402 (BP-02: JSDoc documentation for tool registration functions)
- Purely additive change: 163 insertions, 0 deletions

## Details
Each `register*Tool` function now has a JSDoc comment describing what the tool does. This improves IDE hover documentation and code navigability across the codebase.

No changeset needed — this is a docs-only change that does not affect published package behavior.

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] Format check passes (`pnpm format:check`)
- [ ] CI checks pass on PR