### PR TITLE
fix(github): improve issue-close URL parsing and handle pr-checks exit code 8

### DIFF
--- a/.changeset/github-p0-parser-error.md
+++ b/.changeset/github-p0-parser-error.md
@@ -1,0 +1,5 @@
+---
+"@paretools/github": minor
+---
+
+fix(github): improve issue-close URL parsing robustness and handle pr-checks exit code 8 (pending checks)

--- a/packages/server-github/__tests__/pr-checks.test.ts
+++ b/packages/server-github/__tests__/pr-checks.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import { parsePrChecks } from "../src/lib/parsers.js";
+import {
+  formatPrChecks,
+  compactPrChecksMap,
+  formatPrChecksCompact,
+} from "../src/lib/formatters.js";
+import type { PrChecksResult } from "../src/schemas/index.js";
+
+// ── Parser tests ────────────────────────────────────────────────────
+
+describe("parsePrChecks (exit code 8 — pending checks)", () => {
+  it("parses all-pending checks JSON (exit code 8 scenario)", () => {
+    // gh pr checks returns exit code 8 when checks are pending, but still
+    // outputs valid JSON. The parser must handle this gracefully.
+    const json = JSON.stringify([
+      {
+        name: "CI / build",
+        state: "PENDING",
+        bucket: "pending",
+        description: "",
+        event: "pull_request",
+        workflow: "CI",
+        link: "https://github.com/owner/repo/actions/runs/100/job/200",
+        startedAt: "2024-06-01T12:00:00Z",
+        completedAt: "",
+      },
+      {
+        name: "CI / test",
+        state: "PENDING",
+        bucket: "pending",
+        description: "",
+        event: "pull_request",
+        workflow: "CI",
+        link: "https://github.com/owner/repo/actions/runs/100/job/201",
+        startedAt: "2024-06-01T12:00:00Z",
+        completedAt: "",
+      },
+    ]);
+
+    const result = parsePrChecks(json, 77);
+
+    expect(result.pr).toBe(77);
+    expect(result.checks).toHaveLength(2);
+    expect(result.summary.total).toBe(2);
+    expect(result.summary.pending).toBe(2);
+    expect(result.summary.passed).toBe(0);
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.skipped).toBe(0);
+    expect(result.summary.cancelled).toBe(0);
+  });
+
+  it("parses mixed pending and passed checks (exit code 8 scenario)", () => {
+    const json = JSON.stringify([
+      {
+        name: "lint",
+        state: "SUCCESS",
+        bucket: "pass",
+        description: "Linting passed",
+        event: "pull_request",
+        workflow: "CI",
+        link: "",
+        startedAt: "2024-06-01T12:00:00Z",
+        completedAt: "2024-06-01T12:01:00Z",
+      },
+      {
+        name: "deploy",
+        state: "PENDING",
+        bucket: "pending",
+        description: "",
+        event: "pull_request",
+        workflow: "Deploy",
+        link: "",
+        startedAt: "2024-06-01T12:01:00Z",
+        completedAt: "",
+      },
+    ]);
+
+    const result = parsePrChecks(json, 88);
+
+    expect(result.pr).toBe(88);
+    expect(result.summary.total).toBe(2);
+    expect(result.summary.passed).toBe(1);
+    expect(result.summary.pending).toBe(1);
+    expect(result.summary.failed).toBe(0);
+  });
+
+  it("includes required and conclusion fields when present", () => {
+    const json = JSON.stringify([
+      {
+        name: "required-check",
+        state: "PENDING",
+        bucket: "pending",
+        description: "",
+        event: "pull_request",
+        workflow: "CI",
+        link: "",
+        startedAt: "",
+        completedAt: "",
+        isRequired: true,
+        conclusion: null,
+      },
+    ]);
+
+    const result = parsePrChecks(json, 1);
+
+    expect(result.checks[0].required).toBe(true);
+    // null conclusion maps to undefined via the ?? operator in the parser
+    expect(result.checks[0].conclusion).toBeUndefined();
+  });
+});
+
+// ── Formatter tests ─────────────────────────────────────────────────
+
+describe("formatPrChecks (pending checks)", () => {
+  it("formats pending checks summary correctly", () => {
+    const data: PrChecksResult = {
+      pr: 42,
+      checks: [
+        {
+          name: "CI / build",
+          state: "PENDING",
+          bucket: "pending",
+          description: "",
+          event: "pull_request",
+          workflow: "CI",
+          link: "",
+          startedAt: "",
+          completedAt: "",
+        },
+      ],
+      summary: { total: 1, passed: 0, failed: 0, pending: 1, skipped: 0, cancelled: 0 },
+    };
+
+    const output = formatPrChecks(data);
+    expect(output).toContain("PR #42: 1 checks (0 passed, 0 failed, 1 pending)");
+    expect(output).toContain("CI / build: PENDING (pending) [CI]");
+  });
+});
+
+describe("compactPrChecks (pending checks)", () => {
+  it("maps pending checks to compact format", () => {
+    const data: PrChecksResult = {
+      pr: 50,
+      checks: [
+        {
+          name: "a",
+          state: "PENDING",
+          bucket: "pending",
+          description: "",
+          event: "",
+          workflow: "",
+          link: "",
+          startedAt: "",
+          completedAt: "",
+        },
+        {
+          name: "b",
+          state: "SUCCESS",
+          bucket: "pass",
+          description: "",
+          event: "",
+          workflow: "",
+          link: "",
+          startedAt: "",
+          completedAt: "",
+        },
+      ],
+      summary: { total: 2, passed: 1, failed: 0, pending: 1, skipped: 0, cancelled: 0 },
+    };
+
+    const compact = compactPrChecksMap(data);
+    expect(compact.pr).toBe(50);
+    expect(compact.total).toBe(2);
+    expect(compact.passed).toBe(1);
+    expect(compact.pending).toBe(1);
+    expect(compact.failed).toBe(0);
+
+    const text = formatPrChecksCompact(compact);
+    expect(text).toContain("PR #50: 2 checks (1 passed, 0 failed, 1 pending)");
+  });
+});

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -334,7 +334,10 @@ export function parseIssueCreate(stdout: string, labels?: string[]): IssueCreate
 
 /**
  * Parses `gh issue close` output into structured data.
- * The gh CLI prints a confirmation URL to stdout. We extract the number from it.
+ * The gh CLI may print a confirmation message plus URL to stdout.
+ * We robustly extract the issue URL using a regex rather than assuming
+ * the entire stdout is just a URL (handles extra text, whitespace, and
+ * different output formats).
  * S-gap: Enhanced to include reason and commentUrl.
  */
 export function parseIssueClose(
@@ -343,7 +346,9 @@ export function parseIssueClose(
   reason?: string,
   comment?: string,
 ): IssueCloseResult {
-  const url = stdout.trim();
+  // Robust URL extraction: find the GitHub issue URL anywhere in the output
+  const urlMatch = stdout.match(/(https:\/\/github\.com\/[^\s]+\/issues\/\d+)/);
+  const url = urlMatch ? urlMatch[1] : stdout.trim();
   // S-gap: Extract comment URL from output if a comment was added
   const commentUrlMatch = stdout.match(/(https:\/\/github\.com\/[^\s]+#issuecomment-\d+)/);
   return {

--- a/packages/server-github/src/tools/pr-checks.ts
+++ b/packages/server-github/src/tools/pr-checks.ts
@@ -59,7 +59,8 @@ export function registerPrChecksTool(server: McpServer) {
       if (required) args.push("--required");
       const result = await ghCmd(args);
 
-      if (result.exitCode !== 0) {
+      // Exit code 8 means checks are still pending — gh still returns valid JSON
+      if (result.exitCode !== 0 && result.exitCode !== 8) {
         throw new Error(`gh pr checks failed: ${result.stderr}`);
       }
 


### PR DESCRIPTION
## Summary
- **#37 issue-close URL parsing**: Replaced naive `stdout.trim()` with regex-based URL extraction (`/https:\/\/github\.com\/[^\s]+\/issues\/\d+/`). Now correctly extracts the issue URL from multi-line output, confirmation messages with prefix text, extra whitespace, and varied `gh` CLI output formats. Falls back to trimmed stdout when no pattern matches.
- **#40 pr-checks exit code 8**: `gh pr checks` returns exit code 8 when checks are still pending but still outputs valid JSON. The tool now detects exit code 8 and parses the response normally instead of throwing a generic error, allowing agents to see structured pending-checks status with proper summary counts.

## Changed files
- `packages/server-github/src/lib/parsers.ts` — Robust URL extraction in `parseIssueClose`
- `packages/server-github/src/tools/pr-checks.ts` — Allow exit code 8 (pending checks)
- `packages/server-github/__tests__/issue-close.test.ts` — 8 new test cases for URL edge cases
- `packages/server-github/__tests__/parsers.test.ts` — 2 new pending-checks parser tests
- `packages/server-github/__tests__/pr-checks.test.ts` — New test file (5 tests) for pending checks
- `.changeset/github-p0-parser-error.md` — Minor changeset for `@paretools/github`

## Test plan
- [x] All 246 tests pass (`pnpm --filter @paretools/github test`)
- [x] Build succeeds (`pnpm build`)
- [ ] CI matrix passes (ubuntu/windows/macos x node 20/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)