### PR TITLE
feat(k8s): expand metadata, add helm history and template (P1)

### DIFF
--- a/.changeset/k8s-p1-gaps.md
+++ b/.changeset/k8s-p1-gaps.md
@@ -1,0 +1,9 @@
+---
+"@paretools/k8s": minor
+---
+
+feat(k8s): expand resource metadata, add helm history and template actions (P1)
+
+- Add annotations, ownerReferences, finalizers, resourceVersion, uid to K8sResourceSchema
+- Add helm `history` action for release revision history
+- Add helm `template` action for local chart template rendering


### PR DESCRIPTION
## Summary
- Expand K8sResourceSchema with annotations, ownerReferences, finalizers, resourceVersion, uid
- Add helm `history` action for release revision history with JSON parsing
- Add helm `template` action for local chart rendering with manifest counting

## Test plan
- [x] Unit tests for metadata extraction (annotations, ownerReferences, finalizers, resourceVersion, uid)
- [x] Unit tests for helm history parsing (success, failure, invalid JSON, optional fields)
- [x] Unit tests for helm template parsing (multiple manifests, single manifest, empty output)
- [x] Formatter tests for expanded metadata display
- [x] Formatter and compact tests for helm history and template
- [x] All existing tests still pass (295 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)