### PR TITLE
feat(lint): implement S-complexity gaps

### DIFF
--- a/.changeset/lint-s-gaps.md
+++ b/.changeset/lint-s-gaps.md
@@ -1,0 +1,16 @@
+---
+"@paretools/lint": minor
+---
+
+Add S-complexity gap params and output schema enhancements across all lint tools:
+
+- biome-check: since, configPath, linterEnabled/formatterEnabled, maxDiagnostics, skip
+- biome-format: since, configPath
+- format-check: config, ignorePath, parser
+- hadolint: config, requireLabel, shell, errorRules/warningRules/infoRules severity overrides
+- lint (eslint): maxWarnings, config, fixType, rule
+- oxlint: config, deny/warn/allow, plugins, tsconfig, ignorePath
+- prettier-format: config
+- shellcheck: exclude, enable, include, rcfile, sourcePath
+- stylelint: maxWarnings, config, ignorePath
+- Output schema: column in diagnostics (eslint, stylelint, oxlint, shellcheck, hadolint, biome), fixableErrorCount/fixableWarningCount (eslint), wikiUrl for hadolint DL rules

--- a/packages/server-lint/__tests__/biome-check.test.ts
+++ b/packages/server-lint/__tests__/biome-check.test.ts
@@ -40,6 +40,7 @@ describe("parseBiomeJson", () => {
     expect(result.diagnostics[0]).toEqual({
       file: "src/index.ts",
       line: 5,
+      column: 10,
       severity: "error",
       rule: "lint/suspicious/noDoubleEquals",
       message: "Use === instead of ==.",
@@ -48,6 +49,7 @@ describe("parseBiomeJson", () => {
     expect(result.diagnostics[1]).toEqual({
       file: "src/utils.ts",
       line: 12,
+      column: 1,
       severity: "warning",
       rule: "lint/style/useConst",
       message: "Use const instead of let.",
@@ -148,6 +150,7 @@ describe("parseBiomeJson", () => {
 
     expect(result.diagnostics[0].file).toBe("unknown");
     expect(result.diagnostics[0].line).toBe(0);
+    expect(result.diagnostics[0].column).toBeUndefined();
   });
 
   it("handles mixed lint and format diagnostics", () => {

--- a/packages/server-lint/src/lib/formatters.ts
+++ b/packages/server-lint/src/lib/formatters.ts
@@ -5,8 +5,13 @@ export function formatLint(data: LintResult): string {
   if (data.total === 0) return `Lint: no issues found (${data.filesChecked} files checked).`;
 
   const lines = [`Lint: ${data.errors} errors, ${data.warnings} warnings`];
+  if (data.fixableErrorCount || data.fixableWarningCount) {
+    lines[0] += ` (${data.fixableErrorCount ?? 0} fixable errors, ${data.fixableWarningCount ?? 0} fixable warnings)`;
+  }
   for (const d of data.diagnostics ?? []) {
-    lines.push(`  ${d.file}:${d.line} ${d.severity} ${d.rule}: ${d.message}`);
+    const loc = d.column ? `${d.file}:${d.line}:${d.column}` : `${d.file}:${d.line}`;
+    const extra = d.wikiUrl ? ` (${d.wikiUrl})` : "";
+    lines.push(`  ${loc} ${d.severity} ${d.rule}: ${d.message}${extra}`);
   }
   return lines.join("\n");
 }

--- a/packages/server-lint/src/schemas/index.ts
+++ b/packages/server-lint/src/schemas/index.ts
@@ -4,9 +4,11 @@ import { z } from "zod";
 export const LintDiagnosticSchema = z.object({
   file: z.string(),
   line: z.number(),
+  column: z.number().optional(),
   severity: z.enum(["error", "warning", "info"]),
   rule: z.string(),
   message: z.string(),
+  wikiUrl: z.string().optional(),
 });
 
 /** Zod schema for structured ESLint output including diagnostics, counts, and files checked. */
@@ -15,6 +17,8 @@ export const LintResultSchema = z.object({
   total: z.number(),
   errors: z.number(),
   warnings: z.number(),
+  fixableErrorCount: z.number().optional(),
+  fixableWarningCount: z.number().optional(),
   filesChecked: z.number(),
 });
 

--- a/packages/server-lint/src/tools/biome-format.ts
+++ b/packages/server-lint/src/tools/biome-format.ts
@@ -35,6 +35,16 @@ export function registerBiomeFormatTool(server: McpServer) {
           .optional()
           .describe("Only format VCS-changed files (maps to --changed)"),
         staged: z.boolean().optional().describe("Only format staged files (maps to --staged)"),
+        since: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Only format files changed since this git ref (maps to --since)"),
+        configPath: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to Biome configuration file (maps to --config-path)"),
         indentStyle: z
           .enum(["tab", "space"])
           .optional()
@@ -64,6 +74,8 @@ export function registerBiomeFormatTool(server: McpServer) {
       patterns,
       changed,
       staged,
+      since,
+      configPath,
       indentStyle,
       lineWidth,
       quoteStyle,
@@ -78,6 +90,14 @@ export function registerBiomeFormatTool(server: McpServer) {
       const args = ["format", "--write"];
       if (changed) args.push("--changed");
       if (staged) args.push("--staged");
+      if (since) {
+        assertNoFlagInjection(since, "since");
+        args.push(`--since=${since}`);
+      }
+      if (configPath) {
+        assertNoFlagInjection(configPath, "configPath");
+        args.push(`--config-path=${configPath}`);
+      }
       if (indentStyle) args.push(`--indent-style=${indentStyle}`);
       if (lineWidth !== undefined) args.push(`--line-width=${lineWidth}`);
       if (quoteStyle) args.push(`--quote-style=${quoteStyle}`);

--- a/packages/server-lint/src/tools/format-check.ts
+++ b/packages/server-lint/src/tools/format-check.ts
@@ -46,6 +46,21 @@ export function registerFormatCheckTool(server: McpServer) {
           .enum(["silent", "error", "warn", "log", "debug"])
           .optional()
           .describe("Log level to control output verbosity"),
+        config: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to a Prettier configuration file (maps to --config)"),
+        ignorePath: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to a custom ignore file (maps to --ignore-path)"),
+        parser: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Force a specific parser for ambiguous file types (maps to --parser)"),
         compact: z
           .boolean()
           .optional()
@@ -56,7 +71,18 @@ export function registerFormatCheckTool(server: McpServer) {
       },
       outputSchema: FormatCheckResultSchema,
     },
-    async ({ path, patterns, ignoreUnknown, cache, noConfig, logLevel, compact }) => {
+    async ({
+      path,
+      patterns,
+      ignoreUnknown,
+      cache,
+      noConfig,
+      logLevel,
+      config,
+      ignorePath,
+      parser,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
       for (const p of patterns ?? []) {
         assertNoFlagInjection(p, "patterns");
@@ -66,6 +92,18 @@ export function registerFormatCheckTool(server: McpServer) {
       if (cache) args.push("--cache");
       if (noConfig) args.push("--no-config");
       if (logLevel) args.push(`--log-level=${logLevel}`);
+      if (config) {
+        assertNoFlagInjection(config, "config");
+        args.push(`--config=${config}`);
+      }
+      if (ignorePath) {
+        assertNoFlagInjection(ignorePath, "ignorePath");
+        args.push(`--ignore-path=${ignorePath}`);
+      }
+      if (parser) {
+        assertNoFlagInjection(parser, "parser");
+        args.push(`--parser=${parser}`);
+      }
       args.push(...(patterns || ["."]));
 
       const result = await prettier(args, cwd);

--- a/packages/server-lint/src/tools/hadolint.ts
+++ b/packages/server-lint/src/tools/hadolint.ts
@@ -49,6 +49,40 @@ export function registerHadolintTool(server: McpServer) {
           .optional()
           .describe("Enforce strict label schema (maps to --strict-labels)"),
         verbose: z.boolean().optional().describe("Enable verbose output (maps to --verbose)"),
+        config: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to Hadolint configuration file (maps to --config)"),
+        requireLabel: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe(
+            "Required labels in Dockerfiles, e.g. ['maintainer:text'] (maps to --require-label)",
+          ),
+        shell: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe(
+            "Default shell for RUN instruction linting, e.g. '/bin/bash' (maps to --shell)",
+          ),
+        errorRules: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Rule codes to treat as errors (maps to --error)"),
+        warningRules: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Rule codes to treat as warnings (maps to --warning)"),
+        infoRules: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Rule codes to treat as info (maps to --info)"),
         compact: z
           .boolean()
           .optional()
@@ -68,6 +102,12 @@ export function registerHadolintTool(server: McpServer) {
       noFail,
       strictLabels,
       verbose,
+      config,
+      requireLabel,
+      shell,
+      errorRules,
+      warningRules,
+      infoRules,
       compact,
     }) => {
       const cwd = path || process.cwd();
@@ -94,6 +134,44 @@ export function registerHadolintTool(server: McpServer) {
       if (noFail) args.push("--no-fail");
       if (strictLabels) args.push("--strict-labels");
       if (verbose) args.push("--verbose");
+
+      if (config) {
+        assertNoFlagInjection(config, "config");
+        args.push(`--config=${config}`);
+      }
+
+      if (requireLabel) {
+        for (const label of requireLabel) {
+          assertNoFlagInjection(label, "requireLabel");
+          args.push(`--require-label=${label}`);
+        }
+      }
+
+      if (shell) {
+        assertNoFlagInjection(shell, "shell");
+        args.push(`--shell=${shell}`);
+      }
+
+      if (errorRules) {
+        for (const rule of errorRules) {
+          assertNoFlagInjection(rule, "errorRules");
+          args.push(`--error=${rule}`);
+        }
+      }
+
+      if (warningRules) {
+        for (const rule of warningRules) {
+          assertNoFlagInjection(rule, "warningRules");
+          args.push(`--warning=${rule}`);
+        }
+      }
+
+      if (infoRules) {
+        for (const rule of infoRules) {
+          assertNoFlagInjection(rule, "infoRules");
+          args.push(`--info=${rule}`);
+        }
+      }
 
       args.push(...(patterns || ["Dockerfile"]));
 

--- a/packages/server-lint/src/tools/oxlint.ts
+++ b/packages/server-lint/src/tools/oxlint.ts
@@ -13,7 +13,7 @@ export function registerOxlintTool(server: McpServer) {
     {
       title: "Oxlint Check",
       description:
-        "Runs Oxlint and returns structured diagnostics (file, line, rule, severity, message). Use instead of running `oxlint` in the terminal.",
+        "Runs Oxlint and returns structured diagnostics (file, line, column, rule, severity, message). Use instead of running `oxlint` in the terminal.",
       inputSchema: {
         path: z
           .string()
@@ -37,6 +37,43 @@ export function registerOxlintTool(server: McpServer) {
           .describe("Apply suggestion-level fixes (maps to --fix-suggestions)"),
         threads: z.number().optional().describe("Number of threads to use for parallel linting"),
         noIgnore: z.boolean().optional().describe("Disable ignore patterns (maps to --no-ignore)"),
+        config: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to Oxlint configuration file (maps to --config)"),
+        deny: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Rules to deny (error level) (maps to -D)"),
+        warn: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Rules to warn on (maps to -W)"),
+        allow: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Rules to allow (disable) (maps to -A)"),
+        plugins: z
+          .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe(
+            "Plugin categories to enable (e.g., 'import', 'jest', 'jsx-a11y') (maps to --<plugin>-plugin)",
+          ),
+        tsconfig: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to tsconfig.json for type-aware rules (maps to --tsconfig)"),
+        ignorePath: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to an alternate ignore file (maps to --ignore-path)"),
         compact: z
           .boolean()
           .optional()
@@ -47,7 +84,23 @@ export function registerOxlintTool(server: McpServer) {
       },
       outputSchema: LintResultSchema,
     },
-    async ({ path, patterns, fix, quiet, fixSuggestions, threads, noIgnore, compact }) => {
+    async ({
+      path,
+      patterns,
+      fix,
+      quiet,
+      fixSuggestions,
+      threads,
+      noIgnore,
+      config,
+      deny,
+      warn,
+      allow,
+      plugins,
+      tsconfig,
+      ignorePath,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
       for (const p of patterns ?? []) {
         assertNoFlagInjection(p, "patterns");
@@ -58,6 +111,42 @@ export function registerOxlintTool(server: McpServer) {
       if (fixSuggestions) args.push("--fix-suggestions");
       if (threads !== undefined) args.push(`--threads=${threads}`);
       if (noIgnore) args.push("--no-ignore");
+      if (config) {
+        assertNoFlagInjection(config, "config");
+        args.push(`--config=${config}`);
+      }
+      if (deny) {
+        for (const rule of deny) {
+          assertNoFlagInjection(rule, "deny");
+          args.push("-D", rule);
+        }
+      }
+      if (warn) {
+        for (const rule of warn) {
+          assertNoFlagInjection(rule, "warn");
+          args.push("-W", rule);
+        }
+      }
+      if (allow) {
+        for (const rule of allow) {
+          assertNoFlagInjection(rule, "allow");
+          args.push("-A", rule);
+        }
+      }
+      if (plugins) {
+        for (const plugin of plugins) {
+          assertNoFlagInjection(plugin, "plugins");
+          args.push(`--${plugin}-plugin`);
+        }
+      }
+      if (tsconfig) {
+        assertNoFlagInjection(tsconfig, "tsconfig");
+        args.push(`--tsconfig=${tsconfig}`);
+      }
+      if (ignorePath) {
+        assertNoFlagInjection(ignorePath, "ignorePath");
+        args.push(`--ignore-path=${ignorePath}`);
+      }
 
       const result = await oxlintCmd(args, cwd);
       const data = parseOxlintJson(result.stdout);

--- a/packages/server-lint/src/tools/prettier-format.ts
+++ b/packages/server-lint/src/tools/prettier-format.ts
@@ -50,6 +50,11 @@ export function registerPrettierFormatTool(server: McpServer) {
           .enum(["lf", "crlf", "cr", "auto"])
           .optional()
           .describe("Line ending style override"),
+        config: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to a Prettier configuration file (maps to --config)"),
         compact: z
           .boolean()
           .optional()
@@ -60,7 +65,17 @@ export function registerPrettierFormatTool(server: McpServer) {
       },
       outputSchema: FormatWriteResultSchema,
     },
-    async ({ path, patterns, ignoreUnknown, cache, noConfig, logLevel, endOfLine, compact }) => {
+    async ({
+      path,
+      patterns,
+      ignoreUnknown,
+      cache,
+      noConfig,
+      logLevel,
+      endOfLine,
+      config,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
       for (const p of patterns ?? []) {
         assertNoFlagInjection(p, "patterns");
@@ -71,6 +86,10 @@ export function registerPrettierFormatTool(server: McpServer) {
       if (noConfig) args.push("--no-config");
       if (logLevel) args.push(`--log-level=${logLevel}`);
       if (endOfLine) args.push(`--end-of-line=${endOfLine}`);
+      if (config) {
+        assertNoFlagInjection(config, "config");
+        args.push(`--config=${config}`);
+      }
       args.push(...(patterns || ["."]));
 
       const result = await prettier(args, cwd);


### PR DESCRIPTION
## Summary
- Add 38 S-complexity gap implementations across all 9 lint tools (biome-check, biome-format, format-check, hadolint, lint/eslint, oxlint, prettier-format, shellcheck, stylelint)
- New validated input params: `since`, `configPath`, `linterEnabled`/`formatterEnabled`, `maxDiagnostics`, `skip`, `config`, `ignorePath`, `parser`, `requireLabel`, `shell`, severity overrides (`errorRules`/`warningRules`/`infoRules`), `maxWarnings`, `fixType`, `rule`, `deny`/`warn`/`allow`, `plugins`, `tsconfig`, `exclude`, `enable`, `include`, `rcfile`, `sourcePath`
- Output schema enhancements: `column` in `LintDiagnosticSchema`, `fixableErrorCount`/`fixableWarningCount` in `LintResultSchema`, `wikiUrl` for Hadolint DL rules
- All string params use `assertNoFlagInjection()` for security
- Tests updated to cover new fields (216 tests passing)

## Test plan
- [x] `pnpm --filter @paretools/lint build` passes
- [x] `pnpm --filter @paretools/lint test` passes (216/216 tests)
- [ ] CI matrix (ubuntu/windows/macos x node 20/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)