### PR TITLE
feat(build): implement S-complexity gaps

### DIFF
--- a/.changeset/build-s-gaps.md
+++ b/.changeset/build-s-gaps.md
@@ -1,0 +1,13 @@
+---
+"@paretools/build": minor
+---
+
+Add S-complexity gap params and output schema enhancements across all build tools:
+
+- build: exitCode in output schema, timeout param, stdout/stderr/outputLines in schema
+- esbuild: target, external, sourcemap enum expansion, tsconfig, drop
+- nx: configuration, head, projects, exclude
+- tsc: declaration/declarationDir, pretty (--pretty false for parser normalization)
+- turbo: args with assertNoFlagInjection, outputLogs enum
+- vite-build: outDir, config, sourcemap, base, ssr
+- webpack: entry, target, devtool, analyze

--- a/packages/server-build/src/lib/build-runner.ts
+++ b/packages/server-build/src/lib/build-runner.ts
@@ -8,9 +8,10 @@ export async function runBuildCommand(
   cmd: string,
   args: string[],
   cwd?: string,
+  timeout?: number,
 ): Promise<RunResult> {
   // Build commands can take minutes for large projects
-  return run(cmd, args, { cwd, timeout: 300_000 });
+  return run(cmd, args, { cwd, timeout: timeout ?? 300_000 });
 }
 
 export async function esbuildCmd(args: string[], cwd?: string): Promise<RunResult> {

--- a/packages/server-build/src/lib/formatters.ts
+++ b/packages/server-build/src/lib/formatters.ts
@@ -26,13 +26,16 @@ export function formatTsc(data: TscResult): string {
 
 /** Formats structured build command results into a human-readable success/failure summary. */
 export function formatBuildCommand(data: BuildResult): string {
+  const exitInfo = data.exitCode !== undefined ? ` (exit ${data.exitCode})` : "";
+
   if (data.success) {
-    const parts = [`Build succeeded in ${data.duration}s`];
+    const parts = [`Build succeeded in ${data.duration}s${exitInfo}`];
     if ((data.warnings ?? []).length) parts.push(`${(data.warnings ?? []).length} warnings`);
+    if (data.outputLines !== undefined) parts.push(`${data.outputLines} output lines`);
     return parts.join(", ");
   }
 
-  const lines = [`Build failed (${data.duration}s)`];
+  const lines = [`Build failed (${data.duration}s)${exitInfo}`];
   for (const err of data.errors ?? []) {
     lines.push(`  ${err}`);
   }
@@ -284,6 +287,7 @@ export interface BuildCompact {
   [key: string]: unknown;
   success: boolean;
   duration: number;
+  exitCode?: number;
   errors?: string[];
   warnings?: string[];
 }
@@ -293,6 +297,7 @@ export function compactBuildMap(data: BuildResult): BuildCompact {
     success: data.success,
     duration: data.duration,
   };
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
   if (data.errors?.length) compact.errors = data.errors;
   if (data.warnings?.length) compact.warnings = data.warnings;
   return compact;

--- a/packages/server-build/src/lib/parsers.ts
+++ b/packages/server-build/src/lib/parsers.ts
@@ -73,9 +73,13 @@ export function parseBuildCommandOutput(
 
   return {
     success: exitCode === 0,
+    exitCode,
     duration,
     errors,
     warnings,
+    stdout: stdout || undefined,
+    stderr: stderr || undefined,
+    outputLines: lines.length,
   };
 }
 

--- a/packages/server-build/src/schemas/index.ts
+++ b/packages/server-build/src/schemas/index.ts
@@ -46,18 +46,26 @@ export interface TscResult {
  *  In compact mode, error/warning arrays are omitted. */
 export const BuildResultSchema = z.object({
   success: z.boolean(),
+  exitCode: z.number().optional(),
   duration: z.number(),
   errors: z.array(z.string()).optional(),
   warnings: z.array(z.string()).optional(),
+  stdout: z.string().optional(),
+  stderr: z.string().optional(),
+  outputLines: z.number().optional(),
 });
 
 /** Full build result -- always returned by the parser. */
 export interface BuildResult {
   [key: string]: unknown;
   success: boolean;
+  exitCode?: number;
   duration: number;
   errors?: string[];
   warnings?: string[];
+  stdout?: string;
+  stderr?: string;
+  outputLines?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server-build/src/tools/tsc.ts
+++ b/packages/server-build/src/tools/tsc.ts
@@ -45,6 +45,23 @@ export function registerTscTool(server: McpServer) {
           .describe(
             "Only emit .d.ts declaration files without JS output (maps to --emitDeclarationOnly)",
           ),
+        declaration: z
+          .boolean()
+          .optional()
+          .describe("Generate .d.ts declaration files (maps to --declaration)"),
+        declarationDir: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe(
+            "Output directory for .d.ts declaration files (maps to --declarationDir). Use with --declaration.",
+          ),
+        pretty: z
+          .boolean()
+          .optional()
+          .describe(
+            "Enable or disable pretty-printed output (maps to --pretty). Set false for normalized parser-friendly output.",
+          ),
         compact: z
           .boolean()
           .optional()
@@ -55,9 +72,21 @@ export function registerTscTool(server: McpServer) {
       },
       outputSchema: TscResultSchema,
     },
-    async ({ path, noEmit, project, incremental, skipLibCheck, emitDeclarationOnly, compact }) => {
+    async ({
+      path,
+      noEmit,
+      project,
+      incremental,
+      skipLibCheck,
+      emitDeclarationOnly,
+      declaration,
+      declarationDir,
+      pretty,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
       if (project) assertNoFlagInjection(project, "project");
+      if (declarationDir) assertNoFlagInjection(declarationDir, "declarationDir");
 
       const args: string[] = [];
       if (noEmit !== false) args.push("--noEmit");
@@ -65,6 +94,9 @@ export function registerTscTool(server: McpServer) {
       if (incremental) args.push("--incremental");
       if (skipLibCheck) args.push("--skipLibCheck");
       if (emitDeclarationOnly) args.push("--emitDeclarationOnly");
+      if (declaration) args.push("--declaration");
+      if (declarationDir) args.push("--declarationDir", declarationDir);
+      if (pretty === false) args.push("--pretty", "false");
 
       const result = await tsc(args, cwd);
       const rawOutput = result.stdout + "\n" + result.stderr;

--- a/packages/server-build/src/tools/webpack.ts
+++ b/packages/server-build/src/tools/webpack.ts
@@ -29,6 +29,29 @@ export function registerWebpackTool(server: McpServer) {
           .enum(["production", "development", "none"])
           .optional()
           .describe("Build mode (production, development, none)"),
+        entry: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Entry point file to build (maps to --entry)"),
+        target: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe(
+            "Build target environment (e.g., 'web', 'node', 'electron-main'). Maps to --target.",
+          ),
+        devtool: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe(
+            "Source map strategy (e.g., 'source-map', 'eval', 'cheap-module-source-map'). Maps to --devtool.",
+          ),
+        analyze: z
+          .boolean()
+          .optional()
+          .describe("Enable webpack-bundle-analyzer for bundle size analysis (maps to --analyze)"),
         bail: z
           .boolean()
           .optional()
@@ -53,9 +76,12 @@ export function registerWebpackTool(server: McpServer) {
       },
       outputSchema: WebpackResultSchema,
     },
-    async ({ path, config, mode, bail, cache, args, compact }) => {
+    async ({ path, config, mode, entry, target, devtool, analyze, bail, cache, args, compact }) => {
       const cwd = path || process.cwd();
       if (config) assertNoFlagInjection(config, "config");
+      if (entry) assertNoFlagInjection(entry, "entry");
+      if (target) assertNoFlagInjection(target, "target");
+      if (devtool) assertNoFlagInjection(devtool, "devtool");
       for (const a of args ?? []) {
         assertNoFlagInjection(a, "args");
       }
@@ -64,6 +90,10 @@ export function registerWebpackTool(server: McpServer) {
 
       if (config) cliArgs.push("--config", config);
       if (mode) cliArgs.push("--mode", mode);
+      if (entry) cliArgs.push("--entry", entry);
+      if (target) cliArgs.push("--target", target);
+      if (devtool) cliArgs.push("--devtool", devtool);
+      if (analyze) cliArgs.push("--analyze");
       if (bail) cliArgs.push("--bail");
       if (cache !== undefined) {
         cliArgs.push(cache ? "--cache" : "--no-cache");


### PR DESCRIPTION
## Summary
- Add 26 S-complexity gap implementations across all 7 build tools (build, esbuild, nx, tsc, turbo, vite-build, webpack)
- New validated input params: `timeout`, `target`, `external`, `tsconfig`, `drop`, sourcemap enum expansion (`true`/`linked`/`inline`/`external`/`both`), `configuration`, `head`, `projects`, `exclude`, `declaration`/`declarationDir`, `pretty`, `args` with `assertNoFlagInjection`, `outputLogs` enum, `outDir`, `config`, `base`, `ssr`, `entry`, `devtool`, `analyze`
- Output schema enhancements: `exitCode`, `stdout`, `stderr`, `outputLines` in `BuildResultSchema`
- Build runner updated to accept configurable timeout parameter
- All string params use `assertNoFlagInjection()` for security
- Tests all passing (193 tests)

## Test plan
- [x] `pnpm --filter @paretools/build build` passes
- [x] `pnpm --filter @paretools/build test` passes (193/193 tests)
- [ ] CI matrix (ubuntu/windows/macos x node 20/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)