### PR TITLE
fix: align all package versions via changesets fixed group

### DIFF
--- a/.changeset/align-shared-version.md
+++ b/.changeset/align-shared-version.md
@@ -1,0 +1,5 @@
+---
+"@paretools/shared": patch
+---
+
+Align @paretools/shared version with all server packages

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,27 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "Dave-London/Pare" }],
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    [
+      "@paretools/shared",
+      "@paretools/git",
+      "@paretools/github",
+      "@paretools/docker",
+      "@paretools/python",
+      "@paretools/cargo",
+      "@paretools/go",
+      "@paretools/npm",
+      "@paretools/lint",
+      "@paretools/build",
+      "@paretools/k8s",
+      "@paretools/search",
+      "@paretools/http",
+      "@paretools/test",
+      "@paretools/security",
+      "@paretools/make",
+      "@paretools/process"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Summary
- Adds all `@paretools/*` packages to the changesets `fixed` group so they always share the same version number going forward
- Includes a patch changeset for `@paretools/shared` to bring it from 0.8.3 up to match servers at 0.8.5 (all packages will align)
- Prevents the recurring cascade gap where bumping shared causes servers to increment ahead

## Background
`@paretools/shared` has been one patch behind the server packages since 0.8.2. The `updateInternalDependencies: "patch"` setting causes servers to cascade-bump whenever shared is bumped independently, making alignment impossible without `fixed`.

## Test plan
- [ ] CI passes
- [ ] After merge, Version Packages PR shows all packages at same version