### PR TITLE
feat(npm): add XS-complexity missing flags and security fixes

### DIFF
--- a/.changeset/npm-xs-gaps.md
+++ b/.changeset/npm-xs-gaps.md
@@ -1,0 +1,14 @@
+---
+"@paretools/npm": minor
+---
+
+Add XS-complexity missing flags and security fixes across all npm tools:
+
+- **init**: `force` (--force), `private` (yarn --private)
+- **install**: `saveDev` (--save-dev), `frozenLockfile` (--frozen-lockfile / npm ci), `dryRun` (--dry-run), `production` (--omit=dev / --prod / --production), `legacyPeerDeps` (--legacy-peer-deps), `force` (--force), `noAudit` (--no-audit), `exact` (--save-exact)
+- **list**: `production` (--omit=dev / --prod), `all` (--all), `long` (--long), `global` (--global), security fix for `filter` param
+- **outdated**: `production` (--omit=dev / --prod), `all` (--all), `long` (--long), `compatible` (--compatible), `devOnly` (--dev), security fix for `filter` param
+- **run**: `ifPresent` (--if-present), `recursive` (--recursive / --workspaces), `ignoreScripts` (--ignore-scripts), `silent` (--silent), `parallel` (--parallel), `stream` (--stream)
+- **test**: `ifPresent` (--if-present), `recursive` (--recursive / --workspaces), `ignoreScripts` (--ignore-scripts), `silent` (--silent), `parallel` (--parallel), `stream` (--stream)
+- **search**: `preferOnline` (--prefer-online)
+- **audit**: `packageLockOnly` (--package-lock-only)

--- a/packages/server-npm/src/tools/search.ts
+++ b/packages/server-npm/src/tools/search.ts
@@ -34,16 +34,25 @@ export function registerSearchTool(server: McpServer) {
           .describe(
             "Auto-compact when structured output exceeds raw CLI tokens. Set false to always get full schema.",
           ),
+        preferOnline: z
+          .boolean()
+          .optional()
+          .describe(
+            "Bypass cache and fetch fresh results from the registry (maps to --prefer-online)",
+          ),
       },
       outputSchema: NpmSearchSchema,
     },
-    async ({ query, path, limit, compact }) => {
+    async ({ query, path, limit, compact, preferOnline }) => {
       const cwd = path || process.cwd();
       assertNoFlagInjection(query, "query");
 
       const args = ["search", query, "--json"];
       if (limit !== undefined) {
         args.push(`--searchlimit=${limit}`);
+      }
+      if (preferOnline) {
+        args.push("--prefer-online");
       }
 
       // Always use npm for search — pnpm doesn't have a search command


### PR DESCRIPTION
## Summary
- Add 35 missing parameter flags across 8 npm tools covering all XS-complexity gaps from the CLI capability audit
- Fix `assertNoFlagInjection` security gaps on `list` and `outdated` `filter` params
- Flags are PM-aware: map to correct CLI flags for npm, pnpm, and yarn where applicable

### Tools updated
| Tool | New params |
|------|-----------|
| **init** | `force`, `private` |
| **install** | `saveDev`, `frozenLockfile`, `dryRun`, `production`, `legacyPeerDeps`, `force`, `noAudit`, `exact` |
| **list** | `production`, `all`, `long`, `global` + security fix |
| **outdated** | `production`, `all`, `long`, `compatible`, `devOnly` + security fix |
| **run** | `ifPresent`, `recursive`, `ignoreScripts`, `silent`, `parallel`, `stream` |
| **test** | `ifPresent`, `recursive`, `ignoreScripts`, `silent`, `parallel`, `stream` |
| **search** | `preferOnline` |
| **audit** | `packageLockOnly` |

## Test plan
- [x] `pnpm build --filter @paretools/npm` passes
- [x] `pnpm --filter @paretools/npm test` passes (261/261 tests)
- [ ] CI matrix (ubuntu/windows/macos x node 20/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)