### PR TITLE
fix(cargo): fix P0 parser bugs in add, audit, and fmt tools

### DIFF
--- a/.changeset/cargo-p0-parser.md
+++ b/.changeset/cargo-p0-parser.md
@@ -1,0 +1,5 @@
+---
+"@paretools/cargo": minor
+---
+
+fix(cargo): fix dry-run output parsing, CVSS severity extraction, and fmt file change detection

--- a/packages/server-cargo/__tests__/add-remove.test.ts
+++ b/packages/server-cargo/__tests__/add-remove.test.ts
@@ -114,6 +114,29 @@ describe("formatCargoAdd", () => {
 
     expect(output).toBe("cargo add: success, no packages added.");
   });
+
+  it("formats dry-run add with packages", () => {
+    const output = formatCargoAdd({
+      success: true,
+      added: [{ name: "serde", version: "1.0.217" }],
+      total: 1,
+      dryRun: true,
+    });
+
+    expect(output).toContain("cargo add: 1 package(s) added (dry-run)");
+    expect(output).toContain("serde v1.0.217");
+  });
+
+  it("formats dry-run add with no packages", () => {
+    const output = formatCargoAdd({
+      success: true,
+      added: [],
+      total: 0,
+      dryRun: true,
+    });
+
+    expect(output).toContain("dry-run");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/server-cargo/__tests__/fmt.test.ts
+++ b/packages/server-cargo/__tests__/fmt.test.ts
@@ -70,7 +70,7 @@ describe("parseCargoFmtOutput", () => {
   });
 
   describe("fix mode", () => {
-    it("returns empty files list in fix mode", () => {
+    it("returns empty files list when no files needed reformatting", () => {
       const result = parseCargoFmtOutput("", "", 0, false);
 
       expect(result.success).toBe(true);
@@ -82,6 +82,25 @@ describe("parseCargoFmtOutput", () => {
       const result = parseCargoFmtOutput("", "", 0, false);
 
       expect(result.success).toBe(true);
+    });
+
+    it("reports reformatted files in fix mode via -l flag output", () => {
+      const stdout = ["src/main.rs", "src/lib.rs"].join("\n");
+      const result = parseCargoFmtOutput(stdout, "", 0, false);
+
+      expect(result.success).toBe(true);
+      expect(result.filesChanged).toBe(2);
+      expect(result.files).toContain("src/main.rs");
+      expect(result.files).toContain("src/lib.rs");
+    });
+
+    it("handles single reformatted file in fix mode", () => {
+      const stdout = "src/utils.rs";
+      const result = parseCargoFmtOutput(stdout, "", 0, false);
+
+      expect(result.success).toBe(true);
+      expect(result.filesChanged).toBe(1);
+      expect(result.files).toEqual(["src/utils.rs"]);
     });
   });
 

--- a/packages/server-cargo/src/lib/formatters.ts
+++ b/packages/server-cargo/src/lib/formatters.ts
@@ -57,6 +57,7 @@ export interface CargoAddCompact {
   success: boolean;
   packages: string[];
   total: number;
+  dryRun?: boolean;
   error?: string;
 }
 
@@ -136,9 +137,12 @@ export function formatCargoAdd(data: CargoAddResult): string {
     return `cargo add: failed${err}`;
   }
 
-  if (data.total === 0) return "cargo add: success, no packages added.";
+  const dryRunSuffix = data.dryRun ? " (dry-run)" : "";
 
-  const lines = [`cargo add: ${data.total} package(s) added`];
+  if (data.total === 0)
+    return `cargo add: success, no packages added.${dryRunSuffix ? ` ${dryRunSuffix.trim()}` : ""}`;
+
+  const lines = [`cargo add: ${data.total} package(s) added${dryRunSuffix}`];
   for (const pkg of data.added ?? []) {
     lines.push(`  ${pkg.name} v${pkg.version}`);
   }
@@ -231,6 +235,7 @@ export function compactAddMap(data: CargoAddResult): CargoAddCompact {
     packages: (data.added ?? []).map((p) => p.name),
     total: data.total,
   };
+  if (data.dryRun) compact.dryRun = true;
   if (data.error) compact.error = data.error;
   return compact;
 }
@@ -286,8 +291,10 @@ export function formatAddCompact(data: CargoAddCompact): string {
     const err = data.error ? `: ${data.error}` : "";
     return `cargo add: failed${err}`;
   }
-  if (data.total === 0) return "cargo add: success, no packages added.";
-  return `cargo add: ${data.total} package(s) added: ${data.packages.join(", ")}`;
+  const dryRunSuffix = data.dryRun ? " (dry-run)" : "";
+  if (data.total === 0)
+    return `cargo add: success, no packages added.${dryRunSuffix ? ` ${dryRunSuffix.trim()}` : ""}`;
+  return `cargo add: ${data.total} package(s) added${dryRunSuffix}: ${data.packages.join(", ")}`;
 }
 
 export function formatRemoveCompact(data: CargoRemoveCompact): string {

--- a/packages/server-cargo/src/lib/parsers.ts
+++ b/packages/server-cargo/src/lib/parsers.ts
@@ -110,9 +110,11 @@ export function parseCargoRunOutput(
 }
 
 /**
- * Parses `cargo add` output.
+ * Parses `cargo add` output (including `--dry-run` mode).
  * Lines like: "      Adding serde v1.0.217 to dependencies"
  * Also handles: "      Adding serde v1.0.217 to dev-dependencies"
+ * Dry-run mode outputs the same Adding lines followed by:
+ *   "warning: aborting add due to dry run"
  * On failure, captures the error message.
  */
 export function parseCargoAddOutput(
@@ -124,10 +126,20 @@ export function parseCargoAddOutput(
   const lines = combined.split("\n");
   const added: { name: string; version: string }[] = [];
 
+  // Detect dry-run mode from the cargo warning message
+  const isDryRun = /warning[:\s]*aborting add due to dry run/i.test(combined);
+
   for (const line of lines) {
-    const match = line.match(/Adding\s+(\S+)\s+v(\S+)\s+to\s+/);
-    if (match) {
-      added.push({ name: match[1], version: match[2] });
+    // Match both "Adding" (normal and dry-run) and "Updating" lines
+    const addMatch = line.match(/Adding\s+(\S+)\s+v(\S+)\s+to\s+/);
+    if (addMatch) {
+      added.push({ name: addMatch[1], version: addMatch[2] });
+      continue;
+    }
+    // Some cargo versions use "Updating" in dry-run output when a dep is already present
+    const updateMatch = line.match(/Updating\s+(\S+)\s+v\S+\s+->\s+v(\S+)/);
+    if (updateMatch) {
+      added.push({ name: updateMatch[1], version: updateMatch[2] });
     }
   }
 
@@ -137,10 +149,15 @@ export function parseCargoAddOutput(
     total: added.length,
   };
 
+  if (isDryRun) {
+    result.dryRun = true;
+  }
+
   if (exitCode !== 0) {
-    // Extract error message from stderr
+    // Extract error message from stderr, filtering out dry-run warnings
     const errorLines = stderr
       .split("\n")
+      .filter((l) => !/aborting add due to dry run/i.test(l))
       .map((l) => l.replace(/^\s*error\s*:\s*/i, "").trim())
       .filter(Boolean);
     if (errorLines.length > 0) {
@@ -192,9 +209,11 @@ export function parseCargoRemoveOutput(
 }
 
 /**
- * Parses `cargo fmt --check` output.
- * In check mode, lists files with formatting differences (one path per line).
- * In fix mode, returns empty list (files are reformatted in place).
+ * Parses `cargo fmt` output in both check and fix (non-check) modes.
+ *
+ * Check mode: parses "Diff in <file>:" lines or bare file paths from `--check` output.
+ * Fix mode: parses file paths from `-- -l` (--files-with-diff) output, which lists
+ *   files that were actually reformatted, one path per line on stdout.
  */
 export function parseCargoFmtOutput(
   stdout: string,
@@ -228,6 +247,25 @@ export function parseCargoFmtOutput(
         !trimmed.startsWith("+") &&
         !trimmed.startsWith("-") &&
         !trimmed.startsWith("@") &&
+        trimmed.endsWith(".rs")
+      ) {
+        if (!files.includes(trimmed)) {
+          files.push(trimmed);
+        }
+      }
+    }
+  } else {
+    // In fix mode with -l flag, rustfmt lists reformatted file paths on stdout,
+    // one per line. Parse those to report which files were actually changed.
+    const combined = stdout + "\n" + stderr;
+    const lines = combined.split("\n");
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (
+        trimmed &&
+        !trimmed.startsWith("warning") &&
+        !trimmed.startsWith("error") &&
         trimmed.endsWith(".rs")
       ) {
         if (!files.includes(trimmed)) {
@@ -332,32 +370,207 @@ export function parseCargoTreeOutput(
 }
 
 /**
- * Converts a CVSS v3 base score to a severity label.
+ * Converts a CVSS score (numeric string or v2/v3/v4 vector string) to a severity label.
  * See https://www.first.org/cvss/specification-document#Qualitative-Severity-Rating-Scale
+ *
+ * Supports:
+ *   - Plain numeric scores: "9.8", "5.5", "0.0"
+ *   - CVSS v3.x vector strings: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+ *   - CVSS v2 vector strings: "(AV:N/AC:L/Au:N/C:C/I:C/A:C)"
  */
-function cvssToSeverity(
+export function cvssToSeverity(
   cvss: string | null | undefined,
 ): "critical" | "high" | "medium" | "low" | "informational" | "unknown" {
   if (!cvss) return "unknown";
 
-  // Extract numeric score from CVSS vector or raw number
-  let score: number;
-  const vectorMatch = cvss.match(/CVSS:\d+\.\d+\/.*?$/);
-  if (vectorMatch) {
-    // Try to extract the base score from the end or use a simple heuristic
-    // CVSS vectors don't embed the score directly; we need to look at AV/AC/etc.
-    // However, cargo audit often provides the score separately or we parse from the vector.
-    // In practice, cargo audit JSON may include a numeric score field too.
+  const trimmed = cvss.trim();
+
+  // Try CVSS v3.x vector string: "CVSS:3.0/..." or "CVSS:3.1/..."
+  const v3Match = trimmed.match(/^CVSS:3\.\d+\/(.*)/);
+  if (v3Match) {
+    const score = computeCvss3BaseScore(v3Match[1]);
+    if (score !== null) return scoreToSeverity(score);
     return "unknown";
   }
 
-  score = parseFloat(cvss);
+  // Try CVSS v2 vector string: "(AV:N/AC:L/Au:N/C:C/I:C/A:C)" or "AV:N/AC:L/..."
+  const v2Cleaned = trimmed.replace(/^\(|\)$/g, "");
+  if (/^AV:[NAL]\/AC:[HML]\/Au:[MSN]\/C:[NPC]\/I:[NPC]\/A:[NPC]/.test(v2Cleaned)) {
+    const score = computeCvss2BaseScore(v2Cleaned);
+    if (score !== null) return scoreToSeverity(score);
+    return "unknown";
+  }
+
+  // Try plain numeric score
+  const score = parseFloat(trimmed);
   if (isNaN(score)) return "unknown";
+  return scoreToSeverity(score);
+}
+
+/**
+ * Maps a numeric CVSS score (0.0-10.0) to a severity label.
+ */
+function scoreToSeverity(score: number): "critical" | "high" | "medium" | "low" | "informational" {
   if (score >= 9.0) return "critical";
   if (score >= 7.0) return "high";
   if (score >= 4.0) return "medium";
   if (score > 0.0) return "low";
   return "informational";
+}
+
+/**
+ * Computes the CVSS v3 base score from a vector string (without the "CVSS:3.x/" prefix).
+ * Implements the CVSS v3.1 specification scoring equations.
+ * See https://www.first.org/cvss/v3.1/specification-document#7-4-Metric-Values
+ */
+function computeCvss3BaseScore(vector: string): number | null {
+  const metrics = parseVectorMetrics(vector);
+
+  // Required base metrics
+  const av = metrics["AV"];
+  const ac = metrics["AC"];
+  const pr = metrics["PR"];
+  const ui = metrics["UI"];
+  const s = metrics["S"];
+  const c = metrics["C"];
+  const i = metrics["I"];
+  const a = metrics["A"];
+
+  if (!av || !ac || !pr || !ui || !s || !c || !i || !a) return null;
+
+  // Attack Vector
+  const avScores: Record<string, number> = { N: 0.85, A: 0.62, L: 0.55, P: 0.2 };
+  // Attack Complexity
+  const acScores: Record<string, number> = { L: 0.77, H: 0.44 };
+  // User Interaction
+  const uiScores: Record<string, number> = { N: 0.85, R: 0.62 };
+  // Confidentiality, Integrity, Availability Impact
+  const impactScores: Record<string, number> = { H: 0.56, L: 0.22, N: 0 };
+
+  // Privileges Required (depends on Scope)
+  const scopeChanged = s === "C";
+  const prScores: Record<string, Record<string, number>> = {
+    U: { N: 0.85, L: 0.62, H: 0.27 },
+    C: { N: 0.85, L: 0.68, H: 0.5 },
+  };
+
+  const avVal = avScores[av];
+  const acVal = acScores[ac];
+  const prVal = prScores[scopeChanged ? "C" : "U"]?.[pr];
+  const uiVal = uiScores[ui];
+  const cVal = impactScores[c];
+  const iVal = impactScores[i];
+  const aVal = impactScores[a];
+
+  if (
+    avVal === undefined ||
+    acVal === undefined ||
+    prVal === undefined ||
+    uiVal === undefined ||
+    cVal === undefined ||
+    iVal === undefined ||
+    aVal === undefined
+  ) {
+    return null;
+  }
+
+  // ISS = 1 - [(1 - C) x (1 - I) x (1 - A)]
+  const iss = 1 - (1 - cVal) * (1 - iVal) * (1 - aVal);
+
+  // Impact
+  let impact: number;
+  if (scopeChanged) {
+    impact = 7.52 * (iss - 0.029) - 3.25 * Math.pow(iss - 0.02, 15);
+  } else {
+    impact = 6.42 * iss;
+  }
+
+  if (impact <= 0) return 0;
+
+  // Exploitability = 8.22 x AV x AC x PR x UI
+  const exploitability = 8.22 * avVal * acVal * prVal * uiVal;
+
+  let baseScore: number;
+  if (scopeChanged) {
+    baseScore = Math.min(1.08 * (impact + exploitability), 10);
+  } else {
+    baseScore = Math.min(impact + exploitability, 10);
+  }
+
+  // Round up to 1 decimal place (CVSS rounding)
+  return roundUp(baseScore);
+}
+
+/**
+ * Computes the CVSS v2 base score from a vector string.
+ * Implements the simplified CVSS v2 specification scoring equations.
+ * See https://www.first.org/cvss/v2/guide#3-2-1-Base-Equation
+ */
+function computeCvss2BaseScore(vector: string): number | null {
+  const metrics = parseVectorMetrics(vector);
+
+  const av = metrics["AV"];
+  const ac = metrics["AC"];
+  const au = metrics["Au"];
+  const c = metrics["C"];
+  const i = metrics["I"];
+  const a = metrics["A"];
+
+  if (!av || !ac || !au || !c || !i || !a) return null;
+
+  const avScores: Record<string, number> = { L: 0.395, A: 0.646, N: 1.0 };
+  const acScores: Record<string, number> = { H: 0.35, M: 0.61, L: 0.71 };
+  const auScores: Record<string, number> = { M: 0.45, S: 0.56, N: 0.704 };
+  const impactScores: Record<string, number> = { N: 0, P: 0.275, C: 0.66 };
+
+  const avVal = avScores[av];
+  const acVal = acScores[ac];
+  const auVal = auScores[au];
+  const cVal = impactScores[c];
+  const iVal = impactScores[i];
+  const aVal = impactScores[a];
+
+  if (
+    avVal === undefined ||
+    acVal === undefined ||
+    auVal === undefined ||
+    cVal === undefined ||
+    iVal === undefined ||
+    aVal === undefined
+  ) {
+    return null;
+  }
+
+  const impact = 10.41 * (1 - (1 - cVal) * (1 - iVal) * (1 - aVal));
+  const exploitability = 20 * avVal * acVal * auVal;
+  const fImpact = impact === 0 ? 0 : 1.176;
+  const baseScore = (0.6 * impact + 0.4 * exploitability - 1.5) * fImpact;
+
+  return roundUp(Math.max(0, baseScore));
+}
+
+/**
+ * Parses a CVSS vector string into key-value metric pairs.
+ * Example: "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" -> {AV:"N", AC:"L", ...}
+ */
+function parseVectorMetrics(vector: string): Record<string, string> {
+  const metrics: Record<string, string> = {};
+  for (const part of vector.split("/")) {
+    const colonIdx = part.indexOf(":");
+    if (colonIdx > 0) {
+      metrics[part.substring(0, colonIdx)] = part.substring(colonIdx + 1);
+    }
+  }
+  return metrics;
+}
+
+/**
+ * Rounds up to 1 decimal place per CVSS specification.
+ * "If the value to be rounded has more than one decimal place, round up."
+ */
+function roundUp(value: number): number {
+  const rounded = Math.ceil(value * 10) / 10;
+  return rounded;
 }
 
 /**

--- a/packages/server-cargo/src/schemas/index.ts
+++ b/packages/server-cargo/src/schemas/index.ts
@@ -72,6 +72,10 @@ export const CargoAddResultSchema = z.object({
   success: z.boolean(),
   added: z.array(CargoAddedPackageSchema).optional(),
   total: z.number(),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("True when --dry-run was used; Cargo.toml was not modified"),
   error: z.string().optional(),
 });
 

--- a/packages/server-cargo/src/tools/fmt.ts
+++ b/packages/server-cargo/src/tools/fmt.ts
@@ -96,6 +96,8 @@ export function registerFmtTool(server: McpServer) {
       if (config) rustfmtArgs.push("--config", config);
       if (configPath) rustfmtArgs.push("--config-path", configPath);
       if (emit) rustfmtArgs.push("--emit", emit);
+      // In non-check mode, pass -l (--files-with-diff) to get list of reformatted files
+      if (!check) rustfmtArgs.push("-l");
       if (rustfmtArgs.length > 0) {
         args.push("--", ...rustfmtArgs);
       }


### PR DESCRIPTION
## Summary

- **cargo/add**: Fix dry-run output parsing -- detect `warning: aborting add due to dry run`, expose `dryRun` field in schema, parse `Updating` lines for version bumps, filter dry-run warning from error messages
- **cargo/audit**: Rewrite `cvssToSeverity()` to compute base scores from CVSS v3.x and v2 vector strings (previously returned `"unknown"` for all vectors). Implements full CVSS v3.1 and v2 scoring equations with correct metric weight tables
- **cargo/fmt**: In non-check (fix) mode, pass `-l` (`--files-with-diff`) to rustfmt to report which files were actually reformatted instead of returning empty file list with `filesChanged: 0`

## Test plan

- [x] All 231 existing + new cargo tests pass (`pnpm --filter @paretools/cargo test`)
- [x] Build passes (`pnpm build`)
- [x] Lint clean (`pnpm --filter @paretools/cargo lint`)
- [x] Prettier formatting verified
- [ ] CI matrix (ubuntu/windows/macos x node 20/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)