### PR TITLE
feat(test): implement S-complexity gaps

### DIFF
--- a/.changeset/test-s-gaps.md
+++ b/.changeset/test-s-gaps.md
@@ -1,0 +1,9 @@
+---
+"@paretools/test": minor
+---
+
+Implement S-complexity gaps for test tools
+
+- coverage: Add args, source, exclude, filter params with per-framework flag mapping
+- playwright: Add grep, browser, shard, trace (enum), config params
+- run: Add shard, config params with per-framework flag mapping

--- a/packages/server-test/__tests__/tools-helpers.test.ts
+++ b/packages/server-test/__tests__/tools-helpers.test.ts
@@ -67,28 +67,28 @@ describe("getRunCommand", () => {
 // ---------------------------------------------------------------------------
 describe("getCoverageCommand", () => {
   it("returns python -m pytest --cov for pytest", () => {
-    const { cmd, cmdArgs } = getCoverageCommand("pytest");
+    const { cmd, cmdArgs } = getCoverageCommand("pytest", []);
     expect(cmd).toBe("python");
     expect(cmdArgs).toContain("--cov");
     expect(cmdArgs).toContain("--cov-report=term-missing");
   });
 
   it("returns npx jest --coverage for jest", () => {
-    const { cmd, cmdArgs } = getCoverageCommand("jest");
+    const { cmd, cmdArgs } = getCoverageCommand("jest", []);
     expect(cmd).toBe("npx");
     expect(cmdArgs).toContain("jest");
     expect(cmdArgs).toContain("--coverage");
   });
 
   it("returns npx vitest run --coverage for vitest", () => {
-    const { cmd, cmdArgs } = getCoverageCommand("vitest");
+    const { cmd, cmdArgs } = getCoverageCommand("vitest", []);
     expect(cmd).toBe("npx");
     expect(cmdArgs).toContain("vitest");
     expect(cmdArgs).toContain("--coverage");
   });
 
   it("returns npx nyc mocha for mocha", () => {
-    const { cmd, cmdArgs } = getCoverageCommand("mocha");
+    const { cmd, cmdArgs } = getCoverageCommand("mocha", []);
     expect(cmd).toBe("npx");
     expect(cmdArgs[0]).toBe("nyc");
     expect(cmdArgs).toContain("mocha");

--- a/packages/server-test/src/tools/playwright.ts
+++ b/packages/server-test/src/tools/playwright.ts
@@ -17,6 +17,11 @@ import { PlaywrightResultSchema } from "../schemas/index.js";
 export function buildPlaywrightExtraArgs(opts: {
   filter?: string;
   project?: string;
+  grep?: string;
+  browser?: string;
+  shard?: string;
+  trace?: "on" | "off" | "retain-on-failure";
+  config?: string;
   headed?: boolean;
   updateSnapshots?: boolean;
   workers?: number;
@@ -37,6 +42,26 @@ export function buildPlaywrightExtraArgs(opts: {
 
   if (opts.project) {
     extraArgs.push("--project", opts.project);
+  }
+
+  if (opts.grep) {
+    extraArgs.push("--grep", opts.grep);
+  }
+
+  if (opts.browser) {
+    extraArgs.push("--browser", opts.browser);
+  }
+
+  if (opts.shard) {
+    extraArgs.push("--shard", opts.shard);
+  }
+
+  if (opts.trace) {
+    extraArgs.push("--trace", opts.trace);
+  }
+
+  if (opts.config) {
+    extraArgs.push("--config", opts.config);
   }
 
   if (opts.headed) {
@@ -99,6 +124,30 @@ export function registerPlaywrightTool(server: McpServer) {
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe("Playwright project name (e.g., 'chromium', 'firefox', 'webkit')"),
+        grep: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Regex pattern for matching tests by title (--grep)"),
+        browser: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe('Browser to use (e.g., "chromium", "firefox", "webkit") via --browser'),
+        shard: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe('Shard spec for distributed E2E test execution (e.g., "1/3") via --shard'),
+        trace: z
+          .enum(["on", "off", "retain-on-failure"])
+          .optional()
+          .describe("Trace recording mode (--trace)"),
+        config: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to non-default Playwright config file (--config)"),
         headed: z.boolean().optional().default(false).describe("Run tests in headed browser mode"),
         updateSnapshots: z
           .boolean()
@@ -157,6 +206,11 @@ export function registerPlaywrightTool(server: McpServer) {
       path,
       filter,
       project,
+      grep,
+      browser,
+      shard,
+      trace,
+      config,
       headed,
       updateSnapshots,
       workers,
@@ -179,11 +233,28 @@ export function registerPlaywrightTool(server: McpServer) {
       if (project) {
         assertNoFlagInjection(project, "project");
       }
+      if (grep) {
+        assertNoFlagInjection(grep, "grep");
+      }
+      if (browser) {
+        assertNoFlagInjection(browser, "browser");
+      }
+      if (shard) {
+        assertNoFlagInjection(shard, "shard");
+      }
+      if (config) {
+        assertNoFlagInjection(config, "config");
+      }
 
       const cwd = path || process.cwd();
       const extraArgs = buildPlaywrightExtraArgs({
         filter,
         project,
+        grep,
+        browser,
+        shard,
+        trace,
+        config,
         headed,
         updateSnapshots,
         workers,


### PR DESCRIPTION
## Summary
- Implements **12 S-complexity gaps** across all 3 test tools (coverage, playwright, run)
- Adds validated params with `assertNoFlagInjection()`, enum types, and per-framework conditional flag mapping
- All 172 existing tests pass; updated 4 test helper calls to match new `getCoverageCommand` signature

### Tools modified (3):
| Tool | Changes |
|------|---------|
| `coverage` | `args` (string[]), `source` (string[]), `exclude` (string[]), `filter` (string) params with per-framework mapping |
| `playwright` | `grep`, `browser`, `shard`, `trace` (enum: on/off/retain-on-failure), `config` params |
| `run` | `shard`, `config` params with per-framework mapping |

## Test plan
- [x] All 172 tests pass (`pnpm --filter @paretools/test test`)
- [x] Build succeeds (`pnpm --filter @paretools/test build`)
- [ ] CI matrix passes (ubuntu/windows/macos x node 20/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)