### PR TITLE
feat(http): add missing CLI flag parameters

### DIFF
--- a/.changeset/http-xs-gaps.md
+++ b/.changeset/http-xs-gaps.md
@@ -1,0 +1,10 @@
+---
+"@paretools/http": minor
+---
+
+Add missing CLI flag parameters from XS-complexity audit gaps
+
+- get: insecure, retry, compressed
+- head: insecure, retry
+- post: insecure, accept, compressed
+- request: insecure, retry, compressed

--- a/packages/server-http/src/tools/get.ts
+++ b/packages/server-http/src/tools/get.ts
@@ -44,6 +44,20 @@ export function registerGetTool(server: McpServer) {
           .optional()
           .default(true)
           .describe("Follow HTTP redirects (default: true)"),
+        insecure: z
+          .boolean()
+          .optional()
+          .describe("Allow insecure TLS connections, e.g. self-signed certificates (-k)"),
+        retry: z
+          .number()
+          .min(0)
+          .max(10)
+          .optional()
+          .describe("Number of retries on transient failures (--retry)"),
+        compressed: z
+          .boolean()
+          .optional()
+          .describe("Request compressed response and decompress automatically (--compressed)"),
         compact: z
           .boolean()
           .optional()
@@ -59,7 +73,17 @@ export function registerGetTool(server: McpServer) {
       },
       outputSchema: HttpResponseSchema,
     },
-    async ({ url, headers, timeout, followRedirects, compact, path }) => {
+    async ({
+      url,
+      headers,
+      timeout,
+      followRedirects,
+      insecure,
+      retry,
+      compressed,
+      compact,
+      path,
+    }) => {
       assertSafeUrl(url);
 
       const args = buildCurlArgs({
@@ -68,6 +92,9 @@ export function registerGetTool(server: McpServer) {
         headers,
         timeout: timeout ?? 30,
         followRedirects: followRedirects ?? true,
+        insecure,
+        retry,
+        compressed,
       });
 
       const cwd = path || process.cwd();

--- a/packages/server-http/src/tools/head.ts
+++ b/packages/server-http/src/tools/head.ts
@@ -44,6 +44,16 @@ export function registerHeadTool(server: McpServer) {
           .optional()
           .default(true)
           .describe("Follow HTTP redirects (default: true)"),
+        insecure: z
+          .boolean()
+          .optional()
+          .describe("Allow insecure TLS connections, e.g. self-signed certificates (-k)"),
+        retry: z
+          .number()
+          .min(0)
+          .max(10)
+          .optional()
+          .describe("Number of retries on transient failures (--retry)"),
         compact: z
           .boolean()
           .optional()
@@ -59,7 +69,7 @@ export function registerHeadTool(server: McpServer) {
       },
       outputSchema: HttpHeadResponseSchema,
     },
-    async ({ url, headers, timeout, followRedirects, compact, path }) => {
+    async ({ url, headers, timeout, followRedirects, insecure, retry, compact, path }) => {
       assertSafeUrl(url);
 
       const args = buildCurlArgs({
@@ -68,6 +78,8 @@ export function registerHeadTool(server: McpServer) {
         headers,
         timeout: timeout ?? 30,
         followRedirects: followRedirects ?? true,
+        insecure,
+        retry,
       });
 
       const cwd = path || process.cwd();


### PR DESCRIPTION
## Summary
- Implements all XS-complexity gaps from the CLI capability audit for `@paretools/http`
- **get** tool: `insecure`, `retry`, `compressed`
- **head** tool: `insecure`, `retry`
- **post** tool: `insecure`, `accept`, `compressed`
- **request** tool: `insecure`, `retry`, `compressed`
- Updated shared `buildCurlArgs` to accept new optional flags

## Test plan
- [x] `pnpm build --filter @paretools/http` passes
- [x] `pnpm --filter @paretools/http test` passes (85 tests)
- [ ] Manual verification of new flags with real curl invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)