### PR TITLE
fix(python): fix P0 parser bugs and error-handling gaps

### DIFF
--- a/.changeset/python-p0-parser-error.md
+++ b/.changeset/python-p0-parser-error.md
@@ -1,0 +1,5 @@
+---
+"@paretools/python": minor
+---
+
+fix(python): fix pip-audit redundant arg, pip-install dry-run parsing, pyenv current detection, ruff-format check mode parsing, black exit code distinction, and uv-install resolution error parsing

--- a/packages/server-python/__tests__/compact.test.ts
+++ b/packages/server-python/__tests__/compact.test.ts
@@ -522,7 +522,7 @@ describe("formatRuffFormatCompact", () => {
   });
 
   it("formats check mode with files needing formatting", () => {
-    const compact = { success: false, filesChanged: 2 };
+    const compact = { success: false, filesChanged: 2, checkMode: true };
     expect(formatRuffFormatCompact(compact)).toBe("ruff format: 2 files would be reformatted");
   });
 });

--- a/packages/server-python/__tests__/formatters.test.ts
+++ b/packages/server-python/__tests__/formatters.test.ts
@@ -350,6 +350,19 @@ describe("formatBlack — edge cases", () => {
     // Should not list any files
     expect(output.split("\n")).toHaveLength(1);
   });
+
+  it("formats internal error (exit 123)", () => {
+    const data: BlackResult = {
+      filesChanged: 0,
+      filesUnchanged: 0,
+      filesChecked: 0,
+      success: false,
+      exitCode: 123,
+      errorType: "internal_error",
+      wouldReformat: [],
+    };
+    expect(formatBlack(data)).toBe("black: internal error (exit 123). Check for syntax errors.");
+  });
 });
 
 // ─── pip-list formatter tests ────────────────────────────────────────────────
@@ -443,6 +456,7 @@ describe("formatRuffFormat", () => {
       success: true,
       filesChanged: 2,
       files: ["src/main.py", "src/utils.py"],
+      checkMode: false,
     };
     const output = formatRuffFormat(data);
     expect(output).toContain("2 files reformatted");
@@ -455,6 +469,7 @@ describe("formatRuffFormat", () => {
       success: false,
       filesChanged: 1,
       files: ["src/main.py"],
+      checkMode: true,
     };
     const output = formatRuffFormat(data);
     expect(output).toContain("1 files would be reformatted");

--- a/packages/server-python/__tests__/pyenv.test.ts
+++ b/packages/server-python/__tests__/pyenv.test.ts
@@ -7,13 +7,15 @@ import type { PyenvResult } from "../src/schemas/index.js";
 
 describe("parsePyenvOutput", () => {
   describe("versions action", () => {
-    it("parses list of installed versions with --bare output", () => {
-      const stdout = "2.7.18\n3.10.13\n3.11.7\n3.12.0\n";
+    it("parses list of installed versions (without --bare)", () => {
+      // pyenv versions (no --bare) includes leading spaces and * marker for current
+      const stdout = "  2.7.18\n  3.10.13\n* 3.11.7 (set by /home/user/.pyenv/version)\n  3.12.0\n";
       const result = parsePyenvOutput(stdout, "", 0, "versions");
 
       expect(result.success).toBe(true);
       expect(result.action).toBe("versions");
       expect(result.versions).toEqual(["2.7.18", "3.10.13", "3.11.7", "3.12.0"]);
+      expect(result.current).toBe("3.11.7");
     });
 
     it("parses versions with current marker", () => {
@@ -25,6 +27,15 @@ describe("parsePyenvOutput", () => {
       expect(result.versions).toContain("2.7.18");
       expect(result.versions).toContain("3.11.7");
       expect(result.current).toBe("3.12.0");
+    });
+
+    it("parses versions without any current marker (no version set)", () => {
+      const stdout = "  2.7.18\n  3.10.13\n  3.12.0\n";
+      const result = parsePyenvOutput(stdout, "", 0, "versions");
+
+      expect(result.success).toBe(true);
+      expect(result.versions).toEqual(["2.7.18", "3.10.13", "3.12.0"]);
+      expect(result.current).toBeUndefined();
     });
 
     it("handles empty versions list", () => {

--- a/packages/server-python/src/lib/python-runner.ts
+++ b/packages/server-python/src/lib/python-runner.ts
@@ -34,3 +34,8 @@ export async function pyenv(args: string[], cwd?: string): Promise<RunResult> {
 export async function poetry(args: string[], cwd?: string): Promise<RunResult> {
   return run("poetry", args, { cwd, timeout: 180_000 });
 }
+
+/** pip-audit is a standalone binary, NOT a pip subcommand. */
+export async function pipAudit(args: string[], cwd?: string): Promise<RunResult> {
+  return run("pip-audit", args, { cwd, timeout: 180_000 });
+}

--- a/packages/server-python/src/schemas/index.ts
+++ b/packages/server-python/src/schemas/index.ts
@@ -12,6 +12,7 @@ export const PipInstallSchema = z.object({
     )
     .optional(),
   alreadySatisfied: z.boolean(),
+  dryRun: z.boolean().optional(),
   total: z.number(),
 });
 
@@ -99,6 +100,12 @@ export const PytestResultSchema = z.object({
 
 export type PytestResult = z.infer<typeof PytestResultSchema>;
 
+/** Zod schema for a single resolution conflict from uv install. */
+export const UvResolutionConflictSchema = z.object({
+  package: z.string(),
+  constraint: z.string(),
+});
+
 /** Zod schema for structured uv install output with installed packages and count. */
 export const UvInstallSchema = z.object({
   success: z.boolean(),
@@ -112,6 +119,8 @@ export const UvInstallSchema = z.object({
     .optional(),
   total: z.number(),
   duration: z.number(),
+  error: z.string().optional(),
+  resolutionConflicts: z.array(UvResolutionConflictSchema).optional(),
 });
 
 export type UvInstall = z.infer<typeof UvInstallSchema>;
@@ -127,12 +136,16 @@ export const UvRunSchema = z.object({
 
 export type UvRun = z.infer<typeof UvRunSchema>;
 
-/** Zod schema for structured Black formatter output with file counts and reformat list. */
+/** Zod schema for structured Black formatter output with file counts and reformat list.
+ *  errorType distinguishes "check_failed" (exit 1, files need reformatting) from
+ *  "internal_error" (exit 123, parse error or crash). */
 export const BlackResultSchema = z.object({
   filesChanged: z.number(),
   filesUnchanged: z.number(),
   filesChecked: z.number(),
   success: z.boolean(),
+  exitCode: z.number().optional(),
+  errorType: z.enum(["check_failed", "internal_error"]).optional(),
   wouldReformat: z.array(z.string()).optional(),
 });
 
@@ -179,6 +192,7 @@ export const RuffFormatResultSchema = z.object({
   success: z.boolean(),
   filesChanged: z.number(),
   files: z.array(z.string()).optional(),
+  checkMode: z.boolean().optional(),
 });
 
 export type RuffFormatResult = z.infer<typeof RuffFormatResultSchema>;

--- a/packages/server-python/src/tools/pip-audit.ts
+++ b/packages/server-python/src/tools/pip-audit.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { compactDualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { pipAudit } from "../lib/python-runner.js";
 import { parsePipAuditJson } from "../lib/parsers.js";
 import { formatPipAudit, compactPipAuditMap, formatPipAuditCompact } from "../lib/formatters.js";
 import { PipAuditResultSchema } from "../schemas/index.js";
@@ -113,9 +114,8 @@ export function registerPipAuditTool(server: McpServer) {
         args.push("--ignore-vuln", v);
       }
 
-      // pip-audit is a separate tool: pip-audit (not pip audit)
-      const { run } = await import("@paretools/shared");
-      const result = await run("pip-audit", args, { cwd });
+      // pip-audit is a standalone binary, NOT a pip subcommand
+      const result = await pipAudit(args, cwd);
       const data = parsePipAuditJson(result.stdout, result.exitCode);
       return compactDualOutput(
         data,

--- a/packages/server-python/src/tools/pyenv.ts
+++ b/packages/server-python/src/tools/pyenv.ts
@@ -64,7 +64,8 @@ export function registerPyenvTool(server: McpServer) {
 
       switch (action) {
         case "versions":
-          args.push("versions", "--bare");
+          // Do NOT use --bare: it strips the * marker needed for current version detection
+          args.push("versions");
           break;
         case "version":
           args.push("version");


### PR DESCRIPTION
## Summary

- **#64 pip-audit**: Replace dynamic `run()` import with dedicated `pipAudit()` runner in `python-runner.ts`, ensuring `pip-audit` is always called as a standalone binary (not as a `pip audit` subcommand)
- **#65 pip-install**: Parse `Would install` lines from `--dry-run` output; add `dryRun` field to `PipInstallSchema` so agents can detect dry-run results
- **#67 pyenv**: Remove `--bare` flag from `versions` action so the `*` current-version marker is preserved in output, fixing current version detection
- **#70 ruff-format**: Add `checkMode` field to `RuffFormatResultSchema` to correctly distinguish `Would reformat` (check mode) from `reformatted` (fix mode) in parser output
- **#63 black**: Add `exitCode` and `errorType` fields to `BlackResultSchema` to differentiate exit 1 (`check_failed`: files need reformatting) from exit 123 (`internal_error`: parse error or crash)
- **#71 uv-install**: Parse resolution conflict errors from stderr on failure; extract conflicting package names and version constraints into structured `resolutionConflicts` array and `error` string

## Test plan

- [x] All 349 existing + new parser/formatter/compact tests pass
- [x] Build succeeds with `pnpm build`
- [ ] Verify pip-install dry-run parsing with real `pip install --dry-run requests`
- [ ] Verify pyenv versions output includes current marker without `--bare`
- [ ] Verify black exit code 1 vs 123 distinction with real malformed Python files
- [ ] Verify uv-install resolution conflicts parsed from `uv pip install` with conflicting deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)