### PR TITLE
feat(process): implement S-complexity gaps

### DIFF
--- a/.changeset/process-s-gaps.md
+++ b/.changeset/process-s-gaps.md
@@ -1,0 +1,12 @@
+---
+"@paretools/process": minor
+---
+
+Add S-complexity gap implementations for the process run tool:
+
+- Add `stdin` param for piping input data to commands (e.g., jq, grep)
+- Add `maxBuffer` param to control maximum stdout+stderr buffer size
+- Add `killSignal` param (enum) to control signal sent on timeout
+- Add `maxOutputLines` param to truncate output by line count (agent-friendly)
+- Add `encoding` param (enum) for non-UTF-8 output support
+- Add `stdoutTruncatedLines` and `stderrTruncatedLines` output fields

--- a/packages/server-process/__tests__/parsers.test.ts
+++ b/packages/server-process/__tests__/parsers.test.ts
@@ -71,3 +71,38 @@ describe("parseRunOutput", () => {
     expect(result.signal).toBeUndefined();
   });
 });
+
+describe("parseRunOutput — maxOutputLines truncation", () => {
+  it("truncates stdout to maxOutputLines", () => {
+    const stdout = "line1\nline2\nline3\nline4\nline5\n";
+    const result = parseRunOutput("cmd", stdout, "", 0, 100, false, undefined, 3);
+
+    expect(result.stdout).toBe("line1\nline2\nline3");
+    expect(result.stdoutTruncatedLines).toBe(2);
+    expect(result.stderrTruncatedLines).toBeUndefined();
+  });
+
+  it("truncates stderr to maxOutputLines", () => {
+    const stderr = "err1\nerr2\nerr3\nerr4\n";
+    const result = parseRunOutput("cmd", "", stderr, 1, 100, false, undefined, 2);
+
+    expect(result.stderr).toBe("err1\nerr2");
+    expect(result.stderrTruncatedLines).toBe(2);
+  });
+
+  it("does not truncate when output is within limit", () => {
+    const stdout = "line1\nline2\n";
+    const result = parseRunOutput("cmd", stdout, "", 0, 100, false, undefined, 10);
+
+    expect(result.stdout).toBe("line1\nline2");
+    expect(result.stdoutTruncatedLines).toBeUndefined();
+  });
+
+  it("does not truncate when maxOutputLines is not set", () => {
+    const stdout = "line1\nline2\nline3\nline4\nline5\n";
+    const result = parseRunOutput("cmd", stdout, "", 0, 100, false);
+
+    expect(result.stdout).toBe("line1\nline2\nline3\nline4\nline5");
+    expect(result.stdoutTruncatedLines).toBeUndefined();
+  });
+});

--- a/packages/server-process/src/lib/formatters.ts
+++ b/packages/server-process/src/lib/formatters.ts
@@ -17,7 +17,13 @@ export function formatRun(data: ProcessRunResult): string {
   }
 
   if (data.stdout) lines.push(data.stdout);
+  if (data.stdoutTruncatedLines) {
+    lines.push(`  ... ${data.stdoutTruncatedLines} stdout lines truncated`);
+  }
   if (data.stderr) lines.push(data.stderr);
+  if (data.stderrTruncatedLines) {
+    lines.push(`  ... ${data.stderrTruncatedLines} stderr lines truncated`);
+  }
   return lines.join("\n");
 }
 
@@ -32,6 +38,8 @@ export interface ProcessRunCompact {
   duration: number;
   timedOut: boolean;
   signal?: string;
+  stdoutTruncatedLines?: number;
+  stderrTruncatedLines?: number;
 }
 
 export function compactRunMap(data: ProcessRunResult): ProcessRunCompact {
@@ -42,6 +50,8 @@ export function compactRunMap(data: ProcessRunResult): ProcessRunCompact {
     duration: data.duration,
     timedOut: data.timedOut,
     signal: data.signal,
+    stdoutTruncatedLines: data.stdoutTruncatedLines,
+    stderrTruncatedLines: data.stderrTruncatedLines,
   };
 }
 

--- a/packages/server-process/src/schemas/index.ts
+++ b/packages/server-process/src/schemas/index.ts
@@ -10,6 +10,8 @@ export const ProcessRunResultSchema = z.object({
   duration: z.number(),
   timedOut: z.boolean(),
   signal: z.string().optional(),
+  stdoutTruncatedLines: z.number().optional(),
+  stderrTruncatedLines: z.number().optional(),
 });
 
 export type ProcessRunResult = z.infer<typeof ProcessRunResultSchema>;


### PR DESCRIPTION
## Summary
- Implements **5 S-complexity gaps** for the process `run` tool
- Adds validated input params with enum types, output schema fields for truncation tracking
- All 50 tests pass (46 existing + 4 new for line truncation)

### New Input Parameters
| Param | Type | Description |
|-------|------|-------------|
| `stdin` | `string` | Input data to write to command's stdin (for piping to jq, grep, etc.) |
| `maxBuffer` | `number` | Max combined stdout+stderr buffer size in bytes (1KB-100MB) |
| `killSignal` | `enum` | Signal sent on timeout: SIGTERM, SIGKILL, SIGINT, SIGHUP, SIGQUIT, SIGABRT, SIGUSR1, SIGUSR2 |
| `maxOutputLines` | `number` | Truncate stdout/stderr to max line count (1-100K), more agent-friendly than byte-based maxBuffer |
| `encoding` | `enum` | Output encoding: utf-8, ascii, latin1, binary, hex, base64, utf16le, ucs-2 |

### Output Schema Additions
| Field | Type | Description |
|-------|------|-------------|
| `stdoutTruncatedLines` | `number?` | Lines dropped from stdout by maxOutputLines |
| `stderrTruncatedLines` | `number?` | Lines dropped from stderr by maxOutputLines |

## Test plan
- [x] All 50 unit/integration tests pass (including 4 new truncation tests)
- [x] TypeScript compiles without errors
- [x] Changeset included for minor version bump
- [ ] CI validation (build, lint, format, test across matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)