### PR TITLE
feat(make): add just JSON, phony targets, dependencies, timeout detection (P1)

### DIFF
--- a/.changeset/make-p1-gaps.md
+++ b/.changeset/make-p1-gaps.md
@@ -1,0 +1,10 @@
+---
+"@paretools/make": minor
+---
+
+feat(make): add just JSON dump, phony targets, dependencies, and timeout detection (P1)
+
+- Use `just --dump-format json` for more reliable recipe parsing
+- Extract `.PHONY` targets and add `isPhony` field to target entries
+- Add `dependencies` field to target entries
+- Add `timedOut` detection to run tool output

--- a/packages/server-make/src/schemas/index.ts
+++ b/packages/server-make/src/schemas/index.ts
@@ -9,14 +9,17 @@ export const MakeRunResultSchema = z.object({
   stderr: z.string().optional(),
   duration: z.number(),
   tool: z.enum(["make", "just"]),
+  timedOut: z.boolean(),
 });
 
 export type MakeRunResult = z.infer<typeof MakeRunResultSchema>;
 
-/** Zod schema for a single target entry with name and optional description. */
+/** Zod schema for a single target entry with name, optional description, phony flag, and dependencies. */
 export const MakeTargetSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
+  isPhony: z.boolean().optional(),
+  dependencies: z.array(z.string()).optional(),
 });
 
 /** Zod schema for structured make/just list output with targets and total count. */


### PR DESCRIPTION
## Summary
- Use `just --dump-format json` for reliable recipe parsing with text fallback
- Extract `.PHONY` targets and add `isPhony` field to target entries
- Add `dependencies` field from both make and just sources
- Add `timedOut` boolean to run output for timeout detection

## Test plan
- [x] Unit tests for just JSON dump parsing (7 tests)
- [x] Unit tests for .PHONY extraction (6 tests)
- [x] Unit tests for dependency parsing (4 tests)
- [x] Unit tests for timeout detection (4 tests)
- [x] All existing tests still pass (84 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)