### PR TITLE
feat(cargo): P0 output-schema enrichments for doc, fmt, test, tree, update

### DIFF
--- a/.changeset/cargo-p0-output-schema.md
+++ b/.changeset/cargo-p0-output-schema.md
@@ -1,0 +1,5 @@
+---
+"@paretools/cargo": minor
+---
+
+feat(cargo): add structured warnings to doc, clarify fmt success semantics, capture test failure output, parse tree and update into structured data


### PR DESCRIPTION
## Summary

Implements 5 P0 output-schema enrichments for the `@paretools/cargo` package:

- **cargo/doc (#3)**: Add structured `warningDetails` array with `{file, line, message}` parsed from stderr location markers (e.g., `warning: missing docs` + `--> src/lib.rs:10:1`)
- **cargo/fmt (#5)**: Add `needsFormatting: boolean` to distinguish check-mode "needs formatting" (exit code 1 with files) from actual errors. In fix mode, `needsFormatting` is always `false`
- **cargo/test (#7)**: Capture stdout/stderr for failed tests by parsing `---- <name> stdout ----` sections and attaching output to the failed test entries
- **cargo/tree (#8)**: Parse ASCII dependency tree into structured `dependencies: [{name, version, depth}]` flat list alongside the raw tree text
- **cargo/update (#9)**: Parse `Updating/Locking/Downgrading` lines into structured `updated: [{name, from, to}]` entries with `totalUpdated` count

All changes are backward-compatible schema additions (new optional fields).

## Files changed

- `packages/server-cargo/src/schemas/index.ts` — New Zod schemas for warning details, dependency nodes, updated packages; added `needsFormatting` to fmt, `output` to test cases
- `packages/server-cargo/src/lib/parsers.ts` — Enhanced parsers for all 5 tools with structured data extraction
- `packages/server-cargo/src/lib/formatters.ts` — Updated human-readable and compact formatters to use new fields
- `packages/server-cargo/__tests__/` — Comprehensive test coverage for all new parser and formatter behavior

## Test plan

- [x] `pnpm build` passes (all packages)
- [x] `pnpm --filter @paretools/cargo test` passes (252 tests, 11 test files)
- [ ] CI matrix (ubuntu/windows/macos x node 20/22) passes

Generated with [Claude Code](https://claude.com/claude-code)