### PR TITLE
feat(security): implement S-complexity gaps

### DIFF
--- a/.changeset/security-s-gaps.md
+++ b/.changeset/security-s-gaps.md
@@ -1,0 +1,9 @@
+---
+"@paretools/security": minor
+---
+
+Implement S-complexity gaps for security tools
+
+- gitleaks: Add redact (default: true), config, baselinePath, logOpts, enableRule params
+- semgrep: Change config to accept string | string[] for repeatable --config; add exclude, include, excludeRule, baselineCommit params
+- trivy: Change severity to accept single value or array/CSV; add scanners, vulnType, skipDirs, skipFiles, platform, ignorefile params


### PR DESCRIPTION
## Summary
- Implements **17 S-complexity gaps** across all 3 security tools (gitleaks, semgrep, trivy)
- Adds validated params with `assertNoFlagInjection()`, enum types, union types, and conditional logic
- All 72 existing tests pass with no changes needed

### Tools modified (3):
| Tool | Changes |
|------|---------|
| `gitleaks` | `redact` (default: true for LLM safety), `config`, `baselinePath`, `logOpts`, `enableRule` (string[]) params |
| `semgrep` | `config` changed to `string \| string[]` for repeatable `--config`; `exclude` (string[]), `include` (string[]), `excludeRule` (string[]), `baselineCommit` params |
| `trivy` | `severity` changed to accept single value or array/CSV; `scanners` (enum[]), `vulnType` (enum[]), `skipDirs` (string[]), `skipFiles` (string[]), `platform`, `ignorefile` params |

## Test plan
- [x] All 72 tests pass (`pnpm --filter @paretools/security test`)
- [x] Build succeeds (`pnpm --filter @paretools/security build`)
- [ ] CI matrix passes (ubuntu/windows/macos x node 20/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)