### PR TITLE
feat(build): add all XS-complexity gap items

### DIFF
--- a/.changeset/build-xs-gaps.md
+++ b/.changeset/build-xs-gaps.md
@@ -1,0 +1,13 @@
+---
+"@paretools/build": minor
+---
+
+Add XS-complexity gap items across all build tools:
+
+- build: Add `assertNoFlagInjection` on `args[]` elements; document command allowlist in description
+- esbuild: Add `splitting`, `legalComments`, and `logLevel` params
+- nx: Add `parallel`, `skipNxCache`, `nxBail`, `verbose`, `dryRun`, `outputStyle`, and `graph` params
+- tsc: Add `incremental`, `skipLibCheck`, and `emitDeclarationOnly` params; document compact-mode field loss
+- turbo: Add `force`, `continue`, `dryRun`, `affected`, `graph`, `logOrder`, and `profile` params
+- vite-build: Add `manifest`, `minify`, `logLevel`, `emptyOutDir`, and `reportCompressedSize` params
+- webpack: Add `bail` and `cache` params; append `--no-color` to prevent ANSI in text fallback

--- a/packages/server-build/__tests__/integration.test.ts
+++ b/packages/server-build/__tests__/integration.test.ts
@@ -72,7 +72,7 @@ describe("@paretools/build integration", () => {
     it("returns structured build result", async () => {
       // Use a known-safe command that will fail fast (no actual build needed)
       const result = await client.callTool(
-        { name: "build", arguments: { command: "npm", args: ["--version"] } },
+        { name: "build", arguments: { command: "npm", args: ["version"] } },
         undefined,
         CALL_TIMEOUT,
       );

--- a/packages/server-build/src/tools/build.ts
+++ b/packages/server-build/src/tools/build.ts
@@ -4,6 +4,7 @@ import {
   compactDualOutput,
   assertAllowedCommand,
   assertNoPathQualifiedCommand,
+  assertNoFlagInjection,
   assertAllowedRoot,
   INPUT_LIMITS,
 } from "@paretools/shared";
@@ -19,7 +20,8 @@ export function registerBuildTool(server: McpServer) {
     {
       title: "Run Build",
       description:
-        "Runs a build command and returns structured success/failure with errors and warnings. Use instead of running build commands in the terminal.",
+        "Runs a build command and returns structured success/failure with errors and warnings. Use instead of running build commands in the terminal. " +
+        "Allowed commands: ant, bazel, bun, bunx, cargo, cmake, dotnet, esbuild, go, gradle, gradlew, make, msbuild, mvn, npm, npx, nx, pnpm, rollup, tsc, turbo, vite, webpack, yarn.",
       inputSchema: {
         command: z
           .string()
@@ -48,6 +50,9 @@ export function registerBuildTool(server: McpServer) {
     async ({ command, args, path, compact }) => {
       assertAllowedCommand(command);
       assertNoPathQualifiedCommand(command);
+      for (const a of args ?? []) {
+        assertNoFlagInjection(a, "args");
+      }
       const cwd = path || process.cwd();
       assertAllowedRoot(cwd, "build");
       const start = Date.now();

--- a/packages/server-build/src/tools/esbuild.ts
+++ b/packages/server-build/src/tools/esbuild.ts
@@ -49,6 +49,18 @@ export function registerEsbuildTool(server: McpServer) {
           .optional()
           .default(false)
           .describe("Generate source maps (default: false)"),
+        splitting: z
+          .boolean()
+          .optional()
+          .describe("Enable code splitting (requires format=esm and outdir)"),
+        legalComments: z
+          .enum(["none", "inline", "eof", "linked", "external"])
+          .optional()
+          .describe("How to handle legal comments (license headers)"),
+        logLevel: z
+          .enum(["verbose", "debug", "info", "warning", "error", "silent"])
+          .optional()
+          .describe("Log level to control output verbosity"),
         args: z
           .array(z.string().max(INPUT_LIMITS.STRING_MAX))
           .max(INPUT_LIMITS.ARRAY_MAX)
@@ -75,6 +87,9 @@ export function registerEsbuildTool(server: McpServer) {
       format,
       platform,
       sourcemap,
+      splitting,
+      legalComments,
+      logLevel,
       args,
       compact,
     }) => {
@@ -94,6 +109,9 @@ export function registerEsbuildTool(server: McpServer) {
       if (format) cliArgs.push(`--format=${format}`);
       if (platform) cliArgs.push(`--platform=${platform}`);
       if (sourcemap) cliArgs.push("--sourcemap");
+      if (splitting) cliArgs.push("--splitting");
+      if (legalComments) cliArgs.push(`--legal-comments=${legalComments}`);
+      if (logLevel) cliArgs.push(`--log-level=${logLevel}`);
 
       for (const a of args ?? []) {
         assertNoFlagInjection(a, "args");

--- a/packages/server-build/src/tools/nx.ts
+++ b/packages/server-build/src/tools/nx.ts
@@ -39,6 +39,34 @@ export function registerNxTool(server: McpServer) {
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe("Project root path (default: cwd)"),
+        parallel: z
+          .number()
+          .optional()
+          .describe("Max number of parallel tasks (maps to --parallel)"),
+        skipNxCache: z
+          .boolean()
+          .optional()
+          .describe("Skip the Nx cache and re-run all tasks (maps to --skip-nx-cache)"),
+        nxBail: z
+          .boolean()
+          .optional()
+          .describe("Stop task execution after the first failure (maps to --nx-bail)"),
+        verbose: z
+          .boolean()
+          .optional()
+          .describe("Enable verbose output for debugging (maps to --verbose)"),
+        dryRun: z
+          .boolean()
+          .optional()
+          .describe("Preview the task graph without executing (maps to --dry-run)"),
+        outputStyle: z
+          .enum(["dynamic", "static", "stream", "stream-without-prefixes", "compact"])
+          .optional()
+          .describe("Output style for task logs"),
+        graph: z
+          .boolean()
+          .optional()
+          .describe("Generate the task graph visualization (maps to --graph)"),
         args: z
           .array(z.string().max(INPUT_LIMITS.STRING_MAX))
           .max(INPUT_LIMITS.ARRAY_MAX)
@@ -55,7 +83,22 @@ export function registerNxTool(server: McpServer) {
       },
       outputSchema: NxResultSchema,
     },
-    async ({ target, project, affected, base, path, args, compact }) => {
+    async ({
+      target,
+      project,
+      affected,
+      base,
+      path,
+      parallel,
+      skipNxCache,
+      nxBail,
+      verbose,
+      dryRun,
+      outputStyle,
+      graph,
+      args,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
       assertNoFlagInjection(target, "target");
       if (project) assertNoFlagInjection(project, "project");
@@ -74,6 +117,14 @@ export function registerNxTool(server: McpServer) {
       } else {
         cliArgs.push("run-many", `--target=${target}`);
       }
+
+      if (parallel !== undefined) cliArgs.push(`--parallel=${parallel}`);
+      if (skipNxCache) cliArgs.push("--skip-nx-cache");
+      if (nxBail) cliArgs.push("--nx-bail");
+      if (verbose) cliArgs.push("--verbose");
+      if (dryRun) cliArgs.push("--dry-run");
+      if (outputStyle) cliArgs.push(`--output-style=${outputStyle}`);
+      if (graph) cliArgs.push("--graph");
 
       if (args) {
         cliArgs.push(...args);

--- a/packages/server-build/src/tools/turbo.ts
+++ b/packages/server-build/src/tools/turbo.ts
@@ -25,6 +25,38 @@ export function registerTurboTool(server: McpServer) {
           .optional()
           .describe("Package filter (e.g., '@scope/pkg' or 'pkg...')"),
         concurrency: z.number().optional().describe("Maximum number of concurrent tasks"),
+        force: z
+          .boolean()
+          .optional()
+          .describe("Bypass the turbo cache and re-run all tasks (maps to --force)"),
+        continue_on_error: z
+          .boolean()
+          .optional()
+          .describe(
+            "Continue running tasks even after failures to surface all errors (maps to --continue)",
+          ),
+        dryRun: z
+          .boolean()
+          .optional()
+          .describe("Preview the task graph without executing (maps to --dry-run)"),
+        affected: z
+          .boolean()
+          .optional()
+          .describe(
+            "Run only tasks affected by changes since the base branch (maps to --affected)",
+          ),
+        graph: z
+          .boolean()
+          .optional()
+          .describe("Generate the task graph visualization (maps to --graph)"),
+        logOrder: z
+          .enum(["stream", "grouped", "auto"])
+          .optional()
+          .describe("Order of task log output"),
+        profile: z
+          .boolean()
+          .optional()
+          .describe("Generate a performance profile (maps to --profile)"),
         path: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
@@ -40,7 +72,20 @@ export function registerTurboTool(server: McpServer) {
       },
       outputSchema: TurboResultSchema,
     },
-    async ({ task, filter, concurrency, path, compact }) => {
+    async ({
+      task,
+      filter,
+      concurrency,
+      force,
+      continue_on_error,
+      dryRun,
+      affected,
+      graph,
+      logOrder,
+      profile,
+      path,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
       assertNoFlagInjection(task, "task");
       if (filter) assertNoFlagInjection(filter, "filter");
@@ -49,6 +94,13 @@ export function registerTurboTool(server: McpServer) {
 
       if (filter) cliArgs.push("--filter", filter);
       if (concurrency !== undefined) cliArgs.push("--concurrency", String(concurrency));
+      if (force) cliArgs.push("--force");
+      if (continue_on_error) cliArgs.push("--continue");
+      if (dryRun) cliArgs.push("--dry-run");
+      if (affected) cliArgs.push("--affected");
+      if (graph) cliArgs.push("--graph");
+      if (logOrder) cliArgs.push(`--log-order=${logOrder}`);
+      if (profile) cliArgs.push("--profile");
 
       const start = Date.now();
       const result = await turboCmd(cliArgs, cwd);

--- a/packages/server-build/src/tools/webpack.ts
+++ b/packages/server-build/src/tools/webpack.ts
@@ -29,6 +29,14 @@ export function registerWebpackTool(server: McpServer) {
           .enum(["production", "development", "none"])
           .optional()
           .describe("Build mode (production, development, none)"),
+        bail: z
+          .boolean()
+          .optional()
+          .describe("Fail on the first error instead of tolerating them (maps to --bail)"),
+        cache: z
+          .boolean()
+          .optional()
+          .describe("Enable or disable webpack caching (maps to --cache / --no-cache)"),
         args: z
           .array(z.string().max(INPUT_LIMITS.STRING_MAX))
           .max(INPUT_LIMITS.ARRAY_MAX)
@@ -45,7 +53,7 @@ export function registerWebpackTool(server: McpServer) {
       },
       outputSchema: WebpackResultSchema,
     },
-    async ({ path, config, mode, args, compact }) => {
+    async ({ path, config, mode, bail, cache, args, compact }) => {
       const cwd = path || process.cwd();
       if (config) assertNoFlagInjection(config, "config");
       for (const a of args ?? []) {
@@ -56,7 +64,12 @@ export function registerWebpackTool(server: McpServer) {
 
       if (config) cliArgs.push("--config", config);
       if (mode) cliArgs.push("--mode", mode);
+      if (bail) cliArgs.push("--bail");
+      if (cache !== undefined) {
+        cliArgs.push(cache ? "--cache" : "--no-cache");
+      }
       cliArgs.push("--json");
+      cliArgs.push("--no-color");
 
       if (args) {
         cliArgs.push(...args);


### PR DESCRIPTION
## Summary
- Implements all 31 XS-complexity gap items from the build gap backlog across 7 tools
- **build**: Add `assertNoFlagInjection` on `args[]` (P0 security), document command allowlist in tool description (P2)
- **esbuild**: Add `splitting` (P1), `legalComments` (P2), `logLevel` (P2) params
- **nx**: Add `parallel` (P0), `skipNxCache` (P0), `nxBail` (P1), `verbose` (P1), `dryRun` (P2), `outputStyle` (P2), `graph` (P2) params
- **tsc**: Add `incremental` (P0), `skipLibCheck` (P1), `emitDeclarationOnly` (P1) params; document compact-mode field loss (P2)
- **turbo**: Add `force` (P0), `continue` (P1), `dryRun` (P1), `affected` (P1), `graph` (P2), `logOrder` (P2), `profile` (P2) params
- **vite-build**: Add `manifest` (P1), `minify` (P2), `logLevel` (P2), `emptyOutDir` (P2), `reportCompressedSize` (P2) params
- **webpack**: Add `bail` (P1), `cache` (P2) params; append `--no-color` to CLI args (P2)

## Test plan
- [x] `pnpm build --filter @paretools/build` passes
- [x] `pnpm --filter @paretools/build test` passes (193/193 tests)
- [ ] CI matrix (ubuntu/windows/macos x node 20/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)