### PR TITLE
feat(git): enrich output schemas for 10 tools (P0)

### DIFF
--- a/.changeset/git-p0-output-schema.md
+++ b/.changeset/git-p0-output-schema.md
@@ -1,0 +1,16 @@
+---
+"@paretools/git": minor
+---
+
+Enrich output schemas for 10 git tools with structured fields:
+
+- git/add: `files` now returns `Array<{file, status}>` instead of `string[]`
+- git/branch: populate `upstream` field from `-vv` output
+- git/cherry-pick: add `state` field ("completed", "conflict", "in-progress")
+- git/diff: add `binary: boolean` field for binary file detection
+- git/merge: add `state` field ("completed", "conflict", "already-up-to-date", "fast-forward")
+- git/rebase: add `state` field ("completed", "conflict", "in-progress")
+- git/reflog: add `totalAvailable` field for total entry count
+- git/reset: add `previousRef`/`newRef` fields
+- git/restore: add post-restore verification (`verified`, `verifiedFiles`)
+- git/worktree: add `locked`/`prunable` fields

--- a/packages/server-git/__tests__/add.test.ts
+++ b/packages/server-git/__tests__/add.test.ts
@@ -10,7 +10,10 @@ describe("parseAdd", () => {
     const result = parseAdd(statusOutput);
 
     expect(result.staged).toBe(2);
-    expect(result.files).toEqual(["src/new-file.ts", "src/index.ts"]);
+    expect(result.files).toEqual([
+      { file: "src/new-file.ts", status: "added" },
+      { file: "src/index.ts", status: "modified" },
+    ]);
   });
 
   it("handles no staged files", () => {
@@ -35,7 +38,7 @@ describe("parseAdd", () => {
     const result = parseAdd(statusOutput);
 
     expect(result.staged).toBe(1);
-    expect(result.files).toEqual(["new-name.ts"]);
+    expect(result.files).toEqual([{ file: "new-name.ts", status: "modified" }]);
   });
 
   it("handles deleted files", () => {
@@ -44,7 +47,7 @@ describe("parseAdd", () => {
     const result = parseAdd(statusOutput);
 
     expect(result.staged).toBe(1);
-    expect(result.files).toEqual(["removed-file.ts"]);
+    expect(result.files).toEqual([{ file: "removed-file.ts", status: "deleted" }]);
   });
 
   it("handles mix of staged and unstaged changes", () => {
@@ -59,7 +62,10 @@ describe("parseAdd", () => {
     const result = parseAdd(statusOutput);
 
     expect(result.staged).toBe(2);
-    expect(result.files).toEqual(["staged.ts", "added.ts"]);
+    expect(result.files).toEqual([
+      { file: "staged.ts", status: "modified" },
+      { file: "added.ts", status: "added" },
+    ]);
   });
 
   it("handles all files staged via git add -A", () => {
@@ -68,14 +74,25 @@ describe("parseAdd", () => {
     const result = parseAdd(statusOutput);
 
     expect(result.staged).toBe(4);
-    expect(result.files).toEqual(["src/a.ts", "src/b.ts", "src/c.ts", "src/old.ts"]);
+    expect(result.files).toEqual([
+      { file: "src/a.ts", status: "added" },
+      { file: "src/b.ts", status: "added" },
+      { file: "src/c.ts", status: "modified" },
+      { file: "src/old.ts", status: "deleted" },
+    ]);
   });
 });
 
 describe("formatAdd", () => {
   it("formats staged files", () => {
-    const data: GitAdd = { staged: 2, files: ["src/a.ts", "src/b.ts"] };
-    expect(formatAdd(data)).toBe("Staged 2 file(s): src/a.ts, src/b.ts");
+    const data: GitAdd = {
+      staged: 2,
+      files: [
+        { file: "src/a.ts", status: "added" },
+        { file: "src/b.ts", status: "modified" },
+      ],
+    };
+    expect(formatAdd(data)).toBe("Staged 2 file(s): a:src/a.ts, m:src/b.ts");
   });
 
   it("formats no staged files", () => {
@@ -84,7 +101,7 @@ describe("formatAdd", () => {
   });
 
   it("formats single staged file", () => {
-    const data: GitAdd = { staged: 1, files: ["README.md"] };
-    expect(formatAdd(data)).toBe("Staged 1 file(s): README.md");
+    const data: GitAdd = { staged: 1, files: [{ file: "README.md", status: "added" }] };
+    expect(formatAdd(data)).toBe("Staged 1 file(s): a:README.md");
   });
 });

--- a/packages/server-git/__tests__/cherry-pick.test.ts
+++ b/packages/server-git/__tests__/cherry-pick.test.ts
@@ -84,34 +84,41 @@ describe("formatCherryPick", () => {
   it("formats successful single-commit cherry-pick", () => {
     const data: GitCherryPick = {
       success: true,
+      state: "completed",
       applied: ["abc1234"],
       conflicts: [],
     };
     const output = formatCherryPick(data);
 
-    expect(output).toBe("Cherry-pick applied 1 commit(s): abc1234");
+    expect(output).toContain("Cherry-pick applied 1 commit(s)");
+    expect(output).toContain("[completed]");
+    expect(output).toContain("abc1234");
   });
 
   it("formats successful multi-commit cherry-pick", () => {
     const data: GitCherryPick = {
       success: true,
+      state: "completed",
       applied: ["abc1234", "def5678"],
       conflicts: [],
     };
     const output = formatCherryPick(data);
 
-    expect(output).toBe("Cherry-pick applied 2 commit(s): abc1234, def5678");
+    expect(output).toContain("Cherry-pick applied 2 commit(s)");
+    expect(output).toContain("abc1234, def5678");
   });
 
   it("formats cherry-pick with conflicts", () => {
     const data: GitCherryPick = {
       success: false,
+      state: "conflict",
       applied: [],
       conflicts: ["src/index.ts", "src/utils.ts"],
     };
     const output = formatCherryPick(data);
 
-    expect(output).toContain("Cherry-pick paused due to conflicts:");
+    expect(output).toContain("Cherry-pick paused due to conflicts");
+    expect(output).toContain("[conflict]");
     expect(output).toContain("CONFLICT: src/index.ts");
     expect(output).toContain("CONFLICT: src/utils.ts");
   });
@@ -119,23 +126,27 @@ describe("formatCherryPick", () => {
   it("formats failed cherry-pick without conflicts", () => {
     const data: GitCherryPick = {
       success: false,
+      state: "in-progress",
       applied: [],
       conflicts: [],
     };
     const output = formatCherryPick(data);
 
-    expect(output).toBe("Cherry-pick failed");
+    expect(output).toContain("Cherry-pick failed");
+    expect(output).toContain("[in-progress]");
   });
 
   it("formats abort (no commits applied)", () => {
     const data: GitCherryPick = {
       success: true,
+      state: "completed",
       applied: [],
       conflicts: [],
     };
     const output = formatCherryPick(data);
 
-    expect(output).toBe("Cherry-pick completed (no commits applied)");
+    expect(output).toContain("Cherry-pick completed");
+    expect(output).toContain("[completed]");
   });
 });
 

--- a/packages/server-git/__tests__/fidelity.test.ts
+++ b/packages/server-git/__tests__/fidelity.test.ts
@@ -715,8 +715,8 @@ describe("fidelity: git add (write tool)", () => {
     const result = parseAdd(statusOut);
 
     expect(result.staged).toBe(2);
-    expect(result.files).toContain("a.ts");
-    expect(result.files).toContain("b.ts");
+    expect(result.files.map((f) => f.file)).toContain("a.ts");
+    expect(result.files.map((f) => f.file)).toContain("b.ts");
   });
 
   it("parseAdd captures staged deletions", () => {
@@ -726,7 +726,8 @@ describe("fidelity: git add (write tool)", () => {
     const result = parseAdd(statusOut);
 
     expect(result.staged).toBe(1);
-    expect(result.files).toContain("initial.txt");
+    expect(result.files.map((f) => f.file)).toContain("initial.txt");
+    expect(result.files[0].status).toBe("deleted");
   });
 
   it("parseAdd captures staged modifications", () => {
@@ -737,7 +738,8 @@ describe("fidelity: git add (write tool)", () => {
     const result = parseAdd(statusOut);
 
     expect(result.staged).toBe(1);
-    expect(result.files).toContain("initial.txt");
+    expect(result.files.map((f) => f.file)).toContain("initial.txt");
+    expect(result.files[0].status).toBe("modified");
   });
 
   it("parseAdd ignores unstaged and untracked files", () => {
@@ -763,9 +765,9 @@ describe("fidelity: git add (write tool)", () => {
     const result = parseAdd(statusOut);
 
     expect(result.staged).toBe(3);
-    expect(result.files).toContain("new1.ts");
-    expect(result.files).toContain("new2.ts");
-    expect(result.files).toContain("initial.txt");
+    expect(result.files.map((f) => f.file)).toContain("new1.ts");
+    expect(result.files.map((f) => f.file)).toContain("new2.ts");
+    expect(result.files.map((f) => f.file)).toContain("initial.txt");
   });
 });
 

--- a/packages/server-git/__tests__/rebase.test.ts
+++ b/packages/server-git/__tests__/rebase.test.ts
@@ -9,6 +9,7 @@ describe("parseRebase", () => {
     const result = parseRebase(stdout, "", "main", "feature");
 
     expect(result.success).toBe(true);
+    expect(result.state).toBe("completed");
     expect(result.branch).toBe("main");
     expect(result.current).toBe("feature");
     expect(result.conflicts).toEqual([]);
@@ -26,6 +27,7 @@ hint: "git add/rm <conflicted_files>", then run "git rebase --continue".`;
     const result = parseRebase("", stderr, "main", "feature");
 
     expect(result.success).toBe(false);
+    expect(result.state).toBe("conflict");
     expect(result.branch).toBe("main");
     expect(result.current).toBe("feature");
     expect(result.conflicts).toEqual(["src/index.ts", "src/utils.ts"]);
@@ -57,6 +59,7 @@ error: could not apply abc1234... Update readme`;
     const result = parseRebase(stdout, stderr, "", "feature");
 
     expect(result.success).toBe(true);
+    expect(result.state).toBe("completed");
     expect(result.branch).toBe("");
     expect(result.current).toBe("feature");
     expect(result.conflicts).toEqual([]);
@@ -98,6 +101,7 @@ describe("formatRebase", () => {
   it("formats successful rebase", () => {
     const data: GitRebase = {
       success: true,
+      state: "completed",
       branch: "main",
       current: "feature",
       conflicts: [],
@@ -106,25 +110,28 @@ describe("formatRebase", () => {
     const output = formatRebase(data);
 
     expect(output).toContain("Rebased 'feature' onto 'main'");
+    expect(output).toContain("[completed]");
     expect(output).toContain("3 commit(s) rebased");
   });
 
   it("formats rebase with conflicts", () => {
     const data: GitRebase = {
       success: false,
+      state: "conflict",
       branch: "main",
       current: "feature",
       conflicts: ["src/index.ts", "src/utils.ts"],
     };
     const output = formatRebase(data);
 
-    expect(output).toContain("paused with conflicts");
+    expect(output).toContain("paused with conflicts [conflict]");
     expect(output).toContain("Conflicts: src/index.ts, src/utils.ts");
   });
 
   it("formats rebase abort", () => {
     const data: GitRebase = {
       success: true,
+      state: "completed",
       branch: "",
       current: "feature",
       conflicts: [],
@@ -137,18 +144,20 @@ describe("formatRebase", () => {
   it("formats successful rebase without commit count", () => {
     const data: GitRebase = {
       success: true,
+      state: "completed",
       branch: "main",
       current: "feature",
       conflicts: [],
     };
     const output = formatRebase(data);
 
-    expect(output).toBe("Rebased 'feature' onto 'main'");
+    expect(output).toContain("Rebased 'feature' onto 'main' [completed]");
   });
 
   it("formats rebase with conflicts but no conflict file list", () => {
     const data: GitRebase = {
       success: false,
+      state: "conflict",
       branch: "main",
       current: "feature",
       conflicts: [],

--- a/packages/server-git/src/tools/branch.ts
+++ b/packages/server-git/src/tools/branch.ts
@@ -149,8 +149,8 @@ export function registerBranchTool(server: McpServer) {
         }
       }
 
-      // List branches
-      const args = ["branch"];
+      // List branches — always use -vv to get upstream tracking info
+      const args = ["branch", "-vv"];
       if (all) args.push("-a");
       if (remotes) args.push("-r");
       if (merged) args.push("--merged");

--- a/packages/server-git/src/tools/diff.ts
+++ b/packages/server-git/src/tools/diff.ts
@@ -178,14 +178,19 @@ export function registerDiffTool(server: McpServer) {
             if (fileMatch) {
               const matchedFile = diff.files.find((f) => f.file === fileMatch[1]);
               if (matchedFile) {
-                const chunks = patch.split(/^@@/m).slice(1);
-                matchedFile.chunks = chunks.map((chunk) => {
-                  const headerEnd = chunk.indexOf("\n");
-                  return {
-                    header: `@@${chunk.slice(0, headerEnd)}`,
-                    lines: chunk.slice(headerEnd + 1),
-                  };
-                });
+                // Detect binary files from full patch output
+                if (/Binary files .* differ/.test(patch)) {
+                  matchedFile.binary = true;
+                } else {
+                  const chunks = patch.split(/^@@/m).slice(1);
+                  matchedFile.chunks = chunks.map((chunk) => {
+                    const headerEnd = chunk.indexOf("\n");
+                    return {
+                      header: `@@${chunk.slice(0, headerEnd)}`,
+                      lines: chunk.slice(headerEnd + 1),
+                    };
+                  });
+                }
               }
             }
           }

--- a/packages/server-git/src/tools/reflog.ts
+++ b/packages/server-git/src/tools/reflog.ts
@@ -131,6 +131,20 @@ export function registerReflogTool(server: McpServer) {
       }
 
       const reflog = parseReflogOutput(result.stdout);
+
+      // Count total available entries (without limit) to populate totalAvailable
+      const countArgs = ["reflog", "show", `--format=%H`];
+      if (all) countArgs.push("--all");
+      if (grepReflog) countArgs.push(`--grep-reflog=${grepReflog}`);
+      if (since) countArgs.push(`--since=${since}`);
+      if (until) countArgs.push(`--until=${until}`);
+      if (ref) countArgs.push(ref);
+      const countResult = await git(countArgs, cwd);
+      if (countResult.exitCode === 0) {
+        const totalAvailable = countResult.stdout.trim().split("\n").filter(Boolean).length;
+        reflog.totalAvailable = totalAvailable;
+      }
+
       return compactDualOutput(
         reflog,
         result.stdout,


### PR DESCRIPTION
## Summary
- Enriches output schemas for 10 `@paretools/git` tools with richer structured fields that agents can act on directly
- **git/add**: `files` now returns `Array<{file, status}>` instead of `string[]` (status: added/modified/deleted)
- **git/branch**: populates `upstream` field by parsing `-vv` output
- **git/cherry-pick**: adds `state` enum ("completed", "conflict", "in-progress")
- **git/diff**: adds `binary: boolean` field for binary file detection
- **git/merge**: adds `state` enum ("completed", "conflict", "already-up-to-date", "fast-forward")
- **git/rebase**: adds `state` enum ("completed", "conflict", "in-progress")
- **git/reflog**: adds `totalAvailable` field for total entry count (vs limited result)
- **git/reset**: adds `previousRef`/`newRef` fields via `rev-parse HEAD` before/after
- **git/restore**: adds post-restore verification (`verified`, `verifiedFiles`)
- **git/worktree**: adds `locked`/`lockReason`/`prunable` fields from porcelain output

## Changes
- **schemas/index.ts**: Updated 8 Zod schemas with new fields
- **lib/parsers.ts**: Updated 9 parser functions to extract new data
- **lib/formatters.ts**: Updated 9 formatter functions for human-readable output
- **tools/**: Updated 5 tool files (branch, diff, reflog, reset, restore) with new CLI queries
- **tests/**: Updated 7 test files with 100+ new/updated test cases covering all enrichments

## Test plan
- [x] All 557 tests pass (`pnpm --filter @paretools/git test`)
- [x] Build succeeds (`pnpm build --filter @paretools/git`)
- [x] Parser tests verify new structured fields for all 10 tools
- [x] Formatter tests verify human-readable output for all enriched fields
- [x] Fidelity tests verify real CLI output mapping for git/add changes
- [x] Integration tests verify end-to-end MCP tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)