### PR TITLE
feat(lint): improve biome, prettier, and shellcheck parsers (P1)

### DIFF
--- a/.changeset/lint-p1-gaps.md
+++ b/.changeset/lint-p1-gaps.md
@@ -1,0 +1,10 @@
+---
+"@paretools/lint": minor
+---
+
+feat(lint): improve biome, prettier, and shellcheck parsers (P1)
+
+- Improve biome-check line number extraction from JSON output (support both v2+ start/end format and legacy sourceCode format)
+- Improve biome-format parser to use --reporter=json for accurate changed/unchanged file counts
+- Use --list-different for more accurate prettier-format change counting
+- Validate shellcheck file patterns and automatically expand directories to shell script files

--- a/packages/server-lint/__tests__/biome-format.test.ts
+++ b/packages/server-lint/__tests__/biome-format.test.ts
@@ -4,7 +4,62 @@ import { formatFormatWrite } from "../src/lib/formatters.js";
 import type { FormatWriteResult } from "../src/schemas/index.js";
 
 describe("parseBiomeFormat", () => {
-  it("parses file paths from Biome format --write output", () => {
+  it("parses JSON output from biome format --write --reporter=json", () => {
+    const json = JSON.stringify({
+      summary: { changed: 2, unchanged: 3, errors: 0, warnings: 0 },
+      diagnostics: [],
+      command: "format",
+    });
+
+    const result = parseBiomeFormat(json, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(2);
+    expect(result.filesUnchanged).toBe(3);
+  });
+
+  it("parses JSON output with format diagnostics containing file paths", () => {
+    const json = JSON.stringify({
+      summary: { changed: 0, unchanged: 1, errors: 1, warnings: 0 },
+      diagnostics: [
+        {
+          severity: "error",
+          message: "Formatter would have printed the following content:",
+          category: "format",
+          location: {
+            path: "/tmp/test.ts",
+            start: { line: 0, column: 0 },
+            end: { line: 0, column: 0 },
+          },
+          advices: [],
+        },
+      ],
+      command: "format",
+    });
+
+    const result = parseBiomeFormat(json, "", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.filesChanged).toBe(0);
+    expect(result.filesUnchanged).toBe(1);
+    expect(result.files).toEqual(["/tmp/test.ts"]);
+  });
+
+  it("parses JSON with all files changed and no unchanged", () => {
+    const json = JSON.stringify({
+      summary: { changed: 5, unchanged: 0, errors: 0, warnings: 0 },
+      diagnostics: [],
+      command: "format",
+    });
+
+    const result = parseBiomeFormat(json, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(5);
+    expect(result.filesUnchanged).toBeUndefined();
+  });
+
+  it("falls back to text parsing for non-JSON output", () => {
     const stdout = ["src/index.ts", "src/utils.ts"].join("\n");
 
     const result = parseBiomeFormat(stdout, "", 0);
@@ -14,12 +69,11 @@ describe("parseBiomeFormat", () => {
     expect(result.files).toEqual(["src/index.ts", "src/utils.ts"]);
   });
 
-  it("returns empty files when no files were formatted", () => {
+  it("returns empty files when no files were formatted (text)", () => {
     const result = parseBiomeFormat("", "", 0);
 
     expect(result.success).toBe(true);
     expect(result.filesChanged).toBe(0);
-    expect(result.files).toEqual([]);
   });
 
   it("handles exit code failure", () => {
@@ -29,21 +83,21 @@ describe("parseBiomeFormat", () => {
     expect(result.filesChanged).toBe(0);
   });
 
-  it("filters out summary lines from Biome output", () => {
+  it("parses text summary with Fixed count", () => {
     const stdout = [
       "src/index.ts",
       "src/utils.ts",
-      "Formatted 2 files in 50ms.",
-      "Fixed 2 files.",
+      "Formatted 5 files in 50ms. Fixed 2 files.",
     ].join("\n");
 
     const result = parseBiomeFormat(stdout, "", 0);
 
-    expect(result.files).toEqual(["src/index.ts", "src/utils.ts"]);
     expect(result.filesChanged).toBe(2);
+    expect(result.filesUnchanged).toBe(3);
+    expect(result.files).toEqual(["src/index.ts", "src/utils.ts"]);
   });
 
-  it("filters out Checked summary lines", () => {
+  it("filters out Checked summary lines in text mode", () => {
     const stdout = ["src/app.tsx", "Checked 5 files in 20ms. No fixes needed."].join("\n");
 
     const result = parseBiomeFormat(stdout, "", 0);
@@ -52,7 +106,7 @@ describe("parseBiomeFormat", () => {
     expect(result.filesChanged).toBe(1);
   });
 
-  it("handles various file extensions", () => {
+  it("handles various file extensions in text mode", () => {
     const stdout = ["src/app.tsx", "styles/main.css", "config.json", "lib/helpers.js"].join("\n");
 
     const result = parseBiomeFormat(stdout, "", 0);
@@ -64,6 +118,32 @@ describe("parseBiomeFormat", () => {
       "config.json",
       "lib/helpers.js",
     ]);
+  });
+
+  it("skips --json unstable warning line in text output", () => {
+    const stdout = [
+      "The --json option is unstable/experimental and its output might change between patches/minor releases.",
+      "src/app.tsx",
+    ].join("\n");
+
+    const result = parseBiomeFormat(stdout, "", 0);
+
+    expect(result.files).toEqual(["src/app.tsx"]);
+    expect(result.filesChanged).toBe(1);
+  });
+
+  it("parses JSON summary with zero changed (all already formatted)", () => {
+    const json = JSON.stringify({
+      summary: { changed: 0, unchanged: 10, errors: 0, warnings: 0 },
+      diagnostics: [],
+      command: "format",
+    });
+
+    const result = parseBiomeFormat(json, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.filesUnchanged).toBe(10);
   });
 });
 
@@ -100,5 +180,29 @@ describe("formatFormatWrite (biome context)", () => {
     };
 
     expect(formatFormatWrite(data)).toBe("Format failed.");
+  });
+
+  it("formats result with filesUnchanged count", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 2,
+      filesUnchanged: 8,
+      files: ["src/a.ts", "src/b.ts"],
+      success: true,
+    };
+
+    const output = formatFormatWrite(data);
+    expect(output).toContain("Formatted 2 files (8 already formatted):");
+    expect(output).toContain("src/a.ts");
+  });
+
+  it("formats result with all unchanged and filesUnchanged", () => {
+    const data: FormatWriteResult = {
+      filesChanged: 0,
+      filesUnchanged: 10,
+      files: [],
+      success: true,
+    };
+
+    expect(formatFormatWrite(data)).toBe("All 10 files already formatted.");
   });
 });

--- a/packages/server-lint/__tests__/shellcheck-patterns.test.ts
+++ b/packages/server-lint/__tests__/shellcheck-patterns.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { resolveShellcheckPatterns, validateShellcheckPatterns } from "../src/lib/parsers.js";
+
+const TEST_DIR = join("/tmp", "pare-shellcheck-test-" + process.pid);
+
+beforeEach(async () => {
+  await mkdir(TEST_DIR, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("validateShellcheckPatterns", () => {
+  it("returns null for valid file patterns", () => {
+    expect(validateShellcheckPatterns(["deploy.sh", "build.sh"])).toBeNull();
+  });
+
+  it("returns error for bare dot directory", () => {
+    const result = validateShellcheckPatterns(["."]);
+    expect(result).toContain("ShellCheck requires file paths, not directories");
+    expect(result).toContain(".");
+  });
+
+  it("returns error for dot-dot directory", () => {
+    const result = validateShellcheckPatterns([".."]);
+    expect(result).toContain("ShellCheck requires file paths, not directories");
+  });
+
+  it("returns error for trailing-slash directories", () => {
+    const result = validateShellcheckPatterns(["src/"]);
+    expect(result).toContain("ShellCheck requires file paths, not directories");
+    expect(result).toContain("src/");
+  });
+
+  it("does not flag glob patterns as directories", () => {
+    expect(validateShellcheckPatterns(["src/**/*.sh"])).toBeNull();
+  });
+
+  it("does not flag patterns without trailing slash", () => {
+    expect(validateShellcheckPatterns(["deploy.sh", "scripts/build.sh"])).toBeNull();
+  });
+
+  it("returns error listing multiple bare directories", () => {
+    const result = validateShellcheckPatterns([".", "src/", ".."]);
+    expect(result).toContain(".");
+    expect(result).toContain("src/");
+    expect(result).toContain("..");
+  });
+});
+
+describe("resolveShellcheckPatterns", () => {
+  it("resolves a single shell file path", async () => {
+    const filePath = join(TEST_DIR, "test.sh");
+    await writeFile(filePath, "#!/bin/bash\necho hello\n");
+
+    const result = await resolveShellcheckPatterns(["test.sh"], TEST_DIR);
+
+    expect(result).toEqual([filePath]);
+  });
+
+  it("resolves an absolute file path", async () => {
+    const filePath = join(TEST_DIR, "test.sh");
+    await writeFile(filePath, "#!/bin/bash\necho hello\n");
+
+    const result = await resolveShellcheckPatterns([filePath], TEST_DIR);
+
+    expect(result).toEqual([filePath]);
+  });
+
+  it("expands a directory to shell script files", async () => {
+    const subDir = join(TEST_DIR, "scripts");
+    await mkdir(subDir, { recursive: true });
+    await writeFile(join(subDir, "deploy.sh"), "#!/bin/bash\n");
+    await writeFile(join(subDir, "build.bash"), "#!/bin/bash\n");
+    await writeFile(join(subDir, "not-a-script.txt"), "hello\n");
+
+    const result = await resolveShellcheckPatterns(["scripts"], TEST_DIR);
+
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(join(subDir, "deploy.sh"));
+    expect(result).toContainEqual(join(subDir, "build.bash"));
+  });
+
+  it("recursively expands nested directories", async () => {
+    const nested = join(TEST_DIR, "scripts", "nested");
+    await mkdir(nested, { recursive: true });
+    await writeFile(join(TEST_DIR, "scripts", "top.sh"), "#!/bin/bash\n");
+    await writeFile(join(nested, "deep.sh"), "#!/bin/bash\n");
+
+    const result = await resolveShellcheckPatterns(["scripts"], TEST_DIR);
+
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(join(TEST_DIR, "scripts", "top.sh"));
+    expect(result).toContainEqual(join(nested, "deep.sh"));
+  });
+
+  it("returns empty array for directory with no shell scripts", async () => {
+    const subDir = join(TEST_DIR, "empty");
+    await mkdir(subDir, { recursive: true });
+    await writeFile(join(subDir, "readme.md"), "# hello\n");
+
+    const result = await resolveShellcheckPatterns(["empty"], TEST_DIR);
+
+    expect(result).toEqual([]);
+  });
+
+  it("passes through non-existent patterns as-is", async () => {
+    const result = await resolveShellcheckPatterns(["nonexistent.sh"], TEST_DIR);
+
+    expect(result).toEqual(["nonexistent.sh"]);
+  });
+
+  it("handles multiple patterns including directories and files", async () => {
+    const subDir = join(TEST_DIR, "scripts");
+    await mkdir(subDir, { recursive: true });
+    await writeFile(join(subDir, "build.sh"), "#!/bin/bash\n");
+    const singleFile = join(TEST_DIR, "deploy.sh");
+    await writeFile(singleFile, "#!/bin/bash\n");
+
+    const result = await resolveShellcheckPatterns(["deploy.sh", "scripts"], TEST_DIR);
+
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(singleFile);
+    expect(result).toContainEqual(join(subDir, "build.sh"));
+  });
+
+  it("supports .zsh and .ksh extensions", async () => {
+    const subDir = join(TEST_DIR, "shells");
+    await mkdir(subDir, { recursive: true });
+    await writeFile(join(subDir, "config.zsh"), "#!/bin/zsh\n");
+    await writeFile(join(subDir, "init.ksh"), "#!/bin/ksh\n");
+
+    const result = await resolveShellcheckPatterns(["shells"], TEST_DIR);
+
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(join(subDir, "config.zsh"));
+    expect(result).toContainEqual(join(subDir, "init.ksh"));
+  });
+});

--- a/packages/server-lint/src/lib/formatters.ts
+++ b/packages/server-lint/src/lib/formatters.ts
@@ -30,9 +30,17 @@ export function formatFormatCheck(data: FormatCheckResult): string {
 /** Formats structured format-write results into a human-readable summary. */
 export function formatFormatWrite(data: FormatWriteResult): string {
   if (!data.success) return "Format failed.";
-  if (data.filesChanged === 0) return "All files already formatted.";
+  if (data.filesChanged === 0) {
+    if (data.filesUnchanged !== undefined && data.filesUnchanged > 0) {
+      return `All ${data.filesUnchanged} files already formatted.`;
+    }
+    return "All files already formatted.";
+  }
 
   const lines = [`Formatted ${data.filesChanged} files:`];
+  if (data.filesUnchanged !== undefined && data.filesUnchanged > 0) {
+    lines[0] = `Formatted ${data.filesChanged} files (${data.filesUnchanged} already formatted):`;
+  }
   for (const f of data.files ?? []) {
     lines.push(`  ${f}`);
   }
@@ -88,17 +96,25 @@ export interface FormatWriteResultCompact {
   [key: string]: unknown;
   success: boolean;
   filesChanged: number;
+  filesUnchanged?: number;
 }
 
 export function compactFormatWriteMap(data: FormatWriteResult): FormatWriteResultCompact {
-  return {
+  const result: FormatWriteResultCompact = {
     success: data.success,
     filesChanged: data.filesChanged,
   };
+  if (data.filesUnchanged !== undefined) {
+    result.filesUnchanged = data.filesUnchanged;
+  }
+  return result;
 }
 
 export function formatFormatWriteCompact(data: FormatWriteResultCompact): string {
   if (!data.success) return "Format failed.";
   if (data.filesChanged === 0) return "All files already formatted.";
+  if (data.filesUnchanged !== undefined && data.filesUnchanged > 0) {
+    return `Formatted ${data.filesChanged} files (${data.filesUnchanged} already formatted).`;
+  }
   return `Formatted ${data.filesChanged} files.`;
 }

--- a/packages/server-lint/src/schemas/index.ts
+++ b/packages/server-lint/src/schemas/index.ts
@@ -37,6 +37,7 @@ export type FormatCheckResult = z.infer<typeof FormatCheckResultSchema>;
 /** Zod schema for structured format-write output (Prettier --write, Biome format --write). */
 export const FormatWriteResultSchema = z.object({
   filesChanged: z.number(),
+  filesUnchanged: z.number().optional(),
   files: z.array(z.string()).optional(),
   success: z.boolean(),
 });

--- a/packages/server-lint/src/tools/biome-format.ts
+++ b/packages/server-lint/src/tools/biome-format.ts
@@ -87,7 +87,7 @@ export function registerBiomeFormatTool(server: McpServer) {
       for (const p of patterns ?? []) {
         assertNoFlagInjection(p, "patterns");
       }
-      const args = ["format", "--write"];
+      const args = ["format", "--write", "--reporter=json"];
       if (changed) args.push("--changed");
       if (staged) args.push("--staged");
       if (since) {


### PR DESCRIPTION
## Summary
- Improve biome-check line number extraction: support both Biome v2+ format (`location.start.line/column`) and legacy format (`sourceCode.lineNumber`), handle path as string or object
- Improve biome-format parser: use `--reporter=json` for accurate changed/unchanged file counts from Biome's summary object, with text fallback
- Add `--list-different` pre-pass to prettier-format for accurate change counting, distinguishing reformatted files from already-formatted ones
- Validate shellcheck file patterns: automatically expand directory inputs to shell script files via recursive readdir, return helpful error when no shell files found
- Add `filesUnchanged` field to `FormatWriteResult` schema and formatters

## Test plan
- [x] Unit tests for biome-check line number extraction (new v2+ format, legacy format, both-formats-present)
- [x] Unit tests for biome-format JSON parsing and text fallback
- [x] Unit tests for prettier `--list-different` parsing and `buildPrettierWriteResult`
- [x] Unit tests for shellcheck pattern validation and directory expansion
- [x] All 256 existing + new tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)