### PR TITLE
fix(shared): standardize all timeout levels to 180s

### DIFF
--- a/.changeset/standardize-timeouts.md
+++ b/.changeset/standardize-timeouts.md
@@ -1,0 +1,5 @@
+---
+"@paretools/shared": patch
+---
+
+Raise default runner and test timeouts from 60s/120s to 180s to fix Windows CI flakiness

--- a/packages/server-build/__tests__/integration.test.ts
+++ b/packages/server-build/__tests__/integration.test.ts
@@ -8,7 +8,7 @@ const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const SERVER_PATH = resolve(__dirname, "../dist/index.js");
 
 /** MCP SDK defaults to 60 s request timeout; override for CI where npx + cmd.exe is slow. */
-const CALL_TIMEOUT = { timeout: 120_000 };
+const CALL_TIMEOUT = { timeout: 180_000 };
 
 describe("@paretools/build integration", () => {
   let client: Client;
@@ -304,7 +304,7 @@ describe("@paretools/build integration", () => {
         // MCP SDK may throw (timeout, transport error, etc.) — acceptable
         // since nx may not be installed and npx resolution can fail.
       }
-    }, 120_000);
+    }, 180_000);
 
     it("rejects flag injection in target", async () => {
       const result = await client.callTool({

--- a/packages/server-build/src/lib/build-runner.ts
+++ b/packages/server-build/src/lib/build-runner.ts
@@ -1,7 +1,7 @@
 import { run, type RunResult } from "@paretools/shared";
 
 export async function tsc(args: string[], cwd?: string): Promise<RunResult> {
-  return run("npx", ["tsc", ...args], { cwd, timeout: 120_000 });
+  return run("npx", ["tsc", ...args], { cwd, timeout: 180_000 });
 }
 
 export async function runBuildCommand(
@@ -15,7 +15,7 @@ export async function runBuildCommand(
 }
 
 export async function esbuildCmd(args: string[], cwd?: string): Promise<RunResult> {
-  return run("npx", ["esbuild", ...args], { cwd, timeout: 120_000 });
+  return run("npx", ["esbuild", ...args], { cwd, timeout: 180_000 });
 }
 
 export async function viteCmd(args: string[], cwd?: string): Promise<RunResult> {

--- a/packages/server-cargo/__tests__/integration.test.ts
+++ b/packages/server-cargo/__tests__/integration.test.ts
@@ -59,14 +59,14 @@ describe("@paretools/cargo integration", () => {
   describe("clippy", () => {
     // cargo clippy on a cold toolchain (especially Windows CI) can take
     // well over 60s; give it enough room to finish or fail clearly.
-    it("returns structured data or a command-not-found error", { timeout: 120_000 }, async () => {
+    it("returns structured data or a command-not-found error", { timeout: 180_000 }, async () => {
       const result = await client.callTool(
         {
           name: "clippy",
           arguments: { path: resolve(__dirname, "../../..") },
         },
         undefined,
-        { timeout: 120_000 },
+        { timeout: 180_000 },
       );
 
       if (result.isError) {

--- a/packages/server-docker/__tests__/integration.test.ts
+++ b/packages/server-docker/__tests__/integration.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const SERVER_PATH = resolve(__dirname, "../dist/index.js");
-const CALL_TIMEOUT = 120_000;
+const CALL_TIMEOUT = 180_000;
 
 describe("@paretools/docker integration", () => {
   let client: Client;

--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const SERVER_PATH = resolve(__dirname, "../dist/index.js");
-const CALL_TIMEOUT = 120_000;
+const CALL_TIMEOUT = 180_000;
 
 describe("@paretools/git integration", () => {
   let client: Client;

--- a/packages/server-github/__tests__/integration.test.ts
+++ b/packages/server-github/__tests__/integration.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const SERVER_PATH = resolve(__dirname, "../dist/index.js");
-const CALL_TIMEOUT = 120_000;
+const CALL_TIMEOUT = 180_000;
 
 describe("@paretools/github integration", () => {
   let client: Client;

--- a/packages/server-go/__tests__/go-runner.test.ts
+++ b/packages/server-go/__tests__/go-runner.test.ts
@@ -96,10 +96,10 @@ describe("gofmtCmd", () => {
     expect(mockRun.mock.calls[0][2]).toMatchObject({ cwd: "/my/project" });
   });
 
-  it("sets timeout to 120 seconds (120_000ms)", async () => {
+  it("sets timeout to 180 seconds (180_000ms)", async () => {
     await gofmtCmd(["-l", "."], "/project");
 
-    expect(mockRun.mock.calls[0][2]).toMatchObject({ timeout: 120_000 });
+    expect(mockRun.mock.calls[0][2]).toMatchObject({ timeout: 180_000 });
   });
 
   it("passes undefined cwd when not provided", async () => {

--- a/packages/server-go/__tests__/integration.test.ts
+++ b/packages/server-go/__tests__/integration.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const SERVER_PATH = resolve(__dirname, "../dist/index.js");
-const CALL_TIMEOUT = 120_000;
+const CALL_TIMEOUT = 180_000;
 
 describe("@paretools/go integration", () => {
   let client: Client;

--- a/packages/server-go/src/lib/go-runner.ts
+++ b/packages/server-go/src/lib/go-runner.ts
@@ -6,7 +6,7 @@ export async function goCmd(args: string[], cwd?: string, timeout?: number): Pro
 }
 
 export async function gofmtCmd(args: string[], cwd?: string): Promise<RunResult> {
-  return run("gofmt", args, { cwd, timeout: 120_000 });
+  return run("gofmt", args, { cwd, timeout: 180_000 });
 }
 
 export async function golangciLintCmd(args: string[], cwd?: string): Promise<RunResult> {

--- a/packages/server-http/src/lib/curl-runner.ts
+++ b/packages/server-http/src/lib/curl-runner.ts
@@ -5,5 +5,5 @@ import { run, type RunResult } from "@paretools/shared";
  * Uses a generous timeout since HTTP requests can be slow.
  */
 export async function curlCmd(args: string[], cwd?: string): Promise<RunResult> {
-  return run("curl", args, { cwd, timeout: 120_000 });
+  return run("curl", args, { cwd, timeout: 180_000 });
 }

--- a/packages/server-k8s/__tests__/integration.test.ts
+++ b/packages/server-k8s/__tests__/integration.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const SERVER_PATH = resolve(__dirname, "../dist/index.js");
-const CALL_TIMEOUT = 120_000;
+const CALL_TIMEOUT = 180_000;
 
 describe("@paretools/k8s integration", () => {
   let client: Client;

--- a/packages/server-k8s/src/tools/apply.ts
+++ b/packages/server-k8s/src/tools/apply.ts
@@ -178,7 +178,7 @@ export function registerApplyTool(server: McpServer) {
       }
       args.push("-o", "json");
 
-      const result = await run("kubectl", args, { timeout: 60_000 });
+      const result = await run("kubectl", args, { timeout: 180_000 });
       const data = parseApplyOutput(result.stdout, result.stderr, result.exitCode);
       const rawOutput = (result.stdout + "\n" + result.stderr).trim();
 

--- a/packages/server-k8s/src/tools/describe.ts
+++ b/packages/server-k8s/src/tools/describe.ts
@@ -95,7 +95,7 @@ export function registerDescribeTool(server: McpServer) {
       if (context) args.push("--context", context);
       if (kubeconfig) args.push("--kubeconfig", kubeconfig);
 
-      const result = await run("kubectl", args, { timeout: 60_000 });
+      const result = await run("kubectl", args, { timeout: 180_000 });
       const data = parseDescribeOutput(
         result.stdout,
         result.stderr,

--- a/packages/server-k8s/src/tools/get.ts
+++ b/packages/server-k8s/src/tools/get.ts
@@ -146,7 +146,7 @@ export function registerGetTool(server: McpServer) {
       if (subresource) args.push("--subresource", subresource);
       args.push("-o", "json");
 
-      const result = await run("kubectl", args, { timeout: 60_000 });
+      const result = await run("kubectl", args, { timeout: 180_000 });
       const data = parseGetOutput(
         result.stdout,
         result.stderr,

--- a/packages/server-k8s/src/tools/helm.ts
+++ b/packages/server-k8s/src/tools/helm.ts
@@ -202,7 +202,7 @@ export function registerHelmTool(server: McpServer) {
           }
           if (filter) args.push("--filter", filter);
 
-          const result = await run("helm", args, { timeout: 60_000 });
+          const result = await run("helm", args, { timeout: 180_000 });
           const data = parseHelmListOutput(
             result.stdout,
             result.stderr,
@@ -229,7 +229,7 @@ export function registerHelmTool(server: McpServer) {
           if (showResources) args.push("--show-resources");
           if (statusRevision !== undefined) args.push("--revision", String(statusRevision));
 
-          const result = await run("helm", args, { timeout: 60_000 });
+          const result = await run("helm", args, { timeout: 180_000 });
           const data = parseHelmStatusOutput(
             result.stdout,
             result.stderr,
@@ -275,7 +275,7 @@ export function registerHelmTool(server: McpServer) {
           if (noHooks) args.push("--no-hooks");
           if (skipCrds) args.push("--skip-crds");
 
-          const result = await run("helm", args, { timeout: 120_000 });
+          const result = await run("helm", args, { timeout: 180_000 });
           const data = parseHelmInstallOutput(
             result.stdout,
             result.stderr,
@@ -323,7 +323,7 @@ export function registerHelmTool(server: McpServer) {
           if (noHooks) args.push("--no-hooks");
           if (skipCrds) args.push("--skip-crds");
 
-          const result = await run("helm", args, { timeout: 120_000 });
+          const result = await run("helm", args, { timeout: 180_000 });
           const data = parseHelmUpgradeOutput(
             result.stdout,
             result.stderr,

--- a/packages/server-k8s/src/tools/logs.ts
+++ b/packages/server-k8s/src/tools/logs.ts
@@ -140,7 +140,7 @@ export function registerLogsTool(server: McpServer) {
       if (podRunningTimeout) args.push("--pod-running-timeout", podRunningTimeout);
       if (ignoreErrors) args.push("--ignore-errors");
 
-      const result = await run("kubectl", args, { timeout: 60_000 });
+      const result = await run("kubectl", args, { timeout: 180_000 });
       const data = parseLogsOutput(
         result.stdout,
         result.stderr,

--- a/packages/server-lint/__tests__/integration.test.ts
+++ b/packages/server-lint/__tests__/integration.test.ts
@@ -11,7 +11,7 @@ const SERVER_PATH = resolve(__dirname, "../dist/index.js");
 const FIXTURES_DIR = resolve(__dirname, "fixtures");
 
 /** MCP SDK defaults to 60 s request timeout; override for CI where npx + cmd.exe is slow. */
-const CALL_TIMEOUT = { timeout: 120_000 };
+const CALL_TIMEOUT = { timeout: 180_000 };
 
 // ---------------------------------------------------------------------------
 // Tool listing & schema tests

--- a/packages/server-lint/__tests__/lint-runner.test.ts
+++ b/packages/server-lint/__tests__/lint-runner.test.ts
@@ -33,7 +33,7 @@ describe("eslint()", () => {
     expect(mockRun).toHaveBeenCalledOnce();
     expect(mockRun).toHaveBeenCalledWith("npx", ["eslint", "--format", "json", "src/"], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -42,7 +42,7 @@ describe("eslint()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("npx", ["eslint", "--format", "json", "."], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -51,7 +51,7 @@ describe("eslint()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("npx", ["eslint", "--format", "json", "src/", "--fix"], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -61,7 +61,7 @@ describe("eslint()", () => {
     expect(mockRun).toHaveBeenCalledWith(
       "npx",
       ["eslint", "--format", "json", "src/", "lib/", "tests/"],
-      { cwd: "/project", timeout: 120_000 },
+      { cwd: "/project", timeout: 180_000 },
     );
   });
 
@@ -70,7 +70,7 @@ describe("eslint()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("npx", ["eslint", "--format", "json", "."], {
       cwd: undefined,
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -94,7 +94,7 @@ describe("prettier()", () => {
     expect(mockRun).toHaveBeenCalledOnce();
     expect(mockRun).toHaveBeenCalledWith("npx", ["prettier", "--check", "."], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -103,7 +103,7 @@ describe("prettier()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("npx", ["prettier", "--check", "src/", "lib/"], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -112,7 +112,7 @@ describe("prettier()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("npx", ["prettier", "--write", "src/", "lib/"], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -121,7 +121,7 @@ describe("prettier()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("npx", ["prettier", "--check", "."], {
       cwd: undefined,
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -146,7 +146,7 @@ describe("biome()", () => {
     expect(mockRun).toHaveBeenCalledWith(
       "npx",
       ["@biomejs/biome", "check", "--reporter=json", "."],
-      { cwd: "/project", timeout: 120_000 },
+      { cwd: "/project", timeout: 180_000 },
     );
   });
 
@@ -156,7 +156,7 @@ describe("biome()", () => {
     expect(mockRun).toHaveBeenCalledWith(
       "npx",
       ["@biomejs/biome", "check", "--reporter=json", "src/", "lib/"],
-      { cwd: "/project", timeout: 120_000 },
+      { cwd: "/project", timeout: 180_000 },
     );
   });
 
@@ -165,7 +165,7 @@ describe("biome()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("npx", ["@biomejs/biome", "format", "--write", "src/"], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -175,7 +175,7 @@ describe("biome()", () => {
     expect(mockRun).toHaveBeenCalledWith(
       "npx",
       ["@biomejs/biome", "format", "--write", "src/", "lib/", "tests/"],
-      { cwd: "/project", timeout: 120_000 },
+      { cwd: "/project", timeout: 180_000 },
     );
   });
 
@@ -185,7 +185,7 @@ describe("biome()", () => {
     expect(mockRun).toHaveBeenCalledWith(
       "npx",
       ["@biomejs/biome", "check", "--reporter=json", "."],
-      { cwd: undefined, timeout: 120_000 },
+      { cwd: undefined, timeout: 180_000 },
     );
   });
 
@@ -209,7 +209,7 @@ describe("stylelintCmd()", () => {
     expect(mockRun).toHaveBeenCalledOnce();
     expect(mockRun).toHaveBeenCalledWith("npx", ["stylelint", "--formatter", "json", "**/*.css"], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -218,7 +218,7 @@ describe("stylelintCmd()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("npx", ["stylelint", "--formatter", "json", "."], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -228,7 +228,7 @@ describe("stylelintCmd()", () => {
     expect(mockRun).toHaveBeenCalledWith(
       "npx",
       ["stylelint", "--formatter", "json", "**/*.css", "--fix"],
-      { cwd: "/project", timeout: 120_000 },
+      { cwd: "/project", timeout: 180_000 },
     );
   });
 
@@ -237,7 +237,7 @@ describe("stylelintCmd()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("npx", ["stylelint", "--formatter", "json", "."], {
       cwd: undefined,
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -261,7 +261,7 @@ describe("oxlintCmd()", () => {
     expect(mockRun).toHaveBeenCalledOnce();
     expect(mockRun).toHaveBeenCalledWith("npx", ["oxlint", "--format", "json", "."], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -270,7 +270,7 @@ describe("oxlintCmd()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("npx", ["oxlint", "--format", "json", "src/", "lib/"], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -279,7 +279,7 @@ describe("oxlintCmd()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("npx", ["oxlint", "--format", "json", "."], {
       cwd: undefined,
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -303,7 +303,7 @@ describe("shellcheckCmd()", () => {
     expect(mockRun).toHaveBeenCalledOnce();
     expect(mockRun).toHaveBeenCalledWith("shellcheck", ["--format=json", "deploy.sh"], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -313,7 +313,7 @@ describe("shellcheckCmd()", () => {
     expect(mockRun).toHaveBeenCalledWith(
       "shellcheck",
       ["--format=json", "--severity=warning", "deploy.sh"],
-      { cwd: "/project", timeout: 120_000 },
+      { cwd: "/project", timeout: 180_000 },
     );
   });
 
@@ -322,7 +322,7 @@ describe("shellcheckCmd()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("shellcheck", ["--format=json", "deploy.sh", "build.sh"], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -331,7 +331,7 @@ describe("shellcheckCmd()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("shellcheck", ["--format=json", "deploy.sh"], {
       cwd: undefined,
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -355,7 +355,7 @@ describe("hadolintCmd()", () => {
     expect(mockRun).toHaveBeenCalledOnce();
     expect(mockRun).toHaveBeenCalledWith("hadolint", ["--format=json", "Dockerfile"], {
       cwd: "/project",
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 
@@ -365,7 +365,7 @@ describe("hadolintCmd()", () => {
     expect(mockRun).toHaveBeenCalledWith(
       "hadolint",
       ["--format=json", "--trusted-registry=docker.io", "Dockerfile"],
-      { cwd: "/project", timeout: 120_000 },
+      { cwd: "/project", timeout: 180_000 },
     );
   });
 
@@ -378,7 +378,7 @@ describe("hadolintCmd()", () => {
     expect(mockRun).toHaveBeenCalledWith(
       "hadolint",
       ["--format=json", "--ignore=DL3008", "--ignore=DL3013", "Dockerfile"],
-      { cwd: "/project", timeout: 120_000 },
+      { cwd: "/project", timeout: 180_000 },
     );
   });
 
@@ -388,7 +388,7 @@ describe("hadolintCmd()", () => {
     expect(mockRun).toHaveBeenCalledWith(
       "hadolint",
       ["--format=json", "Dockerfile", "Dockerfile.dev"],
-      { cwd: "/project", timeout: 120_000 },
+      { cwd: "/project", timeout: 180_000 },
     );
   });
 
@@ -397,7 +397,7 @@ describe("hadolintCmd()", () => {
 
     expect(mockRun).toHaveBeenCalledWith("hadolint", ["--format=json", "Dockerfile"], {
       cwd: undefined,
-      timeout: 120_000,
+      timeout: 180_000,
     });
   });
 

--- a/packages/server-lint/src/lib/lint-runner.ts
+++ b/packages/server-lint/src/lib/lint-runner.ts
@@ -1,29 +1,29 @@
 import { run, type RunResult } from "@paretools/shared";
 
 export async function eslint(args: string[], cwd?: string): Promise<RunResult> {
-  return run("npx", ["eslint", ...args], { cwd, timeout: 120_000 });
+  return run("npx", ["eslint", ...args], { cwd, timeout: 180_000 });
 }
 
 export async function prettier(args: string[], cwd?: string): Promise<RunResult> {
-  return run("npx", ["prettier", ...args], { cwd, timeout: 120_000 });
+  return run("npx", ["prettier", ...args], { cwd, timeout: 180_000 });
 }
 
 export async function biome(args: string[], cwd?: string): Promise<RunResult> {
-  return run("npx", ["@biomejs/biome", ...args], { cwd, timeout: 120_000 });
+  return run("npx", ["@biomejs/biome", ...args], { cwd, timeout: 180_000 });
 }
 
 export async function stylelintCmd(args: string[], cwd?: string): Promise<RunResult> {
-  return run("npx", ["stylelint", ...args], { cwd, timeout: 120_000 });
+  return run("npx", ["stylelint", ...args], { cwd, timeout: 180_000 });
 }
 
 export async function oxlintCmd(args: string[], cwd?: string): Promise<RunResult> {
-  return run("npx", ["oxlint", ...args], { cwd, timeout: 120_000 });
+  return run("npx", ["oxlint", ...args], { cwd, timeout: 180_000 });
 }
 
 export async function shellcheckCmd(args: string[], cwd?: string): Promise<RunResult> {
-  return run("shellcheck", args, { cwd, timeout: 120_000 });
+  return run("shellcheck", args, { cwd, timeout: 180_000 });
 }
 
 export async function hadolintCmd(args: string[], cwd?: string): Promise<RunResult> {
-  return run("hadolint", args, { cwd, timeout: 120_000 });
+  return run("hadolint", args, { cwd, timeout: 180_000 });
 }

--- a/packages/server-npm/__tests__/integration.test.ts
+++ b/packages/server-npm/__tests__/integration.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const SERVER_PATH = resolve(__dirname, "../dist/index.js");
-const CALL_TIMEOUT = 120_000;
+const CALL_TIMEOUT = 180_000;
 
 describe("@paretools/npm integration", () => {
   let client: Client;

--- a/packages/server-npm/__tests__/npm-runner.test.ts
+++ b/packages/server-npm/__tests__/npm-runner.test.ts
@@ -124,7 +124,7 @@ describe("npm runner", () => {
       expect(mockRun).toHaveBeenCalledWith(
         "npm",
         ["audit", "--json"],
-        expect.objectContaining({ timeout: 60_000 }),
+        expect.objectContaining({ timeout: 180_000 }),
       );
     });
 
@@ -134,7 +134,7 @@ describe("npm runner", () => {
       expect(mockRun).toHaveBeenCalledWith(
         "npm",
         ["outdated", "--json"],
-        expect.objectContaining({ timeout: 60_000 }),
+        expect.objectContaining({ timeout: 180_000 }),
       );
     });
 
@@ -144,7 +144,7 @@ describe("npm runner", () => {
       expect(mockRun).toHaveBeenCalledWith(
         "npm",
         ["ls", "--json", "--depth=0"],
-        expect.objectContaining({ timeout: 60_000 }),
+        expect.objectContaining({ timeout: 180_000 }),
       );
     });
 
@@ -154,7 +154,7 @@ describe("npm runner", () => {
       expect(mockRun).toHaveBeenCalledWith(
         "npm",
         ["init", "-y"],
-        expect.objectContaining({ timeout: 60_000 }),
+        expect.objectContaining({ timeout: 180_000 }),
       );
     });
   });

--- a/packages/server-npm/__tests__/pnpm-runner.test.ts
+++ b/packages/server-npm/__tests__/pnpm-runner.test.ts
@@ -84,7 +84,7 @@ describe("pnpm runner", () => {
       expect(mockRun).toHaveBeenCalledWith(
         "pnpm",
         ["audit", "--json"],
-        expect.objectContaining({ timeout: 60_000 }),
+        expect.objectContaining({ timeout: 180_000 }),
       );
     });
 
@@ -94,7 +94,7 @@ describe("pnpm runner", () => {
       expect(mockRun).toHaveBeenCalledWith(
         "pnpm",
         ["outdated", "--json"],
-        expect.objectContaining({ timeout: 60_000 }),
+        expect.objectContaining({ timeout: 180_000 }),
       );
     });
 
@@ -104,7 +104,7 @@ describe("pnpm runner", () => {
       expect(mockRun).toHaveBeenCalledWith(
         "pnpm",
         ["list", "--json", "--depth=0"],
-        expect.objectContaining({ timeout: 60_000 }),
+        expect.objectContaining({ timeout: 180_000 }),
       );
     });
   });

--- a/packages/server-npm/__tests__/yarn-runner.test.ts
+++ b/packages/server-npm/__tests__/yarn-runner.test.ts
@@ -84,7 +84,7 @@ describe("yarn runner", () => {
       expect(mockRun).toHaveBeenCalledWith(
         "yarn",
         ["audit", "--json"],
-        expect.objectContaining({ timeout: 60_000 }),
+        expect.objectContaining({ timeout: 180_000 }),
       );
     });
 
@@ -94,7 +94,7 @@ describe("yarn runner", () => {
       expect(mockRun).toHaveBeenCalledWith(
         "yarn",
         ["outdated", "--json"],
-        expect.objectContaining({ timeout: 60_000 }),
+        expect.objectContaining({ timeout: 180_000 }),
       );
     });
 
@@ -104,7 +104,7 @@ describe("yarn runner", () => {
       expect(mockRun).toHaveBeenCalledWith(
         "yarn",
         ["list", "--json", "--depth=0"],
-        expect.objectContaining({ timeout: 60_000 }),
+        expect.objectContaining({ timeout: 180_000 }),
       );
     });
   });

--- a/packages/server-npm/src/lib/npm-runner.ts
+++ b/packages/server-npm/src/lib/npm-runner.ts
@@ -16,15 +16,15 @@ function isLongRunning(args: string[]): boolean {
 }
 
 export async function npm(args: string[], cwd?: string): Promise<RunResult> {
-  return run("npm", args, { cwd, timeout: isLongRunning(args) ? 300_000 : 60_000 });
+  return run("npm", args, { cwd, timeout: isLongRunning(args) ? 300_000 : 180_000 });
 }
 
 export async function pnpm(args: string[], cwd?: string): Promise<RunResult> {
-  return run("pnpm", args, { cwd, timeout: isLongRunning(args) ? 300_000 : 60_000 });
+  return run("pnpm", args, { cwd, timeout: isLongRunning(args) ? 300_000 : 180_000 });
 }
 
 export async function yarn(args: string[], cwd?: string): Promise<RunResult> {
-  return run("yarn", args, { cwd, timeout: isLongRunning(args) ? 300_000 : 60_000 });
+  return run("yarn", args, { cwd, timeout: isLongRunning(args) ? 300_000 : 180_000 });
 }
 
 /** Run a command with the appropriate package manager. */

--- a/packages/server-process/__tests__/integration.test.ts
+++ b/packages/server-process/__tests__/integration.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const SERVER_PATH = resolve(__dirname, "../dist/index.js");
-const CALL_TIMEOUT = 120_000;
+const CALL_TIMEOUT = 180_000;
 
 describe("@paretools/process integration", () => {
   let client: Client;

--- a/packages/server-python/__tests__/integration.test.ts
+++ b/packages/server-python/__tests__/integration.test.ts
@@ -8,7 +8,7 @@ const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const SERVER_PATH = resolve(__dirname, "../dist/index.js");
 
 /** MCP SDK defaults to 60 s request timeout; override for CI where shell spawning is slow. */
-const CALL_TIMEOUT = { timeout: 120_000 };
+const CALL_TIMEOUT = { timeout: 180_000 };
 
 describe("@paretools/python integration", () => {
   let client: Client;

--- a/packages/server-python/src/lib/python-runner.ts
+++ b/packages/server-python/src/lib/python-runner.ts
@@ -1,15 +1,15 @@
 import { run, type RunResult } from "@paretools/shared";
 
 export async function pip(args: string[], cwd?: string): Promise<RunResult> {
-  return run("pip", args, { cwd, timeout: 120_000 });
+  return run("pip", args, { cwd, timeout: 180_000 });
 }
 
 export async function mypy(args: string[], cwd?: string): Promise<RunResult> {
-  return run("mypy", args, { cwd, timeout: 120_000 });
+  return run("mypy", args, { cwd, timeout: 180_000 });
 }
 
 export async function ruff(args: string[], cwd?: string): Promise<RunResult> {
-  return run("ruff", args, { cwd, timeout: 120_000 });
+  return run("ruff", args, { cwd, timeout: 180_000 });
 }
 
 export async function pytest(args: string[], cwd?: string): Promise<RunResult> {
@@ -17,20 +17,20 @@ export async function pytest(args: string[], cwd?: string): Promise<RunResult> {
 }
 
 export async function uv(args: string[], cwd?: string): Promise<RunResult> {
-  return run("uv", args, { cwd, timeout: 120_000 });
+  return run("uv", args, { cwd, timeout: 180_000 });
 }
 
 export async function black(args: string[], cwd?: string): Promise<RunResult> {
-  return run("black", args, { cwd, timeout: 120_000 });
+  return run("black", args, { cwd, timeout: 180_000 });
 }
 
 export async function conda(args: string[], cwd?: string): Promise<RunResult> {
-  return run("conda", args, { cwd, timeout: 120_000 });
+  return run("conda", args, { cwd, timeout: 180_000 });
 }
 
 export async function pyenv(args: string[], cwd?: string): Promise<RunResult> {
-  return run("pyenv", args, { cwd, timeout: 120_000 });
+  return run("pyenv", args, { cwd, timeout: 180_000 });
 }
 export async function poetry(args: string[], cwd?: string): Promise<RunResult> {
-  return run("poetry", args, { cwd, timeout: 120_000 });
+  return run("poetry", args, { cwd, timeout: 180_000 });
 }

--- a/packages/server-search/__tests__/integration.test.ts
+++ b/packages/server-search/__tests__/integration.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const SERVER_PATH = resolve(__dirname, "../dist/index.js");
-const CALL_TIMEOUT = 120_000;
+const CALL_TIMEOUT = 180_000;
 
 describe("@paretools/search integration", () => {
   let client: Client;

--- a/packages/server-search/src/lib/search-runner.ts
+++ b/packages/server-search/src/lib/search-runner.ts
@@ -48,16 +48,16 @@ async function runWithInstallHint(
 }
 
 export async function rgCmd(args: string[], cwd?: string): Promise<RunResult> {
-  return runWithInstallHint("rg", args, { cwd, timeout: 120_000 });
+  return runWithInstallHint("rg", args, { cwd, timeout: 180_000 });
 }
 
 export async function fdCmd(args: string[], cwd?: string): Promise<RunResult> {
-  return runWithInstallHint("fd", args, { cwd, timeout: 120_000 });
+  return runWithInstallHint("fd", args, { cwd, timeout: 180_000 });
 }
 
 export async function jqCmd(
   args: string[],
   opts?: { cwd?: string; stdin?: string },
 ): Promise<RunResult> {
-  return runWithInstallHint("jq", args, { cwd: opts?.cwd, stdin: opts?.stdin, timeout: 120_000 });
+  return runWithInstallHint("jq", args, { cwd: opts?.cwd, stdin: opts?.stdin, timeout: 180_000 });
 }

--- a/packages/server-security/__tests__/integration.test.ts
+++ b/packages/server-security/__tests__/integration.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const SERVER_PATH = resolve(__dirname, "../dist/index.js");
-const CALL_TIMEOUT = 120_000;
+const CALL_TIMEOUT = 180_000;
 
 describe("@paretools/security integration", () => {
   let client: Client;

--- a/packages/shared/src/runner.ts
+++ b/packages/shared/src/runner.ts
@@ -179,7 +179,7 @@ export function run(cmd: string, args: string[], opts?: RunOptions): Promise<Run
     // --- Timeout handling (replaces execFile's timeout) ---
     let timedOut = false;
     let timeoutSignal: string | undefined;
-    const timeoutMs = opts?.timeout ?? 60_000;
+    const timeoutMs = opts?.timeout ?? 180_000;
     const timer = setTimeout(() => {
       timedOut = true;
       timeoutSignal = "SIGTERM";

--- a/packages/shared/vitest.shared.ts
+++ b/packages/shared/vitest.shared.ts
@@ -29,7 +29,7 @@ interface VitestConfigOptions {
 }
 
 const defaults = {
-  testTimeout: 120_000,
+  testTimeout: 180_000,
   coverageThresholds: {
     lines: 80,
     functions: 80,


### PR DESCRIPTION
## Summary

- **Runner default** (`packages/shared/src/runner.ts`): `60_000` -> `180_000`
- **Vitest testTimeout** (`packages/shared/vitest.shared.ts`): `120_000` -> `180_000`
- **All server runner files**: explicit `timeout: 120_000` -> `180_000` across 12 server packages (lint, build, go, python, search, http, k8s, npm)
- **npm runner non-long-running fallback**: `60_000` -> `180_000`
- **k8s kubectl/helm tool timeouts**: `60_000` -> `180_000`
- **Integration test CALL_TIMEOUT constants**: updated across all server packages
- **Runner unit test assertions**: updated to match new timeout values

## Motivation

Windows CI has been flaky due to inconsistent timeout levels. The runner default was 60s, vitest was 120s, and most tool runners explicitly passed 120s. This PR standardizes everything to 180s — matching the value already used by `server-test` — to eliminate timeout-related CI failures on slower Windows runners.

## Intentionally left unchanged

- `server-process` run tool `timeout` input parameter default (60s) — this is user-facing, not an internal timeout
- `server-build` integration test per-test overrides at 60s — intentionally shorter for lightweight tests
- `server-test` — already at 180s, no changes needed
- `server-cargo`/`server-go` run tool `.max(600000)` constraints — input validation bounds, not defaults
- Long-running npm operations (install, test, etc.) — remain at 300s

## Test plan

- [x] `pnpm build` passes (all 17 packages)
- [x] `pnpm lint` passes (0 errors)
- [ ] CI matrix (ubuntu/windows/macos x node 20/22) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)