### PR TITLE
chore: bump @paretools/shared to align with 0.8.3

### DIFF
--- a/.changeset/bump-shared-version.md
+++ b/.changeset/bump-shared-version.md
@@ -1,0 +1,5 @@
+---
+"@paretools/shared": patch
+---
+
+Align shared package version with server packages at 0.8.3


### PR DESCRIPTION
## Summary
- Adds a patch changeset for `@paretools/shared` to align it with the 0.8.3 release
- All 16 server packages published 0.8.3, but shared was left at 0.8.2

## Test plan
- [ ] CI passes (no code changes, changeset only)