### PR TITLE
fix(git): use forks pool to prevent v8 coverage race condition

### DIFF
--- a/packages/server-git/vitest.config.ts
+++ b/packages/server-git/vitest.config.ts
@@ -1,5 +1,15 @@
+import { defineConfig, mergeConfig } from "vitest/config";
 import { createVitestConfig } from "../shared/vitest.shared.js";
 
-export default createVitestConfig({
-  hookTimeout: 30_000,
-});
+export default mergeConfig(
+  createVitestConfig({ hookTimeout: 30_000 }),
+  defineConfig({
+    test: {
+      // Use forks pool to prevent v8 coverage temp file race conditions.
+      // The git package has 18 test files including integration tests that
+      // spawn child processes, which can conflict with v8's coverage
+      // collection when using the default threads pool.
+      pool: "forks",
+    },
+  }),
+);


### PR DESCRIPTION
## Summary
- Switches `@paretools/git` test pool from default `threads` to `forks`
- Prevents intermittent `ENOENT: coverage/.tmp/coverage-0.json` errors on CI
- The git package has 18 test files including integration tests that spawn MCP server child processes, which can conflict with v8's coverage temp file collection when using threads

## Context
The coverage CI check has been failing intermittently on main due to this race condition. The git package is the largest test suite (482 tests, 18 files) and the only one spawning child processes during integration tests.

## Test plan
- [x] All 482 git tests pass locally with `pool: 'forks'`
- [x] Coverage thresholds met (91.12% branches)
- [ ] CI coverage check passes consistently