### PR TITLE
feat(k8s): P0 output-schema enrichments for apply and describe

### DIFF
--- a/.changeset/k8s-p0-output-schema.md
+++ b/.changeset/k8s-p0-output-schema.md
@@ -1,0 +1,5 @@
+---
+"@paretools/k8s": minor
+---
+
+feat(k8s): parse apply output into structured resources, parse describe Events and Conditions into structured arrays

--- a/packages/server-k8s/src/schemas/index.ts
+++ b/packages/server-k8s/src/schemas/index.ts
@@ -39,6 +39,27 @@ export type KubectlGetResult = z.infer<typeof KubectlGetResultSchema>;
 
 // ── Describe result ─────────────────────────────────────────────────
 
+/** A single Kubernetes condition from `kubectl describe`. */
+export const K8sConditionSchema = z.object({
+  type: z.string(),
+  status: z.string(),
+  reason: z.string().optional(),
+  message: z.string().optional(),
+});
+
+export type K8sCondition = z.infer<typeof K8sConditionSchema>;
+
+/** A single Kubernetes event from `kubectl describe`. */
+export const K8sEventSchema = z.object({
+  type: z.string(),
+  reason: z.string(),
+  age: z.string(),
+  from: z.string(),
+  message: z.string(),
+});
+
+export type K8sEvent = z.infer<typeof K8sEventSchema>;
+
 /** Zod schema for structured `kubectl describe` output. */
 export const KubectlDescribeResultSchema = z.object({
   action: z.literal("describe"),
@@ -47,6 +68,8 @@ export const KubectlDescribeResultSchema = z.object({
   name: z.string(),
   namespace: z.string().optional(),
   output: z.string().optional(),
+  conditions: z.array(K8sConditionSchema).optional(),
+  events: z.array(K8sEventSchema).optional(),
   exitCode: z.number().optional(),
   error: z.string().optional(),
 });
@@ -72,10 +95,21 @@ export type KubectlLogsResult = z.infer<typeof KubectlLogsResultSchema>;
 
 // ── Apply result ────────────────────────────────────────────────────
 
+/** A single resource affected by `kubectl apply`. */
+export const K8sAppliedResourceSchema = z.object({
+  kind: z.string(),
+  name: z.string(),
+  namespace: z.string().optional(),
+  operation: z.enum(["created", "configured", "unchanged", "deleted", "pruned", "unknown"]),
+});
+
+export type K8sAppliedResource = z.infer<typeof K8sAppliedResourceSchema>;
+
 /** Zod schema for structured `kubectl apply` output. */
 export const KubectlApplyResultSchema = z.object({
   action: z.literal("apply"),
   success: z.boolean(),
+  resources: z.array(K8sAppliedResourceSchema).optional(),
   output: z.string().optional(),
   exitCode: z.number().optional(),
   error: z.string().optional(),

--- a/packages/server-k8s/src/tools/apply.ts
+++ b/packages/server-k8s/src/tools/apply.ts
@@ -176,7 +176,6 @@ export function registerApplyTool(server: McpServer) {
       if (cascade) {
         args.push("--cascade", cascade);
       }
-      args.push("-o", "json");
 
       const result = await run("kubectl", args, { timeout: 180_000 });
       const data = parseApplyOutput(result.stdout, result.stderr, result.exitCode);


### PR DESCRIPTION
## Summary
- **#54 — k8s/apply**: Parse `kubectl apply` text output into structured `resources` array with `{kind, name, namespace, operation}` where operation is `created | configured | unchanged | deleted | pruned | unknown`. Removes `-o json` flag so we get the parseable text output (e.g., `deployment.apps/my-app configured`).
- **#55 — k8s/describe**: Parse the Events section into a structured `events` array with `{type, reason, age, from, message}`.
- **#56 — k8s/describe**: Parse the Conditions section into a structured `conditions` array with `{type, status, reason, message}`.

## Changes
- `schemas/index.ts`: Added `K8sConditionSchema`, `K8sEventSchema`, `K8sAppliedResourceSchema`; enriched `KubectlDescribeResultSchema` with `conditions` and `events` arrays; enriched `KubectlApplyResultSchema` with `resources` array.
- `lib/parsers.ts`: Added `parseDescribeConditions()`, `parseDescribeEvents()`, `parseApplyLine()` parsers; updated `parseDescribeOutput()` and `parseApplyOutput()` to use them.
- `lib/formatters.ts`: Updated full and compact formatters for describe and apply to use the new structured fields.
- `tools/apply.ts`: Removed `-o json` flag to get text output that includes operation status.
- Tests: 239 tests passing (parsers, formatters, compact, integration, security).

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm --filter @paretools/k8s test` — all 239 tests pass
- [x] Integration tests validate structured output against Zod schemas via MCP SDK
- [x] New parser unit tests cover conditions/events/resources parsing with fixtures
- [x] Edge cases: missing sections, `<none>` events, separator lines, dry-run annotations, mixed warning lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)