### PR TITLE
feat(lint): add all XS-complexity gap items

### DIFF
--- a/.changeset/lint-xs-gaps.md
+++ b/.changeset/lint-xs-gaps.md
@@ -1,0 +1,15 @@
+---
+"@paretools/lint": minor
+---
+
+Add XS-complexity gap items across all lint tools:
+
+- biome-check: Add `apply`, `applyUnsafe`, `diagnosticLevel`, `changed`, and `staged` params
+- biome-format: Add `changed`, `staged`, `indentStyle`, `lineWidth`, `quoteStyle`, `semicolons`, and `lineEnding` params
+- format-check: Add `ignoreUnknown`, `cache`, `noConfig`, and `logLevel` params
+- hadolint: Add `failureThreshold`, `noFail`, `strictLabels`, and `verbose` params
+- lint (eslint): Add `quiet`, `noIgnore`, `cache`, and `fixDryRun` params
+- oxlint: Add `fix`, `quiet`, `fixSuggestions`, `threads`, and `noIgnore` params
+- prettier-format: Add `ignoreUnknown`, `cache`, `noConfig`, `logLevel`, and `endOfLine` params
+- shellcheck: Add `shell`, `externalSources`, `checkSourced`, and `norc` params
+- stylelint: Add `quiet`, `allowEmptyInput`, `cache`, `reportNeedlessDisables`, and `ignoreDisables` params

--- a/packages/server-lint/src/tools/hadolint.ts
+++ b/packages/server-lint/src/tools/hadolint.ts
@@ -36,6 +36,19 @@ export function registerHadolintTool(server: McpServer) {
           .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .describe("Rule codes to ignore (e.g., ['DL3008', 'DL3013'])"),
+        failureThreshold: z
+          .enum(["error", "warning", "info", "style", "ignore", "none"])
+          .optional()
+          .describe("Minimum severity to cause a non-zero exit code (maps to --failure-threshold)"),
+        noFail: z
+          .boolean()
+          .optional()
+          .describe("Always exit with 0 for informational-only runs (maps to --no-fail)"),
+        strictLabels: z
+          .boolean()
+          .optional()
+          .describe("Enforce strict label schema (maps to --strict-labels)"),
+        verbose: z.boolean().optional().describe("Enable verbose output (maps to --verbose)"),
         compact: z
           .boolean()
           .optional()
@@ -46,7 +59,17 @@ export function registerHadolintTool(server: McpServer) {
       },
       outputSchema: LintResultSchema,
     },
-    async ({ path, patterns, trustedRegistries, ignoreRules, compact }) => {
+    async ({
+      path,
+      patterns,
+      trustedRegistries,
+      ignoreRules,
+      failureThreshold,
+      noFail,
+      strictLabels,
+      verbose,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
       for (const p of patterns ?? []) {
         assertNoFlagInjection(p, "patterns");
@@ -66,6 +89,11 @@ export function registerHadolintTool(server: McpServer) {
           args.push(`--ignore=${rule}`);
         }
       }
+
+      if (failureThreshold) args.push(`--failure-threshold=${failureThreshold}`);
+      if (noFail) args.push("--no-fail");
+      if (strictLabels) args.push("--strict-labels");
+      if (verbose) args.push("--verbose");
 
       args.push(...(patterns || ["Dockerfile"]));
 

--- a/packages/server-lint/src/tools/lint.ts
+++ b/packages/server-lint/src/tools/lint.ts
@@ -27,6 +27,22 @@ export function registerLintTool(server: McpServer) {
           .default(["."])
           .describe("File patterns to lint (default: ['.'])"),
         fix: z.boolean().optional().default(false).describe("Auto-fix problems"),
+        quiet: z
+          .boolean()
+          .optional()
+          .describe("Report errors only, suppress warnings (maps to --quiet)"),
+        noIgnore: z
+          .boolean()
+          .optional()
+          .describe("Disable ignore patterns to lint normally-ignored files (maps to --no-ignore)"),
+        cache: z
+          .boolean()
+          .optional()
+          .describe("Cache lint results for faster subsequent runs (maps to --cache)"),
+        fixDryRun: z
+          .boolean()
+          .optional()
+          .describe("Preview fixes without writing them (maps to --fix-dry-run)"),
         compact: z
           .boolean()
           .optional()
@@ -37,13 +53,17 @@ export function registerLintTool(server: McpServer) {
       },
       outputSchema: LintResultSchema,
     },
-    async ({ path, patterns, fix, compact }) => {
+    async ({ path, patterns, fix, quiet, noIgnore, cache, fixDryRun, compact }) => {
       const cwd = path || process.cwd();
       for (const p of patterns ?? []) {
         assertNoFlagInjection(p, "patterns");
       }
       const args = ["--format", "json", ...(patterns || ["."])];
       if (fix) args.push("--fix");
+      if (quiet) args.push("--quiet");
+      if (noIgnore) args.push("--no-ignore");
+      if (cache) args.push("--cache");
+      if (fixDryRun) args.push("--fix-dry-run");
 
       const result = await eslint(args, cwd);
       const data = parseEslintJson(result.stdout);

--- a/packages/server-lint/src/tools/oxlint.ts
+++ b/packages/server-lint/src/tools/oxlint.ts
@@ -26,6 +26,17 @@ export function registerOxlintTool(server: McpServer) {
           .optional()
           .default(["."])
           .describe("File patterns to lint (default: ['.'])"),
+        fix: z.boolean().optional().describe("Auto-fix problems (maps to --fix)"),
+        quiet: z
+          .boolean()
+          .optional()
+          .describe("Report errors only, suppress warnings (maps to --quiet)"),
+        fixSuggestions: z
+          .boolean()
+          .optional()
+          .describe("Apply suggestion-level fixes (maps to --fix-suggestions)"),
+        threads: z.number().optional().describe("Number of threads to use for parallel linting"),
+        noIgnore: z.boolean().optional().describe("Disable ignore patterns (maps to --no-ignore)"),
         compact: z
           .boolean()
           .optional()
@@ -36,12 +47,17 @@ export function registerOxlintTool(server: McpServer) {
       },
       outputSchema: LintResultSchema,
     },
-    async ({ path, patterns, compact }) => {
+    async ({ path, patterns, fix, quiet, fixSuggestions, threads, noIgnore, compact }) => {
       const cwd = path || process.cwd();
       for (const p of patterns ?? []) {
         assertNoFlagInjection(p, "patterns");
       }
       const args = ["--format", "json", ...(patterns || ["."])];
+      if (fix) args.push("--fix");
+      if (quiet) args.push("--quiet");
+      if (fixSuggestions) args.push("--fix-suggestions");
+      if (threads !== undefined) args.push(`--threads=${threads}`);
+      if (noIgnore) args.push("--no-ignore");
 
       const result = await oxlintCmd(args, cwd);
       const data = parseOxlintJson(result.stdout);

--- a/packages/server-lint/src/tools/shellcheck.ts
+++ b/packages/server-lint/src/tools/shellcheck.ts
@@ -30,6 +30,24 @@ export function registerShellcheckTool(server: McpServer) {
           .enum(["error", "warning", "info", "style"])
           .optional()
           .describe("Minimum severity level to report (default: style)"),
+        shell: z
+          .enum(["sh", "bash", "dash", "ksh"])
+          .optional()
+          .describe("Shell dialect to assume (maps to --shell)"),
+        externalSources: z
+          .boolean()
+          .optional()
+          .describe(
+            "Allow following source statements to external files (maps to --external-sources)",
+          ),
+        checkSourced: z
+          .boolean()
+          .optional()
+          .describe("Check sourced/included files (maps to --check-sourced)"),
+        norc: z
+          .boolean()
+          .optional()
+          .describe("Disable .shellcheckrc config file lookup (maps to --norc)"),
         compact: z
           .boolean()
           .optional()
@@ -40,15 +58,17 @@ export function registerShellcheckTool(server: McpServer) {
       },
       outputSchema: LintResultSchema,
     },
-    async ({ path, patterns, severity, compact }) => {
+    async ({ path, patterns, severity, shell, externalSources, checkSourced, norc, compact }) => {
       const cwd = path || process.cwd();
       for (const p of patterns ?? []) {
         assertNoFlagInjection(p, "patterns");
       }
       const args = ["--format=json"];
-      if (severity) {
-        args.push(`--severity=${severity}`);
-      }
+      if (severity) args.push(`--severity=${severity}`);
+      if (shell) args.push(`--shell=${shell}`);
+      if (externalSources) args.push("--external-sources");
+      if (checkSourced) args.push("--check-sourced");
+      if (norc) args.push("--norc");
       args.push(...(patterns || ["."]));
 
       const result = await shellcheckCmd(args, cwd);

--- a/packages/server-lint/src/tools/stylelint.ts
+++ b/packages/server-lint/src/tools/stylelint.ts
@@ -27,6 +27,30 @@ export function registerStylelintTool(server: McpServer) {
           .default(["."])
           .describe("File patterns to lint (default: ['.'])"),
         fix: z.boolean().optional().default(false).describe("Auto-fix problems"),
+        quiet: z
+          .boolean()
+          .optional()
+          .describe("Report errors only, suppress warnings (maps to --quiet)"),
+        allowEmptyInput: z
+          .boolean()
+          .optional()
+          .describe("Prevent errors when no files match the pattern (maps to --allow-empty-input)"),
+        cache: z
+          .boolean()
+          .optional()
+          .describe("Cache lint results for faster subsequent runs (maps to --cache)"),
+        reportNeedlessDisables: z
+          .boolean()
+          .optional()
+          .describe(
+            "Report unnecessary stylelint-disable comments (maps to --report-needless-disables)",
+          ),
+        ignoreDisables: z
+          .boolean()
+          .optional()
+          .describe(
+            "Ignore stylelint-disable comments and enforce all rules (maps to --ignore-disables)",
+          ),
         compact: z
           .boolean()
           .optional()
@@ -37,13 +61,28 @@ export function registerStylelintTool(server: McpServer) {
       },
       outputSchema: LintResultSchema,
     },
-    async ({ path, patterns, fix, compact }) => {
+    async ({
+      path,
+      patterns,
+      fix,
+      quiet,
+      allowEmptyInput,
+      cache,
+      reportNeedlessDisables,
+      ignoreDisables,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
       for (const p of patterns ?? []) {
         assertNoFlagInjection(p, "patterns");
       }
       const args = ["--formatter", "json", ...(patterns || ["."])];
       if (fix) args.push("--fix");
+      if (quiet) args.push("--quiet");
+      if (allowEmptyInput) args.push("--allow-empty-input");
+      if (cache) args.push("--cache");
+      if (reportNeedlessDisables) args.push("--report-needless-disables");
+      if (ignoreDisables) args.push("--ignore-disables");
 
       const result = await stylelintCmd(args, cwd);
       const data = parseStylelintJson(result.stdout);


### PR DESCRIPTION
## Summary
- Implements all 43 XS-complexity gap items from the lint gap backlog across 9 tools
- **biome-check**: Add `apply` (P0), `diagnosticLevel` (P0), `changed` (P1), `staged` (P1), `applyUnsafe` (P2) params
- **biome-format**: Add `changed` (P0), `staged` (P0), `indentStyle` (P1), `lineWidth` (P1), `quoteStyle` (P2), `semicolons` (P2), `lineEnding` (P2) params
- **format-check**: Add `ignoreUnknown` (P0), `cache` (P0), `noConfig` (P1), `logLevel` (P1) params
- **hadolint**: Add `failureThreshold` (P0), `noFail` (P1), `strictLabels` (P2), `verbose` (P2) params
- **lint (eslint)**: Add `quiet` (P0), `noIgnore` (P1), `cache` (P1), `fixDryRun` (P2) params
- **oxlint**: Add `fix` (P0), `quiet` (P0), `fixSuggestions` (P2), `threads` (P2), `noIgnore` (P2) params
- **prettier-format**: Add `ignoreUnknown` (P0), `cache` (P0), `noConfig` (P1), `logLevel` (P1), `endOfLine` (P2) params
- **shellcheck**: Add `shell` (P0), `externalSources` (P1), `checkSourced` (P1), `norc` (P2) params
- **stylelint**: Add `quiet` (P0), `allowEmptyInput` (P0), `cache` (P1), `reportNeedlessDisables` (P2), `ignoreDisables` (P2) params

## Test plan
- [x] `pnpm build --filter @paretools/lint` passes
- [x] `pnpm --filter @paretools/lint test` passes (215/215 tests)
- [ ] CI matrix (ubuntu/windows/macos x node 20/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)