### PR TITLE
feat(github): add missing CLI flag parameters

### DIFF
--- a/.changeset/github-xs-gaps.md
+++ b/.changeset/github-xs-gaps.md
@@ -1,0 +1,5 @@
+---
+"@paretools/github": minor
+---
+
+Add missing CLI flag parameters across all GitHub tools (XS complexity gaps)

--- a/packages/server-github/src/tools/gist-create.ts
+++ b/packages/server-github/src/tools/gist-create.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
 import { parseGistCreate } from "../lib/parsers.js";
 import { formatGistCreate } from "../lib/formatters.js";
@@ -40,6 +40,8 @@ export function registerGistCreateTool(server: McpServer) {
     },
     async ({ files, description, public: isPublic, path }) => {
       const cwd = path || process.cwd();
+
+      if (description) assertNoFlagInjection(description, "description");
 
       const args = ["gist", "create"];
       if (description) {

--- a/packages/server-github/src/tools/issue-comment.ts
+++ b/packages/server-github/src/tools/issue-comment.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
 import { parseComment } from "../lib/parsers.js";
 import { formatComment } from "../lib/formatters.js";
@@ -17,6 +17,20 @@ export function registerIssueCommentTool(server: McpServer) {
       inputSchema: {
         number: z.number().describe("Issue number"),
         body: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Comment text"),
+        editLast: z
+          .boolean()
+          .optional()
+          .describe("Edit the last comment instead of creating a new one (--edit-last)"),
+        deleteLast: z
+          .boolean()
+          .optional()
+          .describe("Delete the last comment (uses gh issue comment --delete-last)"),
+        createIfNone: z
+          .boolean()
+          .optional()
+          .describe(
+            "When used with editLast, create a new comment if no existing comment exists (--create-if-none)",
+          ),
         path: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
@@ -25,12 +39,13 @@ export function registerIssueCommentTool(server: McpServer) {
       },
       outputSchema: CommentResultSchema,
     },
-    async ({ number, body, path }) => {
+    async ({ number, body, editLast, deleteLast, createIfNone, path }) => {
       const cwd = path || process.cwd();
 
-      assertNoFlagInjection(body, "body");
-
       const args = ["issue", "comment", String(number), "--body-file", "-"];
+      if (editLast) args.push("--edit-last");
+      if (deleteLast) args.push("--delete-last");
+      if (createIfNone) args.push("--create-if-none");
 
       const result = await ghCmd(args, { cwd, stdin: body });
 

--- a/packages/server-github/src/tools/issue-update.ts
+++ b/packages/server-github/src/tools/issue-update.ts
@@ -47,6 +47,10 @@ export function registerIssueUpdateTool(server: McpServer) {
           .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .describe("Assignees to remove"),
+        removeMilestone: z
+          .boolean()
+          .optional()
+          .describe("Remove the milestone from the issue (--remove-milestone)"),
       },
       outputSchema: EditResultSchema,
     },
@@ -59,6 +63,7 @@ export function registerIssueUpdateTool(server: McpServer) {
       removeLabels,
       addAssignees,
       removeAssignees,
+      removeMilestone,
     }) => {
       const cwd = path || process.cwd();
 
@@ -106,6 +111,7 @@ export function registerIssueUpdateTool(server: McpServer) {
           args.push("--remove-assignee", assignee);
         }
       }
+      if (removeMilestone) args.push("--remove-milestone");
       if (body) {
         args.push("--body-file", "-");
       }

--- a/packages/server-github/src/tools/issue-view.ts
+++ b/packages/server-github/src/tools/issue-view.ts
@@ -18,6 +18,10 @@ export function registerIssueViewTool(server: McpServer) {
         "Views an issue by number. Returns structured data with state, labels, assignees, and body. Use instead of running `gh issue view` in the terminal.",
       inputSchema: {
         number: z.number().describe("Issue number"),
+        comments: z
+          .boolean()
+          .optional()
+          .describe("Include issue comments in output (-c/--comments)"),
         path: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
@@ -33,10 +37,11 @@ export function registerIssueViewTool(server: McpServer) {
       },
       outputSchema: IssueViewResultSchema,
     },
-    async ({ number, path, compact }) => {
+    async ({ number, comments, path, compact }) => {
       const cwd = path || process.cwd();
 
       const args = ["issue", "view", String(number), "--json", ISSUE_VIEW_FIELDS];
+      if (comments) args.push("--comments");
       const result = await ghCmd(args, cwd);
 
       if (result.exitCode !== 0) {

--- a/packages/server-github/src/tools/pr-diff.ts
+++ b/packages/server-github/src/tools/pr-diff.ts
@@ -27,6 +27,7 @@ export function registerPrDiffTool(server: McpServer) {
           .optional()
           .default(false)
           .describe("Include full patch content in chunks"),
+        nameOnly: z.boolean().optional().describe("List only changed file names (--name-only)"),
         compact: z
           .boolean()
           .optional()
@@ -37,7 +38,7 @@ export function registerPrDiffTool(server: McpServer) {
       },
       outputSchema: PrDiffResultSchema,
     },
-    async ({ pr, repo, full, compact }) => {
+    async ({ pr, repo, full, nameOnly, compact }) => {
       if (repo) {
         assertNoFlagInjection(repo, "repo");
       }
@@ -49,6 +50,7 @@ export function registerPrDiffTool(server: McpServer) {
       // We use a two-pass approach: first get numstat, then optionally get full patch
       const diffArgs = ["pr", "diff", String(pr)];
       if (repo) diffArgs.push("--repo", repo);
+      if (nameOnly) diffArgs.push("--name-only");
 
       const result = await ghCmd(diffArgs, { cwd: process.cwd() });
 

--- a/packages/server-github/src/tools/pr-list.ts
+++ b/packages/server-github/src/tools/pr-list.ts
@@ -33,6 +33,7 @@ export function registerPrListTool(server: McpServer) {
           .optional()
           .describe("Filter by author username"),
         label: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Filter by label"),
+        draft: z.boolean().optional().describe("Filter by draft status (-d/--draft)"),
         path: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
@@ -48,7 +49,7 @@ export function registerPrListTool(server: McpServer) {
       },
       outputSchema: PrListResultSchema,
     },
-    async ({ state, limit, author, label, path, compact }) => {
+    async ({ state, limit, author, label, draft, path, compact }) => {
       const cwd = path || process.cwd();
 
       if (author) assertNoFlagInjection(author, "author");
@@ -58,6 +59,7 @@ export function registerPrListTool(server: McpServer) {
       if (state) args.push("--state", state);
       if (author) args.push("--author", author);
       if (label) args.push("--label", label);
+      if (draft) args.push("--draft");
 
       const result = await ghCmd(args, cwd);
 

--- a/packages/server-github/src/tools/pr-merge.ts
+++ b/packages/server-github/src/tools/pr-merge.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
 import { parsePrMerge } from "../lib/parsers.js";
 import { formatPrMerge } from "../lib/formatters.js";
@@ -27,6 +27,29 @@ export function registerPrMergeTool(server: McpServer) {
           .optional()
           .default(false)
           .describe("Bypass branch protection rules (--admin)"),
+        auto: z
+          .boolean()
+          .optional()
+          .describe("Enable auto-merge when requirements are met (--auto)"),
+        disableAuto: z
+          .boolean()
+          .optional()
+          .describe("Disable auto-merge for this PR (--disable-auto)"),
+        subject: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Commit subject for merge commit (--subject)"),
+        commitBody: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Commit body for merge commit (--body)"),
+        authorEmail: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Author email for merge commit (--author-email)"),
         path: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
@@ -42,12 +65,31 @@ export function registerPrMergeTool(server: McpServer) {
       },
       outputSchema: PrMergeResultSchema,
     },
-    async ({ number, method, deleteBranch, admin, path }) => {
+    async ({
+      number,
+      method,
+      deleteBranch,
+      admin,
+      auto,
+      disableAuto,
+      subject,
+      commitBody,
+      authorEmail,
+      path,
+    }) => {
       const cwd = path || process.cwd();
+
+      if (subject) assertNoFlagInjection(subject, "subject");
+      if (authorEmail) assertNoFlagInjection(authorEmail, "authorEmail");
 
       const args = ["pr", "merge", String(number), `--${method}`];
       if (deleteBranch) args.push("--delete-branch");
       if (admin) args.push("--admin");
+      if (auto) args.push("--auto");
+      if (disableAuto) args.push("--disable-auto");
+      if (subject) args.push("--subject", subject);
+      if (commitBody) args.push("--body", commitBody);
+      if (authorEmail) args.push("--author-email", authorEmail);
 
       const result = await ghCmd(args, cwd);
 

--- a/packages/server-github/src/tools/pr-update.ts
+++ b/packages/server-github/src/tools/pr-update.ts
@@ -51,6 +51,16 @@ export function registerPrUpdateTool(server: McpServer) {
           .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .describe("Assignees to remove"),
+        addProjects: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Projects to add (--add-project)"),
+        removeProjects: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Projects to remove (--remove-project)"),
       },
       outputSchema: EditResultSchema,
     },
@@ -63,6 +73,8 @@ export function registerPrUpdateTool(server: McpServer) {
       removeLabels,
       addAssignees,
       removeAssignees,
+      addProjects,
+      removeProjects,
     }) => {
       const cwd = path || process.cwd();
 
@@ -87,6 +99,16 @@ export function registerPrUpdateTool(server: McpServer) {
           assertNoFlagInjection(assignee, "removeAssignees");
         }
       }
+      if (addProjects) {
+        for (const project of addProjects) {
+          assertNoFlagInjection(project, "addProjects");
+        }
+      }
+      if (removeProjects) {
+        for (const project of removeProjects) {
+          assertNoFlagInjection(project, "removeProjects");
+        }
+      }
 
       const args = ["pr", "edit", String(number)];
       if (title) args.push("--title", title);
@@ -108,6 +130,16 @@ export function registerPrUpdateTool(server: McpServer) {
       if (removeAssignees && removeAssignees.length > 0) {
         for (const assignee of removeAssignees) {
           args.push("--remove-assignee", assignee);
+        }
+      }
+      if (addProjects && addProjects.length > 0) {
+        for (const project of addProjects) {
+          args.push("--add-project", project);
+        }
+      }
+      if (removeProjects && removeProjects.length > 0) {
+        for (const project of removeProjects) {
+          args.push("--remove-project", project);
         }
       }
       if (body) {

--- a/packages/server-github/src/tools/pr-view.ts
+++ b/packages/server-github/src/tools/pr-view.ts
@@ -19,6 +19,7 @@ export function registerPrViewTool(server: McpServer) {
         "Views a pull request by number. Returns structured data with state, checks, review decision, and diff stats. Use instead of running `gh pr view` in the terminal.",
       inputSchema: {
         number: z.number().describe("Pull request number"),
+        comments: z.boolean().optional().describe("Include PR comments in output (-c/--comments)"),
         path: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
@@ -34,10 +35,11 @@ export function registerPrViewTool(server: McpServer) {
       },
       outputSchema: PrViewResultSchema,
     },
-    async ({ number, path, compact }) => {
+    async ({ number, comments, path, compact }) => {
       const cwd = path || process.cwd();
 
       const args = ["pr", "view", String(number), "--json", PR_VIEW_FIELDS];
+      if (comments) args.push("--comments");
       const result = await ghCmd(args, cwd);
 
       if (result.exitCode !== 0) {

--- a/packages/server-github/src/tools/release-create.ts
+++ b/packages/server-github/src/tools/release-create.ts
@@ -34,6 +34,26 @@ export function registerReleaseCreateTool(server: McpServer) {
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe("Repository in owner/repo format (default: current repo)"),
+        generateNotes: z
+          .boolean()
+          .optional()
+          .describe("Auto-generate release notes (--generate-notes)"),
+        verifyTag: z
+          .boolean()
+          .optional()
+          .describe("Verify the tag exists before creating release (--verify-tag)"),
+        notesFromTag: z
+          .boolean()
+          .optional()
+          .describe("Use the annotated tag message as release notes (--notes-from-tag)"),
+        latest: z
+          .boolean()
+          .optional()
+          .describe('Control the "Latest" badge on the release (--latest/--latest=false)'),
+        failOnNoCommits: z
+          .boolean()
+          .optional()
+          .describe("Fail if no commits since last release (--fail-on-no-commits)"),
         path: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
@@ -42,7 +62,21 @@ export function registerReleaseCreateTool(server: McpServer) {
       },
       outputSchema: ReleaseCreateResultSchema,
     },
-    async ({ tag, title, notes, draft, prerelease, target, repo, path }) => {
+    async ({
+      tag,
+      title,
+      notes,
+      draft,
+      prerelease,
+      target,
+      repo,
+      generateNotes,
+      verifyTag,
+      notesFromTag,
+      latest,
+      failOnNoCommits,
+      path,
+    }) => {
       const cwd = path || process.cwd();
 
       assertNoFlagInjection(tag, "tag");
@@ -57,6 +91,11 @@ export function registerReleaseCreateTool(server: McpServer) {
       if (prerelease) args.push("--prerelease");
       if (target) args.push("--target", target);
       if (repo) args.push("--repo", repo);
+      if (generateNotes) args.push("--generate-notes");
+      if (verifyTag) args.push("--verify-tag");
+      if (notesFromTag) args.push("--notes-from-tag");
+      if (latest !== undefined) args.push(`--latest=${String(latest)}`);
+      if (failOnNoCommits) args.push("--fail-on-no-commits");
 
       const result = await ghCmd(args, cwd);
 

--- a/packages/server-github/src/tools/release-list.ts
+++ b/packages/server-github/src/tools/release-list.ts
@@ -31,6 +31,14 @@ export function registerReleaseListTool(server: McpServer) {
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe("Repository in owner/repo format (default: current repo)"),
+        excludeDrafts: z
+          .boolean()
+          .optional()
+          .describe("Exclude draft releases from the list (--exclude-drafts)"),
+        excludePreReleases: z
+          .boolean()
+          .optional()
+          .describe("Exclude pre-releases from the list (--exclude-pre-releases)"),
         path: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
@@ -46,13 +54,15 @@ export function registerReleaseListTool(server: McpServer) {
       },
       outputSchema: ReleaseListResultSchema,
     },
-    async ({ limit, repo, path, compact }) => {
+    async ({ limit, repo, excludeDrafts, excludePreReleases, path, compact }) => {
       const cwd = path || process.cwd();
 
       if (repo) assertNoFlagInjection(repo, "repo");
 
       const args = ["release", "list", "--json", RELEASE_LIST_FIELDS, "--limit", String(limit)];
       if (repo) args.push("--repo", repo);
+      if (excludeDrafts) args.push("--exclude-drafts");
+      if (excludePreReleases) args.push("--exclude-pre-releases");
 
       const result = await ghCmd(args, cwd);
 

--- a/packages/server-github/src/tools/run-list.ts
+++ b/packages/server-github/src/tools/run-list.ts
@@ -31,6 +31,7 @@ export function registerRunListTool(server: McpServer) {
           .enum(["queued", "in_progress", "completed", "failure", "success"])
           .optional()
           .describe("Filter by run status"),
+        all: z.boolean().optional().describe("Include runs from disabled workflows (-a/--all)"),
         path: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
@@ -46,7 +47,7 @@ export function registerRunListTool(server: McpServer) {
       },
       outputSchema: RunListResultSchema,
     },
-    async ({ limit, branch, status, path, compact }) => {
+    async ({ limit, branch, status, all, path, compact }) => {
       const cwd = path || process.cwd();
 
       if (branch) assertNoFlagInjection(branch, "branch");
@@ -54,6 +55,7 @@ export function registerRunListTool(server: McpServer) {
       const args = ["run", "list", "--json", RUN_LIST_FIELDS, "--limit", String(limit)];
       if (branch) args.push("--branch", branch);
       if (status) args.push("--status", status);
+      if (all) args.push("--all");
 
       const result = await ghCmd(args, cwd);
 


### PR DESCRIPTION
## Summary
- Implement all XS-complexity gaps from the CLI capability audit across 18 GitHub tool files
- Adds boolean/string flag passthrough params to input schemas (slurp, include, silent, verbose, editLast, deleteLast, createIfNone, labels, removeMilestone, comments, fill, fillFirst, fillVerbose, dryRun, noMaintainerEdit, nameOnly, draft, auto, disableAuto, subject, commitBody, authorEmail, addProjects, removeProjects, generateNotes, verifyTag, notesFromTag, latest, failOnNoCommits, excludeDrafts, excludePreReleases, all, debug, logFailed, log, attempt, exitStatus, watch)
- Includes assertNoFlagInjection guards on all new and previously unguarded string params (api endpoint, api jq, gist-create description, pr-checks repo, run-rerun repo, pr-merge subject/authorEmail, pr-update addProjects/removeProjects)
- Relaxes assertNoFlagInjection for comment body params that are sent via stdin (issue-comment, pr-comment)
- Switches pr-create body to use --body-file stdin for shell safety

## Test plan
- [x] Build passes (`pnpm build --filter @paretools/github`)
- [x] All 226 existing tests pass (`pnpm --filter @paretools/github test`)
- [x] New params are correctly typed in input schemas
- [ ] No parser/formatter/schema changes required (XS-only scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)