### PR TITLE
feat(search): add missing CLI flag parameters

### DIFF
--- a/.changeset/search-xs-gaps.md
+++ b/.changeset/search-xs-gaps.md
@@ -1,0 +1,10 @@
+---
+"@paretools/search": minor
+---
+
+Add missing CLI flag parameters from XS-complexity audit gaps
+
+- count: countMatches, fixedStrings, wordRegexp, invertMatch, hidden, includeZero, maxDepth, noIgnore
+- find: maxDepth, hidden, absolutePath, fullPath, glob, noIgnore, follow
+- jq: nullInput, slurp, compactOutput, rawInput, exitStatus, indent, joinOutput, assertNoFlagInjection on expression
+- search: maxCount, fixedStrings, wordRegexp, invertMatch, multiline, hidden, maxDepth, followSymlinks, noIgnore

--- a/packages/server-search/src/tools/count.ts
+++ b/packages/server-search/src/tools/count.ts
@@ -34,6 +34,29 @@ export function registerCountTool(server: McpServer) {
           .optional()
           .default(true)
           .describe("Case-sensitive search (default: true)"),
+        countMatches: z
+          .boolean()
+          .optional()
+          .describe("Count per-occurrence matches instead of per-line counts (--count-matches)"),
+        fixedStrings: z
+          .boolean()
+          .optional()
+          .describe("Treat pattern as a literal string instead of regex (--fixed-strings)"),
+        wordRegexp: z.boolean().optional().describe("Only match whole words (--word-regexp)"),
+        invertMatch: z
+          .boolean()
+          .optional()
+          .describe("Count non-matching lines instead of matching lines (--invert-match)"),
+        hidden: z.boolean().optional().describe("Search hidden files and directories (--hidden)"),
+        includeZero: z
+          .boolean()
+          .optional()
+          .describe("Show files with zero matches (--include-zero)"),
+        maxDepth: z.number().optional().describe("Maximum directory depth to search (--max-depth)"),
+        noIgnore: z
+          .boolean()
+          .optional()
+          .describe("Don't respect .gitignore and other ignore files (--no-ignore)"),
         compact: z
           .boolean()
           .optional()
@@ -44,16 +67,58 @@ export function registerCountTool(server: McpServer) {
       },
       outputSchema: CountResultSchema,
     },
-    async ({ pattern, path, glob, caseSensitive, compact }) => {
+    async ({
+      pattern,
+      path,
+      glob,
+      caseSensitive,
+      countMatches,
+      fixedStrings,
+      wordRegexp,
+      invertMatch,
+      hidden,
+      includeZero,
+      maxDepth,
+      noIgnore,
+      compact,
+    }) => {
       assertNoFlagInjection(pattern, "pattern");
       if (path) assertNoFlagInjection(path, "path");
       if (glob) assertNoFlagInjection(glob, "glob");
 
       const cwd = path || process.cwd();
-      const args = ["--count"];
+      const args = countMatches ? ["--count-matches"] : ["--count"];
 
       if (!caseSensitive) {
         args.push("--ignore-case");
+      }
+
+      if (fixedStrings) {
+        args.push("--fixed-strings");
+      }
+
+      if (wordRegexp) {
+        args.push("--word-regexp");
+      }
+
+      if (invertMatch) {
+        args.push("--invert-match");
+      }
+
+      if (hidden) {
+        args.push("--hidden");
+      }
+
+      if (includeZero) {
+        args.push("--include-zero");
+      }
+
+      if (maxDepth !== undefined) {
+        args.push("--max-depth", String(maxDepth));
+      }
+
+      if (noIgnore) {
+        args.push("--no-ignore");
       }
 
       if (glob) {

--- a/packages/server-search/src/tools/find.ts
+++ b/packages/server-search/src/tools/find.ts
@@ -39,6 +39,25 @@ export function registerFindTool(server: McpServer) {
           .optional()
           .default(1000)
           .describe("Maximum number of results to return (default: 1000)"),
+        maxDepth: z.number().optional().describe("Maximum directory depth to search (--max-depth)"),
+        hidden: z.boolean().optional().describe("Include hidden files and directories (--hidden)"),
+        absolutePath: z
+          .boolean()
+          .optional()
+          .describe("Return absolute paths instead of relative (--absolute-path)"),
+        fullPath: z
+          .boolean()
+          .optional()
+          .describe("Match pattern against full path, not just filename (--full-path)"),
+        glob: z
+          .boolean()
+          .optional()
+          .describe("Use glob pattern matching instead of regex (--glob)"),
+        noIgnore: z
+          .boolean()
+          .optional()
+          .describe("Don't respect .gitignore and other ignore files (--no-ignore)"),
+        follow: z.boolean().optional().describe("Follow symbolic links (--follow)"),
         compact: z
           .boolean()
           .optional()
@@ -49,7 +68,21 @@ export function registerFindTool(server: McpServer) {
       },
       outputSchema: FindResultSchema,
     },
-    async ({ pattern, path, type, extension, maxResults, compact }) => {
+    async ({
+      pattern,
+      path,
+      type,
+      extension,
+      maxResults,
+      maxDepth,
+      hidden,
+      absolutePath,
+      fullPath,
+      glob,
+      noIgnore,
+      follow,
+      compact,
+    }) => {
       if (pattern) assertNoFlagInjection(pattern, "pattern");
       if (path) assertNoFlagInjection(path, "path");
       if (extension) assertNoFlagInjection(extension, "extension");
@@ -68,6 +101,34 @@ export function registerFindTool(server: McpServer) {
 
       if (maxResults) {
         args.push("--max-results", String(maxResults));
+      }
+
+      if (maxDepth !== undefined) {
+        args.push("--max-depth", String(maxDepth));
+      }
+
+      if (hidden) {
+        args.push("--hidden");
+      }
+
+      if (absolutePath) {
+        args.push("--absolute-path");
+      }
+
+      if (fullPath) {
+        args.push("--full-path");
+      }
+
+      if (glob) {
+        args.push("--glob");
+      }
+
+      if (noIgnore) {
+        args.push("--no-ignore");
+      }
+
+      if (follow) {
+        args.push("--follow");
       }
 
       if (pattern) {

--- a/packages/server-search/src/tools/jq.ts
+++ b/packages/server-search/src/tools/jq.ts
@@ -35,6 +35,35 @@ export function registerJqTool(server: McpServer) {
           .default(false)
           .describe("Output raw strings without JSON quotes (-r flag)"),
         sortKeys: z.boolean().optional().default(false).describe("Sort object keys (-S flag)"),
+        nullInput: z
+          .boolean()
+          .optional()
+          .describe("Don't read any input, useful for generating JSON from scratch (--null-input)"),
+        slurp: z
+          .boolean()
+          .optional()
+          .describe(
+            "Read entire input into a single array, useful for JSONL or multiple objects (--slurp)",
+          ),
+        compactOutput: z
+          .boolean()
+          .optional()
+          .describe("Compact output, no pretty-printing (--compact-output)"),
+        rawInput: z
+          .boolean()
+          .optional()
+          .describe("Read each line as a string instead of JSON (--raw-input)"),
+        exitStatus: z
+          .boolean()
+          .optional()
+          .describe(
+            "Use jq exit status for boolean checks: exit 1 if last output is false/null (--exit-status)",
+          ),
+        indent: z.number().optional().describe("Number of spaces for indentation (--indent)"),
+        joinOutput: z
+          .boolean()
+          .optional()
+          .describe("Don't print newlines between outputs (--join-output)"),
         compact: z
           .boolean()
           .optional()
@@ -45,12 +74,31 @@ export function registerJqTool(server: McpServer) {
       },
       outputSchema: JqResultSchema,
     },
-    async ({ expression, file, input, rawOutput, sortKeys, compact }) => {
+    async ({
+      expression,
+      file,
+      input,
+      rawOutput,
+      sortKeys,
+      nullInput,
+      slurp,
+      compactOutput,
+      rawInput,
+      exitStatus,
+      indent,
+      joinOutput,
+      compact,
+    }) => {
+      assertNoFlagInjection(expression, "expression");
       if (file) assertNoFlagInjection(file, "file");
 
-      if (!file && !input) {
-        const data = parseJqOutput("", "Either 'file' or 'input' must be provided.", 1);
-        const rawText = "jq: error — either 'file' or 'input' must be provided.";
+      if (!file && !input && !nullInput) {
+        const data = parseJqOutput(
+          "",
+          "Either 'file', 'input', or 'nullInput' must be provided.",
+          1,
+        );
+        const rawText = "jq: error — either 'file', 'input', or 'nullInput' must be provided.";
         return compactDualOutput(
           data,
           rawText,
@@ -65,6 +113,13 @@ export function registerJqTool(server: McpServer) {
 
       if (rawOutput) args.push("-r");
       if (sortKeys) args.push("-S");
+      if (nullInput) args.push("--null-input");
+      if (slurp) args.push("--slurp");
+      if (compactOutput) args.push("--compact-output");
+      if (rawInput) args.push("--raw-input");
+      if (exitStatus) args.push("--exit-status");
+      if (indent !== undefined) args.push("--indent", String(indent));
+      if (joinOutput) args.push("--join-output");
 
       args.push(expression);
 

--- a/packages/server-search/src/tools/search.ts
+++ b/packages/server-search/src/tools/search.ts
@@ -39,6 +39,30 @@ export function registerSearchTool(server: McpServer) {
           .optional()
           .default(1000)
           .describe("Maximum number of matches to return (default: 1000)"),
+        maxCount: z
+          .number()
+          .optional()
+          .describe("Maximum matches per file to stop rg early (--max-count)"),
+        fixedStrings: z
+          .boolean()
+          .optional()
+          .describe("Treat pattern as a literal string instead of regex (--fixed-strings)"),
+        wordRegexp: z.boolean().optional().describe("Only match whole words (--word-regexp)"),
+        invertMatch: z
+          .boolean()
+          .optional()
+          .describe("Show lines that do NOT match the pattern (--invert-match)"),
+        multiline: z
+          .boolean()
+          .optional()
+          .describe("Allow patterns to span multiple lines (--multiline)"),
+        hidden: z.boolean().optional().describe("Search hidden files and directories (--hidden)"),
+        maxDepth: z.number().optional().describe("Maximum directory depth to search (--max-depth)"),
+        followSymlinks: z.boolean().optional().describe("Follow symbolic links (--follow)"),
+        noIgnore: z
+          .boolean()
+          .optional()
+          .describe("Don't respect .gitignore and other ignore files (--no-ignore)"),
         compact: z
           .boolean()
           .optional()
@@ -49,7 +73,23 @@ export function registerSearchTool(server: McpServer) {
       },
       outputSchema: SearchResultSchema,
     },
-    async ({ pattern, path, glob, caseSensitive, maxResults, compact }) => {
+    async ({
+      pattern,
+      path,
+      glob,
+      caseSensitive,
+      maxResults,
+      maxCount,
+      fixedStrings,
+      wordRegexp,
+      invertMatch,
+      multiline,
+      hidden,
+      maxDepth,
+      followSymlinks,
+      noIgnore,
+      compact,
+    }) => {
       assertNoFlagInjection(pattern, "pattern");
       if (path) assertNoFlagInjection(path, "path");
       if (glob) assertNoFlagInjection(glob, "glob");
@@ -59,6 +99,42 @@ export function registerSearchTool(server: McpServer) {
 
       if (!caseSensitive) {
         args.push("--ignore-case");
+      }
+
+      if (fixedStrings) {
+        args.push("--fixed-strings");
+      }
+
+      if (wordRegexp) {
+        args.push("--word-regexp");
+      }
+
+      if (invertMatch) {
+        args.push("--invert-match");
+      }
+
+      if (multiline) {
+        args.push("--multiline");
+      }
+
+      if (hidden) {
+        args.push("--hidden");
+      }
+
+      if (maxCount !== undefined) {
+        args.push("--max-count", String(maxCount));
+      }
+
+      if (maxDepth !== undefined) {
+        args.push("--max-depth", String(maxDepth));
+      }
+
+      if (followSymlinks) {
+        args.push("--follow");
+      }
+
+      if (noIgnore) {
+        args.push("--no-ignore");
       }
 
       if (glob) {


### PR DESCRIPTION
## Summary
- Implements all XS-complexity gaps from the CLI capability audit for `@paretools/search`
- **count** tool: `countMatches`, `fixedStrings`, `wordRegexp`, `invertMatch`, `hidden`, `includeZero`, `maxDepth`, `noIgnore`
- **find** tool: `maxDepth`, `hidden`, `absolutePath`, `fullPath`, `glob`, `noIgnore`, `follow`
- **jq** tool: `nullInput`, `slurp`, `compactOutput`, `rawInput`, `exitStatus`, `indent`, `joinOutput`, plus `assertNoFlagInjection` on expression param
- **search** tool: `maxCount`, `fixedStrings`, `wordRegexp`, `invertMatch`, `multiline`, `hidden`, `maxDepth`, `followSymlinks`, `noIgnore`

## Test plan
- [x] `pnpm build --filter @paretools/search` passes
- [x] `pnpm --filter @paretools/search test` passes (65 tests)
- [ ] Manual verification of new flags with real CLI invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)