### PR TITLE
feat(cargo): implement S-complexity gaps

### DIFF
--- a/.changeset/cargo-s-gaps.md
+++ b/.changeset/cargo-s-gaps.md
@@ -1,0 +1,18 @@
+---
+"@paretools/cargo": minor
+---
+
+Add S-complexity gap implementations for Cargo tools:
+
+- add: add package, rename, registry, locked/frozen/offline params; add error message to output schema
+- audit: add success field, ignore, deny, targetArch/Os, file, db/url params; add advisory date; compact preserves informational/unknown counts
+- build: add package, features, allFeatures, noDefaultFeatures, target, profile, locked/frozen/offline, manifestPath params
+- check: add features, allFeatures, noDefaultFeatures, target, locked/frozen/offline params
+- clippy: add success field, package, fix (with allow-dirty), features, locked/frozen/offline params
+- doc: add package, features, target, locked/frozen/offline params; add outputDir to schema
+- fmt: add package, edition, config, configPath, emit params
+- remove: add dryRun, package, locked/frozen/offline, manifestPath params; add error message to output schema
+- run: add bin, example, features, timeout, profile, target, locked/frozen/offline params
+- test: add package, features, testArgs, locked/frozen/offline params
+- tree: add success field (return error instead of throwing), invert, edges, features, format, target, locked/frozen/offline params
+- update: add precise, locked/frozen/offline, manifestPath params

--- a/packages/server-cargo/__tests__/fidelity.test.ts
+++ b/packages/server-cargo/__tests__/fidelity.test.ts
@@ -398,7 +398,7 @@ describe("fidelity: parseCargoTestOutput", () => {
 
 describe("fidelity: parseCargoClippyJson", () => {
   it("clippy warnings with codes: all codes preserved", () => {
-    const result = parseCargoClippyJson(CLIPPY_WARNINGS_WITH_CODES);
+    const result = parseCargoClippyJson(CLIPPY_WARNINGS_WITH_CODES, 0);
 
     expect(result.total).toBe(2);
     expect(result.warnings).toBe(2);
@@ -417,7 +417,7 @@ describe("fidelity: parseCargoClippyJson", () => {
   });
 
   it("mix of errors and warnings: counts are correct", () => {
-    const result = parseCargoClippyJson(CLIPPY_MIXED);
+    const result = parseCargoClippyJson(CLIPPY_MIXED, 0);
 
     expect(result.total).toBe(3);
     expect(result.errors).toBe(1);
@@ -434,7 +434,7 @@ describe("fidelity: parseCargoClippyJson", () => {
   });
 
   it("clean clippy output: zero diagnostics", () => {
-    const result = parseCargoClippyJson(CLIPPY_CLEAN);
+    const result = parseCargoClippyJson(CLIPPY_CLEAN, 0);
 
     expect(result.total).toBe(0);
     expect(result.errors).toBe(0);
@@ -443,7 +443,7 @@ describe("fidelity: parseCargoClippyJson", () => {
   });
 
   it("multiple diagnostics in same file: all captured with distinct locations", () => {
-    const result = parseCargoClippyJson(CLIPPY_SAME_FILE);
+    const result = parseCargoClippyJson(CLIPPY_SAME_FILE, 0);
 
     expect(result.total).toBe(4);
     expect(result.diagnostics).toHaveLength(4);
@@ -470,7 +470,7 @@ describe("fidelity: parseCargoClippyJson", () => {
   });
 
   it("warning without code: code field is undefined", () => {
-    const result = parseCargoClippyJson(CLIPPY_MIXED);
+    const result = parseCargoClippyJson(CLIPPY_MIXED, 0);
 
     // The third diagnostic ("unused variable `x`") has no code
     const noCodeDiag = result.diagnostics.find((d) => d.message === "unused variable `x`");
@@ -485,7 +485,7 @@ describe("fidelity: parseCargoClippyJson", () => {
       "{malformed json: true",
     ].join("\n");
 
-    const result = parseCargoClippyJson(stdout);
+    const result = parseCargoClippyJson(stdout, 0);
 
     expect(result.total).toBe(1);
     expect(result.diagnostics[0].message).toBe("unused variable");

--- a/packages/server-cargo/__tests__/formatters.test.ts
+++ b/packages/server-cargo/__tests__/formatters.test.ts
@@ -156,6 +156,7 @@ describe("formatCargoTest", () => {
 describe("formatCargoClippy", () => {
   it("formats clean clippy result", () => {
     const data: CargoClippyResult = {
+      success: true,
       diagnostics: [],
       total: 0,
       errors: 0,
@@ -166,6 +167,7 @@ describe("formatCargoClippy", () => {
 
   it("formats clippy result with warnings", () => {
     const data: CargoClippyResult = {
+      success: false,
       diagnostics: [
         {
           file: "src/main.rs",
@@ -296,6 +298,7 @@ describe("compactTestMap", () => {
 describe("compactClippyMap", () => {
   it("preserves diagnostics when non-empty", () => {
     const data: CargoClippyResult = {
+      success: false,
       diagnostics: [
         {
           file: "src/main.rs",
@@ -319,6 +322,7 @@ describe("compactClippyMap", () => {
 
   it("omits diagnostics when empty", () => {
     const data: CargoClippyResult = {
+      success: true,
       diagnostics: [],
       total: 0,
       errors: 0,
@@ -329,8 +333,10 @@ describe("compactClippyMap", () => {
   });
 
   it("formats compact clippy output", () => {
-    expect(formatClippyCompact({ errors: 0, warnings: 0, total: 0 })).toBe("clippy: no warnings.");
-    expect(formatClippyCompact({ errors: 1, warnings: 3, total: 4 })).toBe(
+    expect(formatClippyCompact({ success: true, errors: 0, warnings: 0, total: 0 })).toBe(
+      "clippy: no warnings.",
+    );
+    expect(formatClippyCompact({ success: false, errors: 1, warnings: 3, total: 4 })).toBe(
       "clippy: 1 errors, 3 warnings",
     );
   });
@@ -455,6 +461,7 @@ describe("compactDocMap", () => {
 describe("formatCargoAudit", () => {
   it("formats no vulnerabilities", () => {
     const data: CargoAuditResult = {
+      success: true,
       vulnerabilities: [],
       summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, informational: 0, unknown: 0 },
     };
@@ -463,6 +470,7 @@ describe("formatCargoAudit", () => {
 
   it("formats vulnerabilities with patched versions", () => {
     const data: CargoAuditResult = {
+      success: false,
       vulnerabilities: [
         {
           id: "RUSTSEC-2022-0090",
@@ -499,6 +507,7 @@ describe("formatCargoAudit", () => {
 describe("compactAuditMap", () => {
   it("strips vulnerability details and keeps summary counts", () => {
     const data: CargoAuditResult = {
+      success: false,
       vulnerabilities: [
         {
           id: "RUSTSEC-2022-0090",
@@ -513,12 +522,15 @@ describe("compactAuditMap", () => {
     };
     const compact = compactAuditMap(data);
     expect(compact).toEqual({
+      success: false,
       vulnerabilities: [],
       total: 1,
       critical: 1,
       high: 0,
       medium: 0,
       low: 0,
+      informational: 0,
+      unknown: 0,
     });
   });
 

--- a/packages/server-cargo/__tests__/parsers.test.ts
+++ b/packages/server-cargo/__tests__/parsers.test.ts
@@ -135,7 +135,7 @@ describe("parseCargoClippyJson", () => {
       }),
     ].join("\n");
 
-    const result = parseCargoClippyJson(stdout);
+    const result = parseCargoClippyJson(stdout, 0);
     expect(result.total).toBe(1);
     expect(result.warnings).toBe(1);
     expect(result.diagnostics[0].code).toBe("clippy::needless_return");
@@ -143,7 +143,7 @@ describe("parseCargoClippyJson", () => {
 
   it("parses clean clippy", () => {
     const stdout = JSON.stringify({ reason: "build-finished", success: true });
-    const result = parseCargoClippyJson(stdout);
+    const result = parseCargoClippyJson(stdout, 0);
     expect(result.total).toBe(0);
   });
 });
@@ -451,7 +451,7 @@ describe("parseCargoAuditJson", () => {
       },
     });
 
-    const result = parseCargoAuditJson(json);
+    const result = parseCargoAuditJson(json, 0);
 
     expect(result.vulnerabilities).toHaveLength(2);
     expect(result.vulnerabilities[0]).toEqual({
@@ -483,7 +483,7 @@ describe("parseCargoAuditJson", () => {
       },
     });
 
-    const result = parseCargoAuditJson(json);
+    const result = parseCargoAuditJson(json, 0);
 
     expect(result.vulnerabilities).toHaveLength(0);
     expect(result.summary.total).toBe(0);
@@ -509,7 +509,7 @@ describe("parseCargoAuditJson", () => {
       },
     });
 
-    const result = parseCargoAuditJson(json);
+    const result = parseCargoAuditJson(json, 0);
 
     expect(result.vulnerabilities).toHaveLength(1);
     expect(result.vulnerabilities[0].severity).toBe("unknown");
@@ -523,7 +523,7 @@ describe("parseCargoAuditJson", () => {
       database: { advisory_count: 500 },
     });
 
-    const result = parseCargoAuditJson(json);
+    const result = parseCargoAuditJson(json, 0);
 
     expect(result.vulnerabilities).toHaveLength(0);
     expect(result.summary.total).toBe(0);
@@ -564,7 +564,7 @@ describe("parseCargoAuditJson", () => {
       },
     });
 
-    const result = parseCargoAuditJson(json);
+    const result = parseCargoAuditJson(json, 0);
 
     expect(result.vulnerabilities[0].severity).toBe("critical");
     expect(result.vulnerabilities[1].severity).toBe("high");

--- a/packages/server-cargo/__tests__/update-tree.test.ts
+++ b/packages/server-cargo/__tests__/update-tree.test.ts
@@ -65,7 +65,7 @@ describe("parseCargoTreeOutput", () => {
       "└── anyhow v1.0.89",
     ].join("\n");
 
-    const result = parseCargoTreeOutput(stdout);
+    const result = parseCargoTreeOutput(stdout, "", 0);
 
     expect(result.tree).toContain("my-app v0.1.0");
     expect(result.tree).toContain("serde v1.0.217");
@@ -81,14 +81,14 @@ describe("parseCargoTreeOutput", () => {
       "└── serde v1.0.217",
     ].join("\n");
 
-    const result = parseCargoTreeOutput(stdout);
+    const result = parseCargoTreeOutput(stdout, "", 0);
 
     // "serde" appears twice but is counted once, plus "my-app" and "serde_derive"
     expect(result.packages).toBe(3);
   });
 
   it("handles empty tree output", () => {
-    const result = parseCargoTreeOutput("");
+    const result = parseCargoTreeOutput("", "", 0);
 
     expect(result.tree).toBe("");
     expect(result.packages).toBe(0);
@@ -96,7 +96,7 @@ describe("parseCargoTreeOutput", () => {
 
   it("handles single root package", () => {
     const stdout = "my-app v0.1.0 (/home/user/project)";
-    const result = parseCargoTreeOutput(stdout);
+    const result = parseCargoTreeOutput(stdout, "", 0);
 
     expect(result.tree).toBe("my-app v0.1.0 (/home/user/project)");
     expect(result.packages).toBe(1);
@@ -110,7 +110,7 @@ describe("parseCargoTreeOutput", () => {
       "└── my_crate v0.1.0",
     ].join("\n");
 
-    const result = parseCargoTreeOutput(stdout);
+    const result = parseCargoTreeOutput(stdout, "", 0);
 
     expect(result.packages).toBe(4);
   });
@@ -176,6 +176,7 @@ describe("formatUpdateCompact", () => {
 describe("formatCargoTree", () => {
   it("formats tree with package count", () => {
     const data: CargoTreeResult = {
+      success: true,
       tree: "my-app v0.1.0\n├── serde v1.0.217",
       packages: 2,
     };
@@ -186,7 +187,7 @@ describe("formatCargoTree", () => {
   });
 
   it("formats tree with empty tree text", () => {
-    const data: CargoTreeResult = { tree: "", packages: 0 };
+    const data: CargoTreeResult = { success: true, tree: "", packages: 0 };
     expect(formatCargoTree(data)).toBe("cargo tree: 0 unique packages");
   });
 });
@@ -196,11 +197,12 @@ describe("formatCargoTree", () => {
 describe("compactTreeMap", () => {
   it("strips tree text and keeps package count", () => {
     const data: CargoTreeResult = {
+      success: true,
       tree: "my-app v0.1.0\n├── serde v1.0.217\n└── tokio v1.41.1",
       packages: 3,
     };
     const compact = compactTreeMap(data);
-    expect(compact).toEqual({ packages: 3 });
+    expect(compact).toEqual({ success: true, packages: 3 });
     expect(compact).not.toHaveProperty("tree");
   });
 });
@@ -209,10 +211,10 @@ describe("compactTreeMap", () => {
 
 describe("formatTreeCompact", () => {
   it("formats compact tree output", () => {
-    expect(formatTreeCompact({ packages: 5 })).toBe("cargo tree: 5 unique packages");
+    expect(formatTreeCompact({ success: true, packages: 5 })).toBe("cargo tree: 5 unique packages");
   });
 
   it("formats compact tree with zero packages", () => {
-    expect(formatTreeCompact({ packages: 0 })).toBe("cargo tree: 0 unique packages");
+    expect(formatTreeCompact({ success: true, packages: 0 })).toBe("cargo tree: 0 unique packages");
   });
 });

--- a/packages/server-cargo/src/lib/cargo-runner.ts
+++ b/packages/server-cargo/src/lib/cargo-runner.ts
@@ -1,6 +1,6 @@
 import { run, type RunResult } from "@paretools/shared";
 
-export async function cargo(args: string[], cwd?: string): Promise<RunResult> {
+export async function cargo(args: string[], cwd?: string, timeout?: number): Promise<RunResult> {
   // cargo build/test can take minutes for large projects
-  return run("cargo", args, { cwd, timeout: 300_000 });
+  return run("cargo", args, { cwd, timeout: timeout ?? 300_000 });
 }

--- a/packages/server-cargo/src/schemas/index.ts
+++ b/packages/server-cargo/src/schemas/index.ts
@@ -40,8 +40,9 @@ export const CargoTestResultSchema = z.object({
 
 export type CargoTestResult = z.infer<typeof CargoTestResultSchema>;
 
-/** Zod schema for structured cargo clippy output with diagnostics and error/warning counts. */
+/** Zod schema for structured cargo clippy output with diagnostics, success flag, and error/warning counts. */
 export const CargoClippyResultSchema = z.object({
+  success: z.boolean(),
   diagnostics: z.array(CargoDiagnosticSchema).optional(),
   total: z.number(),
   errors: z.number(),
@@ -66,20 +67,22 @@ export const CargoAddedPackageSchema = z.object({
   version: z.string(),
 });
 
-/** Zod schema for structured cargo add output with added packages list. */
+/** Zod schema for structured cargo add output with added packages list and optional error message. */
 export const CargoAddResultSchema = z.object({
   success: z.boolean(),
   added: z.array(CargoAddedPackageSchema).optional(),
   total: z.number(),
+  error: z.string().optional(),
 });
 
 export type CargoAddResult = z.infer<typeof CargoAddResultSchema>;
 
-/** Zod schema for structured cargo remove output with removed package names. */
+/** Zod schema for structured cargo remove output with removed package names and optional error message. */
 export const CargoRemoveResultSchema = z.object({
   success: z.boolean(),
   removed: z.array(z.string()),
   total: z.number(),
+  error: z.string().optional(),
 });
 
 export type CargoRemoveResult = z.infer<typeof CargoRemoveResultSchema>;
@@ -93,10 +96,11 @@ export const CargoFmtResultSchema = z.object({
 
 export type CargoFmtResult = z.infer<typeof CargoFmtResultSchema>;
 
-/** Zod schema for structured cargo doc output with success flag and warning count. */
+/** Zod schema for structured cargo doc output with success flag, warning count, and optional output path. */
 export const CargoDocResultSchema = z.object({
   success: z.boolean(),
   warnings: z.number(),
+  outputDir: z.string().optional(),
 });
 
 export type CargoDocResult = z.infer<typeof CargoDocResultSchema>;
@@ -109,8 +113,9 @@ export const CargoUpdateResultSchema = z.object({
 
 export type CargoUpdateResult = z.infer<typeof CargoUpdateResultSchema>;
 
-/** Zod schema for structured cargo tree output with tree text and unique package count. */
+/** Zod schema for structured cargo tree output with tree text, unique package count, and success flag. */
 export const CargoTreeResultSchema = z.object({
+  success: z.boolean(),
   tree: z.string().optional(),
   packages: z.number(),
 });
@@ -127,12 +132,14 @@ export const CargoAuditVulnSchema = z.object({
     .describe("Severity level derived from CVSS"),
   title: z.string().describe("Short description of the vulnerability"),
   url: z.string().optional().describe("URL with more information"),
+  date: z.string().optional().describe("Date the advisory was published"),
   patched: z.array(z.string()).describe("Version requirements that fix the vulnerability"),
   unaffected: z.array(z.string()).optional().describe("Version requirements not affected"),
 });
 
-/** Zod schema for structured cargo audit output with vulnerability list and severity summary. */
+/** Zod schema for structured cargo audit output with vulnerability list, success flag, and severity summary. */
 export const CargoAuditResultSchema = z.object({
+  success: z.boolean(),
   vulnerabilities: z.array(CargoAuditVulnSchema).optional(),
   summary: z
     .object({

--- a/packages/server-cargo/src/tools/audit.ts
+++ b/packages/server-cargo/src/tools/audit.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoAuditJson } from "../lib/parsers.js";
 import { formatCargoAudit, compactAuditMap, formatAuditCompact } from "../lib/formatters.js";
@@ -27,6 +27,43 @@ export function registerAuditTool(server: McpServer) {
           .describe(
             "Skip fetching the advisory database, use local cache only (--no-fetch). Useful for offline or air-gapped environments.",
           ),
+        ignore: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Advisory IDs to ignore (--ignore <ADVISORY>). Example: ['RUSTSEC-2022-0090']"),
+        deny: z
+          .enum(["critical", "high", "medium", "low", "informational", "unknown"])
+          .optional()
+          .describe(
+            "Minimum severity to treat as an error exit code (--deny <SEVERITY>). " +
+              "Default: any vulnerability triggers a non-zero exit.",
+          ),
+        targetArch: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Filter for target architecture (--target-arch <ARCH>). Example: 'x86_64'"),
+        targetOs: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Filter for target OS (--target-os <OS>). Example: 'linux'"),
+        file: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to Cargo.lock file (--file <PATH>). Default: auto-detected."),
+        db: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to advisory database (--db <PATH>)"),
+        url: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("URL for advisory database (--url <URL>)"),
         compact: z
           .boolean()
           .optional()
@@ -37,15 +74,45 @@ export function registerAuditTool(server: McpServer) {
       },
       outputSchema: CargoAuditResultSchema,
     },
-    async ({ path, noFetch, compact }) => {
+    async ({
+      path,
+      noFetch,
+      ignore,
+      deny,
+      targetArch,
+      targetOs,
+      file,
+      db,
+      url: dbUrl,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
+
+      if (targetArch) assertNoFlagInjection(targetArch, "targetArch");
+      if (targetOs) assertNoFlagInjection(targetOs, "targetOs");
+      if (file) assertNoFlagInjection(file, "file");
+      if (db) assertNoFlagInjection(db, "db");
+
       const args = ["audit", "--json"];
       if (noFetch) args.push("--no-fetch");
+      if (ignore && ignore.length > 0) {
+        for (const id of ignore) {
+          assertNoFlagInjection(id, "ignore");
+          args.push("--ignore", id);
+        }
+      }
+      if (deny) args.push("--deny", deny);
+      if (targetArch) args.push("--target-arch", targetArch);
+      if (targetOs) args.push("--target-os", targetOs);
+      if (file) args.push("--file", file);
+      if (db) args.push("--db", db);
+      if (dbUrl) args.push("--url", dbUrl);
+
       const result = await cargo(args, cwd);
 
       // cargo audit returns exit code 1 when vulnerabilities are found, which is expected
       const output = result.stdout || result.stderr;
-      const data = parseCargoAuditJson(output);
+      const data = parseCargoAuditJson(output, result.exitCode);
       return compactDualOutput(
         data,
         output,

--- a/packages/server-cargo/src/tools/build.ts
+++ b/packages/server-cargo/src/tools/build.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoBuildJson } from "../lib/parsers.js";
 import { formatCargoBuild, compactBuildMap, formatBuildCompact } from "../lib/formatters.js";
@@ -28,6 +28,58 @@ export function registerBuildTool(server: McpServer) {
           .describe(
             "Continue as much as possible after encountering errors (--keep-going). Collects maximum diagnostics in a single run.",
           ),
+        package: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Package to build in a workspace (-p <SPEC>)"),
+        features: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Space or comma separated list of features to activate (--features)"),
+        allFeatures: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Activate all available features (--all-features)"),
+        noDefaultFeatures: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not activate the default feature (--no-default-features)"),
+        target: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "Build for the target triple (--target <TRIPLE>). Example: 'x86_64-unknown-linux-gnu'",
+          ),
+        profile: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Build with a custom profile (--profile <NAME>)"),
+        locked: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Require Cargo.lock is up to date (--locked)"),
+        frozen: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Require Cargo.lock and cache are up to date (--frozen)"),
+        offline: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Run without accessing the network (--offline)"),
+        manifestPath: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to Cargo.toml (--manifest-path <PATH>)"),
         compact: z
           .boolean()
           .optional()
@@ -38,11 +90,46 @@ export function registerBuildTool(server: McpServer) {
       },
       outputSchema: CargoBuildResultSchema,
     },
-    async ({ path, release, keepGoing, compact }) => {
+    async ({
+      path,
+      release,
+      keepGoing,
+      package: pkg,
+      features,
+      allFeatures,
+      noDefaultFeatures,
+      target,
+      profile,
+      locked,
+      frozen,
+      offline,
+      manifestPath,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
+      if (pkg) assertNoFlagInjection(pkg, "package");
+      if (target) assertNoFlagInjection(target, "target");
+      if (profile) assertNoFlagInjection(profile, "profile");
+      if (manifestPath) assertNoFlagInjection(manifestPath, "manifestPath");
+
       const args = ["build", "--message-format=json"];
       if (release) args.push("--release");
       if (keepGoing) args.push("--keep-going");
+      if (pkg) args.push("-p", pkg);
+      if (features && features.length > 0) {
+        for (const f of features) {
+          assertNoFlagInjection(f, "features");
+        }
+        args.push("--features", features.join(","));
+      }
+      if (allFeatures) args.push("--all-features");
+      if (noDefaultFeatures) args.push("--no-default-features");
+      if (target) args.push("--target", target);
+      if (profile) args.push("--profile", profile);
+      if (locked) args.push("--locked");
+      if (frozen) args.push("--frozen");
+      if (offline) args.push("--offline");
+      if (manifestPath) args.push("--manifest-path", manifestPath);
 
       const result = await cargo(args, cwd);
       const data = parseCargoBuildJson(result.stdout, result.exitCode);

--- a/packages/server-cargo/src/tools/check.ts
+++ b/packages/server-cargo/src/tools/check.ts
@@ -47,6 +47,41 @@ export function registerCheckTool(server: McpServer) {
           .optional()
           .default(false)
           .describe("Check all packages in the workspace (--workspace)"),
+        features: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Space or comma separated list of features to activate (--features)"),
+        allFeatures: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Activate all available features (--all-features)"),
+        noDefaultFeatures: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not activate the default feature (--no-default-features)"),
+        target: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Check for the target triple (--target <TRIPLE>)"),
+        locked: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Require Cargo.lock is up to date (--locked)"),
+        frozen: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Require Cargo.lock and cache are up to date (--frozen)"),
+        offline: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Run without accessing the network (--offline)"),
         compact: z
           .boolean()
           .optional()
@@ -57,9 +92,25 @@ export function registerCheckTool(server: McpServer) {
       },
       outputSchema: CargoBuildResultSchema,
     },
-    async ({ path, package: pkg, keepGoing, allTargets, release, workspace, compact }) => {
+    async ({
+      path,
+      package: pkg,
+      keepGoing,
+      allTargets,
+      release,
+      workspace,
+      features,
+      allFeatures,
+      noDefaultFeatures,
+      target,
+      locked,
+      frozen,
+      offline,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
       if (pkg) assertNoFlagInjection(pkg, "package");
+      if (target) assertNoFlagInjection(target, "target");
 
       const args = ["check", "--message-format=json"];
       if (pkg) args.push("-p", pkg);
@@ -67,6 +118,18 @@ export function registerCheckTool(server: McpServer) {
       if (allTargets) args.push("--all-targets");
       if (release) args.push("--release");
       if (workspace) args.push("--workspace");
+      if (features && features.length > 0) {
+        for (const f of features) {
+          assertNoFlagInjection(f, "features");
+        }
+        args.push("--features", features.join(","));
+      }
+      if (allFeatures) args.push("--all-features");
+      if (noDefaultFeatures) args.push("--no-default-features");
+      if (target) args.push("--target", target);
+      if (locked) args.push("--locked");
+      if (frozen) args.push("--frozen");
+      if (offline) args.push("--offline");
 
       const result = await cargo(args, cwd);
       const data = parseCargoBuildJson(result.stdout, result.exitCode);

--- a/packages/server-cargo/src/tools/doc.ts
+++ b/packages/server-cargo/src/tools/doc.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
+import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { cargo } from "../lib/cargo-runner.js";
 import { parseCargoDocOutput } from "../lib/parsers.js";
 import { formatCargoDoc, compactDocMap, formatDocCompact } from "../lib/formatters.js";
@@ -42,6 +42,46 @@ export function registerDocTool(server: McpServer) {
           .optional()
           .default(false)
           .describe("Generate documentation for all packages in the workspace (--workspace)"),
+        package: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Package to document in a workspace (-p <SPEC>)"),
+        features: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Space or comma separated list of features to activate (--features)"),
+        allFeatures: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Activate all available features (--all-features)"),
+        noDefaultFeatures: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not activate the default feature (--no-default-features)"),
+        target: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Generate docs for the target triple (--target <TRIPLE>)"),
+        locked: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Require Cargo.lock is up to date (--locked)"),
+        frozen: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Require Cargo.lock and cache are up to date (--frozen)"),
+        offline: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Run without accessing the network (--offline)"),
         compact: z
           .boolean()
           .optional()
@@ -52,16 +92,47 @@ export function registerDocTool(server: McpServer) {
       },
       outputSchema: CargoDocResultSchema,
     },
-    async ({ path, open, noDeps, documentPrivateItems, workspace, compact }) => {
+    async ({
+      path,
+      open,
+      noDeps,
+      documentPrivateItems,
+      workspace,
+      package: pkg,
+      features,
+      allFeatures,
+      noDefaultFeatures,
+      target,
+      locked,
+      frozen,
+      offline,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
+      if (pkg) assertNoFlagInjection(pkg, "package");
+      if (target) assertNoFlagInjection(target, "target");
+
       const args = ["doc"];
       if (noDeps) args.push("--no-deps");
       if (open) args.push("--open");
       if (documentPrivateItems) args.push("--document-private-items");
       if (workspace) args.push("--workspace");
+      if (pkg) args.push("-p", pkg);
+      if (features && features.length > 0) {
+        for (const f of features) {
+          assertNoFlagInjection(f, "features");
+        }
+        args.push("--features", features.join(","));
+      }
+      if (allFeatures) args.push("--all-features");
+      if (noDefaultFeatures) args.push("--no-default-features");
+      if (target) args.push("--target", target);
+      if (locked) args.push("--locked");
+      if (frozen) args.push("--frozen");
+      if (offline) args.push("--offline");
 
       const result = await cargo(args, cwd);
-      const data = parseCargoDocOutput(result.stderr, result.exitCode);
+      const data = parseCargoDocOutput(result.stderr, result.exitCode, cwd);
       return compactDualOutput(
         data,
         result.stderr,

--- a/packages/server-cargo/src/tools/run.ts
+++ b/packages/server-cargo/src/tools/run.ts
@@ -31,6 +31,66 @@ export function registerRunTool(server: McpServer) {
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe("Package to run in a workspace"),
+        bin: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Name of the binary to run (--bin <NAME>) for multi-binary crates"),
+        example: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Name of the example to run (--example <NAME>)"),
+        features: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Space or comma separated list of features to activate (--features)"),
+        allFeatures: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Activate all available features (--all-features)"),
+        noDefaultFeatures: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not activate the default feature (--no-default-features)"),
+        timeout: z
+          .number()
+          .int()
+          .min(1000)
+          .max(600000)
+          .optional()
+          .describe(
+            "Execution timeout in milliseconds. Overrides the default 300s. " +
+              "Min: 1000 (1s), Max: 600000 (10m).",
+          ),
+        profile: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Build with a custom profile (--profile <NAME>)"),
+        target: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Run for the target triple (--target <TRIPLE>)"),
+        locked: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Require Cargo.lock is up to date (--locked)"),
+        frozen: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Require Cargo.lock and cache are up to date (--frozen)"),
+        offline: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Run without accessing the network (--offline)"),
         compact: z
           .boolean()
           .optional()
@@ -41,9 +101,30 @@ export function registerRunTool(server: McpServer) {
       },
       outputSchema: CargoRunResultSchema,
     },
-    async ({ path, args, release, package: pkg, compact }) => {
+    async ({
+      path,
+      args,
+      release,
+      package: pkg,
+      bin,
+      example,
+      features,
+      allFeatures,
+      noDefaultFeatures,
+      timeout,
+      profile,
+      target,
+      locked,
+      frozen,
+      offline,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
       if (pkg) assertNoFlagInjection(pkg, "package");
+      if (bin) assertNoFlagInjection(bin, "bin");
+      if (example) assertNoFlagInjection(example, "example");
+      if (profile) assertNoFlagInjection(profile, "profile");
+      if (target) assertNoFlagInjection(target, "target");
       // Defense-in-depth: validate args even though they come after "--" separator
       for (const a of args ?? []) {
         assertNoFlagInjection(a, "args");
@@ -52,12 +133,27 @@ export function registerRunTool(server: McpServer) {
       const cargoArgs = ["run"];
       if (release) cargoArgs.push("--release");
       if (pkg) cargoArgs.push("-p", pkg);
+      if (bin) cargoArgs.push("--bin", bin);
+      if (example) cargoArgs.push("--example", example);
+      if (features && features.length > 0) {
+        for (const f of features) {
+          assertNoFlagInjection(f, "features");
+        }
+        cargoArgs.push("--features", features.join(","));
+      }
+      if (allFeatures) cargoArgs.push("--all-features");
+      if (noDefaultFeatures) cargoArgs.push("--no-default-features");
+      if (profile) cargoArgs.push("--profile", profile);
+      if (target) cargoArgs.push("--target", target);
+      if (locked) cargoArgs.push("--locked");
+      if (frozen) cargoArgs.push("--frozen");
+      if (offline) cargoArgs.push("--offline");
       if (args && args.length > 0) {
         cargoArgs.push("--");
         cargoArgs.push(...args);
       }
 
-      const result = await cargo(cargoArgs, cwd);
+      const result = await cargo(cargoArgs, cwd, timeout);
       const data = parseCargoRunOutput(result.stdout, result.stderr, result.exitCode);
       return compactDualOutput(
         data,

--- a/packages/server-cargo/src/tools/tree.ts
+++ b/packages/server-cargo/src/tools/tree.ts
@@ -47,6 +47,73 @@ export function registerTreeTool(server: McpServer) {
           .describe(
             "Prune the given package from the tree display (--prune <SPEC>). Simplifies output by hiding a specific dependency subtree.",
           ),
+        invert: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "Invert the tree to show reverse dependencies (--invert <SPEC>). " +
+              "Critical for tracing which crates depend on a given package.",
+          ),
+        edges: z
+          .enum([
+            "normal",
+            "dev",
+            "build",
+            "dep",
+            "no-normal",
+            "no-dev",
+            "no-build",
+            "no-dep",
+            "features",
+            "no-features",
+            "all",
+          ])
+          .optional()
+          .describe(
+            "Filter dependency edges by kind (--edges <KINDS>). " +
+              "Example: 'normal' to exclude dev/build deps.",
+          ),
+        features: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(INPUT_LIMITS.ARRAY_MAX)
+          .optional()
+          .describe("Space or comma separated list of features to activate (--features)"),
+        allFeatures: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Activate all available features (--all-features)"),
+        noDefaultFeatures: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Do not activate the default feature (--no-default-features)"),
+        format: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Custom format string for each package (--format <FMT>). Example: '{p} {l}'"),
+        target: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Filter for platform-specific dependencies (--target <TRIPLE>)"),
+        locked: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Require Cargo.lock is up to date (--locked)"),
+        frozen: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Require Cargo.lock and cache are up to date (--frozen)"),
+        offline: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Run without accessing the network (--offline)"),
         compact: z
           .boolean()
           .optional()
@@ -57,43 +124,62 @@ export function registerTreeTool(server: McpServer) {
       },
       outputSchema: CargoTreeResultSchema,
     },
-    async ({ path, depth, package: pkg, duplicates, charset, prune, compact }) => {
+    async ({
+      path,
+      depth,
+      package: pkg,
+      duplicates,
+      charset,
+      prune,
+      invert,
+      edges,
+      features,
+      allFeatures,
+      noDefaultFeatures,
+      format,
+      target,
+      locked,
+      frozen,
+      offline,
+      compact,
+    }) => {
       const cwd = path || process.cwd();
 
-      if (pkg) {
-        assertNoFlagInjection(pkg, "package");
-      }
-      if (prune) {
-        assertNoFlagInjection(prune, "prune");
-      }
+      if (pkg) assertNoFlagInjection(pkg, "package");
+      if (prune) assertNoFlagInjection(prune, "prune");
+      if (invert) assertNoFlagInjection(invert, "invert");
+      if (format) assertNoFlagInjection(format, "format");
+      if (target) assertNoFlagInjection(target, "target");
 
       const args = ["tree"];
       if (depth !== undefined) {
         args.push("--depth", String(depth));
       }
-      if (pkg) {
-        args.push("-p", pkg);
+      if (pkg) args.push("-p", pkg);
+      if (duplicates) args.push("--duplicates");
+      if (charset) args.push("--charset", charset);
+      if (prune) args.push("--prune", prune);
+      if (invert) args.push("--invert", invert);
+      if (edges) args.push("--edges", edges);
+      if (features && features.length > 0) {
+        for (const f of features) {
+          assertNoFlagInjection(f, "features");
+        }
+        args.push("--features", features.join(","));
       }
-      if (duplicates) {
-        args.push("--duplicates");
-      }
-      if (charset) {
-        args.push("--charset", charset);
-      }
-      if (prune) {
-        args.push("--prune", prune);
-      }
+      if (allFeatures) args.push("--all-features");
+      if (noDefaultFeatures) args.push("--no-default-features");
+      if (format) args.push("--format", format);
+      if (target) args.push("--target", target);
+      if (locked) args.push("--locked");
+      if (frozen) args.push("--frozen");
+      if (offline) args.push("--offline");
 
       const result = await cargo(args, cwd);
-
-      if (result.exitCode !== 0) {
-        throw new Error(`cargo tree failed: ${result.stderr}`);
-      }
-
-      const data = parseCargoTreeOutput(result.stdout);
+      const data = parseCargoTreeOutput(result.stdout, result.stderr, result.exitCode);
       return compactDualOutput(
         data,
-        result.stdout,
+        result.stdout || result.stderr,
         formatCargoTree,
         compactTreeMap,
         formatTreeCompact,


### PR DESCRIPTION
## Summary
- Add 63 S-complexity gap implementations across all Cargo tools (add, audit, build, check, clippy, doc, fmt, remove, run, test, tree, update)
- Add validated input parameters with `assertNoFlagInjection()` on all string args
- Add `success` field to CargoClippyResult, CargoAuditResult, and CargoTreeResult schemas
- Add `error` field to CargoAddResult and CargoRemoveResult for failure diagnostics
- Add `outputDir` to CargoDocResult and `date` to CargoAuditVulnSchema
- Tree tool now returns `{success: false}` instead of throwing on error
- Compact audit mode now preserves `informational` and `unknown` severity counts
- Update all affected tests to match schema changes (205 tests passing)

### Parameters added per tool:
| Tool | New Params |
|------|-----------|
| add | `package`, `rename`, `registry`, `locked`, `frozen`, `offline` + error message |
| audit | `success` field, `ignore`, `deny`, `targetArch`, `targetOs`, `file`, `db`, `url`, `date` in schema |
| build | `package`, `features`, `allFeatures`, `noDefaultFeatures`, `target`, `profile`, `locked/frozen/offline`, `manifestPath` |
| check | `features`, `allFeatures`, `noDefaultFeatures`, `target`, `locked/frozen/offline` |
| clippy | `success` field, `package`, `fix` (with --allow-dirty), `features`, `locked/frozen/offline` |
| doc | `package`, `features`, `target`, `locked/frozen/offline`, `outputDir` in schema |
| fmt | `package`, `edition`, `config`, `configPath`, `emit` |
| remove | `dryRun`, `package`, `locked/frozen/offline`, `manifestPath` + error message |
| run | `bin`, `example`, `features`, `timeout`, `profile`, `target`, `locked/frozen/offline` |
| test | `package`, `features`, `testArgs`, `locked/frozen/offline` |
| tree | `success` field, `invert`, `edges`, `features`, `format`, `target`, `locked/frozen/offline` |
| update | `precise`, `locked/frozen/offline`, `manifestPath` |

## Test plan
- [x] All 205 existing tests pass (`pnpm --filter @paretools/cargo test`)
- [x] Build succeeds (`pnpm --filter @paretools/cargo build`)
- [ ] CI: build, test, lint, format:check across matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)