### PR TITLE
feat(github,docker): add remaining P0 gaps

### DIFF
--- a/.changeset/github-docker-p0-remaining.md
+++ b/.changeset/github-docker-p0-remaining.md
@@ -1,0 +1,6 @@
+---
+"@paretools/github": minor
+"@paretools/docker": minor
+---
+
+feat(github,docker): add gist path validation, issue-create body stdin, docker/images filter, docker/inspect image support

--- a/packages/server-docker/src/schemas/index.ts
+++ b/packages/server-docker/src/schemas/index.ts
@@ -124,10 +124,16 @@ export const DockerPullSchema = z.object({
 
 export type DockerPull = z.infer<typeof DockerPullSchema>;
 
-/** Zod schema for structured docker inspect output with container/image details. */
+/** Zod schema for structured docker inspect output with container/image details.
+ *  The `inspectType` field distinguishes between container and image inspect results.
+ *  Container-specific fields: `state`, `healthStatus`, `restartPolicy`.
+ *  Image-specific fields: `repoTags`, `repoDigests`, `size`, `cmd`, `entrypoint`.
+ */
 export const DockerInspectSchema = z.object({
   id: z.string(),
   name: z.string(),
+  /** Discriminates between container and image inspect results. */
+  inspectType: z.enum(["container", "image"]).optional(),
   state: z
     .object({
       status: z.string(),
@@ -143,6 +149,17 @@ export const DockerInspectSchema = z.object({
   healthStatus: z.enum(["healthy", "unhealthy", "starting", "none"]).optional(),
   env: z.array(z.string()).optional(),
   restartPolicy: z.string().optional(),
+  // Image-specific fields (present when inspectType === "image")
+  /** Repository tags for the image (e.g., ["nginx:latest", "nginx:1.25"]). */
+  repoTags: z.array(z.string()).optional(),
+  /** Repository digests for the image (e.g., ["nginx@sha256:abc..."]). */
+  repoDigests: z.array(z.string()).optional(),
+  /** Image size in bytes. */
+  size: z.number().optional(),
+  /** Default command (Config.Cmd) for the image. */
+  cmd: z.array(z.string()).optional(),
+  /** Entrypoint (Config.Entrypoint) for the image. */
+  entrypoint: z.array(z.string()).optional(),
 });
 
 export type DockerInspect = z.infer<typeof DockerInspectSchema>;

--- a/packages/server-docker/src/tools/images.ts
+++ b/packages/server-docker/src/tools/images.ts
@@ -25,6 +25,13 @@ export function registerImagesTool(server: McpServer) {
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe("Filter by reference (e.g., 'myapp', 'nginx:*')"),
+        filterExpr: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "Key-value filter expression (--filter). Examples: 'dangling=true', 'reference=myimage:*', 'before=image:tag', 'since=image:tag', 'label=com.example.version'",
+          ),
         digests: z
           .boolean()
           .optional()
@@ -45,11 +52,13 @@ export function registerImagesTool(server: McpServer) {
       },
       outputSchema: DockerImagesSchema,
     },
-    async ({ all, filter, digests, noTrunc, compact }) => {
+    async ({ all, filter, filterExpr, digests, noTrunc, compact }) => {
       if (filter) assertNoFlagInjection(filter, "filter");
+      if (filterExpr) assertNoFlagInjection(filterExpr, "filterExpr");
 
       const args = ["images", "--format", "json"];
       if (all) args.push("-a");
+      if (filterExpr) args.push("--filter", filterExpr);
       if (digests) args.push("--digests");
       if (noTrunc) args.push("--no-trunc");
       if (filter) args.push(filter);

--- a/packages/server-github/__tests__/path-validation.test.ts
+++ b/packages/server-github/__tests__/path-validation.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, symlinkSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { assertSafeFilePath } from "../src/lib/path-validation.js";
+
+const TEST_DIR = join(tmpdir(), "pare-path-validation-test");
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  mkdirSync(join(TEST_DIR, "subdir"), { recursive: true });
+  writeFileSync(join(TEST_DIR, "safe.txt"), "hello");
+  writeFileSync(join(TEST_DIR, "subdir", "nested.txt"), "nested");
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("assertSafeFilePath", () => {
+  it("accepts a simple relative file path", () => {
+    expect(() => assertSafeFilePath("safe.txt", TEST_DIR)).not.toThrow();
+  });
+
+  it("accepts a nested relative file path", () => {
+    expect(() => assertSafeFilePath("subdir/nested.txt", TEST_DIR)).not.toThrow();
+  });
+
+  it("rejects path with .. traversal", () => {
+    expect(() => assertSafeFilePath("../../../etc/passwd", TEST_DIR)).toThrow(/path traversal/);
+  });
+
+  it("rejects path with embedded .. in the middle", () => {
+    expect(() => assertSafeFilePath("subdir/../../etc/passwd", TEST_DIR)).toThrow(/path traversal/);
+  });
+
+  it("rejects absolute path outside cwd", () => {
+    expect(() => assertSafeFilePath("/etc/passwd", TEST_DIR)).toThrow(
+      /outside the working directory/,
+    );
+  });
+
+  it("accepts absolute path inside cwd", () => {
+    const absPath = join(TEST_DIR, "safe.txt");
+    expect(() => assertSafeFilePath(absPath, TEST_DIR)).not.toThrow();
+  });
+
+  it("rejects symlink pointing outside cwd", () => {
+    const linkPath = join(TEST_DIR, "evil-link");
+    symlinkSync("/etc/hosts", linkPath);
+
+    expect(() => assertSafeFilePath("evil-link", TEST_DIR)).toThrow(/symlink resolves to/);
+  });
+
+  it("accepts symlink pointing inside cwd", () => {
+    const linkPath = join(TEST_DIR, "safe-link");
+    symlinkSync(join(TEST_DIR, "safe.txt"), linkPath);
+
+    expect(() => assertSafeFilePath("safe-link", TEST_DIR)).not.toThrow();
+  });
+
+  it("accepts a file that does not exist (no symlink check needed)", () => {
+    // Non-existent files are OK — the traversal/absolute checks still apply
+    expect(() => assertSafeFilePath("does-not-exist.txt", TEST_DIR)).not.toThrow();
+  });
+
+  it("rejects a non-existent file with .. traversal", () => {
+    expect(() => assertSafeFilePath("../nonexistent.txt", TEST_DIR)).toThrow(/path traversal/);
+  });
+});

--- a/packages/server-github/src/lib/path-validation.ts
+++ b/packages/server-github/src/lib/path-validation.ts
@@ -1,0 +1,62 @@
+import { realpathSync, lstatSync } from "node:fs";
+import { resolve, isAbsolute, relative } from "node:path";
+
+/**
+ * Validates that a file path is safe to pass to `gh gist create`.
+ * Rejects paths that:
+ *  - Contain `..` path traversal components
+ *  - Are absolute paths outside the working directory
+ *  - Are symlinks pointing outside the working directory
+ *
+ * @param filePath  The user-supplied file path
+ * @param cwd       The working directory used as the trust boundary
+ * @throws Error if the path is unsafe
+ */
+export function assertSafeFilePath(filePath: string, cwd: string): void {
+  // Reject path traversal via ".."
+  if (filePath.includes("..")) {
+    throw new Error(
+      `Unsafe file path "${filePath}": path traversal ("..") is not allowed. ` +
+        `Provide a relative path within the working directory.`,
+    );
+  }
+
+  // Resolve the path relative to cwd
+  const resolvedPath = resolve(cwd, filePath);
+
+  // Reject absolute paths outside the cwd
+  if (isAbsolute(filePath)) {
+    const rel = relative(cwd, resolvedPath);
+    if (rel.startsWith("..")) {
+      throw new Error(
+        `Unsafe file path "${filePath}": absolute path is outside the working directory "${cwd}". ` +
+          `Provide a relative path within the working directory.`,
+      );
+    }
+  }
+
+  // Check for symlinks pointing outside cwd
+  try {
+    const stat = lstatSync(resolvedPath);
+    if (stat.isSymbolicLink()) {
+      const realTarget = realpathSync(resolvedPath);
+      // Resolve the real cwd too, to handle macOS /var -> /private/var symlinks
+      const realCwd = realpathSync(cwd);
+      const rel = relative(realCwd, realTarget);
+      if (rel.startsWith("..")) {
+        throw new Error(
+          `Unsafe file path "${filePath}": symlink resolves to "${realTarget}" ` +
+            `which is outside the working directory "${cwd}".`,
+        );
+      }
+    }
+  } catch (err) {
+    // If the file doesn't exist yet (ENOENT), we can't check symlinks
+    // but path traversal and absolute path checks above still apply.
+    // Re-throw our own errors, ignore ENOENT.
+    if (err instanceof Error && err.message.startsWith("Unsafe file path")) {
+      throw err;
+    }
+    // File doesn't exist — path-traversal / absolute checks above are sufficient
+  }
+}

--- a/packages/server-github/src/tools/gist-create.ts
+++ b/packages/server-github/src/tools/gist-create.ts
@@ -5,6 +5,7 @@ import { ghCmd } from "../lib/gh-runner.js";
 import { parseGistCreate } from "../lib/parsers.js";
 import { formatGistCreate } from "../lib/formatters.js";
 import { GistCreateResultSchema } from "../schemas/index.js";
+import { assertSafeFilePath } from "../lib/path-validation.js";
 
 /** Registers the `gist-create` tool on the given MCP server. */
 export function registerGistCreateTool(server: McpServer) {
@@ -42,6 +43,12 @@ export function registerGistCreateTool(server: McpServer) {
       const cwd = path || process.cwd();
 
       if (description) assertNoFlagInjection(description, "description");
+
+      // Validate all file paths are safe before passing to gh CLI
+      for (const file of files) {
+        assertNoFlagInjection(file, "files");
+        assertSafeFilePath(file, cwd);
+      }
 
       const args = ["gist", "create"];
       if (description) {

--- a/packages/server-github/src/tools/issue-create.ts
+++ b/packages/server-github/src/tools/issue-create.ts
@@ -79,7 +79,9 @@ export function registerIssueCreateTool(server: McpServer) {
       if (template) assertNoFlagInjection(template, "template");
       if (repo) assertNoFlagInjection(repo, "repo");
 
-      const args = ["issue", "create", "--title", title, "--body", body];
+      // Use --body-file - to pass body via stdin, avoiding shell escaping issues
+      // for long bodies with special characters
+      const args = ["issue", "create", "--title", title, "--body-file", "-"];
       if (labels && labels.length > 0) {
         for (const label of labels) {
           args.push("--label", label);
@@ -100,7 +102,7 @@ export function registerIssueCreateTool(server: McpServer) {
       // S-gap P1: Map repo to --repo
       if (repo) args.push("--repo", repo);
 
-      const result = await ghCmd(args, cwd);
+      const result = await ghCmd(args, { cwd, stdin: body });
 
       if (result.exitCode !== 0) {
         throw new Error(`gh issue create failed: ${result.stderr}`);


### PR DESCRIPTION
## Summary

- **docker/images**: Add `filterExpr` parameter mapping to `--filter` for key-value filters (`dangling=true`, `reference=myimage:*`, `before=image:tag`, `since=image:tag`, `label=...`). Uses `assertNoFlagInjection()` on the value.
- **docker/inspect**: Detect image-type inspect output (no `State` field, has `RepoTags`/`RootFS`) and extract image-specific fields: `repoTags`, `repoDigests`, `size`, `cmd`, `entrypoint`, and `platform` (from `Architecture`+`Os`). Added `inspectType` discriminator field to output schema.
- **github/gist-create**: Add `assertSafeFilePath()` validation that rejects paths with `..` traversal, absolute paths outside CWD, and symlinks pointing outside CWD. Applied to all file paths before passing to `gh gist create`.
- **github/issue-create**: Use `--body-file -` with stdin instead of `--body` arg to avoid shell escaping issues for long bodies with special characters.
- **github/issue-update**: Improve schema documentation with grouped field descriptions, mutual exclusivity notes for milestone/removeMilestone, and clearer `describe()` strings for all parameters.

## Test plan

- [x] All 381 docker tests pass (`pnpm --filter @paretools/docker test`)
- [x] All 273 github tests pass (`pnpm --filter @paretools/github test`)
- [x] New image-inspect parser tests (4 tests) cover image/container detection, minimal fields, and backward compat
- [x] New path validation tests (10 tests) cover traversal, absolute paths, symlinks inside/outside CWD
- [x] Build succeeds for both packages (`pnpm build`)
- [ ] CI matrix (ubuntu/windows/macos x node 20/22) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)