### PR TITLE
feat(npm): implement S-complexity gaps

### DIFF
--- a/.changeset/npm-s-gaps.md
+++ b/.changeset/npm-s-gaps.md
@@ -1,0 +1,25 @@
+---
+"@paretools/npm": minor
+---
+
+Implement S-complexity gaps for npm tools:
+
+**audit**: Add `level` (severity enum), `production` (boolean), `omit` (array), `workspace`, and `args` params. Add `cve`/`cwe` fields to vulnerability output schema.
+
+**info**: Add `registry`, `field`, and `workspace` params. Add `engines`, `peerDependencies`, `deprecated`, `repository`, `keywords`, `versions`, and `dist.integrity` to output schema.
+
+**init**: Add `license`, `authorName`, `authorEmail`, `authorUrl`, `version`, `module`, and `workspace` params.
+
+**install**: Add `global` and `registry` params.
+
+**list**: Add `packages` (string[]), `workspace`, and `args` params.
+
+**nvm**: Add `which` (Node.js binary path) and `arch` (architecture) to output schema.
+
+**outdated**: Add `packages` (string[]), `workspace`, and `args` params.
+
+**run**: Add `workspace` (string or string[]) and `scriptShell` params.
+
+**search**: Add `exclude`, `registry`, and `searchopts` params. Add `keywords`, `score`, `links`, `scope`, and `registryTotal` to output schema.
+
+**test**: Add `workspace` (string or string[]) param.

--- a/packages/server-npm/src/schemas/index.ts
+++ b/packages/server-npm/src/schemas/index.ts
@@ -37,6 +37,8 @@ export const NpmAuditVulnSchema = z.object({
   url: z.string().optional(),
   range: z.string().optional(),
   fixAvailable: z.boolean(),
+  cve: z.string().optional().describe("CVE identifier for cross-referencing"),
+  cwe: z.array(z.string()).optional().describe("CWE identifiers for weakness classification"),
 });
 
 /** Zod schema for structured npm audit output with vulnerability list and severity summary. */
@@ -138,6 +140,12 @@ export const NpmInitSchema = z.object({
 
 export type NpmInit = z.infer<typeof NpmInitSchema>;
 
+/** Zod schema for repository metadata. */
+export const NpmRepositorySchema = z.object({
+  type: z.string().optional(),
+  url: z.string().optional(),
+});
+
 /** Zod schema for structured npm info output with package metadata. */
 export const NpmInfoSchema = z.object({
   packageManager: packageManagerField,
@@ -150,11 +158,31 @@ export const NpmInfoSchema = z.object({
   dist: z
     .object({
       tarball: z.string().optional(),
+      integrity: z.string().optional().describe("Subresource integrity hash"),
     })
     .optional(),
+  engines: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("Node.js and other engine version requirements"),
+  peerDependencies: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("Peer dependencies that must be co-installed"),
+  deprecated: z.string().optional().describe("Deprecation message if package is deprecated"),
+  repository: NpmRepositorySchema.optional().describe("Source code repository info"),
+  keywords: z.array(z.string()).optional().describe("Package keywords for discovery"),
+  versions: z.array(z.string()).optional().describe("All published versions"),
 });
 
 export type NpmInfo = z.infer<typeof NpmInfoSchema>;
+
+/** Zod schema for npm search package links. */
+export const NpmSearchLinksSchema = z.object({
+  npm: z.string().optional(),
+  homepage: z.string().optional(),
+  repository: z.string().optional(),
+});
 
 /** Zod schema for a single package entry in npm search results. */
 export const NpmSearchPackageSchema = z.object({
@@ -163,6 +191,10 @@ export const NpmSearchPackageSchema = z.object({
   description: z.string(),
   author: z.string().optional(),
   date: z.string().optional(),
+  keywords: z.array(z.string()).optional().describe("Package keywords"),
+  score: z.number().optional().describe("Registry-computed relevance score"),
+  links: NpmSearchLinksSchema.optional().describe("Package URLs"),
+  scope: z.string().optional().describe("Package scope (e.g., '@types')"),
 });
 
 /** Zod schema for structured npm search output with matching packages. */
@@ -170,6 +202,10 @@ export const NpmSearchSchema = z.object({
   packageManager: packageManagerField,
   packages: z.array(NpmSearchPackageSchema),
   total: z.number(),
+  registryTotal: z
+    .number()
+    .optional()
+    .describe("Total matching packages in registry (may differ from returned count)"),
 });
 
 export type NpmSearch = z.infer<typeof NpmSearchSchema>;
@@ -179,6 +215,8 @@ export const NvmResultSchema = z.object({
   current: z.string().describe("Currently active Node.js version"),
   versions: z.array(z.string()).describe("List of installed Node.js versions"),
   default: z.string().optional().describe("Default Node.js version (alias default)"),
+  which: z.string().optional().describe("Filesystem path to the active Node.js binary"),
+  arch: z.string().optional().describe("Architecture of the active Node.js (e.g., x64, arm64)"),
 });
 
 export type NvmResult = z.infer<typeof NvmResultSchema>;

--- a/packages/server-npm/src/tools/search.ts
+++ b/packages/server-npm/src/tools/search.ts
@@ -27,6 +27,23 @@ export function registerSearchTool(server: McpServer) {
           .optional()
           .default(20)
           .describe("Maximum number of results to return (default: 20)"),
+        exclude: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Exclude packages matching this text from results (maps to --searchexclude)"),
+        registry: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe(
+            "Registry URL to search (maps to --registry, e.g., 'https://npm.pkg.github.com')",
+          ),
+        searchopts: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Advanced search filtering options (maps to --searchopts)"),
         compact: z
           .boolean()
           .optional()
@@ -43,13 +60,25 @@ export function registerSearchTool(server: McpServer) {
       },
       outputSchema: NpmSearchSchema,
     },
-    async ({ query, path, limit, compact, preferOnline }) => {
+    async ({ query, path, limit, exclude, registry, searchopts, compact, preferOnline }) => {
       const cwd = path || process.cwd();
       assertNoFlagInjection(query, "query");
+      if (exclude) assertNoFlagInjection(exclude, "exclude");
+      if (registry) assertNoFlagInjection(registry, "registry");
+      if (searchopts) assertNoFlagInjection(searchopts, "searchopts");
 
       const args = ["search", query, "--json"];
       if (limit !== undefined) {
         args.push(`--searchlimit=${limit}`);
+      }
+      if (exclude) {
+        args.push(`--searchexclude=${exclude}`);
+      }
+      if (registry) {
+        args.push(`--registry=${registry}`);
+      }
+      if (searchopts) {
+        args.push(`--searchopts=${searchopts}`);
       }
       if (preferOnline) {
         args.push("--prefer-online");


### PR DESCRIPTION
## Summary
- Add **44 S-complexity gaps** across all 10 npm tools (audit, info, init, install, list, nvm, outdated, run, search, test)
- New input params: `level`, `production`, `omit`, `workspace`, `args`, `registry`, `field`, `license`, `authorName`, `authorEmail`, `authorUrl`, `version`, `module`, `global`, `packages`, `scriptShell`, `exclude`, `searchopts`
- New output schema fields: `cve`, `cwe` (audit vulnerabilities), `engines`, `peerDependencies`, `deprecated`, `repository`, `keywords`, `versions`, `dist.integrity` (info), `which`, `arch` (nvm), `keywords`, `score`, `links`, `scope`, `registryTotal` (search)
- All new string params validated with `assertNoFlagInjection()`

## Gap categories
| Tool | Params added | Output fields added |
|------|-------------|-------------------|
| audit | level, production, omit, workspace, args | cve, cwe |
| info | registry, field, workspace | engines, peerDependencies, deprecated, repository, keywords, versions, dist.integrity |
| init | license, authorName, authorEmail, authorUrl, version, module, workspace | - |
| install | global, registry | - |
| list | packages, workspace, args | - |
| nvm | - | which, arch |
| outdated | packages, workspace, args | - |
| run | workspace, scriptShell | - |
| search | exclude, registry, searchopts | keywords, score, links, scope, registryTotal |
| test | workspace | - |

## Test plan
- [x] `pnpm --filter @paretools/npm build` passes
- [x] `pnpm --filter @paretools/npm test` passes (261 tests)
- [x] All new params use `assertNoFlagInjection()` for security
- [x] Changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)