### PR TITLE
feat(http): implement S-complexity gaps

### DIFF
--- a/.changeset/http-s-gaps.md
+++ b/.changeset/http-s-gaps.md
@@ -1,0 +1,11 @@
+---
+"@paretools/http": minor
+---
+
+Add S-complexity gap parameters to HTTP tools:
+
+- **All tools**: `connectTimeout` (--connect-timeout), `basicAuth` (-u), `proxy` (-x)
+- **get**: `queryParams` (URL-encoded query convenience), `httpVersion`, `resolve` (--resolve)
+- **head**: Switch from `-X HEAD` to `-I` for correct HEAD behavior, `httpVersion`, `resolve`, `contentLength` parsed output field
+- **post**: `preserveMethodOnRedirect` (--post301/302/303), `dataUrlencode` (--data-urlencode), `httpVersion`
+- **request**: `httpVersion` (--http1.0/1.1/2), `cookie` (-b), `resolve` (--resolve)

--- a/packages/server-http/__tests__/formatters.test.ts
+++ b/packages/server-http/__tests__/formatters.test.ts
@@ -91,6 +91,37 @@ describe("formatHttpHeadResponse", () => {
     // Should NOT contain body-related content
     expect(output).not.toContain("Size:");
   });
+
+  it("includes contentLength in human-readable output when present", () => {
+    const data: HttpHeadResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {
+        "content-type": "text/html",
+        "content-length": "5000",
+      },
+      timing: { total: 0.15 },
+      contentType: "text/html",
+      contentLength: 5000,
+    };
+
+    const output = formatHttpHeadResponse(data);
+
+    expect(output).toContain("Content-Length: 5000");
+  });
+
+  it("omits contentLength line when not present", () => {
+    const data: HttpHeadResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      timing: { total: 0.1 },
+    };
+
+    const output = formatHttpHeadResponse(data);
+
+    expect(output).not.toContain("Content-Length:");
+  });
 });
 
 describe("compactResponseMap", () => {
@@ -161,6 +192,7 @@ describe("compactHeadResponseMap", () => {
       },
       timing: { total: 0.15 },
       contentType: "text/html",
+      contentLength: 5000,
     };
 
     const compact = compactHeadResponseMap(full);
@@ -168,6 +200,7 @@ describe("compactHeadResponseMap", () => {
     expect(compact.status).toBe(200);
     expect(compact.statusText).toBe("OK");
     expect(compact.contentType).toBe("text/html");
+    expect(compact.contentLength).toBe(5000);
     expect(compact.timing.total).toBe(0.15);
     expect("headers" in compact).toBe(false);
   });
@@ -185,5 +218,19 @@ describe("formatHeadResponseCompact", () => {
     const output = formatHeadResponseCompact(compact);
 
     expect(output).toBe("HTTP 200 OK (text/html) | 0.100s");
+  });
+
+  it("includes contentLength in compact HEAD response", () => {
+    const compact = {
+      status: 200,
+      statusText: "OK",
+      contentType: "text/html",
+      contentLength: 5000,
+      timing: { total: 0.1 },
+    };
+
+    const output = formatHeadResponseCompact(compact);
+
+    expect(output).toBe("HTTP 200 OK (text/html) | 5000 bytes | 0.100s");
   });
 });

--- a/packages/server-http/__tests__/parsers.test.ts
+++ b/packages/server-http/__tests__/parsers.test.ts
@@ -254,4 +254,61 @@ describe("parseCurlHeadOutput", () => {
     // HEAD response should not have a body field
     expect("body" in result).toBe(false);
   });
+
+  it("extracts contentLength as a numeric field from Content-Length header", () => {
+    const stdout = [
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Type: text/html\r\n",
+      "Content-Length: 12345\r\n",
+      "\r\n",
+      `\n${PARE_META_SEPARATOR}\n`,
+      "0.100 0",
+    ].join("");
+
+    const result = parseCurlHeadOutput(stdout, "", 0);
+
+    expect(result.contentLength).toBe(12345);
+  });
+
+  it("returns undefined contentLength when Content-Length header is missing", () => {
+    const stdout = [
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Type: text/html\r\n",
+      "\r\n",
+      `\n${PARE_META_SEPARATOR}\n`,
+      "0.100 0",
+    ].join("");
+
+    const result = parseCurlHeadOutput(stdout, "", 0);
+
+    expect(result.contentLength).toBeUndefined();
+  });
+
+  it("returns undefined contentLength for non-numeric Content-Length", () => {
+    const stdout = [
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Length: invalid\r\n",
+      "\r\n",
+      `\n${PARE_META_SEPARATOR}\n`,
+      "0.100 0",
+    ].join("");
+
+    const result = parseCurlHeadOutput(stdout, "", 0);
+
+    expect(result.contentLength).toBeUndefined();
+  });
+
+  it("handles zero Content-Length", () => {
+    const stdout = [
+      "HTTP/1.1 204 No Content\r\n",
+      "Content-Length: 0\r\n",
+      "\r\n",
+      `\n${PARE_META_SEPARATOR}\n`,
+      "0.050 0",
+    ].join("");
+
+    const result = parseCurlHeadOutput(stdout, "", 0);
+
+    expect(result.contentLength).toBe(0);
+  });
 });

--- a/packages/server-http/__tests__/security.test.ts
+++ b/packages/server-http/__tests__/security.test.ts
@@ -179,6 +179,183 @@ describe("security: buildCurlArgs safety", () => {
     expect(args).toContain("--data-raw");
     expect(args).not.toContain("--data");
   });
+
+  it("includes --connect-timeout for connectTimeout", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      connectTimeout: 5,
+      followRedirects: true,
+    });
+
+    const idx = args.indexOf("--connect-timeout");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("5");
+  });
+
+  it("does not include --connect-timeout when not specified", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      followRedirects: true,
+    });
+
+    expect(args).not.toContain("--connect-timeout");
+  });
+
+  it("includes -u for basicAuth", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      followRedirects: true,
+      basicAuth: "user:pass",
+    });
+
+    const idx = args.indexOf("-u");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("user:pass");
+  });
+
+  it("includes -x for proxy", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      followRedirects: true,
+      proxy: "http://proxy:8080",
+    });
+
+    const idx = args.indexOf("-x");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("http://proxy:8080");
+  });
+
+  it("includes --http1.1 for httpVersion 1.1", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      followRedirects: true,
+      httpVersion: "1.1",
+    });
+
+    expect(args).toContain("--http1.1");
+  });
+
+  it("includes --http2 for httpVersion 2", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      followRedirects: true,
+      httpVersion: "2",
+    });
+
+    expect(args).toContain("--http2");
+  });
+
+  it("includes --http1.0 for httpVersion 1.0", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      followRedirects: true,
+      httpVersion: "1.0",
+    });
+
+    expect(args).toContain("--http1.0");
+  });
+
+  it("includes -b for cookie", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      followRedirects: true,
+      cookie: "session=abc123; theme=dark",
+    });
+
+    const idx = args.indexOf("-b");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("session=abc123; theme=dark");
+  });
+
+  it("includes --resolve for custom DNS resolution", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "GET",
+      timeout: 30,
+      followRedirects: true,
+      resolve: "example.com:443:127.0.0.1",
+    });
+
+    const idx = args.indexOf("--resolve");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("example.com:443:127.0.0.1");
+  });
+
+  it("uses -I flag when useHeadFlag is true (instead of -X HEAD)", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "HEAD",
+      timeout: 30,
+      followRedirects: true,
+      useHeadFlag: true,
+    });
+
+    expect(args).toContain("-I");
+    expect(args).not.toContain("-X");
+  });
+
+  it("includes --post301/302/303 for preserveMethodOnRedirect", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "POST",
+      body: '{"key":"value"}',
+      timeout: 30,
+      followRedirects: true,
+      preserveMethodOnRedirect: true,
+    });
+
+    expect(args).toContain("--post301");
+    expect(args).toContain("--post302");
+    expect(args).toContain("--post303");
+  });
+
+  it("does not include --post301/302/303 when preserveMethodOnRedirect is not set", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "POST",
+      body: '{"key":"value"}',
+      timeout: 30,
+      followRedirects: true,
+    });
+
+    expect(args).not.toContain("--post301");
+    expect(args).not.toContain("--post302");
+    expect(args).not.toContain("--post303");
+  });
+
+  it("includes --data-urlencode for dataUrlencode items", () => {
+    const args = buildCurlArgs({
+      url: "https://example.com",
+      method: "POST",
+      timeout: 30,
+      followRedirects: true,
+      dataUrlencode: ["name=John Doe", "city=New York"],
+    });
+
+    const firstIdx = args.indexOf("--data-urlencode");
+    expect(firstIdx).toBeGreaterThan(-1);
+    expect(args[firstIdx + 1]).toBe("name=John Doe");
+
+    const secondIdx = args.indexOf("--data-urlencode", firstIdx + 1);
+    expect(secondIdx).toBeGreaterThan(-1);
+    expect(args[secondIdx + 1]).toBe("city=New York");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/server-http/src/lib/formatters.ts
+++ b/packages/server-http/src/lib/formatters.ts
@@ -44,6 +44,10 @@ export function formatHttpHeadResponse(data: HttpHeadResponse): string {
     lines.push(`Content-Type: ${data.contentType}`);
   }
 
+  if (data.contentLength !== undefined) {
+    lines.push(`Content-Length: ${data.contentLength}`);
+  }
+
   lines.push(`Time: ${data.timing.total.toFixed(3)}s`);
 
   const headers = data.headers ?? {};
@@ -82,6 +86,7 @@ export function compactHeadResponseMap(data: HttpHeadResponse): HttpHeadResponse
     status: data.status,
     statusText: data.statusText,
     contentType: data.contentType,
+    contentLength: data.contentLength,
     timing: data.timing,
   };
 }
@@ -89,5 +94,6 @@ export function compactHeadResponseMap(data: HttpHeadResponse): HttpHeadResponse
 /** Formats compact HEAD response. */
 export function formatHeadResponseCompact(data: HttpHeadResponseCompact): string {
   const ct = data.contentType ? ` (${data.contentType})` : "";
-  return `HTTP ${data.status} ${data.statusText}${ct} | ${data.timing.total.toFixed(3)}s`;
+  const cl = data.contentLength !== undefined ? ` | ${data.contentLength} bytes` : "";
+  return `HTTP ${data.status} ${data.statusText}${ct}${cl} | ${data.timing.total.toFixed(3)}s`;
 }

--- a/packages/server-http/src/lib/parsers.ts
+++ b/packages/server-http/src/lib/parsers.ts
@@ -61,6 +61,7 @@ export function parseCurlOutput(stdout: string, _stderr: string, _exitCode: numb
 
 /**
  * Parses curl output for HEAD requests (no body expected).
+ * Extracts contentLength as a numeric field from the Content-Length header.
  */
 export function parseCurlHeadOutput(
   stdout: string,
@@ -69,12 +70,24 @@ export function parseCurlHeadOutput(
 ): HttpHeadResponse {
   const full = parseCurlOutput(stdout, stderr, exitCode);
 
+  // Extract Content-Length as a numeric field for easy size checking
+  const headers = full.headers ?? {};
+  const clHeader = headers["content-length"];
+  let contentLength: number | undefined;
+  if (clHeader !== undefined) {
+    const parsed = parseInt(clHeader, 10);
+    if (!isNaN(parsed) && parsed >= 0) {
+      contentLength = parsed;
+    }
+  }
+
   return {
     status: full.status,
     statusText: full.statusText,
     headers: full.headers,
     timing: full.timing,
     contentType: full.contentType,
+    contentLength,
   };
 }
 

--- a/packages/server-http/src/schemas/index.ts
+++ b/packages/server-http/src/schemas/index.ts
@@ -28,6 +28,7 @@ export const HttpHeadResponseSchema = z.object({
   headers: HttpHeadersSchema.optional(),
   timing: HttpTimingSchema,
   contentType: z.string().optional(),
+  contentLength: z.number().optional(),
 });
 
 export type HttpHeadResponse = z.infer<typeof HttpHeadResponseSchema>;
@@ -48,6 +49,7 @@ export const HttpHeadResponseCompactSchema = z.object({
   status: z.number(),
   statusText: z.string(),
   contentType: z.string().optional(),
+  contentLength: z.number().optional(),
   timing: HttpTimingSchema,
 });
 

--- a/packages/server-http/src/tools/get.ts
+++ b/packages/server-http/src/tools/get.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { curlCmd } from "../lib/curl-runner.js";
 import { parseCurlOutput } from "../lib/parsers.js";
 import {
@@ -11,6 +11,8 @@ import {
 import { HttpResponseSchema } from "../schemas/index.js";
 import { assertSafeUrl } from "../lib/url-validation.js";
 import { buildCurlArgs } from "./request.js";
+
+const HTTP_VERSIONS = ["1.0", "1.1", "2"] as const;
 
 /** Registers the `get` tool on the given MCP server. */
 export function registerGetTool(server: McpServer) {
@@ -39,6 +41,14 @@ export function registerGetTool(server: McpServer) {
           .optional()
           .default(30)
           .describe("Request timeout in seconds (default: 30)"),
+        connectTimeout: z
+          .number()
+          .min(1)
+          .max(300)
+          .optional()
+          .describe(
+            "Maximum time in seconds for connection phase only (--connect-timeout). Detects connection failures fast.",
+          ),
         followRedirects: z
           .boolean()
           .optional()
@@ -58,6 +68,36 @@ export function registerGetTool(server: McpServer) {
           .boolean()
           .optional()
           .describe("Request compressed response and decompress automatically (--compressed)"),
+        basicAuth: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Basic auth credentials as 'user:password' (-u)"),
+        proxy: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Proxy URL (e.g., http://proxy:8080) (-x)"),
+        queryParams: z
+          .record(
+            z.string().max(INPUT_LIMITS.SHORT_STRING_MAX),
+            z.string().max(INPUT_LIMITS.STRING_MAX),
+          )
+          .optional()
+          .describe(
+            "Query parameters as key-value pairs. URL-encoded and appended to the URL automatically.",
+          ),
+        httpVersion: z
+          .enum(HTTP_VERSIONS)
+          .optional()
+          .describe("HTTP version to use: '1.0', '1.1', or '2' (--http1.0/--http1.1/--http2)"),
+        resolve: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe(
+            "Custom DNS resolution (--resolve). Format: 'host:port:addr' (e.g., 'example.com:443:127.0.0.1')",
+          ),
         compact: z
           .boolean()
           .optional()
@@ -77,24 +117,49 @@ export function registerGetTool(server: McpServer) {
       url,
       headers,
       timeout,
+      connectTimeout,
       followRedirects,
       insecure,
       retry,
       compressed,
+      basicAuth,
+      proxy,
+      queryParams,
+      httpVersion,
+      resolve,
       compact,
       path,
     }) => {
-      assertSafeUrl(url);
+      // Build URL with query params if provided
+      let finalUrl = url;
+      if (queryParams && Object.keys(queryParams).length > 0) {
+        const params = new URLSearchParams();
+        for (const [key, value] of Object.entries(queryParams)) {
+          params.append(key, value);
+        }
+        const separator = url.includes("?") ? "&" : "?";
+        finalUrl = `${url}${separator}${params.toString()}`;
+      }
+
+      assertSafeUrl(finalUrl);
+      if (basicAuth) assertNoFlagInjection(basicAuth, "basicAuth");
+      if (proxy) assertNoFlagInjection(proxy, "proxy");
+      if (resolve) assertNoFlagInjection(resolve, "resolve");
 
       const args = buildCurlArgs({
-        url,
+        url: finalUrl,
         method: "GET",
         headers,
         timeout: timeout ?? 30,
+        connectTimeout,
         followRedirects: followRedirects ?? true,
         insecure,
         retry,
         compressed,
+        basicAuth,
+        proxy,
+        httpVersion,
+        resolve,
       });
 
       const cwd = path || process.cwd();

--- a/packages/server-http/src/tools/head.ts
+++ b/packages/server-http/src/tools/head.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { curlCmd } from "../lib/curl-runner.js";
 import { parseCurlHeadOutput } from "../lib/parsers.js";
 import {
@@ -11,6 +11,8 @@ import {
 import { HttpHeadResponseSchema } from "../schemas/index.js";
 import { assertSafeUrl } from "../lib/url-validation.js";
 import { buildCurlArgs } from "./request.js";
+
+const HTTP_VERSIONS = ["1.0", "1.1", "2"] as const;
 
 /** Registers the `head` tool on the given MCP server. */
 export function registerHeadTool(server: McpServer) {
@@ -39,6 +41,14 @@ export function registerHeadTool(server: McpServer) {
           .optional()
           .default(30)
           .describe("Request timeout in seconds (default: 30)"),
+        connectTimeout: z
+          .number()
+          .min(1)
+          .max(300)
+          .optional()
+          .describe(
+            "Maximum time in seconds for connection phase only (--connect-timeout). Fast failure for availability probing.",
+          ),
         followRedirects: z
           .boolean()
           .optional()
@@ -54,6 +64,27 @@ export function registerHeadTool(server: McpServer) {
           .max(10)
           .optional()
           .describe("Number of retries on transient failures (--retry)"),
+        basicAuth: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Basic auth credentials as 'user:password' (-u)"),
+        proxy: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Proxy URL (e.g., http://proxy:8080) (-x)"),
+        httpVersion: z
+          .enum(HTTP_VERSIONS)
+          .optional()
+          .describe("HTTP version to use: '1.0', '1.1', or '2' (--http1.0/--http1.1/--http2)"),
+        resolve: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe(
+            "Custom DNS resolution (--resolve). Format: 'host:port:addr' (e.g., 'example.com:443:127.0.0.1')",
+          ),
         compact: z
           .boolean()
           .optional()
@@ -69,17 +100,40 @@ export function registerHeadTool(server: McpServer) {
       },
       outputSchema: HttpHeadResponseSchema,
     },
-    async ({ url, headers, timeout, followRedirects, insecure, retry, compact, path }) => {
+    async ({
+      url,
+      headers,
+      timeout,
+      connectTimeout,
+      followRedirects,
+      insecure,
+      retry,
+      basicAuth,
+      proxy,
+      httpVersion,
+      resolve,
+      compact,
+      path,
+    }) => {
       assertSafeUrl(url);
+      if (basicAuth) assertNoFlagInjection(basicAuth, "basicAuth");
+      if (proxy) assertNoFlagInjection(proxy, "proxy");
+      if (resolve) assertNoFlagInjection(resolve, "resolve");
 
       const args = buildCurlArgs({
         url,
         method: "HEAD",
         headers,
         timeout: timeout ?? 30,
+        connectTimeout,
         followRedirects: followRedirects ?? true,
         insecure,
         retry,
+        basicAuth,
+        proxy,
+        httpVersion,
+        resolve,
+        useHeadFlag: true, // Use -I instead of -X HEAD to avoid potential hangs
       });
 
       const cwd = path || process.cwd();


### PR DESCRIPTION
## Summary
- Implements **25 S-complexity gaps** across all 4 HTTP tools (get, head, post, request)
- Adds validated input params: `connectTimeout`, `basicAuth`, `proxy`, `queryParams`, `httpVersion`, `resolve`, `cookie`, `preserveMethodOnRedirect`, `dataUrlencode`
- Switches HEAD tool from `-X HEAD` to `-I` (curl's native `--head` flag) to avoid potential hangs
- Adds `contentLength` parsed numeric field to HEAD output schema for easy size checking
- All params include `assertNoFlagInjection()` validation on string inputs
- 20 new tests added (105 total, up from 85)

### Gaps by tool:
| Tool | Gaps | Params added |
|------|------|-------------|
| get | 6 | `connectTimeout`, `basicAuth`, `proxy`, `queryParams`, `httpVersion`, `resolve` |
| head | 7 | Switch to `-I`, `connectTimeout`, `basicAuth`, `proxy`, `httpVersion`, `resolve`, `contentLength` output |
| post | 6 | `connectTimeout`, `basicAuth`, `proxy`, `preserveMethodOnRedirect`, `dataUrlencode`, `httpVersion` |
| request | 6 | `connectTimeout`, `basicAuth`, `proxy`, `httpVersion`, `cookie`, `resolve` |

## Test plan
- [x] `pnpm --filter @paretools/http build` passes
- [x] `pnpm --filter @paretools/http test` passes (105/105 tests)
- [x] New `buildCurlArgs` tests verify all new flag mappings
- [x] `contentLength` parsing tested for present, missing, invalid, and zero cases
- [x] Formatter tests updated for `contentLength` in HEAD output

🤖 Generated with [Claude Code](https://claude.com/claude-code)