### PR TITLE
feat(go): add remaining P0 gaps (version resolution, modules, output limits, vet JSON)

### DIFF
--- a/.changeset/go-p0-remaining.md
+++ b/.changeset/go-p0-remaining.md
@@ -1,0 +1,5 @@
+---
+"@paretools/go": minor
+---
+
+feat(go): add go/get version resolution, go/list modules mode, go/run output limits, go/vet JSON parsing

--- a/packages/server-go/__tests__/compact.test.ts
+++ b/packages/server-go/__tests__/compact.test.ts
@@ -495,6 +495,7 @@ describe("compactGetMap", () => {
     const compact = compactGetMap(data);
 
     expect(compact.success).toBe(true);
+    expect(compact.resolvedCount).toBe(0);
     expect(compact.output).toBe("go: downloading github.com/pkg/errors v0.9.1");
   });
 
@@ -507,6 +508,7 @@ describe("compactGetMap", () => {
     const compact = compactGetMap(data);
 
     expect(compact.success).toBe(true);
+    expect(compact.resolvedCount).toBe(0);
     expect(compact).not.toHaveProperty("output");
   });
 
@@ -519,18 +521,41 @@ describe("compactGetMap", () => {
     const compact = compactGetMap(data);
 
     expect(compact.success).toBe(false);
+    expect(compact.resolvedCount).toBe(0);
     expect(compact.output).toBe(
       'go: module github.com/nonexistent/pkg: no matching versions for query "latest"',
     );
+  });
+
+  it("includes resolvedCount when packages are resolved", () => {
+    const data: GoGetResult = {
+      success: true,
+      output: "go: upgraded golang.org/x/text v0.3.7 => v0.14.0",
+      resolvedPackages: [
+        { package: "golang.org/x/text", previousVersion: "v0.3.7", newVersion: "v0.14.0" },
+      ],
+    };
+
+    const compact = compactGetMap(data);
+
+    expect(compact.success).toBe(true);
+    expect(compact.resolvedCount).toBe(1);
+    expect(compact).not.toHaveProperty("output");
   });
 });
 
 describe("formatGetCompact", () => {
   it("formats successful get", () => {
-    expect(formatGetCompact({ success: true })).toBe("go get: success.");
+    expect(formatGetCompact({ success: true, resolvedCount: 0 })).toBe("go get: success.");
   });
 
   it("formats failed get", () => {
-    expect(formatGetCompact({ success: false })).toBe("go get: FAIL");
+    expect(formatGetCompact({ success: false, resolvedCount: 0 })).toBe("go get: FAIL");
+  });
+
+  it("formats successful get with resolved packages", () => {
+    expect(formatGetCompact({ success: true, resolvedCount: 3 })).toBe(
+      "go get: success, 3 packages resolved.",
+    );
   });
 });

--- a/packages/server-go/__tests__/run-tool.test.ts
+++ b/packages/server-go/__tests__/run-tool.test.ts
@@ -63,6 +63,12 @@ describe("parseGoRunOutput", () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("no such file or directory");
   });
+
+  it("does not set truncation flags by default", () => {
+    const result = parseGoRunOutput("output", "errors", 0);
+    expect(result.stdoutTruncated).toBeUndefined();
+    expect(result.stderrTruncated).toBeUndefined();
+  });
 });
 
 describe("formatGoRun", () => {
@@ -112,5 +118,81 @@ describe("formatGoRun", () => {
     expect(output).toContain("go run: success.");
     expect(output).toContain("result: 42");
     expect(output).toContain("debug info");
+  });
+});
+
+describe("output truncation (maxOutput)", () => {
+  it("truncates stdout when exceeding maxOutput and sets flag", () => {
+    const longOutput = "x".repeat(2048);
+    const data = parseGoRunOutput(longOutput + "\n", "", 0);
+    const maxOutput = 1024;
+
+    // Simulate the truncation logic from run.ts
+    if (data.stdout && data.stdout.length > maxOutput) {
+      data.stdout = data.stdout.slice(0, maxOutput) + "\n... (truncated)";
+      data.stdoutTruncated = true;
+    }
+
+    expect(data.stdoutTruncated).toBe(true);
+    expect(data.stdout!.length).toBeLessThan(longOutput.length);
+    expect(data.stdout).toContain("... (truncated)");
+  });
+
+  it("truncates stderr when exceeding maxOutput and sets flag", () => {
+    const longError = "e".repeat(2048);
+    const data = parseGoRunOutput("", longError + "\n", 1);
+    const maxOutput = 1024;
+
+    if (data.stderr && data.stderr.length > maxOutput) {
+      data.stderr = data.stderr.slice(0, maxOutput) + "\n... (truncated)";
+      data.stderrTruncated = true;
+    }
+
+    expect(data.stderrTruncated).toBe(true);
+    expect(data.stderr!.length).toBeLessThan(longError.length);
+    expect(data.stderr).toContain("... (truncated)");
+  });
+
+  it("does not truncate when output is within limit", () => {
+    const data = parseGoRunOutput("short output\n", "short error\n", 0);
+    const maxOutput = 1024;
+
+    if (data.stdout && data.stdout.length > maxOutput) {
+      data.stdout = data.stdout.slice(0, maxOutput) + "\n... (truncated)";
+      data.stdoutTruncated = true;
+    }
+    if (data.stderr && data.stderr.length > maxOutput) {
+      data.stderr = data.stderr.slice(0, maxOutput) + "\n... (truncated)";
+      data.stderrTruncated = true;
+    }
+
+    expect(data.stdoutTruncated).toBeUndefined();
+    expect(data.stderrTruncated).toBeUndefined();
+    expect(data.stdout).toBe("short output");
+    expect(data.stderr).toBe("short error");
+  });
+
+  it("formats truncated output with indicator", () => {
+    const data: GoRunResult = {
+      success: true,
+      exitCode: 0,
+      stdout: "truncated content\n... (truncated)",
+      stderr: "",
+      stdoutTruncated: true,
+    };
+    const output = formatGoRun(data);
+    expect(output).toContain("[stdout truncated]");
+  });
+
+  it("formats truncated stderr with indicator", () => {
+    const data: GoRunResult = {
+      success: false,
+      exitCode: 1,
+      stdout: "",
+      stderr: "truncated errors\n... (truncated)",
+      stderrTruncated: true,
+    };
+    const output = formatGoRun(data);
+    expect(output).toContain("[stderr truncated]");
   });
 });

--- a/packages/server-go/src/schemas/index.ts
+++ b/packages/server-go/src/schemas/index.ts
@@ -48,12 +48,14 @@ export const GoTestResultSchema = z.object({
 
 export type GoTestResult = z.infer<typeof GoTestResultSchema>;
 
-/** Zod schema for a single go vet diagnostic with file location and message. */
+/** Zod schema for a single go vet diagnostic with file location, message, and analyzer name. */
 export const GoVetDiagnosticSchema = z.object({
   file: z.string(),
   line: z.number(),
   column: z.number().optional(),
   message: z.string(),
+  /** The analyzer that produced this diagnostic (e.g., "printf", "shadow", "unusedresult"). */
+  analyzer: z.string().optional(),
 });
 
 /** Zod schema for structured go vet output with diagnostic list, total count, and success status. */
@@ -70,6 +72,10 @@ export const GoRunResultSchema = z.object({
   exitCode: z.number(),
   stdout: z.string().optional(),
   stderr: z.string().optional(),
+  /** Whether stdout was truncated due to maxOutput limit. */
+  stdoutTruncated: z.boolean().optional(),
+  /** Whether stderr was truncated due to maxOutput limit. */
+  stderrTruncated: z.boolean().optional(),
   success: z.boolean(),
 });
 
@@ -123,19 +129,44 @@ export const GoListPackageSchema = z.object({
   imports: z.array(z.string()).optional(),
 });
 
-/** Zod schema for structured go list output with package list and total count. */
+/** Zod schema for a single Go module from go list -m output. */
+export const GoListModuleSchema = z.object({
+  path: z.string(),
+  version: z.string().optional(),
+  dir: z.string().optional(),
+  goMod: z.string().optional(),
+  goVersion: z.string().optional(),
+  main: z.boolean().optional(),
+  indirect: z.boolean().optional(),
+});
+
+/** Zod schema for structured go list output with package/module list and total count. */
 export const GoListResultSchema = z.object({
   success: z.boolean(),
   packages: z.array(GoListPackageSchema).optional(),
+  /** Module list (populated when modules mode is used). */
+  modules: z.array(GoListModuleSchema).optional(),
   total: z.number(),
 });
 
 export type GoListResult = z.infer<typeof GoListResultSchema>;
 
-/** Zod schema for structured go get output with success status and output text. */
+/** Zod schema for a resolved package from go get output. */
+export const GoGetResolvedPackageSchema = z.object({
+  /** The module/package path. */
+  package: z.string(),
+  /** The version the package was at before this operation, if upgraded. */
+  previousVersion: z.string().optional(),
+  /** The newly resolved version. */
+  newVersion: z.string(),
+});
+
+/** Zod schema for structured go get output with success status, output text, and resolved packages. */
 export const GoGetResultSchema = z.object({
   success: z.boolean(),
   output: z.string().optional(),
+  /** Packages resolved/upgraded by go get with version information. */
+  resolvedPackages: z.array(GoGetResolvedPackageSchema).optional(),
 });
 
 export type GoGetResult = z.infer<typeof GoGetResultSchema>;

--- a/packages/server-go/src/tools/run.ts
+++ b/packages/server-go/src/tools/run.ts
@@ -121,13 +121,15 @@ export function registerRunTool(server: McpServer) {
       const result = await goCmd(cmdArgs, cwd, timeout);
       const data = parseGoRunOutput(result.stdout, result.stderr, result.exitCode);
 
-      // Apply maxOutput truncation
+      // Apply maxOutput truncation with truncation flag tracking
       if (maxOutput) {
         if (data.stdout && data.stdout.length > maxOutput) {
           data.stdout = data.stdout.slice(0, maxOutput) + "\n... (truncated)";
+          data.stdoutTruncated = true;
         }
         if (data.stderr && data.stderr.length > maxOutput) {
           data.stderr = data.stderr.slice(0, maxOutput) + "\n... (truncated)";
+          data.stderrTruncated = true;
         }
       }
 

--- a/packages/server-go/src/tools/vet.ts
+++ b/packages/server-go/src/tools/vet.ts
@@ -13,7 +13,7 @@ export function registerVetTool(server: McpServer) {
     {
       title: "Go Vet",
       description:
-        "Runs go vet and returns structured static analysis diagnostics. Use instead of running `go vet` in the terminal.",
+        "Runs go vet and returns structured static analysis diagnostics with analyzer names. Uses -json flag for native JSON output with automatic text fallback. Use instead of running `go vet` in the terminal.",
       inputSchema: {
         path: z
           .string()
@@ -67,7 +67,7 @@ export function registerVetTool(server: McpServer) {
       }
       if (vettool) assertNoFlagInjection(vettool, "vettool");
 
-      const args = ["vet"];
+      const args = ["vet", "-json"];
       if (tags && tags.length > 0) {
         for (const t of tags) {
           assertNoFlagInjection(t, "tags");


### PR DESCRIPTION
## Summary
- **go/get** (#47): Parse resolved versions from `go get` output. Adds `resolvedPackages` array with `package`, `previousVersion`, and `newVersion` fields to the output schema. Extracts version info from lines like `go: upgraded golang.org/x/text v0.3.7 => v0.14.0`.
- **go/list** (#48): Add `modules` boolean parameter that maps to `-m` flag. When true, lists modules instead of packages and populates a new `modules` field with `path`, `version`, `dir`, `goMod`, `goVersion`, `main`, `indirect`.
- **go/run** (#50): Add `stdoutTruncated` and `stderrTruncated` boolean fields to the output schema. These are set to `true` when the existing `maxOutput` parameter causes truncation, giving agents a reliable signal that output was cut.
- **go/vet** (#53): Switch to `go vet -json` for native structured JSON output. Adds `analyzer` field (e.g., `"printf"`, `"shadow"`, `"unusedresult"`) to each diagnostic. Falls back to text parsing if the JSON output is unavailable or malformed.

## Test plan
- [x] All 298 existing + new unit tests pass (`pnpm --filter @paretools/go test`)
- [x] Build succeeds (`pnpm build --filter @paretools/go`)
- [ ] CI matrix (ubuntu/windows/macos x node 20/22)
- [ ] Verify go/get version parsing with real `go get -u` output
- [ ] Verify go/list modules mode with real `go list -json -m all` output
- [ ] Verify go/vet -json with real Go project containing vet diagnostics
- [ ] Verify go/run truncation with output exceeding maxOutput limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)