### PR TITLE
feat(k8s): add missing CLI flag parameters

### DIFF
--- a/.changeset/k8s-xs-gaps.md
+++ b/.changeset/k8s-xs-gaps.md
@@ -1,0 +1,11 @@
+---
+"@paretools/k8s": minor
+---
+
+Add missing CLI flag parameters from XS-complexity audit gaps
+
+- apply: serverSide, wait, recursive, kustomize, prune, force, forceConflicts
+- describe: allNamespaces, showEvents
+- get: ignoreNotFound, chunkSize
+- helm: dryRun, wait, atomic, createNamespace, installOnUpgrade, reuseValues, allNamespaces, showResources, noHooks, skipCrds
+- logs: timestamps, allContainers, limitBytes, prefix, ignoreErrors

--- a/packages/server-k8s/src/tools/get.ts
+++ b/packages/server-k8s/src/tools/get.ts
@@ -38,6 +38,14 @@ export function registerGetTool(server: McpServer) {
           .max(INPUT_LIMITS.STRING_MAX)
           .optional()
           .describe("Label selector (e.g., app=nginx)"),
+        ignoreNotFound: z
+          .boolean()
+          .optional()
+          .describe("Suppress not-found errors instead of failing (--ignore-not-found)"),
+        chunkSize: z
+          .number()
+          .optional()
+          .describe("Number of results to return per request for pagination (--chunk-size)"),
         compact: z
           .boolean()
           .optional()
@@ -48,7 +56,16 @@ export function registerGetTool(server: McpServer) {
       },
       outputSchema: KubectlGetResultSchema,
     },
-    async ({ resource, name, namespace, allNamespaces, selector, compact }) => {
+    async ({
+      resource,
+      name,
+      namespace,
+      allNamespaces,
+      selector,
+      ignoreNotFound,
+      chunkSize,
+      compact,
+    }) => {
       assertNoFlagInjection(resource, "resource");
       if (name) assertNoFlagInjection(name, "name");
       if (namespace) assertNoFlagInjection(namespace, "namespace");
@@ -62,6 +79,8 @@ export function registerGetTool(server: McpServer) {
         args.push("-n", namespace);
       }
       if (selector) args.push("-l", selector);
+      if (ignoreNotFound) args.push("--ignore-not-found");
+      if (chunkSize !== undefined) args.push("--chunk-size", String(chunkSize));
       args.push("-o", "json");
 
       const result = await run("kubectl", args, { timeout: 60_000 });

--- a/packages/server-k8s/src/tools/logs.ts
+++ b/packages/server-k8s/src/tools/logs.ts
@@ -41,6 +41,26 @@ export function registerLogsTool(server: McpServer) {
           .optional()
           .default(false)
           .describe("Get logs from previous terminated container"),
+        timestamps: z
+          .boolean()
+          .optional()
+          .describe("Include timestamps on each line (--timestamps)"),
+        allContainers: z
+          .boolean()
+          .optional()
+          .describe("Get logs from all containers in the pod (--all-containers)"),
+        limitBytes: z
+          .number()
+          .optional()
+          .describe("Maximum bytes of logs to return (--limit-bytes)"),
+        prefix: z
+          .boolean()
+          .optional()
+          .describe("Prefix each log line with pod and container name (--prefix)"),
+        ignoreErrors: z
+          .boolean()
+          .optional()
+          .describe("Continue on errors fetching logs from containers (--ignore-errors)"),
         compact: z
           .boolean()
           .optional()
@@ -51,7 +71,20 @@ export function registerLogsTool(server: McpServer) {
       },
       outputSchema: KubectlLogsResultSchema,
     },
-    async ({ pod, namespace, container, tail, since, previous, compact }) => {
+    async ({
+      pod,
+      namespace,
+      container,
+      tail,
+      since,
+      previous,
+      timestamps,
+      allContainers,
+      limitBytes,
+      prefix,
+      ignoreErrors,
+      compact,
+    }) => {
       assertNoFlagInjection(pod, "pod");
       if (namespace) assertNoFlagInjection(namespace, "namespace");
       if (container) assertNoFlagInjection(container, "container");
@@ -63,6 +96,11 @@ export function registerLogsTool(server: McpServer) {
       if (tail !== undefined) args.push("--tail", String(tail));
       if (since) args.push("--since", since);
       if (previous) args.push("--previous");
+      if (timestamps) args.push("--timestamps");
+      if (allContainers) args.push("--all-containers");
+      if (limitBytes !== undefined) args.push("--limit-bytes", String(limitBytes));
+      if (prefix) args.push("--prefix");
+      if (ignoreErrors) args.push("--ignore-errors");
 
       const result = await run("kubectl", args, { timeout: 60_000 });
       const data = parseLogsOutput(


### PR DESCRIPTION
## Summary
- Implements all XS-complexity gaps from the CLI capability audit for `@paretools/k8s`
- **apply** tool: `serverSide`, `wait`, `recursive`, `kustomize`, `prune`, `force`, `forceConflicts`
- **describe** tool: `allNamespaces`, `showEvents`
- **get** tool: `ignoreNotFound`, `chunkSize`
- **helm** tool: `dryRun`, `wait`, `atomic`, `createNamespace`, `installOnUpgrade`, `reuseValues`, `allNamespaces`, `showResources`, `noHooks`, `skipCrds`
- **logs** tool: `timestamps`, `allContainers`, `limitBytes`, `prefix`, `ignoreErrors`

## Test plan
- [x] `pnpm build --filter @paretools/k8s` passes
- [x] `pnpm --filter @paretools/k8s test` passes (177 tests)
- [ ] Manual verification of new flags with real kubectl/helm invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)