### PR TITLE
feat(go): add missing CLI flag parameters

### DIFF
--- a/.changeset/go-xs-gaps.md
+++ b/.changeset/go-xs-gaps.md
@@ -1,0 +1,5 @@
+---
+"@paretools/go": minor
+---
+
+Add missing CLI flag parameters across all Go tools (XS complexity gaps)

--- a/packages/server-go/src/tools/env.ts
+++ b/packages/server-go/src/tools/env.ts
@@ -25,6 +25,13 @@ export function registerEnvTool(server: McpServer) {
           .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .describe("Specific environment variables to query (e.g., ['GOROOT', 'GOPATH'])"),
+        changed: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Show only variables whose effective value differs from the default (-changed)",
+          ),
         compact: z
           .boolean()
           .optional()
@@ -35,12 +42,14 @@ export function registerEnvTool(server: McpServer) {
       },
       outputSchema: GoEnvResultSchema,
     },
-    async ({ path, vars, compact }) => {
+    async ({ path, vars, changed, compact }) => {
       for (const v of vars || []) {
         assertNoFlagInjection(v, "vars");
       }
       const cwd = path || process.cwd();
-      const args = ["env", "-json", ...(vars || [])];
+      const args = ["env", "-json"];
+      if (changed) args.push("-changed");
+      args.push(...(vars || []));
       const result = await goCmd(args, cwd);
       const data = parseGoEnvOutput(result.stdout);
       const rawOutput = result.stdout.trim();

--- a/packages/server-go/src/tools/golangci-lint.ts
+++ b/packages/server-go/src/tools/golangci-lint.ts
@@ -35,6 +35,26 @@ export function registerGolangciLintTool(server: McpServer) {
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe("Path to golangci-lint config file"),
+        fix: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Automatically fix found issues where possible (--fix)"),
+        fast: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Run only fast linters for quick feedback during iteration (--fast)"),
+        new: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Show only new issues (--new). Useful for incremental linting."),
+        sortResults: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Sort lint results for consistent output (--sort-results)"),
         compact: z
           .boolean()
           .optional()
@@ -45,7 +65,7 @@ export function registerGolangciLintTool(server: McpServer) {
       },
       outputSchema: GolangciLintResultSchema,
     },
-    async ({ path, patterns, config, compact }) => {
+    async ({ path, patterns, config, fix, fast, new: newOnly, sortResults, compact }) => {
       const cwd = path || process.cwd();
       for (const p of patterns ?? []) {
         assertNoFlagInjection(p, "patterns");
@@ -58,6 +78,10 @@ export function registerGolangciLintTool(server: McpServer) {
       if (config) {
         args.push("--config", config);
       }
+      if (fix) args.push("--fix");
+      if (fast) args.push("--fast");
+      if (newOnly) args.push("--new");
+      if (sortResults) args.push("--sort-results");
       args.push(...(patterns || ["./..."]));
 
       const result = await golangciLintCmd(args, cwd);

--- a/packages/server-go/src/tools/run.ts
+++ b/packages/server-go/src/tools/run.ts
@@ -37,7 +37,8 @@ export function registerRunTool(server: McpServer) {
           .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .default([])
-          .describe("Build flags to pass to go run (e.g., -race, -tags)"),
+          .describe("Build flags to pass to go run (e.g., -tags)"),
+        race: z.boolean().optional().default(false).describe("Enable data race detection (-race)"),
         compact: z
           .boolean()
           .optional()
@@ -48,14 +49,16 @@ export function registerRunTool(server: McpServer) {
       },
       outputSchema: GoRunResultSchema,
     },
-    async ({ path, file, args, buildArgs, compact }) => {
+    async ({ path, file, args, buildArgs, race, compact }) => {
       const cwd = path || process.cwd();
       const target = file || ".";
       assertNoFlagInjection(target, "file");
       for (const a of buildArgs ?? []) {
         assertNoFlagInjection(a, "buildArgs");
       }
-      const cmdArgs = ["run", ...(buildArgs || []), target];
+      const cmdArgs = ["run"];
+      if (race) cmdArgs.push("-race");
+      cmdArgs.push(...(buildArgs || []), target);
       const programArgs = args || [];
       if (programArgs.length > 0) {
         cmdArgs.push("--", ...programArgs);


### PR DESCRIPTION
## Summary
- Implement all XS-complexity gaps from the CLI capability audit for `@paretools/go`
- Adds 29 new flag parameters across 10 tools: build, env, fmt, generate, get, golangci-lint, list, mod-tidy, run, test
- All new params follow existing patterns: boolean flags with defaults, `assertNoFlagInjection` on string params

### New parameters by tool
- **build**: `race`, `trimpath`, `verbose`
- **env**: `changed`
- **fmt**: `diff`, `simplify`, `allErrors`
- **generate**: `dryRun`, `verbose`, `commands`
- **get**: `testDeps`, `verbose`, `downloadOnly`
- **golangci-lint**: `fix`, `fast`, `new`, `sortResults`
- **list**: `updates`, `deps`, `tolerateErrors`, `versions`, `find`
- **mod-tidy**: `diff`, `verbose`, `continueOnError`
- **run**: `race`
- **test**: `failfast`, `short`, `race`

## Test plan
- [x] Build passes (`pnpm build --filter @paretools/go`)
- [x] All 238 existing tests pass (`pnpm --filter @paretools/go test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)