### PR TITLE
feat(make): add missing CLI flag parameters

### DIFF
--- a/.changeset/make-xs-gaps.md
+++ b/.changeset/make-xs-gaps.md
@@ -1,0 +1,8 @@
+---
+"@paretools/make": minor
+---
+
+Add missing CLI flag parameters from XS-complexity audit gaps
+
+- run: dryRun, jobs, silent, keepGoing, alwaysMake, verbose, trace, question
+- list: includeSubmodules, unsorted

--- a/packages/server-make/src/tools/run.ts
+++ b/packages/server-make/src/tools/run.ts
@@ -32,6 +32,34 @@ export function registerRunTool(server: McpServer) {
           .optional()
           .default("auto")
           .describe('Task runner to use: "auto" detects from files, or force "make"/"just"'),
+        dryRun: z
+          .boolean()
+          .optional()
+          .describe("Preview commands without executing (make -n / just --dry-run)"),
+        jobs: z.number().optional().describe("Number of parallel jobs (make -j N, make only)"),
+        silent: z
+          .boolean()
+          .optional()
+          .describe("Suppress command echoing (make -s / just --quiet)"),
+        keepGoing: z
+          .boolean()
+          .optional()
+          .describe("Continue after errors in independent targets (make -k, make only)"),
+        alwaysMake: z
+          .boolean()
+          .optional()
+          .describe("Force rebuild regardless of timestamps (make -B, make only)"),
+        verbose: z
+          .boolean()
+          .optional()
+          .describe("Enable verbose output (just --verbose, just only)"),
+        trace: z.boolean().optional().describe("Trace execution order (make --trace, make only)"),
+        question: z
+          .boolean()
+          .optional()
+          .describe(
+            "Check if target is up to date without executing (make -q, make only). Exit code 0 = up to date.",
+          ),
         compact: z
           .boolean()
           .optional()
@@ -42,7 +70,21 @@ export function registerRunTool(server: McpServer) {
       },
       outputSchema: MakeRunResultSchema,
     },
-    async ({ target, args, path, tool, compact }) => {
+    async ({
+      target,
+      args,
+      path,
+      tool,
+      dryRun,
+      jobs,
+      silent,
+      keepGoing,
+      alwaysMake,
+      verbose,
+      trace,
+      question,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
       assertNoFlagInjection(target, "target");
       for (const a of args ?? []) {
@@ -50,7 +92,25 @@ export function registerRunTool(server: McpServer) {
       }
 
       const resolved = resolveTool(tool || "auto", cwd);
-      const cmdArgs = [target, ...(args || [])];
+
+      // Build flags before the target
+      const flags: string[] = [];
+      if (resolved === "just") {
+        if (dryRun) flags.push("--dry-run");
+        if (silent) flags.push("--quiet");
+        if (verbose) flags.push("--verbose");
+      } else {
+        // make
+        if (dryRun) flags.push("-n");
+        if (jobs !== undefined) flags.push("-j", String(jobs));
+        if (silent) flags.push("-s");
+        if (keepGoing) flags.push("-k");
+        if (alwaysMake) flags.push("-B");
+        if (trace) flags.push("--trace");
+        if (question) flags.push("-q");
+      }
+
+      const cmdArgs = [...flags, target, ...(args || [])];
 
       const start = Date.now();
       const result =


### PR DESCRIPTION
## Summary
- Implements all XS-complexity gaps from the CLI capability audit for `@paretools/make`
- **run** tool: `dryRun`, `jobs`, `silent`, `keepGoing`, `alwaysMake`, `verbose`, `trace`, `question` (make/just specific flags mapped correctly per tool)
- **list** tool: `includeSubmodules`, `unsorted` (just only)

## Test plan
- [x] `pnpm build --filter @paretools/make` passes
- [x] `pnpm --filter @paretools/make test` passes (44 tests)
- [ ] Manual verification of new flags with real make/just invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)