### PR TITLE
feat(http): add expanded timing, HEAD compact mode, POST form param (P1)

### DIFF
--- a/.changeset/http-p1-gaps.md
+++ b/.changeset/http-p1-gaps.md
@@ -1,0 +1,9 @@
+---
+"@paretools/http": minor
+---
+
+feat(http): add expanded timing, HEAD compact mode, and POST form param (P1)
+
+- Add detailed timing breakdown (namelookup, connect, starttransfer, etc.) to all HTTP tools
+- Preserve key headers in HEAD compact mode (content-length, cache-control, etag, etc.)
+- Add `form` parameter to POST for multipart form data uploads

--- a/packages/server-http/__tests__/formatters.test.ts
+++ b/packages/server-http/__tests__/formatters.test.ts
@@ -67,6 +67,58 @@ describe("formatHttpResponse", () => {
     // Body preview should be truncated to ~500 chars
     expect(output.length).toBeLessThan(longBody.length + 200);
   });
+
+  it("formats response with expanded timing details", () => {
+    const data: HttpResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      timing: {
+        total: 0.5,
+        details: {
+          namelookup: 0.01,
+          connect: 0.05,
+          appconnect: 0.12,
+          pretransfer: 0.125,
+          starttransfer: 0.4,
+        },
+      },
+      size: 100,
+    };
+
+    const output = formatHttpResponse(data);
+
+    expect(output).toContain("Time: 0.500s");
+    expect(output).toContain("dns=0.010s");
+    expect(output).toContain("tcp=0.050s");
+    expect(output).toContain("tls=0.120s");
+    expect(output).toContain("pre=0.125s");
+    expect(output).toContain("ttfb=0.400s");
+  });
+
+  it("formats response with timing details without TLS (no appconnect)", () => {
+    const data: HttpResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      timing: {
+        total: 0.3,
+        details: {
+          namelookup: 0.005,
+          connect: 0.03,
+          starttransfer: 0.2,
+        },
+      },
+      size: 50,
+    };
+
+    const output = formatHttpResponse(data);
+
+    expect(output).toContain("dns=0.005s");
+    expect(output).toContain("tcp=0.030s");
+    expect(output).not.toContain("tls=");
+    expect(output).toContain("ttfb=0.200s");
+  });
 });
 
 describe("formatHttpHeadResponse", () => {
@@ -122,6 +174,29 @@ describe("formatHttpHeadResponse", () => {
 
     expect(output).not.toContain("Content-Length:");
   });
+
+  it("formats HEAD response with expanded timing details", () => {
+    const data: HttpHeadResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      timing: {
+        total: 0.2,
+        details: {
+          namelookup: 0.008,
+          connect: 0.04,
+          appconnect: 0.11,
+        },
+      },
+    };
+
+    const output = formatHttpHeadResponse(data);
+
+    expect(output).toContain("Time: 0.200s");
+    expect(output).toContain("dns=0.008s");
+    expect(output).toContain("tcp=0.040s");
+    expect(output).toContain("tls=0.110s");
+  });
 });
 
 describe("compactResponseMap", () => {
@@ -149,6 +224,30 @@ describe("compactResponseMap", () => {
     // Should NOT have headers or body
     expect("headers" in compact).toBe(false);
     expect("body" in compact).toBe(false);
+  });
+
+  it("preserves timing details in compact form", () => {
+    const full: HttpResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      timing: {
+        total: 0.5,
+        details: {
+          namelookup: 0.01,
+          connect: 0.05,
+          starttransfer: 0.4,
+        },
+      },
+      size: 100,
+    };
+
+    const compact = compactResponseMap(full);
+
+    expect(compact.timing.details).toBeDefined();
+    expect(compact.timing.details!.namelookup).toBe(0.01);
+    expect(compact.timing.details!.connect).toBe(0.05);
+    expect(compact.timing.details!.starttransfer).toBe(0.4);
   });
 });
 
@@ -202,7 +301,91 @@ describe("compactHeadResponseMap", () => {
     expect(compact.contentType).toBe("text/html");
     expect(compact.contentLength).toBe(5000);
     expect(compact.timing.total).toBe(0.15);
-    expect("headers" in compact).toBe(false);
+  });
+
+  it("preserves essential headers in compact HEAD mode", () => {
+    const full: HttpHeadResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {
+        "content-type": "text/html",
+        "content-length": "5000",
+        "cache-control": "max-age=3600",
+        etag: '"abc123"',
+        "last-modified": "Wed, 21 Oct 2025 07:28:00 GMT",
+        "x-request-id": "req-12345",
+        "x-powered-by": "Express",
+        server: "nginx",
+      },
+      timing: { total: 0.15 },
+      contentType: "text/html",
+      contentLength: 5000,
+    };
+
+    const compact = compactHeadResponseMap(full);
+
+    // Essential headers should be preserved
+    expect(compact.essentialHeaders).toBeDefined();
+    expect(compact.essentialHeaders!["content-type"]).toBe("text/html");
+    expect(compact.essentialHeaders!["content-length"]).toBe("5000");
+    expect(compact.essentialHeaders!["cache-control"]).toBe("max-age=3600");
+    expect(compact.essentialHeaders!["etag"]).toBe('"abc123"');
+    expect(compact.essentialHeaders!["last-modified"]).toBe("Wed, 21 Oct 2025 07:28:00 GMT");
+
+    // Non-essential headers should NOT be preserved
+    expect(compact.essentialHeaders!["x-request-id"]).toBeUndefined();
+    expect(compact.essentialHeaders!["x-powered-by"]).toBeUndefined();
+    expect(compact.essentialHeaders!["server"]).toBeUndefined();
+  });
+
+  it("omits essentialHeaders when none of the essential headers are present", () => {
+    const full: HttpHeadResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {
+        "x-request-id": "req-12345",
+        server: "nginx",
+      },
+      timing: { total: 0.1 },
+    };
+
+    const compact = compactHeadResponseMap(full);
+
+    expect(compact.essentialHeaders).toBeUndefined();
+  });
+
+  it("handles missing headers gracefully", () => {
+    const full: HttpHeadResponse = {
+      status: 200,
+      statusText: "OK",
+      timing: { total: 0.1 },
+    };
+
+    const compact = compactHeadResponseMap(full);
+
+    expect(compact.essentialHeaders).toBeUndefined();
+  });
+
+  it("preserves timing details in compact HEAD form", () => {
+    const full: HttpHeadResponse = {
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      timing: {
+        total: 0.2,
+        details: {
+          namelookup: 0.008,
+          connect: 0.04,
+          appconnect: 0.11,
+        },
+      },
+    };
+
+    const compact = compactHeadResponseMap(full);
+
+    expect(compact.timing.details).toBeDefined();
+    expect(compact.timing.details!.namelookup).toBe(0.008);
+    expect(compact.timing.details!.appconnect).toBe(0.11);
   });
 });
 
@@ -232,5 +415,34 @@ describe("formatHeadResponseCompact", () => {
     const output = formatHeadResponseCompact(compact);
 
     expect(output).toBe("HTTP 200 OK (text/html) | 5000 bytes | 0.100s");
+  });
+
+  it("includes essential headers (excluding content-type and content-length) in compact output", () => {
+    const compact = {
+      status: 200,
+      statusText: "OK",
+      contentType: "text/html",
+      contentLength: 5000,
+      timing: { total: 0.1 },
+      essentialHeaders: {
+        "content-type": "text/html",
+        "content-length": "5000",
+        "cache-control": "max-age=3600",
+        etag: '"abc123"',
+      },
+    };
+
+    const output = formatHeadResponseCompact(compact);
+
+    // First line should have status and size
+    expect(output).toContain("HTTP 200 OK (text/html) | 5000 bytes | 0.100s");
+    // Additional lines for cache-control and etag (content-type and content-length are excluded since shown above)
+    expect(output).toContain("cache-control: max-age=3600");
+    expect(output).toContain('etag: "abc123"');
+    // content-type and content-length should NOT appear again in header lines
+    const lines = output.split("\n");
+    const headerLines = lines.slice(1);
+    expect(headerLines.some((l) => l.includes("content-type:"))).toBe(false);
+    expect(headerLines.some((l) => l.includes("content-length:"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Add detailed timing breakdown (namelookup, connect, appconnect, pretransfer, starttransfer) to GET, HEAD, POST, and request tools via curl's `-w` format variables
- Preserve essential headers (content-length, cache-control, etag, last-modified, content-type) in HEAD compact mode
- Add `form` parameter to POST for multipart form data uploads (`-F` flag)

## Test plan
- [x] Unit tests for timing field extraction from expanded meta format
- [x] Unit tests for backward compatibility with old 2-field meta format
- [x] Unit tests for HEAD compact mode essential header preservation
- [x] Unit tests for form parameter to `-F` flag mapping
- [x] Unit tests for form taking priority over body/dataUrlencode
- [x] Unit tests for expanded timing in human-readable formatters
- [x] All existing tests still pass (124 total, up from 105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)