### PR TITLE
fix(go): resolve P0 parser bugs for build, fmt, and test

### DIFF
--- a/.changeset/go-p0-parser.md
+++ b/.changeset/go-p0-parser.md
@@ -1,0 +1,5 @@
+---
+"@paretools/go": minor
+---
+
+fix(go): capture non-file build errors, fix fmt files-changed detection, populate test failure output, surface package-level test failures

--- a/packages/server-go/__tests__/fmt.test.ts
+++ b/packages/server-go/__tests__/fmt.test.ts
@@ -41,13 +41,32 @@ describe("parseGoFmtOutput", () => {
     });
   });
 
-  describe("fix mode (-w)", () => {
-    it("parses successful fix with no output", () => {
+  describe("fix mode (-l -w)", () => {
+    it("parses successful fix with no output (already formatted)", () => {
       const result = parseGoFmtOutput("", "", 0, false);
 
       expect(result.success).toBe(true);
       expect(result.filesChanged).toBe(0);
       expect(result.files).toEqual([]);
+    });
+
+    it("reports files that were reformatted", () => {
+      // When -l -w is used, stdout lists files that gofmt rewrote
+      const stdout = "main.go\nutil.go\nhandler.go\n";
+      const result = parseGoFmtOutput(stdout, "", 0, false);
+
+      expect(result.success).toBe(true);
+      expect(result.filesChanged).toBe(3);
+      expect(result.files).toEqual(["main.go", "util.go", "handler.go"]);
+    });
+
+    it("reports single file reformatted", () => {
+      const stdout = "main.go\n";
+      const result = parseGoFmtOutput(stdout, "", 0, false);
+
+      expect(result.success).toBe(true);
+      expect(result.filesChanged).toBe(1);
+      expect(result.files).toEqual(["main.go"]);
     });
 
     it("handles error exit code", () => {

--- a/packages/server-go/src/schemas/index.ts
+++ b/packages/server-go/src/schemas/index.ts
@@ -12,6 +12,8 @@ export const GoBuildErrorSchema = z.object({
 export const GoBuildResultSchema = z.object({
   success: z.boolean(),
   errors: z.array(GoBuildErrorSchema).optional(),
+  /** Non-file errors (package-level, linker, build constraint) that don't match file:line:col format. */
+  rawErrors: z.array(z.string()).optional(),
   total: z.number(),
 });
 
@@ -26,10 +28,18 @@ export const GoTestCaseSchema = z.object({
   output: z.string().optional(),
 });
 
+/** Zod schema for a package-level test failure (build error, missing dependency, etc.). */
+export const GoTestPackageFailureSchema = z.object({
+  package: z.string(),
+  output: z.string().optional(),
+});
+
 /** Zod schema for structured go test output with test list and pass/fail/skip counts. */
 export const GoTestResultSchema = z.object({
   success: z.boolean(),
   tests: z.array(GoTestCaseSchema).optional(),
+  /** Package-level failures (build errors, missing dependencies) where no individual test ran. */
+  packageFailures: z.array(GoTestPackageFailureSchema).optional(),
   total: z.number(),
   passed: z.number(),
   failed: z.number(),

--- a/packages/server-go/src/tools/fmt.ts
+++ b/packages/server-go/src/tools/fmt.ts
@@ -61,8 +61,9 @@ export function registerFmtTool(server: McpServer) {
       for (const p of patterns ?? []) {
         assertNoFlagInjection(p, "patterns");
       }
-      const flag = check ? "-l" : "-w";
-      const args = [flag];
+      // In fix mode, pass both -l and -w so gofmt lists changed files AND rewrites them.
+      // In check mode, only pass -l to list files that need formatting.
+      const args = check ? ["-l"] : ["-l", "-w"];
       if (diff) args.push("-d");
       if (simplify) args.push("-s");
       if (allErrors) args.push("-e");


### PR DESCRIPTION
## Summary
- **build**: Capture non-file errors (package-level, linker, CGO, module) via new `rawErrors` field in schema. Previously errors not matching `file.go:line:col:` format were silently dropped.
- **fmt**: Fix `filesChanged` always reporting 0 in fix mode by passing `-l` alongside `-w` so gofmt prints reformatted filenames to stdout.
- **test**: Populate `output` field on failed tests by collecting `output` action events and attaching them to the corresponding test entry.
- **test**: Surface package-level build failures via new `packageFailures` schema field. Previously package events without a `Test` field were skipped entirely.

Resolves #45, #46, #51, #52

## Changes
### Schemas (`schemas/index.ts`)
- `GoBuildResultSchema`: Added optional `rawErrors: z.array(z.string())` field
- `GoTestResultSchema`: Added optional `packageFailures` array with `GoTestPackageFailureSchema`

### Parsers (`lib/parsers.ts`)
- `parseGoBuildOutput`: Added pattern matching for non-file errors (GOROOT/GOPATH, linker, CGO, module, build constraint). `total` now counts both file errors and raw errors.
- `parseGoTestJson`: Collects output lines per test and attaches to failed tests. Tracks package-level fail events and surfaces them when no individual tests ran for that package.
- `parseGoFmtOutput`: Updated comment to reflect `-l -w` usage pattern

### Formatters (`lib/formatters.ts`)
- `formatGoBuild`: Renders `rawErrors` below file errors
- `formatGoTest`: Renders test output indented below failed tests; renders package failures section
- Compact types updated to carry `rawErrors` and `packageFailures` through

### Tools (`tools/fmt.ts`)
- Fix mode now passes `["-l", "-w"]` instead of just `["-w"]`

## Test plan
- [x] 27 new tests across parsers, formatters, fidelity, and fmt test files
- [x] All 265 tests pass (`pnpm --filter @paretools/go test`)
- [x] Build passes (`pnpm build --filter @paretools/go`)
- [ ] CI: build, test, lint, format:check

🤖 Generated with [Claude Code](https://claude.com/claude-code)