### PR TITLE
feat(docker): implement S-complexity gaps

### DIFF
--- a/.changeset/docker-s-gaps.md
+++ b/.changeset/docker-s-gaps.md
@@ -1,0 +1,23 @@
+---
+"@paretools/docker": minor
+---
+
+Implement S-complexity gaps for Docker tools
+
+- build: Add buildArgs, target, platform, label, cacheFrom, cacheTo, secret, ssh params
+- compose-build: Add file, ssh, builder params
+- compose-down: Add rmi enum param, services positional args
+- compose-logs: Add until param, file param for compose file targeting
+- compose-ps: Add file, services, status, filter params; state field changed to enum
+- compose-up: Add pull enum param (always/missing/never)
+- exec: Add user, envFile params; add duration to output schema
+- images: Add digest field to output schema
+- inspect: Add type enum, size param; add healthStatus, env, restartPolicy to output
+- logs: Add until param for time-bounded queries
+- network-ls: Add filter param (string or string[]); add createdAt to output; preserve id in compact
+- ps: Add filter param; preserve full container ID (no truncation)
+- pull: Preserve digest in compact output
+- run: Add workdir, network, platform, entrypoint, user, restart, memory, hostname, shmSize, pull, envFile params
+- stats: Add path param; preserve memoryUsage in compact output
+- volume-ls: Add filter param (string or string[]); add createdAt to output; preserve mountpoint in compact
+- compose-logs compact: Preserve timestamps in head/tail entries

--- a/packages/server-docker/__tests__/compact.test.ts
+++ b/packages/server-docker/__tests__/compact.test.ts
@@ -280,7 +280,7 @@ describe("formatLogsCompact", () => {
 });
 
 describe("compactPullMap", () => {
-  it("drops digest", () => {
+  it("preserves digest in compact output", () => {
     const data: DockerPull = {
       image: "nginx",
       tag: "latest",
@@ -290,8 +290,13 @@ describe("compactPullMap", () => {
 
     const compact = compactPullMap(data);
 
-    expect(compact).toEqual({ image: "nginx", tag: "latest", success: true });
-    expect(compact).not.toHaveProperty("digest");
+    expect(compact).toEqual({
+      image: "nginx",
+      tag: "latest",
+      digest: "sha256:abc123def456",
+      success: true,
+    });
+    expect(compact).toHaveProperty("digest", "sha256:abc123def456");
   });
 });
 

--- a/packages/server-docker/__tests__/formatters.test.ts
+++ b/packages/server-docker/__tests__/formatters.test.ts
@@ -561,7 +561,7 @@ describe("formatStatsCompact", () => {
     const output = formatStatsCompact(compact);
     expect(output).toContain("1 containers:");
     expect(output).toContain("web (abc123) CPU: 1.23%");
-    expect(output).toContain("Mem: 14.65%");
+    expect(output).toContain("Mem: 150MiB (14.65%)");
     expect(output).toContain("PIDs: 12");
     // Compact should NOT contain I/O details
     expect(output).not.toContain("Net:");

--- a/packages/server-docker/__tests__/parsers.test.ts
+++ b/packages/server-docker/__tests__/parsers.test.ts
@@ -89,7 +89,7 @@ describe("parsePsJson", () => {
     expect(result.containers[0].ports).toEqual([]);
   });
 
-  it("truncates long container IDs to 12 characters", () => {
+  it("preserves full container IDs (no truncation) since --no-trunc is passed", () => {
     const stdout = JSON.stringify({
       ID: "abc123def456789012345678901234567890123456789012345678901234abcd",
       Names: "long-id-app",
@@ -101,10 +101,10 @@ describe("parsePsJson", () => {
     });
 
     const result = parsePsJson(stdout);
-    expect(result.containers[0].id).toBe("abc123def456");
-    expect(result.containers[0].id).toHaveLength(12);
+    expect(result.containers[0].id).toBe(
+      "abc123def456789012345678901234567890123456789012345678901234abcd",
+    );
   });
-
   it("prefers RunningFor over CreatedAt for relative timestamps", () => {
     const stdout = JSON.stringify({
       ID: "abc123def456",

--- a/packages/server-docker/src/schemas/index.ts
+++ b/packages/server-docker/src/schemas/index.ts
@@ -56,12 +56,13 @@ export const DockerLogsSchema = z.object({
 
 export type DockerLogs = z.infer<typeof DockerLogsSchema>;
 
-/** Zod schema for a single Docker image with ID, repository, tag, size, and creation time. */
+/** Zod schema for a single Docker image with ID, repository, tag, size, digest, and creation time. */
 export const ImageSchema = z.object({
   id: z.string(),
   repository: z.string(),
   tag: z.string(),
   size: z.string(),
+  digest: z.string().optional(),
   created: z.string().optional(),
 });
 
@@ -83,12 +84,13 @@ export const DockerRunSchema = z.object({
 
 export type DockerRun = z.infer<typeof DockerRunSchema>;
 
-/** Zod schema for structured docker exec output with exit code, stdout, stderr, and success flag. */
+/** Zod schema for structured docker exec output with exit code, stdout, stderr, success flag, and duration. */
 export const DockerExecSchema = z.object({
   exitCode: z.number(),
   stdout: z.string().optional(),
   stderr: z.string().optional(),
   success: z.boolean(),
+  duration: z.number().optional(),
 });
 
 export type DockerExec = z.infer<typeof DockerExecSchema>;
@@ -137,6 +139,9 @@ export const DockerInspectSchema = z.object({
   created: z.string().optional(),
   status: z.string().optional(),
   running: z.boolean().optional(),
+  healthStatus: z.enum(["healthy", "unhealthy", "starting", "none"]).optional(),
+  env: z.array(z.string()).optional(),
+  restartPolicy: z.string().optional(),
 });
 
 export type DockerInspect = z.infer<typeof DockerInspectSchema>;
@@ -147,6 +152,7 @@ export const NetworkSchema = z.object({
   name: z.string(),
   driver: z.string(),
   scope: z.string().optional(),
+  createdAt: z.string().optional(),
 });
 
 /** Zod schema for structured docker network ls output. */
@@ -163,6 +169,7 @@ export const VolumeSchema = z.object({
   driver: z.string(),
   mountpoint: z.string().optional(),
   scope: z.string().optional(),
+  createdAt: z.string().optional(),
 });
 
 /** Zod schema for structured docker volume ls output. */
@@ -177,7 +184,9 @@ export type DockerVolumeLs = z.infer<typeof DockerVolumeLsSchema>;
 export const ComposeServiceSchema = z.object({
   name: z.string(),
   service: z.string(),
-  state: z.string(),
+  state: z
+    .enum(["running", "exited", "paused", "restarting", "dead", "created", "removing"])
+    .catch("created"),
   status: z.string().optional(),
   ports: z.string().optional(),
 });
@@ -209,6 +218,7 @@ export const DockerComposeLogsSchema = z.object({
       z.object({
         service: z.string(),
         message: z.string(),
+        timestamp: z.string().optional(),
       }),
     )
     .optional(),
@@ -217,6 +227,7 @@ export const DockerComposeLogsSchema = z.object({
       z.object({
         service: z.string(),
         message: z.string(),
+        timestamp: z.string().optional(),
       }),
     )
     .optional(),

--- a/packages/server-docker/src/tools/compose-up.ts
+++ b/packages/server-docker/src/tools/compose-up.ts
@@ -36,6 +36,10 @@ export function registerComposeUpTool(server: McpServer) {
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe("Compose file path (default: docker-compose.yml)"),
+        pull: z
+          .enum(["always", "missing", "never"])
+          .optional()
+          .describe('Pull image policy: "always", "missing", or "never" (--pull)'),
         wait: z
           .boolean()
           .optional()
@@ -94,6 +98,7 @@ export function registerComposeUpTool(server: McpServer) {
       detach,
       build,
       file,
+      pull,
       wait,
       forceRecreate,
       timeout,
@@ -117,6 +122,7 @@ export function registerComposeUpTool(server: McpServer) {
       args.push("up");
       if (detach) args.push("-d");
       if (build) args.push("--build");
+      if (pull) args.push("--pull", pull);
       if (wait) args.push("--wait");
       if (forceRecreate) args.push("--force-recreate");
       if (timeout != null) args.push("--timeout", String(timeout));

--- a/packages/server-docker/src/tools/inspect.ts
+++ b/packages/server-docker/src/tools/inspect.ts
@@ -19,6 +19,17 @@ export function registerInspectTool(server: McpServer) {
           .string()
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .describe("Container or image name/ID to inspect"),
+        type: z
+          .enum(["container", "image", "volume", "network"])
+          .optional()
+          .describe(
+            'Object type to inspect: "container", "image", "volume", or "network" (--type)',
+          ),
+        size: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Display total file sizes (-s, --size)"),
         path: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
@@ -34,10 +45,13 @@ export function registerInspectTool(server: McpServer) {
       },
       outputSchema: DockerInspectSchema,
     },
-    async ({ target, path, compact }) => {
+    async ({ target, type, size, path, compact }) => {
       assertNoFlagInjection(target, "target");
 
-      const args = ["inspect", "--format", "json", target];
+      const args = ["inspect", "--format", "json"];
+      if (type) args.push("--type", type);
+      if (size) args.push("-s");
+      args.push(target);
       const result = await docker(args, path);
 
       if (result.exitCode !== 0) {

--- a/packages/server-docker/src/tools/logs.ts
+++ b/packages/server-docker/src/tools/logs.ts
@@ -26,6 +26,13 @@ export function registerLogsTool(server: McpServer) {
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe("Show logs since timestamp (e.g., '10m', '2024-01-01')"),
+        until: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "Show logs until timestamp (e.g., '5m', '2024-01-02') for time-bounded queries",
+          ),
         limit: z
           .number()
           .optional()
@@ -53,12 +60,14 @@ export function registerLogsTool(server: McpServer) {
       },
       outputSchema: DockerLogsSchema,
     },
-    async ({ container, tail, since, limit, timestamps, details, compact }) => {
+    async ({ container, tail, since, until, limit, timestamps, details, compact }) => {
       assertNoFlagInjection(container, "container");
       if (since) assertNoFlagInjection(since, "since");
+      if (until) assertNoFlagInjection(until, "until");
 
       const args = ["logs", container, "--tail", String(tail ?? 100)];
       if (since) args.push("--since", since);
+      if (until) args.push("--until", until);
       if (timestamps) args.push("--timestamps");
       if (details) args.push("--details");
 

--- a/packages/server-docker/src/tools/stats.ts
+++ b/packages/server-docker/src/tools/stats.ts
@@ -29,6 +29,11 @@ export function registerStatsTool(server: McpServer) {
           .optional()
           .default(false)
           .describe("Do not truncate container IDs (default: false)"),
+        path: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Working directory (default: cwd), consistent with all other Docker tools"),
         compact: z
           .boolean()
           .optional()
@@ -39,7 +44,7 @@ export function registerStatsTool(server: McpServer) {
       },
       outputSchema: DockerStatsSchema,
     },
-    async ({ containers, all, noTrunc, compact }) => {
+    async ({ containers, all, noTrunc, path, compact }) => {
       if (containers) {
         for (const c of containers) {
           assertNoFlagInjection(c, "container");
@@ -53,7 +58,7 @@ export function registerStatsTool(server: McpServer) {
         args.push(...containers);
       }
 
-      const result = await docker(args);
+      const result = await docker(args, path);
       const data = parseStatsJson(result.stdout);
       return compactDualOutput(
         data,


### PR DESCRIPTION
## Summary
- Implements **54 S-complexity gaps** across all 16 Docker tools
- Adds validated params with `assertNoFlagInjection()`, enum types, conditional logic, and output schema enhancements
- All 370 existing tests pass; updated 3 tests to match intentional behavioral changes (full container IDs, digest preservation, memoryUsage in compact)

### Tools modified (16):
| Tool | Changes |
|------|---------|
| `build` | `buildArgs`, `target`, `platform`, `label`, `cacheFrom`, `cacheTo`, `secret`, `ssh` params |
| `compose-build` | `file`, `ssh`, `builder` params |
| `compose-down` | `rmi` enum, `services` positional args |
| `compose-logs` | `until`, `file` params; timestamps in compact |
| `compose-ps` | `file`, `services`, `status`, `filter` params; `state` field changed to enum |
| `compose-up` | `pull` enum (always/missing/never) |
| `exec` | `user`, `envFile` params; `duration` in output schema |
| `images` | `digest` field in output schema |
| `inspect` | `type` enum, `size` param; `healthStatus`, `env`, `restartPolicy` in output |
| `logs` | `until` param |
| `network-ls` | `filter` (string\|string[]); `createdAt` output; `id` preserved in compact |
| `ps` | `filter` param; full container ID preserved |
| `pull` | `digest` preserved in compact output |
| `run` | `workdir`, `network`, `platform`, `entrypoint`, `user`, `restart`, `memory`, `hostname`, `shmSize`, `pull`, `envFile` params |
| `stats` | `path` param; `memoryUsage` preserved in compact |
| `volume-ls` | `filter` (string\|string[]); `createdAt` output; `mountpoint` preserved in compact |

## Test plan
- [x] All 370 tests pass (`pnpm --filter @paretools/docker test`)
- [x] Build succeeds (`pnpm --filter @paretools/docker build`)
- [ ] CI matrix passes (ubuntu/windows/macos x node 20/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)