### PR TITLE
test(shared): fix coverage threshold failures

### DIFF
--- a/packages/shared/__tests__/runner.test.ts
+++ b/packages/shared/__tests__/runner.test.ts
@@ -91,6 +91,23 @@ describe("run", () => {
   });
 });
 
+describe("run – env and edge cases", () => {
+  it("passes custom env vars to the child process", async () => {
+    const result = await run("node", ["-e", "console.log(process.env.PARE_TEST_VAR)"], {
+      env: { PARE_TEST_VAR: "hello_from_test" },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("hello_from_test");
+  });
+
+  it("rejects with permission denied on EACCES", async () => {
+    // Try to execute a directory — triggers EACCES on Unix
+    if (process.platform !== "win32") {
+      await expect(run("/tmp", [])).rejects.toThrow(/[Pp]ermission denied|EACCES/);
+    }
+  });
+});
+
 describe("run – timeout and process cleanup", () => {
   const FIXTURE_PATH = resolve(__dirname, "fixtures/parent-with-children.cjs");
 


### PR DESCRIPTION
## Summary
- Adds tests for `PARE_SANITIZE_ALL_PATHS=true` broad mode in `sanitize.test.ts` (Unix system paths, Windows non-user paths, mixed paths, env var disabled)
- Adds runner tests for custom `env` option and `EACCES` error handling
- Brings `@paretools/shared` branch coverage from **66.26% → 74.69%**, clearing the 70% threshold
- Fixes the `coverage` CI check that has been failing

## Test plan
- [x] `pnpm --filter @paretools/shared test -- --coverage` passes locally (190 tests, all thresholds met)
- [ ] CI coverage check passes