### PR TITLE
feat(build): add env params, improve parsers, normalize outputs (P1)

### DIFF
--- a/.changeset/build-p1-gaps.md
+++ b/.changeset/build-p1-gaps.md
@@ -1,0 +1,13 @@
+---
+"@paretools/build": minor
+---
+
+feat(build): add env params, improve parsers, normalize output fields (P1)
+
+- Add `env` parameter to build and webpack tools
+- Improve error/warning detection heuristics
+- Add `define` and `metafile` params to esbuild
+- Distinguish local vs remote cache in Nx output
+- Normalize duration to milliseconds in Turbo output
+- Normalize file sizes to bytes in Vite output
+- Add `profile` param to webpack

--- a/packages/server-build/__tests__/parsers.test.ts
+++ b/packages/server-build/__tests__/parsers.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { parseTscOutput, parseBuildCommandOutput } from "../src/lib/parsers.js";
+import {
+  parseTscOutput,
+  parseBuildCommandOutput,
+  parseDurationToMs,
+  parseSizeToBytes,
+  parseEsbuildMetafile,
+  parseWebpackProfile,
+} from "../src/lib/parsers.js";
 
 describe("parseTscOutput", () => {
   it("parses typical tsc errors", () => {
@@ -81,12 +88,12 @@ describe("parseBuildCommandOutput", () => {
 
   it("parses failed build with errors", () => {
     const stdout = "Compiling...\nError: Module not found: ./missing";
-    const stderr = "Build error: compilation failed";
+    const stderr = "build failed: compilation error";
     const result = parseBuildCommandOutput(stdout, stderr, 1, 2.0);
 
     expect(result.success).toBe(false);
     expect(result.duration).toBe(2.0);
-    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors!.length).toBeGreaterThan(0);
   });
 
   it("captures warnings", () => {
@@ -102,5 +109,206 @@ describe("parseBuildCommandOutput", () => {
     expect(result.success).toBe(true);
     expect(result.errors).toEqual([]);
     expect(result.warnings).toEqual([]);
+  });
+
+  // Gap #78: improved error/warning heuristic tests
+  it("detects TypeScript-style errors like error TS1234", () => {
+    const stdout = "src/index.ts(5,3): error TS2322: Type mismatch.";
+    const result = parseBuildCommandOutput(stdout, "", 1, 1.0);
+    expect(result.errors!.length).toBe(1);
+    expect(result.errors![0]).toContain("error TS2322");
+  });
+
+  it("detects webpack-style ERROR in lines", () => {
+    const stdout = "ERROR in ./src/index.ts\nModule not found";
+    const result = parseBuildCommandOutput(stdout, "", 1, 1.0);
+    expect(result.errors!.length).toBeGreaterThanOrEqual(1);
+    expect(result.errors![0]).toContain("ERROR in");
+  });
+
+  it("does not classify '0 errors' as an error", () => {
+    const stdout = "Compiled with 0 errors and 0 warnings";
+    const result = parseBuildCommandOutput(stdout, "", 0, 1.0);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("detects SyntaxError lines", () => {
+    const stdout = "SyntaxError: Unexpected token at line 5";
+    const result = parseBuildCommandOutput(stdout, "", 1, 0.5);
+    expect(result.errors!.length).toBe(1);
+  });
+
+  it("detects 'build failed' as error", () => {
+    const stdout = "build failed with 3 errors";
+    const result = parseBuildCommandOutput(stdout, "", 1, 1.0);
+    expect(result.errors!.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("detects WARNING in lines for webpack", () => {
+    const stdout = "WARNING in ./src/utils.ts\nUnused export";
+    const result = parseBuildCommandOutput(stdout, "", 0, 1.0);
+    expect(result.warnings!.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("detects DeprecationWarning as warning", () => {
+    const stdout = "DeprecationWarning: Buffer() is deprecated";
+    const result = parseBuildCommandOutput(stdout, "", 0, 0.5);
+    expect(result.warnings!.length).toBe(1);
+  });
+
+  it("does not classify 'no errors' as error", () => {
+    const stdout = "Build completed with no errors";
+    const result = parseBuildCommandOutput(stdout, "", 0, 1.0);
+    expect(result.errors).toEqual([]);
+  });
+});
+
+// Gap #82: duration normalization
+describe("parseDurationToMs", () => {
+  it("parses milliseconds", () => {
+    expect(parseDurationToMs("100ms")).toBe(100);
+    expect(parseDurationToMs("1234ms")).toBe(1234);
+    expect(parseDurationToMs("0ms")).toBe(0);
+  });
+
+  it("parses seconds", () => {
+    expect(parseDurationToMs("2.5s")).toBe(2500);
+    expect(parseDurationToMs("10s")).toBe(10000);
+    expect(parseDurationToMs("0.1s")).toBe(100);
+  });
+
+  it("parses minutes and seconds", () => {
+    expect(parseDurationToMs("1m30s")).toBe(90000);
+    expect(parseDurationToMs("2m0s")).toBe(120000);
+  });
+
+  it("parses minutes only", () => {
+    expect(parseDurationToMs("5m")).toBe(300000);
+  });
+
+  it("returns undefined for unparseable strings", () => {
+    expect(parseDurationToMs("unknown")).toBeUndefined();
+    expect(parseDurationToMs("")).toBeUndefined();
+    expect(parseDurationToMs("abc")).toBeUndefined();
+  });
+});
+
+// Gap #83: size normalization
+describe("parseSizeToBytes", () => {
+  it("parses bytes", () => {
+    expect(parseSizeToBytes("320 B")).toBe(320);
+    expect(parseSizeToBytes("0 B")).toBe(0);
+    expect(parseSizeToBytes("1B")).toBe(1);
+  });
+
+  it("parses kilobytes", () => {
+    expect(parseSizeToBytes("45.2 kB")).toBe(45200);
+    expect(parseSizeToBytes("1 kB")).toBe(1000);
+    expect(parseSizeToBytes("0.5 kB")).toBe(500);
+    expect(parseSizeToBytes("100kB")).toBe(100000);
+  });
+
+  it("parses megabytes", () => {
+    expect(parseSizeToBytes("1.5 MB")).toBe(1500000);
+    expect(parseSizeToBytes("0.1 MB")).toBe(100000);
+  });
+
+  it("parses gigabytes", () => {
+    expect(parseSizeToBytes("1 GB")).toBe(1000000000);
+    expect(parseSizeToBytes("2.5 GB")).toBe(2500000000);
+  });
+
+  it("returns undefined for invalid strings", () => {
+    expect(parseSizeToBytes("")).toBeUndefined();
+    expect(parseSizeToBytes("abc")).toBeUndefined();
+    expect(parseSizeToBytes("45.2")).toBeUndefined();
+  });
+
+  it("is case-insensitive for units", () => {
+    expect(parseSizeToBytes("10 KB")).toBe(10000);
+    expect(parseSizeToBytes("10 Kb")).toBe(10000);
+    expect(parseSizeToBytes("10 kb")).toBe(10000);
+  });
+});
+
+// Gap #80: esbuild metafile parsing
+describe("parseEsbuildMetafile", () => {
+  it("parses valid metafile JSON", () => {
+    const content = JSON.stringify({
+      inputs: {
+        "src/index.ts": { bytes: 1234 },
+        "src/utils.ts": { bytes: 567 },
+      },
+      outputs: {
+        "dist/index.js": { bytes: 8901 },
+        "dist/index.js.map": { bytes: 2345 },
+      },
+    });
+    const result = parseEsbuildMetafile(content);
+    expect(result).toBeDefined();
+    expect(result!.inputs["src/index.ts"].bytes).toBe(1234);
+    expect(result!.inputs["src/utils.ts"].bytes).toBe(567);
+    expect(result!.outputs["dist/index.js"].bytes).toBe(8901);
+    expect(result!.outputs["dist/index.js.map"].bytes).toBe(2345);
+  });
+
+  it("returns undefined for invalid JSON", () => {
+    expect(parseEsbuildMetafile("not json")).toBeUndefined();
+  });
+
+  it("handles empty inputs/outputs", () => {
+    const content = JSON.stringify({ inputs: {}, outputs: {} });
+    const result = parseEsbuildMetafile(content);
+    expect(result).toBeDefined();
+    expect(Object.keys(result!.inputs)).toHaveLength(0);
+    expect(Object.keys(result!.outputs)).toHaveLength(0);
+  });
+
+  it("handles missing inputs/outputs gracefully", () => {
+    const content = JSON.stringify({});
+    const result = parseEsbuildMetafile(content);
+    expect(result).toBeDefined();
+    expect(Object.keys(result!.inputs)).toHaveLength(0);
+    expect(Object.keys(result!.outputs)).toHaveLength(0);
+  });
+});
+
+// Gap #85: webpack profile parsing
+describe("parseWebpackProfile", () => {
+  it("extracts timing data from modules with profile info", () => {
+    const modules = [
+      { name: "./src/index.ts", profile: { factory: 10, building: 20, dependencies: 5 } },
+      { name: "./src/app.ts", profile: { factory: 5, building: 15, dependencies: 3 } },
+    ];
+    const result = parseWebpackProfile(modules);
+    expect(result).toBeDefined();
+    expect(result!.modules).toHaveLength(2);
+    expect(result!.modules[0]).toEqual({ name: "./src/index.ts", time: 35 });
+    expect(result!.modules[1]).toEqual({ name: "./src/app.ts", time: 23 });
+  });
+
+  it("uses time field as fallback", () => {
+    const modules = [{ name: "./src/index.ts", time: 42 }];
+    const result = parseWebpackProfile(modules);
+    expect(result).toBeDefined();
+    expect(result!.modules[0]).toEqual({ name: "./src/index.ts", time: 42 });
+  });
+
+  it("returns undefined when no timing data", () => {
+    const modules = [{ name: "./src/index.ts" }, { name: "./src/app.ts" }];
+    const result = parseWebpackProfile(modules);
+    expect(result).toBeUndefined();
+  });
+
+  it("skips modules with zero time", () => {
+    const modules = [
+      { name: "./src/index.ts", profile: { factory: 0, building: 0, dependencies: 0 } },
+      { name: "./src/app.ts", profile: { factory: 5, building: 10, dependencies: 2 } },
+    ];
+    const result = parseWebpackProfile(modules);
+    expect(result).toBeDefined();
+    expect(result!.modules).toHaveLength(1);
+    expect(result!.modules[0].name).toBe("./src/app.ts");
   });
 });

--- a/packages/server-build/__tests__/turbo.test.ts
+++ b/packages/server-build/__tests__/turbo.test.ts
@@ -84,6 +84,7 @@ describe("parseTurboOutput", () => {
       task: "build",
       status: "pass",
       duration: "100ms",
+      durationMs: 100,
       cache: "hit",
     });
   });
@@ -100,11 +101,17 @@ describe("parseTurboOutput", () => {
     // First task is cached
     expect(result.tasks[0].cache).toBe("hit");
     expect(result.tasks[0].package).toBe("@paretools/shared");
+    expect(result.tasks[0].durationMs).toBe(100);
 
     // Second task is a miss
     expect(result.tasks[1].cache).toBe("miss");
     expect(result.tasks[1].package).toBe("@paretools/git");
     expect(result.tasks[1].duration).toBe("2.5s");
+    expect(result.tasks[1].durationMs).toBe(2500);
+
+    // Third task
+    expect(result.tasks[2].duration).toBe("3.1s");
+    expect(result.tasks[2].durationMs).toBe(3100);
   });
 
   it("parses failed run with exit code 1", () => {
@@ -144,10 +151,12 @@ describe("parseTurboOutput", () => {
     expect(result.tasks[0].package).toBe("@paretools/shared");
     expect(result.tasks[0].task).toBe("test");
     expect(result.tasks[0].cache).toBe("miss");
+    expect(result.tasks[0].durationMs).toBe(1500);
 
     expect(result.tasks[1].package).toBe("@paretools/git");
     expect(result.tasks[1].task).toBe("test");
     expect(result.tasks[1].cache).toBe("hit");
+    expect(result.tasks[1].durationMs).toBe(200);
   });
 
   it("parses ERROR task lines", () => {
@@ -196,6 +205,7 @@ describe("formatTurbo", () => {
           task: "build",
           status: "pass",
           duration: "100ms",
+          durationMs: 100,
           cache: "hit",
         },
         {
@@ -203,6 +213,7 @@ describe("formatTurbo", () => {
           task: "build",
           status: "pass",
           duration: "2.5s",
+          durationMs: 2500,
           cache: "miss",
         },
       ],
@@ -215,14 +226,25 @@ describe("formatTurbo", () => {
     expect(output).toContain("turbo: 2 tasks completed in 2.5s");
     expect(output).toContain("1 cached");
     expect(output).toContain("@paretools/shared#build: pass [hit] (100ms)");
+    expect(output).toContain("[100ms]");
     expect(output).toContain("@paretools/git#build: pass [miss] (2.5s)");
+    expect(output).toContain("[2500ms]");
   });
 
   it("formats successful run with no cached tasks", () => {
     const data: TurboResult = {
       success: true,
       duration: 5.0,
-      tasks: [{ package: "web", task: "lint", status: "pass", duration: "3s", cache: "miss" }],
+      tasks: [
+        {
+          package: "web",
+          task: "lint",
+          status: "pass",
+          duration: "3s",
+          durationMs: 3000,
+          cache: "miss",
+        },
+      ],
       totalTasks: 1,
       passed: 1,
       failed: 0,
@@ -243,6 +265,7 @@ describe("formatTurbo", () => {
           task: "build",
           status: "pass",
           duration: "100ms",
+          durationMs: 100,
           cache: "hit",
         },
         { package: "@paretools/git", task: "build", status: "fail", cache: "miss" },

--- a/packages/server-build/src/lib/build-runner.ts
+++ b/packages/server-build/src/lib/build-runner.ts
@@ -9,9 +9,10 @@ export async function runBuildCommand(
   args: string[],
   cwd?: string,
   timeout?: number,
+  env?: Record<string, string>,
 ): Promise<RunResult> {
   // Build commands can take minutes for large projects
-  return run(cmd, args, { cwd, timeout: timeout ?? 300_000 });
+  return run(cmd, args, { cwd, timeout: timeout ?? 300_000, env });
 }
 
 export async function esbuildCmd(args: string[], cwd?: string): Promise<RunResult> {
@@ -22,8 +23,12 @@ export async function viteCmd(args: string[], cwd?: string): Promise<RunResult> 
   return run("npx", ["vite", "build", ...args], { cwd, timeout: 300_000 });
 }
 
-export async function webpackCmd(args: string[], cwd?: string): Promise<RunResult> {
-  return run("npx", ["webpack", ...args], { cwd, timeout: 300_000 });
+export async function webpackCmd(
+  args: string[],
+  cwd?: string,
+  env?: Record<string, string>,
+): Promise<RunResult> {
+  return run("npx", ["webpack", ...args], { cwd, timeout: 300_000, env });
 }
 
 export async function turboCmd(args: string[], cwd?: string): Promise<RunResult> {


### PR DESCRIPTION
## Summary
- Add `env` parameter to build and webpack tools for environment variables
- Improve error/warning detection heuristics with specific patterns (TypeScript, webpack, Vite, SyntaxError, etc.)
- Add `define` and `metafile` params to esbuild tool for compile-time constants and bundle analysis
- Distinguish `local`/`remote`/`miss` cache states in Nx output (was boolean)
- Normalize `durationMs` (numeric milliseconds) in Turbo task output
- Normalize `sizeBytes` (numeric bytes) in Vite output file entries
- Add `profile` param to webpack for per-module timing data

## Test plan
- [x] Unit tests for improved error/warning patterns (parsers.test.ts)
- [x] Unit tests for esbuild define and metafile parsing (parsers.test.ts)
- [x] Unit tests for Nx cache state parsing (nx.test.ts)
- [x] Unit tests for Turbo duration normalization (turbo.test.ts)
- [x] Unit tests for Vite size normalization (vite-build.test.ts)
- [x] Unit tests for webpack profile parsing (webpack.test.ts, parsers.test.ts)
- [x] All 224 existing tests pass (11 test files)
- [x] Build succeeds with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)