### PR TITLE
feat(k8s): implement S-complexity gaps

### DIFF
--- a/.changeset/k8s-s-gaps.md
+++ b/.changeset/k8s-s-gaps.md
@@ -1,0 +1,11 @@
+---
+"@paretools/k8s": minor
+---
+
+Add S-complexity gap parameters to K8s tools:
+
+- **get**: `fieldSelector`, `context`, `kubeconfig`, `sortBy`, `filename`, `subresource`
+- **describe**: Make `name` optional, add `selector`, `context`, `kubeconfig`
+- **apply**: Multi-file support (`string | string[]`), `validate` enum, `waitTimeout`, `fieldManager`, `context`, `selector`, `cascade` enum
+- **helm**: `version`, `waitTimeout`, multi-values (`string | string[]`), `filter`, `statusRevision`, `repo`, `description`
+- **logs**: `sinceTime`, `selector`, `context`, `podRunningTimeout`

--- a/packages/server-k8s/__tests__/security.test.ts
+++ b/packages/server-k8s/__tests__/security.test.ts
@@ -95,6 +95,110 @@ describe("assertNoFlagInjection — kubectl (namespace param)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// assertNoFlagInjection — new kubectl params (fieldSelector, context, etc.)
+// ---------------------------------------------------------------------------
+
+describe("assertNoFlagInjection — kubectl get (fieldSelector param)", () => {
+  it("accepts a normal field selector", () => {
+    expect(() => assertNoFlagInjection("status.phase=Running", "fieldSelector")).not.toThrow();
+  });
+
+  it("accepts field selector with metadata", () => {
+    expect(() => assertNoFlagInjection("metadata.name=my-pod", "fieldSelector")).not.toThrow();
+  });
+
+  it("rejects flag injection in fieldSelector", () => {
+    expect(() => assertNoFlagInjection("--all", "fieldSelector")).toThrow(/Invalid fieldSelector/);
+  });
+});
+
+describe("assertNoFlagInjection — kubectl (context param)", () => {
+  it("accepts a normal context name", () => {
+    expect(() => assertNoFlagInjection("my-cluster-context", "context")).not.toThrow();
+  });
+
+  it("rejects flag injection in context", () => {
+    expect(() => assertNoFlagInjection("--all-namespaces", "context")).toThrow(/Invalid context/);
+  });
+});
+
+describe("assertNoFlagInjection — kubectl (kubeconfig param)", () => {
+  it("accepts a normal kubeconfig path", () => {
+    expect(() => assertNoFlagInjection("/home/user/.kube/config", "kubeconfig")).not.toThrow();
+  });
+
+  it("rejects flag injection in kubeconfig", () => {
+    expect(() => assertNoFlagInjection("--exec", "kubeconfig")).toThrow(/Invalid kubeconfig/);
+  });
+});
+
+describe("assertNoFlagInjection — kubectl get (sortBy param)", () => {
+  it("accepts a JSONPath expression", () => {
+    expect(() => assertNoFlagInjection(".metadata.creationTimestamp", "sortBy")).not.toThrow();
+  });
+
+  it("rejects flag injection in sortBy", () => {
+    expect(() => assertNoFlagInjection("--output", "sortBy")).toThrow(/Invalid sortBy/);
+  });
+});
+
+describe("assertNoFlagInjection — kubectl apply (fieldManager param)", () => {
+  it("accepts a normal field manager name", () => {
+    expect(() => assertNoFlagInjection("my-controller", "fieldManager")).not.toThrow();
+  });
+
+  it("rejects flag injection in fieldManager", () => {
+    expect(() => assertNoFlagInjection("--force", "fieldManager")).toThrow(/Invalid fieldManager/);
+  });
+});
+
+describe("assertNoFlagInjection — kubectl apply (selector param)", () => {
+  it("accepts a normal label selector", () => {
+    expect(() => assertNoFlagInjection("app=nginx", "selector")).not.toThrow();
+  });
+
+  it("rejects flag injection in selector", () => {
+    expect(() => assertNoFlagInjection("--prune", "selector")).toThrow(/Invalid selector/);
+  });
+});
+
+describe("assertNoFlagInjection — kubectl logs (sinceTime param)", () => {
+  it("accepts an RFC3339 timestamp", () => {
+    expect(() => assertNoFlagInjection("2024-01-15T10:00:00Z", "sinceTime")).not.toThrow();
+  });
+
+  it("rejects flag injection in sinceTime", () => {
+    expect(() => assertNoFlagInjection("--follow", "sinceTime")).toThrow(/Invalid sinceTime/);
+  });
+});
+
+describe("assertNoFlagInjection — kubectl get (subresource param)", () => {
+  it("accepts a normal subresource name", () => {
+    expect(() => assertNoFlagInjection("status", "subresource")).not.toThrow();
+  });
+
+  it("accepts 'scale' subresource", () => {
+    expect(() => assertNoFlagInjection("scale", "subresource")).not.toThrow();
+  });
+
+  it("rejects flag injection in subresource", () => {
+    expect(() => assertNoFlagInjection("--exec", "subresource")).toThrow(/Invalid subresource/);
+  });
+});
+
+describe("assertNoFlagInjection — kubectl logs (podRunningTimeout param)", () => {
+  it("accepts a duration string", () => {
+    expect(() => assertNoFlagInjection("20s", "podRunningTimeout")).not.toThrow();
+  });
+
+  it("rejects flag injection in podRunningTimeout", () => {
+    expect(() => assertNoFlagInjection("--follow", "podRunningTimeout")).toThrow(
+      /Invalid podRunningTimeout/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // assertNoFlagInjection — helm (release, chart, namespace)
 // ---------------------------------------------------------------------------
 
@@ -153,6 +257,64 @@ describe("assertNoFlagInjection — helm (setValues items)", () => {
 
   it("rejects --namespace as setValues item", () => {
     expect(() => assertNoFlagInjection("--namespace", "setValues")).toThrow(/Invalid setValues/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertNoFlagInjection — new helm params (version, filter, repo, etc.)
+// ---------------------------------------------------------------------------
+
+describe("assertNoFlagInjection — helm (version param)", () => {
+  it("accepts a semver version", () => {
+    expect(() => assertNoFlagInjection("1.2.3", "version")).not.toThrow();
+  });
+
+  it("accepts a version with v prefix", () => {
+    expect(() => assertNoFlagInjection("v1.0.0", "version")).not.toThrow();
+  });
+
+  it("rejects flag injection in version", () => {
+    expect(() => assertNoFlagInjection("--set", "version")).toThrow(/Invalid version/);
+  });
+});
+
+describe("assertNoFlagInjection — helm (filter param)", () => {
+  it("accepts a regex pattern", () => {
+    expect(() => assertNoFlagInjection("nginx.*", "filter")).not.toThrow();
+  });
+
+  it("rejects flag injection in filter", () => {
+    expect(() => assertNoFlagInjection("--all", "filter")).toThrow(/Invalid filter/);
+  });
+});
+
+describe("assertNoFlagInjection — helm (repo param)", () => {
+  it("accepts a URL", () => {
+    expect(() => assertNoFlagInjection("https://charts.bitnami.com/bitnami", "repo")).not.toThrow();
+  });
+
+  it("rejects flag injection in repo", () => {
+    expect(() => assertNoFlagInjection("--set", "repo")).toThrow(/Invalid repo/);
+  });
+});
+
+describe("assertNoFlagInjection — helm (description param)", () => {
+  it("accepts a description string", () => {
+    expect(() => assertNoFlagInjection("Initial release for staging", "description")).not.toThrow();
+  });
+
+  it("rejects flag injection in description", () => {
+    expect(() => assertNoFlagInjection("--force", "description")).toThrow(/Invalid description/);
+  });
+});
+
+describe("assertNoFlagInjection — helm (waitTimeout param)", () => {
+  it("accepts a duration string", () => {
+    expect(() => assertNoFlagInjection("5m0s", "waitTimeout")).not.toThrow();
+  });
+
+  it("rejects flag injection in waitTimeout", () => {
+    expect(() => assertNoFlagInjection("--force", "waitTimeout")).toThrow(/Invalid waitTimeout/);
   });
 });
 
@@ -248,6 +410,32 @@ describe("Zod .max() constraints — K8s tool schemas", () => {
 
     it("rejects set value exceeding STRING_MAX", () => {
       const oversized = ["k=" + "v".repeat(INPUT_LIMITS.STRING_MAX)];
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("fieldSelector parameter (STRING_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.STRING_MAX);
+
+    it("accepts a field selector within the limit", () => {
+      expect(schema.safeParse("status.phase=Running").success).toBe(true);
+    });
+
+    it("rejects a field selector exceeding STRING_MAX", () => {
+      const oversized = "f".repeat(INPUT_LIMITS.STRING_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("context parameter (SHORT_STRING_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.SHORT_STRING_MAX);
+
+    it("accepts a context name within the limit", () => {
+      expect(schema.safeParse("my-cluster").success).toBe(true);
+    });
+
+    it("rejects a context exceeding SHORT_STRING_MAX", () => {
+      const oversized = "c".repeat(INPUT_LIMITS.SHORT_STRING_MAX + 1);
       expect(schema.safeParse(oversized).success).toBe(false);
     });
   });

--- a/packages/server-k8s/src/tools/get.ts
+++ b/packages/server-k8s/src/tools/get.ts
@@ -38,6 +38,30 @@ export function registerGetTool(server: McpServer) {
           .max(INPUT_LIMITS.STRING_MAX)
           .optional()
           .describe("Label selector (e.g., app=nginx)"),
+        fieldSelector: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe(
+            "Field selector for filtering by resource fields (--field-selector). E.g., 'status.phase=Running'",
+          ),
+        context: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Kubernetes context for multi-cluster operations (--context)"),
+        kubeconfig: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to kubeconfig file (--kubeconfig)"),
+        sortBy: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe(
+            "JSONPath expression for sorting results (--sort-by). E.g., '.metadata.creationTimestamp'",
+          ),
         ignoreNotFound: z
           .boolean()
           .optional()
@@ -46,6 +70,19 @@ export function registerGetTool(server: McpServer) {
           .number()
           .optional()
           .describe("Number of results to return per request for pagination (--chunk-size)"),
+        filename: z
+          .array(z.string().max(INPUT_LIMITS.PATH_MAX))
+          .optional()
+          .describe(
+            "Identify resources from file paths (-f). Use to get resources defined in manifest files.",
+          ),
+        subresource: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "Subresource to access (--subresource). E.g., 'status' or 'scale' for status/scale subresource.",
+          ),
         compact: z
           .boolean()
           .optional()
@@ -62,14 +99,30 @@ export function registerGetTool(server: McpServer) {
       namespace,
       allNamespaces,
       selector,
+      fieldSelector,
+      context,
+      kubeconfig,
+      sortBy,
       ignoreNotFound,
       chunkSize,
+      filename,
+      subresource,
       compact,
     }) => {
       assertNoFlagInjection(resource, "resource");
       if (name) assertNoFlagInjection(name, "name");
       if (namespace) assertNoFlagInjection(namespace, "namespace");
       if (selector) assertNoFlagInjection(selector, "selector");
+      if (fieldSelector) assertNoFlagInjection(fieldSelector, "fieldSelector");
+      if (context) assertNoFlagInjection(context, "context");
+      if (kubeconfig) assertNoFlagInjection(kubeconfig, "kubeconfig");
+      if (sortBy) assertNoFlagInjection(sortBy, "sortBy");
+      if (subresource) assertNoFlagInjection(subresource, "subresource");
+      if (filename) {
+        for (const f of filename) {
+          assertNoFlagInjection(f, "filename");
+        }
+      }
 
       const args = ["get", resource];
       if (name) args.push(name);
@@ -79,8 +132,18 @@ export function registerGetTool(server: McpServer) {
         args.push("-n", namespace);
       }
       if (selector) args.push("-l", selector);
+      if (fieldSelector) args.push("--field-selector", fieldSelector);
+      if (context) args.push("--context", context);
+      if (kubeconfig) args.push("--kubeconfig", kubeconfig);
+      if (sortBy) args.push("--sort-by", sortBy);
       if (ignoreNotFound) args.push("--ignore-not-found");
       if (chunkSize !== undefined) args.push("--chunk-size", String(chunkSize));
+      if (filename) {
+        for (const f of filename) {
+          args.push("-f", f);
+        }
+      }
+      if (subresource) args.push("--subresource", subresource);
       args.push("-o", "json");
 
       const result = await run("kubectl", args, { timeout: 60_000 });

--- a/packages/server-k8s/src/tools/helm.ts
+++ b/packages/server-k8s/src/tools/helm.ts
@@ -58,10 +58,21 @@ export function registerHelmTool(server: McpServer) {
           .optional()
           .describe("Values to set via --set (e.g., ['key1=val1', 'key2=val2'])"),
         values: z
-          .string()
-          .max(INPUT_LIMITS.PATH_MAX)
+          .union([
+            z.string().max(INPUT_LIMITS.PATH_MAX),
+            z.array(z.string().max(INPUT_LIMITS.PATH_MAX)),
+          ])
           .optional()
-          .describe("Path to a values YAML file (--values)"),
+          .describe(
+            "Path(s) to values YAML file(s) (--values). Accepts a single path or an array of paths.",
+          ),
+        version: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "Chart version to install/upgrade (--version). For reproducible pinned versions.",
+          ),
         dryRun: z
           .boolean()
           .optional()
@@ -70,6 +81,13 @@ export function registerHelmTool(server: McpServer) {
           .boolean()
           .optional()
           .describe("Wait until resources are ready after install/upgrade (--wait)"),
+        waitTimeout: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "Timeout for --wait (--timeout). E.g., '5m0s'. Only effective when wait is true.",
+          ),
         atomic: z
           .boolean()
           .optional()
@@ -90,10 +108,33 @@ export function registerHelmTool(server: McpServer) {
           .boolean()
           .optional()
           .describe("List releases across all namespaces (-A, list action only)"),
+        filter: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Regex filter for release names in list action (--filter)"),
         showResources: z
           .boolean()
           .optional()
           .describe("Show resources in status output (--show-resources, status action only)"),
+        statusRevision: z
+          .number()
+          .optional()
+          .describe(
+            "Show status for a specific historical revision (--revision, status action only)",
+          ),
+        repo: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Chart repository URL (--repo). For installing from a specific repo."),
+        description: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe(
+            "Custom description for the release (--description). Added to the release metadata.",
+          ),
         noHooks: z.boolean().optional().describe("Skip execution of hooks (--no-hooks)"),
         skipCrds: z.boolean().optional().describe("Skip CRD installation (--skip-crds)"),
         compact: z
@@ -118,14 +159,20 @@ export function registerHelmTool(server: McpServer) {
       namespace,
       setValues,
       values,
+      version,
       dryRun,
       wait,
+      waitTimeout,
       atomic,
       createNamespace,
       installOnUpgrade,
       reuseValues,
       allNamespaces,
+      filter,
       showResources,
+      statusRevision,
+      repo,
+      description,
       noHooks,
       skipCrds,
       compact,
@@ -133,7 +180,17 @@ export function registerHelmTool(server: McpServer) {
       if (release) assertNoFlagInjection(release, "release");
       if (chart) assertNoFlagInjection(chart, "chart");
       if (namespace) assertNoFlagInjection(namespace, "namespace");
-      if (values) assertNoFlagInjection(values, "values");
+      if (version) assertNoFlagInjection(version, "version");
+      if (filter) assertNoFlagInjection(filter, "filter");
+      if (repo) assertNoFlagInjection(repo, "repo");
+      if (description) assertNoFlagInjection(description, "description");
+      if (waitTimeout) assertNoFlagInjection(waitTimeout, "waitTimeout");
+
+      // Normalize values to array
+      const valuesFiles = values ? (Array.isArray(values) ? values : [values]) : [];
+      for (const v of valuesFiles) {
+        assertNoFlagInjection(v, "values");
+      }
 
       switch (action) {
         case "list": {
@@ -143,6 +200,7 @@ export function registerHelmTool(server: McpServer) {
           } else if (namespace) {
             args.push("-n", namespace);
           }
+          if (filter) args.push("--filter", filter);
 
           const result = await run("helm", args, { timeout: 60_000 });
           const data = parseHelmListOutput(
@@ -169,6 +227,7 @@ export function registerHelmTool(server: McpServer) {
           const args = ["status", release, "-o", "json"];
           if (namespace) args.push("-n", namespace);
           if (showResources) args.push("--show-resources");
+          if (statusRevision !== undefined) args.push("--revision", String(statusRevision));
 
           const result = await run("helm", args, { timeout: 60_000 });
           const data = parseHelmStatusOutput(
@@ -196,7 +255,10 @@ export function registerHelmTool(server: McpServer) {
 
           const args = ["install", release, chart, "-o", "json"];
           if (namespace) args.push("-n", namespace);
-          if (values) args.push("--values", values);
+          if (version) args.push("--version", version);
+          for (const v of valuesFiles) {
+            args.push("--values", v);
+          }
           if (setValues) {
             for (const sv of setValues) {
               assertNoFlagInjection(sv, "setValues");
@@ -205,8 +267,11 @@ export function registerHelmTool(server: McpServer) {
           }
           if (dryRun) args.push("--dry-run");
           if (wait) args.push("--wait");
+          if (waitTimeout) args.push("--timeout", waitTimeout);
           if (atomic) args.push("--atomic");
           if (createNamespace) args.push("--create-namespace");
+          if (repo) args.push("--repo", repo);
+          if (description) args.push("--description", description);
           if (noHooks) args.push("--no-hooks");
           if (skipCrds) args.push("--skip-crds");
 
@@ -236,7 +301,10 @@ export function registerHelmTool(server: McpServer) {
 
           const args = ["upgrade", release, chart, "-o", "json"];
           if (namespace) args.push("-n", namespace);
-          if (values) args.push("--values", values);
+          if (version) args.push("--version", version);
+          for (const v of valuesFiles) {
+            args.push("--values", v);
+          }
           if (setValues) {
             for (const sv of setValues) {
               assertNoFlagInjection(sv, "setValues");
@@ -245,10 +313,13 @@ export function registerHelmTool(server: McpServer) {
           }
           if (dryRun) args.push("--dry-run");
           if (wait) args.push("--wait");
+          if (waitTimeout) args.push("--timeout", waitTimeout);
           if (atomic) args.push("--atomic");
           if (createNamespace) args.push("--create-namespace");
           if (installOnUpgrade) args.push("--install");
           if (reuseValues) args.push("--reuse-values");
+          if (repo) args.push("--repo", repo);
+          if (description) args.push("--description", description);
           if (noHooks) args.push("--no-hooks");
           if (skipCrds) args.push("--skip-crds");
 


### PR DESCRIPTION
## Summary
- Implements **28 S-complexity gaps** across all 5 K8s tools (get, describe, apply, helm, logs)
- Adds validated input params with `assertNoFlagInjection()` on all string inputs
- Introduces union types for multi-file/multi-values support (`string | string[]`)
- Adds enum params for `validate` and `cascade` modes
- Makes `describe.name` optional to allow describing all resources of a type
- 35 new security tests added (212 total, up from 177)

### Gaps by tool:
| Tool | Gaps | Params added |
|------|------|-------------|
| get | 6 | `fieldSelector`, `context`, `kubeconfig`, `sortBy`, `filename` (string[]), `subresource` |
| describe | 4 | Make `name` optional, `selector`, `context`, `kubeconfig` |
| apply | 7 | Multi-file `string \| string[]`, `validate` enum, `waitTimeout`, `fieldManager`, `context`, `selector`, `cascade` enum |
| helm | 7 | `version`, `waitTimeout`, multi-values `string \| string[]`, `filter`, `statusRevision`, `repo`, `description` |
| logs | 4 | `sinceTime`, `selector`, `context`, `podRunningTimeout` |

## Test plan
- [x] `pnpm --filter @paretools/k8s build` passes
- [x] `pnpm --filter @paretools/k8s test` passes (212/212 tests)
- [x] New security tests verify `assertNoFlagInjection` on all new string params
- [x] Zod .max() constraint tests for new params

🤖 Generated with [Claude Code](https://claude.com/claude-code)