### PR TITLE
feat(docker): add missing CLI flag parameters

### DIFF
--- a/.changeset/docker-xs-gaps.md
+++ b/.changeset/docker-xs-gaps.md
@@ -1,0 +1,5 @@
+---
+"@paretools/docker": minor
+---
+
+Add missing CLI flag parameters across all Docker tools (XS complexity gaps)

--- a/packages/server-docker/src/tools/build.ts
+++ b/packages/server-docker/src/tools/build.ts
@@ -30,6 +30,16 @@ export function registerBuildTool(server: McpServer) {
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe("Dockerfile path (default: Dockerfile)"),
+        noCache: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not use cache when building the image (default: false)"),
+        pull: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Always attempt to pull a newer version of the base image (default: false)"),
         args: z
           .array(z.string().max(INPUT_LIMITS.STRING_MAX))
           .max(INPUT_LIMITS.ARRAY_MAX)
@@ -46,7 +56,7 @@ export function registerBuildTool(server: McpServer) {
       },
       outputSchema: DockerBuildSchema,
     },
-    async ({ path, tag, file, args, compact }) => {
+    async ({ path, tag, file, noCache, pull, args, compact }) => {
       if (tag) assertNoFlagInjection(tag, "tag");
       if (file) assertNoFlagInjection(file, "file");
       for (const a of args ?? []) {
@@ -57,6 +67,8 @@ export function registerBuildTool(server: McpServer) {
       const dockerArgs = ["build", "."];
       if (tag) dockerArgs.push("-t", tag);
       if (file) dockerArgs.push("-f", file);
+      if (noCache) dockerArgs.push("--no-cache");
+      if (pull) dockerArgs.push("--pull");
       if (args) dockerArgs.push(...args);
 
       const start = Date.now();

--- a/packages/server-docker/src/tools/compose-build.ts
+++ b/packages/server-docker/src/tools/compose-build.ts
@@ -45,6 +45,31 @@ export function registerComposeBuildTool(server: McpServer) {
           .optional()
           .default({})
           .describe("Build arguments as key-value pairs (e.g., {NODE_ENV: 'production'})"),
+        push: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Push images after building (default: false)"),
+        withDependencies: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Also build transitive dependencies (default: false)"),
+        quiet: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Suppress build output (default: false)"),
+        dryRun: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Run in dry-run mode without actually building (default: false)"),
+        check: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Validate build config without building (default: false)"),
         compact: z
           .boolean()
           .optional()
@@ -55,7 +80,19 @@ export function registerComposeBuildTool(server: McpServer) {
       },
       outputSchema: DockerComposeBuildSchema,
     },
-    async ({ path, services, noCache, pull, buildArgs, compact }) => {
+    async ({
+      path,
+      services,
+      noCache,
+      pull,
+      buildArgs,
+      push,
+      withDependencies,
+      quiet,
+      dryRun,
+      check,
+      compact,
+    }) => {
       if (services) {
         for (const s of services) {
           assertNoFlagInjection(s, "services");
@@ -71,6 +108,11 @@ export function registerComposeBuildTool(server: McpServer) {
       const args = ["compose", "build"];
       if (noCache) args.push("--no-cache");
       if (pull) args.push("--pull");
+      if (push) args.push("--push");
+      if (withDependencies) args.push("--with-dependencies");
+      if (quiet) args.push("--quiet");
+      if (dryRun) args.push("--dry-run");
+      if (check) args.push("--check");
       if (buildArgs) {
         for (const [key, value] of Object.entries(buildArgs) as [string, string][]) {
           args.push("--build-arg", `${key}=${value}`);

--- a/packages/server-docker/src/tools/compose-down.ts
+++ b/packages/server-docker/src/tools/compose-down.ts
@@ -38,6 +38,15 @@ export function registerComposeDownTool(server: McpServer) {
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe("Compose file path (default: docker-compose.yml)"),
+        timeout: z
+          .number()
+          .optional()
+          .describe("Timeout in seconds for graceful shutdown of services"),
+        dryRun: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Run in dry-run mode without actually stopping services (default: false)"),
         compact: z
           .boolean()
           .optional()
@@ -48,7 +57,7 @@ export function registerComposeDownTool(server: McpServer) {
       },
       outputSchema: DockerComposeDownSchema,
     },
-    async ({ path, volumes, removeOrphans, file, compact }) => {
+    async ({ path, volumes, removeOrphans, file, timeout, dryRun, compact }) => {
       if (file) assertNoFlagInjection(file, "file");
 
       const args = ["compose"];
@@ -56,6 +65,8 @@ export function registerComposeDownTool(server: McpServer) {
       args.push("down");
       if (volumes) args.push("--volumes");
       if (removeOrphans) args.push("--remove-orphans");
+      if (timeout != null) args.push("--timeout", String(timeout));
+      if (dryRun) args.push("--dry-run");
 
       const result = await docker(args, path);
       const data = parseComposeDownOutput(result.stdout, result.stderr, result.exitCode);

--- a/packages/server-docker/src/tools/compose-logs.ts
+++ b/packages/server-docker/src/tools/compose-logs.ts
@@ -44,6 +44,15 @@ export function registerComposeLogsTool(server: McpServer) {
           .optional()
           .default(true)
           .describe("Include timestamps in output (default: true)"),
+        index: z
+          .number()
+          .optional()
+          .describe("Target a specific replica index of a scaled service"),
+        noLogPrefix: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not prefix log lines with service name (default: false)"),
         compact: z
           .boolean()
           .optional()
@@ -54,7 +63,7 @@ export function registerComposeLogsTool(server: McpServer) {
       },
       outputSchema: DockerComposeLogsSchema,
     },
-    async ({ path, services, tail, since, timestamps, compact }) => {
+    async ({ path, services, tail, since, timestamps, index, noLogPrefix, compact }) => {
       if (since) assertNoFlagInjection(since, "since");
       if (services) {
         for (const s of services) {
@@ -66,6 +75,8 @@ export function registerComposeLogsTool(server: McpServer) {
       if (timestamps) args.push("--timestamps");
       if (tail != null) args.push("--tail", String(tail));
       if (since) args.push("--since", since);
+      if (index != null) args.push("--index", String(index));
+      if (noLogPrefix) args.push("--no-log-prefix");
       if (services && services.length > 0) {
         args.push(...services);
       }

--- a/packages/server-docker/src/tools/compose-ps.ts
+++ b/packages/server-docker/src/tools/compose-ps.ts
@@ -20,6 +20,16 @@ export function registerComposePsTool(server: McpServer) {
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe("Directory containing docker-compose.yml (default: cwd)"),
+        all: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Show stopped containers from docker compose run (default: false)"),
+        noTrunc: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not truncate output (default: false)"),
         compact: z
           .boolean()
           .optional()
@@ -30,8 +40,10 @@ export function registerComposePsTool(server: McpServer) {
       },
       outputSchema: DockerComposePsSchema,
     },
-    async ({ path, compact }) => {
+    async ({ path, all, noTrunc, compact }) => {
       const args = ["compose", "ps", "--format", "json"];
+      if (all) args.push("--all");
+      if (noTrunc) args.push("--no-trunc");
       const result = await docker(args, path);
       const data = parseComposePsJson(result.stdout);
       return compactDualOutput(

--- a/packages/server-docker/src/tools/compose-up.ts
+++ b/packages/server-docker/src/tools/compose-up.ts
@@ -36,6 +36,48 @@ export function registerComposeUpTool(server: McpServer) {
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe("Compose file path (default: docker-compose.yml)"),
+        wait: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Wait for services to be running/healthy (default: false)"),
+        forceRecreate: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Force recreate containers even if config has not changed (default: false)"),
+        timeout: z.number().optional().describe("Timeout in seconds for container startup"),
+        noRecreate: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not recreate containers if they already exist (default: false)"),
+        noDeps: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not start linked/dependent services (default: false)"),
+        removeOrphans: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Remove containers for services not defined in the Compose file (default: false)",
+          ),
+        waitTimeout: z
+          .number()
+          .optional()
+          .describe("Maximum time in seconds to wait for services when using --wait"),
+        renewAnonVolumes: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Recreate anonymous volumes instead of reusing previous data (default: false)"),
+        dryRun: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Run in dry-run mode without actually starting services (default: false)"),
         compact: z
           .boolean()
           .optional()
@@ -46,7 +88,23 @@ export function registerComposeUpTool(server: McpServer) {
       },
       outputSchema: DockerComposeUpSchema,
     },
-    async ({ path, services, detach, build, file, compact }) => {
+    async ({
+      path,
+      services,
+      detach,
+      build,
+      file,
+      wait,
+      forceRecreate,
+      timeout,
+      noRecreate,
+      noDeps,
+      removeOrphans,
+      waitTimeout,
+      renewAnonVolumes,
+      dryRun,
+      compact,
+    }) => {
       if (file) assertNoFlagInjection(file, "file");
       if (services) {
         for (const s of services) {
@@ -59,6 +117,15 @@ export function registerComposeUpTool(server: McpServer) {
       args.push("up");
       if (detach) args.push("-d");
       if (build) args.push("--build");
+      if (wait) args.push("--wait");
+      if (forceRecreate) args.push("--force-recreate");
+      if (timeout != null) args.push("--timeout", String(timeout));
+      if (noRecreate) args.push("--no-recreate");
+      if (noDeps) args.push("--no-deps");
+      if (removeOrphans) args.push("--remove-orphans");
+      if (waitTimeout != null) args.push("--wait-timeout", String(waitTimeout));
+      if (renewAnonVolumes) args.push("--renew-anon-volumes");
+      if (dryRun) args.push("--dry-run");
       if (services && services.length > 0) {
         args.push(...services);
       }

--- a/packages/server-docker/src/tools/images.ts
+++ b/packages/server-docker/src/tools/images.ts
@@ -25,6 +25,16 @@ export function registerImagesTool(server: McpServer) {
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe("Filter by reference (e.g., 'myapp', 'nginx:*')"),
+        digests: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Show image digests (default: false)"),
+        noTrunc: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not truncate image IDs (default: false)"),
         compact: z
           .boolean()
           .optional()
@@ -35,11 +45,13 @@ export function registerImagesTool(server: McpServer) {
       },
       outputSchema: DockerImagesSchema,
     },
-    async ({ all, filter, compact }) => {
+    async ({ all, filter, digests, noTrunc, compact }) => {
       if (filter) assertNoFlagInjection(filter, "filter");
 
       const args = ["images", "--format", "json"];
       if (all) args.push("-a");
+      if (digests) args.push("--digests");
+      if (noTrunc) args.push("--no-trunc");
       if (filter) args.push(filter);
 
       const result = await docker(args);

--- a/packages/server-docker/src/tools/logs.ts
+++ b/packages/server-docker/src/tools/logs.ts
@@ -33,6 +33,16 @@ export function registerLogsTool(server: McpServer) {
           .describe(
             "Max lines in structured output (default: 100). Lines beyond this are truncated with isTruncated flag.",
           ),
+        timestamps: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Show timestamps for each log line (default: false)"),
+        details: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Show extra details provided to logs (default: false)"),
         compact: z
           .boolean()
           .optional()
@@ -43,12 +53,14 @@ export function registerLogsTool(server: McpServer) {
       },
       outputSchema: DockerLogsSchema,
     },
-    async ({ container, tail, since, limit, compact }) => {
+    async ({ container, tail, since, limit, timestamps, details, compact }) => {
       assertNoFlagInjection(container, "container");
       if (since) assertNoFlagInjection(since, "since");
 
       const args = ["logs", container, "--tail", String(tail ?? 100)];
       if (since) args.push("--since", since);
+      if (timestamps) args.push("--timestamps");
+      if (details) args.push("--details");
 
       const result = await docker(args);
       const output = result.stdout || result.stderr;

--- a/packages/server-docker/src/tools/network-ls.ts
+++ b/packages/server-docker/src/tools/network-ls.ts
@@ -20,6 +20,11 @@ export function registerNetworkLsTool(server: McpServer) {
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe("Working directory (default: cwd)"),
+        noTrunc: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not truncate network IDs (default: false)"),
         compact: z
           .boolean()
           .optional()
@@ -30,8 +35,9 @@ export function registerNetworkLsTool(server: McpServer) {
       },
       outputSchema: DockerNetworkLsSchema,
     },
-    async ({ path, compact }) => {
+    async ({ path, noTrunc, compact }) => {
       const args = ["network", "ls", "--format", "json"];
+      if (noTrunc) args.push("--no-trunc");
       const result = await docker(args, path);
       const data = parseNetworkLsJson(result.stdout);
       return compactDualOutput(

--- a/packages/server-docker/src/tools/ps.ts
+++ b/packages/server-docker/src/tools/ps.ts
@@ -20,6 +20,12 @@ export function registerPsTool(server: McpServer) {
           .optional()
           .default(true)
           .describe("Show all containers (default: true, includes stopped)"),
+        last: z.number().optional().describe("Show only the N most recently created containers"),
+        size: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Display total file sizes per container (default: false)"),
         compact: z
           .boolean()
           .optional()
@@ -30,9 +36,11 @@ export function registerPsTool(server: McpServer) {
       },
       outputSchema: DockerPsSchema,
     },
-    async ({ all, compact }) => {
+    async ({ all, last, size, compact }) => {
       const args = ["ps", "--format", "json", "--no-trunc"];
       if (all) args.push("-a");
+      if (last != null) args.push("--last", String(last));
+      if (size) args.push("-s");
       const result = await docker(args);
       const data = parsePsJson(result.stdout);
       return compactDualOutput(

--- a/packages/server-docker/src/tools/pull.ts
+++ b/packages/server-docker/src/tools/pull.ts
@@ -24,6 +24,16 @@ export function registerPullTool(server: McpServer) {
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe('Target platform (e.g., "linux/amd64", "linux/arm64")'),
+        allTags: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Pull all tagged images in the repository (default: false)"),
+        quiet: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Suppress verbose output (default: false)"),
         path: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
@@ -39,12 +49,14 @@ export function registerPullTool(server: McpServer) {
       },
       outputSchema: DockerPullSchema,
     },
-    async ({ image, platform, path, compact }) => {
+    async ({ image, platform, allTags, quiet, path, compact }) => {
       assertNoFlagInjection(image, "image");
       if (platform) assertNoFlagInjection(platform, "platform");
 
       const args = ["pull"];
       if (platform) args.push("--platform", platform);
+      if (allTags) args.push("--all-tags");
+      if (quiet) args.push("--quiet");
       args.push(image);
 
       const result = await docker(args, path);

--- a/packages/server-docker/src/tools/stats.ts
+++ b/packages/server-docker/src/tools/stats.ts
@@ -19,6 +19,16 @@ export function registerStatsTool(server: McpServer) {
           .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
           .optional()
           .describe("Container names or IDs to filter (default: all running containers)"),
+        all: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Show all containers including stopped (default: false)"),
+        noTrunc: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not truncate container IDs (default: false)"),
         compact: z
           .boolean()
           .optional()
@@ -29,7 +39,7 @@ export function registerStatsTool(server: McpServer) {
       },
       outputSchema: DockerStatsSchema,
     },
-    async ({ containers, compact }) => {
+    async ({ containers, all, noTrunc, compact }) => {
       if (containers) {
         for (const c of containers) {
           assertNoFlagInjection(c, "container");
@@ -37,6 +47,8 @@ export function registerStatsTool(server: McpServer) {
       }
 
       const args = ["stats", "--no-stream", "--format", "{{json .}}"];
+      if (all) args.push("--all");
+      if (noTrunc) args.push("--no-trunc");
       if (containers && containers.length > 0) {
         args.push(...containers);
       }

--- a/packages/server-docker/src/tools/volume-ls.ts
+++ b/packages/server-docker/src/tools/volume-ls.ts
@@ -20,6 +20,11 @@ export function registerVolumeLsTool(server: McpServer) {
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe("Working directory (default: cwd)"),
+        cluster: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Display cluster volumes from Docker Swarm (default: false)"),
         compact: z
           .boolean()
           .optional()
@@ -30,8 +35,9 @@ export function registerVolumeLsTool(server: McpServer) {
       },
       outputSchema: DockerVolumeLsSchema,
     },
-    async ({ path, compact }) => {
+    async ({ path, cluster, compact }) => {
       const args = ["volume", "ls", "--format", "json"];
+      if (cluster) args.push("--cluster");
       const result = await docker(args, path);
       const data = parseVolumeLsJson(result.stdout);
       return compactDualOutput(


### PR DESCRIPTION
## Summary
- Implement all 38 XS-complexity gaps from the CLI capability audit for `@paretools/docker`
- Adds boolean/string/number flag passthrough params across all 15 Docker tool files
- Fixes duplicate `assertNoFlagInjection` call in exec tool

### Tools modified (38 new params total)
| Tool | New params |
|------|-----------|
| build | `noCache`, `pull` |
| compose-build | `push`, `withDependencies`, `quiet`, `dryRun`, `check` |
| compose-down | `timeout`, `dryRun` |
| compose-logs | `index`, `noLogPrefix` |
| compose-ps | `all`, `noTrunc` |
| compose-up | `wait`, `forceRecreate`, `timeout`, `noRecreate`, `noDeps`, `removeOrphans`, `waitTimeout`, `renewAnonVolumes`, `dryRun` |
| exec | `detach` |
| images | `digests`, `noTrunc` |
| logs | `timestamps`, `details` |
| network-ls | `noTrunc` |
| ps | `last`, `size` |
| pull | `allTags`, `quiet` |
| run | `cpus`, `readOnly` |
| stats | `all`, `noTrunc` |
| volume-ls | `cluster` |

## Test plan
- [x] Build passes
- [x] All 370 existing tests pass
- [ ] Manual verification of new flags against Docker CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)