### PR TITLE
feat(docker,go,python): enrich P0 output schemas

### DIFF
--- a/.changeset/misc-p0-output-schema.md
+++ b/.changeset/misc-p0-output-schema.md
@@ -1,0 +1,7 @@
+---
+"@paretools/docker": minor
+"@paretools/go": minor
+"@paretools/python": minor
+---
+
+Enrich output schemas for docker/compose-ps (structured ports), docker/pull (status enum), go/list (imports field), and python/ruff-format (filesUnchanged count)

--- a/packages/server-docker/__tests__/compact.test.ts
+++ b/packages/server-docker/__tests__/compact.test.ts
@@ -280,11 +280,12 @@ describe("formatLogsCompact", () => {
 });
 
 describe("compactPullMap", () => {
-  it("preserves digest in compact output", () => {
+  it("preserves digest and status in compact output", () => {
     const data: DockerPull = {
       image: "nginx",
       tag: "latest",
       digest: "sha256:abc123def456",
+      status: "pulled",
       success: true,
     };
 
@@ -294,20 +295,57 @@ describe("compactPullMap", () => {
       image: "nginx",
       tag: "latest",
       digest: "sha256:abc123def456",
+      status: "pulled",
       success: true,
     });
     expect(compact).toHaveProperty("digest", "sha256:abc123def456");
+    expect(compact).toHaveProperty("status", "pulled");
+  });
+
+  it("preserves up-to-date status", () => {
+    const data: DockerPull = {
+      image: "ubuntu",
+      tag: "latest",
+      status: "up-to-date",
+      success: true,
+    };
+
+    const compact = compactPullMap(data);
+
+    expect(compact.status).toBe("up-to-date");
+    expect(compact.success).toBe(true);
   });
 });
 
 describe("formatPullCompact", () => {
   it("formats compact pull", () => {
-    const compact = { image: "nginx", tag: "latest", success: true };
+    const compact = {
+      image: "nginx",
+      tag: "latest",
+      status: "pulled" as const,
+      success: true,
+    };
     expect(formatPullCompact(compact)).toBe("Pulled nginx:latest");
   });
 
+  it("formats compact pull up-to-date", () => {
+    const compact = {
+      image: "ubuntu",
+      tag: "latest",
+      digest: "sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+      status: "up-to-date" as const,
+      success: true,
+    };
+    expect(formatPullCompact(compact)).toBe("ubuntu:latest is up to date (sha256:abc123def456...)");
+  });
+
   it("formats compact pull failure", () => {
-    const compact = { image: "nginx", tag: "latest", success: false };
+    const compact = {
+      image: "nginx",
+      tag: "latest",
+      status: "error" as const,
+      success: false,
+    };
     expect(formatPullCompact(compact)).toBe("Pull failed for nginx:latest");
   });
 });

--- a/packages/server-docker/__tests__/formatters.test.ts
+++ b/packages/server-docker/__tests__/formatters.test.ts
@@ -333,7 +333,7 @@ describe("formatVolumeLs", () => {
 });
 
 describe("formatComposePs", () => {
-  it("formats compose service list with ports", () => {
+  it("formats compose service list with structured ports", () => {
     const data: DockerComposePs = {
       services: [
         {
@@ -341,7 +341,7 @@ describe("formatComposePs", () => {
           service: "web",
           state: "running",
           status: "Up 2 hours",
-          ports: "0.0.0.0:8080->80/tcp",
+          ports: [{ host: 8080, container: 80, protocol: "tcp" }],
         },
         { name: "myapp-db-1", service: "db", state: "running", status: "Up 2 hours" },
       ],
@@ -350,8 +350,26 @@ describe("formatComposePs", () => {
     const output = formatComposePs(data);
     expect(output).toContain("2 services:");
     expect(output).toContain("myapp-web-1 (web)");
-    expect(output).toContain("[0.0.0.0:8080->80/tcp]");
+    expect(output).toContain("[8080->80/tcp]");
     expect(output).toContain("myapp-db-1 (db)");
+  });
+
+  it("formats compose service with container-only port (no host)", () => {
+    const data: DockerComposePs = {
+      services: [
+        {
+          name: "myapp-web-1",
+          service: "web",
+          state: "running",
+          status: "Up 1 hour",
+          ports: [{ container: 3000, protocol: "tcp" }],
+        },
+      ],
+      total: 1,
+    };
+    const output = formatComposePs(data);
+    expect(output).toContain("[3000/tcp]");
+    expect(output).not.toContain("->");
   });
 
   it("formats empty compose service list", () => {

--- a/packages/server-docker/src/schemas/index.ts
+++ b/packages/server-docker/src/schemas/index.ts
@@ -113,11 +113,12 @@ export const DockerComposeDownSchema = z.object({
 
 export type DockerComposeDown = z.infer<typeof DockerComposeDownSchema>;
 
-/** Zod schema for structured docker pull output with image, tag, digest, and success flag. */
+/** Zod schema for structured docker pull output with image, tag, digest, status, and success flag. */
 export const DockerPullSchema = z.object({
   image: z.string(),
   tag: z.string(),
   digest: z.string().optional(),
+  status: z.enum(["pulled", "up-to-date", "error"]),
   success: z.boolean(),
 });
 
@@ -180,6 +181,13 @@ export const DockerVolumeLsSchema = z.object({
 
 export type DockerVolumeLs = z.infer<typeof DockerVolumeLsSchema>;
 
+/** Zod schema for a single Docker Compose service port entry parsed from the Publishers array. */
+export const ComposeServicePortSchema = z.object({
+  host: z.number().optional(),
+  container: z.number(),
+  protocol: z.enum(["tcp", "udp"]),
+});
+
 /** Zod schema for a single Docker Compose service entry. */
 export const ComposeServiceSchema = z.object({
   name: z.string(),
@@ -188,7 +196,7 @@ export const ComposeServiceSchema = z.object({
     .enum(["running", "exited", "paused", "restarting", "dead", "created", "removing"])
     .catch("created"),
   status: z.string().optional(),
-  ports: z.string().optional(),
+  ports: z.array(ComposeServicePortSchema).optional(),
 });
 
 /** Zod schema for structured docker compose ps output. */

--- a/packages/server-go/__tests__/parsers.test.ts
+++ b/packages/server-go/__tests__/parsers.test.ts
@@ -437,6 +437,35 @@ describe("parseGoListOutput", () => {
     expect(result.total).toBe(1);
     expect(result.packages[0].goFiles).toBeUndefined();
   });
+
+  it("captures Imports field from go list -json output", () => {
+    const stdout = JSON.stringify({
+      Dir: "/home/user/project",
+      ImportPath: "github.com/user/project",
+      Name: "main",
+      GoFiles: ["main.go"],
+      Imports: ["fmt", "os", "github.com/user/project/pkg/util"],
+    });
+
+    const result = parseGoListOutput(stdout, 0);
+
+    expect(result.total).toBe(1);
+    expect(result.packages[0].imports).toEqual(["fmt", "os", "github.com/user/project/pkg/util"]);
+  });
+
+  it("handles package without Imports field", () => {
+    const stdout = JSON.stringify({
+      Dir: "/home/user/project",
+      ImportPath: "github.com/user/project",
+      Name: "main",
+      GoFiles: ["main.go"],
+    });
+
+    const result = parseGoListOutput(stdout, 0);
+
+    expect(result.total).toBe(1);
+    expect(result.packages[0].imports).toBeUndefined();
+  });
 });
 
 describe("parseGoGetOutput", () => {

--- a/packages/server-go/src/lib/formatters.ts
+++ b/packages/server-go/src/lib/formatters.ts
@@ -316,7 +316,9 @@ export function formatGoList(data: GoListResult): string {
 
   const lines = [`go list: ${data.total} packages`];
   for (const pkg of data.packages ?? []) {
-    lines.push(`  ${pkg.importPath} (${pkg.name})`);
+    const importsCount = pkg.imports?.length ?? 0;
+    const importsSuffix = importsCount > 0 ? ` [${importsCount} imports]` : "";
+    lines.push(`  ${pkg.importPath} (${pkg.name})${importsSuffix}`);
   }
   return lines.join("\n");
 }

--- a/packages/server-go/src/lib/parsers.ts
+++ b/packages/server-go/src/lib/parsers.ts
@@ -334,6 +334,7 @@ export function parseGoListOutput(stdout: string, exitCode: number): GoListResul
     name: string;
     goFiles?: string[];
     testGoFiles?: string[];
+    imports?: string[];
   }[] = [];
 
   if (!stdout.trim()) {
@@ -353,6 +354,7 @@ export function parseGoListOutput(stdout: string, exitCode: number): GoListResul
         name: pkg.Name ?? "",
         goFiles: pkg.GoFiles,
         testGoFiles: pkg.TestGoFiles,
+        imports: pkg.Imports,
       });
     } catch {
       // skip malformed JSON chunks

--- a/packages/server-go/src/schemas/index.ts
+++ b/packages/server-go/src/schemas/index.ts
@@ -120,6 +120,7 @@ export const GoListPackageSchema = z.object({
   name: z.string(),
   goFiles: z.array(z.string()).optional(),
   testGoFiles: z.array(z.string()).optional(),
+  imports: z.array(z.string()).optional(),
 });
 
 /** Zod schema for structured go list output with package list and total count. */

--- a/packages/server-python/__tests__/compact.test.ts
+++ b/packages/server-python/__tests__/compact.test.ts
@@ -495,10 +495,11 @@ describe("formatPipShowCompact", () => {
 // ── Ruff Format compact ──────────────────────────────────────────────
 
 describe("compactRuffFormatMap", () => {
-  it("keeps success and filesChanged, drops file list", () => {
+  it("keeps success, filesChanged, filesUnchanged; drops file list", () => {
     const data: RuffFormatResult = {
       success: true,
       filesChanged: 3,
+      filesUnchanged: 7,
       files: ["a.py", "b.py", "c.py"],
     };
 
@@ -506,23 +507,38 @@ describe("compactRuffFormatMap", () => {
 
     expect(compact.success).toBe(true);
     expect(compact.filesChanged).toBe(3);
+    expect(compact.filesUnchanged).toBe(7);
     expect(compact).not.toHaveProperty("files");
   });
 });
 
 describe("formatRuffFormatCompact", () => {
-  it("formats all clean", () => {
-    const compact = { success: true, filesChanged: 0 };
+  it("formats all clean with unchanged count", () => {
+    const compact = { success: true, filesChanged: 0, filesUnchanged: 10 };
+    expect(formatRuffFormatCompact(compact)).toBe(
+      "ruff format: all files already formatted. (10 unchanged)",
+    );
+  });
+
+  it("formats all clean without unchanged count", () => {
+    const compact = { success: true, filesChanged: 0, filesUnchanged: 0 };
     expect(formatRuffFormatCompact(compact)).toBe("ruff format: all files already formatted.");
   });
 
-  it("formats with reformatted files", () => {
-    const compact = { success: true, filesChanged: 3 };
+  it("formats with reformatted files and unchanged", () => {
+    const compact = { success: true, filesChanged: 3, filesUnchanged: 7 };
+    expect(formatRuffFormatCompact(compact)).toBe("ruff format: 3 files reformatted, 7 unchanged");
+  });
+
+  it("formats with reformatted files and no unchanged", () => {
+    const compact = { success: true, filesChanged: 3, filesUnchanged: 0 };
     expect(formatRuffFormatCompact(compact)).toBe("ruff format: 3 files reformatted");
   });
 
   it("formats check mode with files needing formatting", () => {
-    const compact = { success: false, filesChanged: 2, checkMode: true };
-    expect(formatRuffFormatCompact(compact)).toBe("ruff format: 2 files would be reformatted");
+    const compact = { success: false, filesChanged: 2, filesUnchanged: 5, checkMode: true };
+    expect(formatRuffFormatCompact(compact)).toBe(
+      "ruff format: 2 files would be reformatted, 5 unchanged",
+    );
   });
 });

--- a/packages/server-python/__tests__/parsers.test.ts
+++ b/packages/server-python/__tests__/parsers.test.ts
@@ -592,6 +592,7 @@ describe("parseRuffFormatOutput", () => {
 
     expect(result.success).toBe(false);
     expect(result.filesChanged).toBe(2);
+    expect(result.filesUnchanged).toBe(0);
     expect(result.files).toEqual(["src/main.py", "src/utils.py"]);
     expect(result.checkMode).toBe(true);
   });
@@ -603,6 +604,7 @@ describe("parseRuffFormatOutput", () => {
 
     expect(result.success).toBe(true);
     expect(result.filesChanged).toBe(1);
+    expect(result.filesUnchanged).toBe(0);
     expect(result.files).toEqual(["src/main.py"]);
     expect(result.checkMode).toBe(false);
   });
@@ -614,6 +616,7 @@ describe("parseRuffFormatOutput", () => {
 
     expect(result.success).toBe(true);
     expect(result.filesChanged).toBe(0);
+    expect(result.filesUnchanged).toBe(0);
     expect(result.files).toBeUndefined();
     expect(result.checkMode).toBe(false);
   });
@@ -623,6 +626,7 @@ describe("parseRuffFormatOutput", () => {
 
     expect(result.success).toBe(true);
     expect(result.filesChanged).toBe(0);
+    expect(result.filesUnchanged).toBe(0);
     expect(result.files).toBeUndefined();
     expect(result.checkMode).toBe(false);
   });
@@ -633,6 +637,40 @@ describe("parseRuffFormatOutput", () => {
 
     expect(result.checkMode).toBe(true);
     expect(result.filesChanged).toBe(3);
+  });
+
+  it("parses filesUnchanged from summary with both changed and unchanged", () => {
+    const stderr = ["reformatted: src/main.py", "1 file reformatted, 5 files left unchanged"].join(
+      "\n",
+    );
+
+    const result = parseRuffFormatOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(1);
+    expect(result.filesUnchanged).toBe(5);
+    expect(result.files).toEqual(["src/main.py"]);
+  });
+
+  it("parses filesUnchanged when all files are unchanged", () => {
+    const stderr = "10 files left unchanged";
+
+    const result = parseRuffFormatOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.filesUnchanged).toBe(10);
+    expect(result.files).toBeUndefined();
+  });
+
+  it("parses check mode with unchanged count", () => {
+    const stderr = "2 files would be reformatted, 8 files would be left unchanged";
+
+    const result = parseRuffFormatOutput("", stderr, 1);
+
+    expect(result.checkMode).toBe(true);
+    expect(result.filesChanged).toBe(2);
+    expect(result.filesUnchanged).toBe(8);
   });
 });
 

--- a/packages/server-python/src/lib/formatters.ts
+++ b/packages/server-python/src/lib/formatters.ts
@@ -450,12 +450,14 @@ export function formatPipShowCompact(data: PipShowCompact): string {
 /** Formats structured ruff format results into a human-readable summary. */
 export function formatRuffFormat(data: RuffFormatResult): string {
   if (data.success && data.filesChanged === 0) {
-    return "ruff format: all files already formatted.";
+    const unchanged = data.filesUnchanged > 0 ? ` (${data.filesUnchanged} unchanged)` : "";
+    return `ruff format: all files already formatted.${unchanged}`;
   }
 
   const lines: string[] = [];
   const verb = data.checkMode ? "would be reformatted" : "reformatted";
-  lines.push(`ruff format: ${data.filesChanged} files ${verb}`);
+  const unchanged = data.filesUnchanged > 0 ? `, ${data.filesUnchanged} unchanged` : "";
+  lines.push(`ruff format: ${data.filesChanged} files ${verb}${unchanged}`);
 
   if (data.files && data.files.length > 0) {
     for (const f of data.files) {
@@ -466,11 +468,12 @@ export function formatRuffFormat(data: RuffFormatResult): string {
   return lines.join("\n");
 }
 
-/** Compact ruff-format: success + filesChanged count + checkMode. Drop individual file lists. */
+/** Compact ruff-format: success + filesChanged count + filesUnchanged + checkMode. Drop individual file lists. */
 export interface RuffFormatResultCompact {
   [key: string]: unknown;
   success: boolean;
   filesChanged: number;
+  filesUnchanged: number;
   checkMode?: boolean;
 }
 
@@ -478,16 +481,19 @@ export function compactRuffFormatMap(data: RuffFormatResult): RuffFormatResultCo
   return {
     success: data.success,
     filesChanged: data.filesChanged,
+    filesUnchanged: data.filesUnchanged,
     checkMode: data.checkMode || undefined,
   };
 }
 
 export function formatRuffFormatCompact(data: RuffFormatResultCompact): string {
   if (data.success && data.filesChanged === 0) {
-    return "ruff format: all files already formatted.";
+    const unchanged = data.filesUnchanged > 0 ? ` (${data.filesUnchanged} unchanged)` : "";
+    return `ruff format: all files already formatted.${unchanged}`;
   }
   const verb = data.checkMode ? "would be reformatted" : "reformatted";
-  return `ruff format: ${data.filesChanged} files ${verb}`;
+  const unchanged = data.filesUnchanged > 0 ? `, ${data.filesUnchanged} unchanged` : "";
+  return `ruff format: ${data.filesChanged} files ${verb}${unchanged}`;
 }
 
 // ── conda formatters ─────────────────────────────────────────────────

--- a/packages/server-python/src/lib/parsers.ts
+++ b/packages/server-python/src/lib/parsers.ts
@@ -618,9 +618,14 @@ export function parseRuffFormatOutput(
   const reformattedMatch = output.match(/(\d+) files? (?:would be )?reformatted/);
   const filesChanged = reformattedMatch ? parseInt(reformattedMatch[1], 10) : files.length;
 
+  // Parse unchanged count: "N files left unchanged" or "N files would be left unchanged"
+  const unchangedMatch = output.match(/(\d+) files? (?:would be )?left unchanged/);
+  const filesUnchanged = unchangedMatch ? parseInt(unchangedMatch[1], 10) : 0;
+
   return {
     success: exitCode === 0,
     filesChanged: filesChanged || files.length,
+    filesUnchanged,
     files: files.length > 0 ? files : undefined,
     checkMode,
   };

--- a/packages/server-python/src/schemas/index.ts
+++ b/packages/server-python/src/schemas/index.ts
@@ -191,6 +191,7 @@ export type PipShow = z.infer<typeof PipShowSchema>;
 export const RuffFormatResultSchema = z.object({
   success: z.boolean(),
   filesChanged: z.number(),
+  filesUnchanged: z.number(),
   files: z.array(z.string()).optional(),
   checkMode: z.boolean().optional(),
 });


### PR DESCRIPTION
## Summary
- **docker/compose-ps**: Parse `Publishers` array from `docker compose ps --format json` into structured port objects `{host, container, protocol}` instead of raw string. Handles both PascalCase and snake_case JSON keys from different compose versions.
- **docker/pull**: Add `status` field with enum `"pulled" | "up-to-date" | "error"` to detect pull result state from output parsing.
- **go/list**: Add `imports: string[]` to the package schema, capturing the `Imports` field from `go list -json` output.
- **python/ruff-format**: Add `filesUnchanged: number` to the schema by parsing the ruff format summary output (e.g., "5 files left unchanged").

All 4 items are P0 output-schema enrichments that add structured data agents can act on.

## Test plan
- [x] All docker tests pass (377 tests, 10 test files)
- [x] All python tests pass (354 tests, 11 test files)
- [x] All go tests pass (267 tests, 12 test files)
- [x] Build succeeds for all 3 packages
- [x] New unit tests cover compose-ps structured ports, pull status enum, go list imports, ruff-format filesUnchanged
- [x] Compact tests updated for docker/pull status and python/ruff-format filesUnchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)