### PR TITLE
feat(make): implement S-complexity gaps

### DIFF
--- a/.changeset/make-s-gaps.md
+++ b/.changeset/make-s-gaps.md
@@ -1,0 +1,9 @@
+---
+"@paretools/make": minor
+---
+
+Implement S-complexity gaps for make tools:
+
+**list**: Add `file` param (maps to `make -f` / `just --justfile`) for non-default makefiles/justfiles. Add `filter` param for client-side regex filtering on target names.
+
+**run**: Add `file` param (maps to `make -f` / `just --justfile`) for non-default makefiles/justfiles. Add `env` param (Record<string, string>) for environment variable passthrough to target execution.


### PR DESCRIPTION
## Summary
- Add **4 S-complexity gaps** across make list and run tools
- New input params: `file` (list + run), `filter` (list), `env` (run)
- `file` maps to `make -f FILE` / `just --justfile FILE` for non-default makefiles/justfiles
- `filter` provides client-side regex filtering on target names
- `env` passes key-value environment variables as `VAR=VALUE` positional args
- All new string params validated with `assertNoFlagInjection()`

## Gap categories
| Tool | Params added | Description |
|------|-------------|-------------|
| list | file, filter | Non-default makefile support + client-side target filtering |
| run | file, env | Non-default makefile support + environment variable passthrough |

## Test plan
- [x] `pnpm --filter @paretools/make build` passes
- [x] `pnpm --filter @paretools/make test` passes (44 tests)
- [x] All new params use `assertNoFlagInjection()` for security
- [x] Changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)