### PR TITLE
feat(git): improve output schemas and add remote/stash subcommands (P1)

### DIFF
--- a/.changeset/git-p1-gaps.md
+++ b/.changeset/git-p1-gaps.md
@@ -1,0 +1,16 @@
+---
+"@paretools/git": minor
+---
+
+feat(git): improve add, blame, commit, log, pull, remote, reset, show, stash output (P1)
+
+- Add newlyStaged count to add output
+- Use full 40-char hashes in blame
+- Improve commit hash extraction for special branch names
+- Add fullMessage field to log output
+- Add parsed refs to log-graph entries
+- Add conflict and changed file parsing to pull
+- Add remote rename, set-url, prune, show subcommands
+- Add files+mode validation to reset
+- Guard against @@ delimiter corruption in show
+- Add stash show action and stash-list content summary

--- a/packages/server-git/src/tools/log.ts
+++ b/packages/server-git/src/tools/log.ts
@@ -7,8 +7,11 @@ import { parseLog } from "../lib/parsers.js";
 import { formatLog, compactLogMap, formatLogCompact } from "../lib/formatters.js";
 import { GitLogSchema } from "../schemas/index.js";
 
-const DELIMITER = "@@";
-const LOG_FORMAT = `%H${DELIMITER}%h${DELIMITER}%an <%ae>${DELIMITER}%ar${DELIMITER}%D${DELIMITER}%s`;
+// Use NUL byte as field delimiter to avoid corruption from @@ in commit messages.
+// %x00 is the NUL byte format specifier in git.
+const NUL = "%x00";
+const RECORD_END = "%x01";
+const LOG_FORMAT = `%H${NUL}%h${NUL}%an <%ae>${NUL}%ar${NUL}%D${NUL}%s${NUL}%b${RECORD_END}`;
 
 /** Registers the `log` tool on the given MCP server. */
 export function registerLogTool(server: McpServer) {
@@ -116,7 +119,7 @@ export function registerLogTool(server: McpServer) {
     }) => {
       const cwd = path || process.cwd();
       const logFormat = dateFormat
-        ? `%H${DELIMITER}%h${DELIMITER}%an <%ae>${DELIMITER}%ad${DELIMITER}%D${DELIMITER}%s`
+        ? `%H${NUL}%h${NUL}%an <%ae>${NUL}%ad${NUL}%D${NUL}%s${NUL}%b${RECORD_END}`
         : LOG_FORMAT;
       const args = ["log", `--format=${logFormat}`, `--max-count=${maxCount ?? 10}`];
 

--- a/packages/server-git/src/tools/remote.ts
+++ b/packages/server-git/src/tools/remote.ts
@@ -7,7 +7,7 @@ import {
   INPUT_LIMITS,
 } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
-import { parseRemoteOutput } from "../lib/parsers.js";
+import { parseRemoteOutput, parseRemoteShow, parseRemotePrune } from "../lib/parsers.js";
 import {
   formatRemote,
   compactRemoteMap,
@@ -23,7 +23,7 @@ export function registerRemoteTool(server: McpServer) {
     {
       title: "Git Remote",
       description:
-        "Manages remote repositories. Supports list (default), add, and remove actions. Returns structured remote data. Use instead of running `git remote` in the terminal.",
+        "Manages remote repositories. Supports list (default), add, remove, rename, set-url, prune, and show actions. Returns structured remote data. Use instead of running `git remote` in the terminal.",
       inputSchema: {
         path: z
           .string()
@@ -31,7 +31,7 @@ export function registerRemoteTool(server: McpServer) {
           .optional()
           .describe("Repository path (default: cwd)"),
         action: z
-          .enum(["list", "add", "remove"])
+          .enum(["list", "add", "remove", "rename", "set-url", "prune", "show"])
           .optional()
           .default("list")
           .describe("Remote action to perform (default: list)"),
@@ -39,12 +39,22 @@ export function registerRemoteTool(server: McpServer) {
           .string()
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
-          .describe("Remote name (required for add and remove actions)"),
+          .describe("Remote name (required for add, remove, set-url, prune, show)"),
         url: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
-          .describe("Remote URL (required for add action)"),
+          .describe("Remote URL (required for add and set-url actions)"),
+        oldName: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Old remote name (required for rename action)"),
+        newName: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("New remote name (required for rename action)"),
         compact: z
           .boolean()
           .optional()
@@ -55,7 +65,7 @@ export function registerRemoteTool(server: McpServer) {
       },
       outputSchema: GitRemoteSchema,
     },
-    async ({ path, action, name, url, compact }) => {
+    async ({ path, action, name, url, oldName, newName, compact }) => {
       const cwd = path || process.cwd();
 
       if (action === "add") {
@@ -98,6 +108,118 @@ export function registerRemoteTool(server: McpServer) {
 
         return dualOutput(
           { success: true, action: "remove" as const, name, message: `Remote '${name}' removed` },
+          formatRemoteMutate,
+        );
+      }
+
+      // Gap #133: rename
+      if (action === "rename") {
+        if (!oldName) {
+          throw new Error("The 'oldName' parameter is required for remote rename");
+        }
+        if (!newName) {
+          throw new Error("The 'newName' parameter is required for remote rename");
+        }
+        assertNoFlagInjection(oldName, "oldName");
+        assertNoFlagInjection(newName, "newName");
+
+        const result = await git(["remote", "rename", oldName, newName], cwd);
+        if (result.exitCode !== 0) {
+          throw new Error(`git remote rename failed: ${result.stderr}`);
+        }
+
+        return dualOutput(
+          {
+            success: true,
+            action: "rename" as const,
+            name: newName,
+            oldName,
+            newName,
+            message: `Remote '${oldName}' renamed to '${newName}'`,
+          },
+          formatRemoteMutate,
+        );
+      }
+
+      // Gap #134: set-url
+      if (action === "set-url") {
+        if (!name) {
+          throw new Error("The 'name' parameter is required for remote set-url");
+        }
+        if (!url) {
+          throw new Error("The 'url' parameter is required for remote set-url");
+        }
+        assertNoFlagInjection(name, "name");
+        assertNoFlagInjection(url, "url");
+
+        const result = await git(["remote", "set-url", name, url], cwd);
+        if (result.exitCode !== 0) {
+          throw new Error(`git remote set-url failed: ${result.stderr}`);
+        }
+
+        return dualOutput(
+          {
+            success: true,
+            action: "set-url" as const,
+            name,
+            url,
+            message: `Remote '${name}' URL set to ${url}`,
+          },
+          formatRemoteMutate,
+        );
+      }
+
+      // Gap #135: prune
+      if (action === "prune") {
+        if (!name) {
+          throw new Error("The 'name' parameter is required for remote prune");
+        }
+        assertNoFlagInjection(name, "name");
+
+        const result = await git(["remote", "prune", name], cwd);
+        if (result.exitCode !== 0) {
+          throw new Error(`git remote prune failed: ${result.stderr}`);
+        }
+
+        const prunedBranches = parseRemotePrune(result.stdout, result.stderr);
+
+        return dualOutput(
+          {
+            success: true,
+            action: "prune" as const,
+            name,
+            prunedBranches,
+            message:
+              prunedBranches.length > 0
+                ? `Pruned ${prunedBranches.length} stale branch(es) from '${name}'`
+                : `Nothing to prune from '${name}'`,
+          },
+          formatRemoteMutate,
+        );
+      }
+
+      // Gap #136: show
+      if (action === "show") {
+        if (!name) {
+          throw new Error("The 'name' parameter is required for remote show");
+        }
+        assertNoFlagInjection(name, "name");
+
+        const result = await git(["remote", "show", name], cwd);
+        if (result.exitCode !== 0) {
+          throw new Error(`git remote show failed: ${result.stderr}`);
+        }
+
+        const showDetails = parseRemoteShow(result.stdout);
+
+        return dualOutput(
+          {
+            success: true,
+            action: "show" as const,
+            name,
+            showDetails,
+            message: `Remote '${name}' details`,
+          },
           formatRemoteMutate,
         );
       }

--- a/packages/server-git/src/tools/reset.ts
+++ b/packages/server-git/src/tools/reset.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
 import { git, resolveFilePaths } from "../lib/git-runner.js";
-import { parseReset } from "../lib/parsers.js";
+import { parseReset, validateResetArgs } from "../lib/parsers.js";
 import { formatReset } from "../lib/formatters.js";
 import { GitResetSchema } from "../schemas/index.js";
 
@@ -60,6 +60,12 @@ export function registerResetTool(server: McpServer) {
           "Safety guard: git reset --hard permanently discards all uncommitted changes (staged and unstaged). " +
             "This action cannot be undone. Set confirm=true to proceed.",
         );
+      }
+
+      // Gap #137: Validate files+mode combination before executing
+      const validationError = validateResetArgs(mode, files);
+      if (validationError) {
+        throw new Error(validationError);
       }
 
       assertNoFlagInjection(ref, "ref");

--- a/packages/server-git/src/tools/show.ts
+++ b/packages/server-git/src/tools/show.ts
@@ -7,8 +7,11 @@ import { parseShow } from "../lib/parsers.js";
 import { formatShow, compactShowMap, formatShowCompact } from "../lib/formatters.js";
 import { GitShowSchema } from "../schemas/index.js";
 
-const DELIMITER = "@@";
-const SHOW_FORMAT = `%H${DELIMITER}%an <%ae>${DELIMITER}%ar${DELIMITER}%B`;
+// Use NUL byte as field delimiter to prevent corruption when commit messages
+// or diffs contain "@@" (e.g. diff hunk headers). NUL bytes cannot appear in
+// commit messages or file content, making them a safe delimiter. (Gap #138)
+const NUL = "%x00";
+const SHOW_FORMAT = `%H${NUL}%an <%ae>${NUL}%ar${NUL}%B`;
 
 /** Registers the `show` tool on the given MCP server. */
 export function registerShowTool(server: McpServer) {
@@ -77,9 +80,7 @@ export function registerShowTool(server: McpServer) {
       if (diffFilter) assertNoFlagInjection(diffFilter, "diffFilter");
 
       // Build format string — use --date if dateFormat specified
-      const showFormat = dateFormat
-        ? `%H${DELIMITER}%an <%ae>${DELIMITER}%ad${DELIMITER}%B`
-        : SHOW_FORMAT;
+      const showFormat = dateFormat ? `%H${NUL}%an <%ae>${NUL}%ad${NUL}%B` : SHOW_FORMAT;
 
       // Get commit info
       const infoArgs = ["show", "--no-patch", `--format=${showFormat}`];


### PR DESCRIPTION
## Summary
- Add `newlyStaged` count to git add output
- Use full 40-char hashes in blame for collision safety
- Improve commit regex for special branch name characters
- Add `fullMessage` to log and parsed `refs` to log-graph
- Add conflict files and changed files to pull output
- Add remote `rename`, `set-url`, `prune`, `show` subcommands
- Validate reset files+mode combinations
- Fix show `@@` delimiter corruption vulnerability
- Add stash `show` action and stash-list file summaries

## Test plan
- [x] Unit tests for newlyStaged counting
- [x] Unit tests for full hash blame parsing
- [x] Unit tests for commit regex with special chars
- [x] Unit tests for log fullMessage and log-graph refs
- [x] Unit tests for pull conflict/changed file parsing
- [x] Unit tests for remote subcommands
- [x] Unit tests for reset validation
- [x] Unit tests for show delimiter safety
- [x] Unit tests for stash show and stash-list summary
- [x] All existing tests still pass (634/634)

🤖 Generated with [Claude Code](https://claude.com/claude-code)