### PR TITLE
fix(github): replace z.union with z.string for number params

### DIFF
--- a/.changeset/fix-github-union-bug.md
+++ b/.changeset/fix-github-union-bug.md
@@ -1,0 +1,5 @@
+---
+"@paretools/github": patch
+---
+
+fix(github): replace z.union with z.string for number params to fix MCP SDK validation

--- a/packages/server-github/src/tools/issue-close.ts
+++ b/packages/server-github/src/tools/issue-close.ts
@@ -15,10 +15,7 @@ export function registerIssueCloseTool(server: McpServer) {
       description:
         "Closes an issue with an optional comment and reason. Returns structured data with issue number, state, URL, reason, and comment URL. Use instead of running `gh issue close` in the terminal.",
       inputSchema: {
-        // S-gap P1: Accept number or URL via union
-        number: z
-          .union([z.number(), z.string().max(INPUT_LIMITS.STRING_MAX)])
-          .describe("Issue number or URL"),
+        number: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Issue number or URL"),
         comment: z.string().max(INPUT_LIMITS.STRING_MAX).optional().describe("Closing comment"),
         reason: z
           .enum(["completed", "not planned"])

--- a/packages/server-github/src/tools/issue-comment.ts
+++ b/packages/server-github/src/tools/issue-comment.ts
@@ -15,10 +15,7 @@ export function registerIssueCommentTool(server: McpServer) {
       description:
         "Adds, edits, or deletes a comment on an issue. Returns structured data with the comment URL, operation type, comment ID, issue number, and body echo. Use instead of running `gh issue comment` in the terminal.",
       inputSchema: {
-        // S-gap P1: Accept number or URL via union
-        number: z
-          .union([z.number(), z.string().max(INPUT_LIMITS.STRING_MAX)])
-          .describe("Issue number or URL"),
+        number: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Issue number or URL"),
         body: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Comment text"),
         editLast: z
           .boolean()

--- a/packages/server-github/src/tools/issue-update.ts
+++ b/packages/server-github/src/tools/issue-update.ts
@@ -22,7 +22,8 @@ export function registerIssueUpdateTool(server: McpServer) {
         // ── Target ──────────────────────────────────────────────────
         /** Issue number (integer) or full GitHub issue URL. */
         number: z
-          .union([z.number(), z.string().max(INPUT_LIMITS.STRING_MAX)])
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
           .describe("Issue number or full GitHub issue URL to update"),
         /** Repository path on disk. Defaults to cwd. */
         path: z

--- a/packages/server-github/src/tools/issue-view.ts
+++ b/packages/server-github/src/tools/issue-view.ts
@@ -19,10 +19,7 @@ export function registerIssueViewTool(server: McpServer) {
       description:
         "Views an issue by number or URL. Returns structured data with state, labels, assignees, author, milestone, close reason, and body. Use instead of running `gh issue view` in the terminal.",
       inputSchema: {
-        // S-gap P1: Accept number or URL via union
-        number: z
-          .union([z.number(), z.string().max(INPUT_LIMITS.STRING_MAX)])
-          .describe("Issue number or URL"),
+        number: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Issue number or URL"),
         comments: z
           .boolean()
           .optional()

--- a/packages/server-github/src/tools/pr-checks.ts
+++ b/packages/server-github/src/tools/pr-checks.ts
@@ -19,9 +19,9 @@ export function registerPrChecksTool(server: McpServer) {
       description:
         "Lists check/status results for a pull request. Returns structured data with check names, states, conclusions, required status, URLs, and summary counts (passed, failed, pending). Use instead of running `gh pr checks` in the terminal.",
       inputSchema: {
-        // S-gap P1: Accept PR by number, URL, or branch via union
         pr: z
-          .union([z.number(), z.string().max(INPUT_LIMITS.STRING_MAX)])
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
           .describe("Pull request number, URL, or branch name"),
         repo: z
           .string()

--- a/packages/server-github/src/tools/pr-comment.ts
+++ b/packages/server-github/src/tools/pr-comment.ts
@@ -15,9 +15,9 @@ export function registerPrCommentTool(server: McpServer) {
       description:
         "Adds, edits, or deletes a comment on a pull request. Returns structured data with the comment URL, operation type, comment ID, and body echo. Use instead of running `gh pr comment` in the terminal.",
       inputSchema: {
-        // S-gap P1: Accept PR by number, URL, or branch via union
         number: z
-          .union([z.number(), z.string().max(INPUT_LIMITS.STRING_MAX)])
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
           .describe("Pull request number, URL, or branch name"),
         body: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Comment text"),
         editLast: z

--- a/packages/server-github/src/tools/pr-diff.ts
+++ b/packages/server-github/src/tools/pr-diff.ts
@@ -18,9 +18,9 @@ export function registerPrDiffTool(server: McpServer) {
       description:
         "Returns file-level diff statistics for a pull request. Use full=true for patch content. Use instead of running `gh pr diff` in the terminal.",
       inputSchema: {
-        // S-gap P1: Accept PR by number, URL, or branch via union
         pr: z
-          .union([z.number(), z.string().max(INPUT_LIMITS.STRING_MAX)])
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
           .describe("Pull request number, URL, or branch name"),
         repo: z
           .string()

--- a/packages/server-github/src/tools/pr-merge.ts
+++ b/packages/server-github/src/tools/pr-merge.ts
@@ -15,9 +15,9 @@ export function registerPrMergeTool(server: McpServer) {
       description:
         "Merges a pull request by number, URL, or branch. Returns structured data with merge status, method, URL, and branch deletion status. Use instead of running `gh pr merge` in the terminal.",
       inputSchema: {
-        // S-gap P1: Accept PR by number, URL, or branch via union
         number: z
-          .union([z.number(), z.string().max(INPUT_LIMITS.STRING_MAX)])
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
           .describe("Pull request number, URL, or branch name"),
         method: z
           .enum(["squash", "merge", "rebase"])

--- a/packages/server-github/src/tools/pr-review.ts
+++ b/packages/server-github/src/tools/pr-review.ts
@@ -15,9 +15,9 @@ export function registerPrReviewTool(server: McpServer) {
       description:
         "Submits a review on a pull request (approve, request-changes, or comment). Returns structured data with the review event, URL, and body echo. Use instead of running `gh pr review` in the terminal.",
       inputSchema: {
-        // S-gap P0: Accept PR by number, URL, or branch via union
         number: z
-          .union([z.number(), z.string().max(INPUT_LIMITS.STRING_MAX)])
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
           .describe("Pull request number, URL, or branch name"),
         event: z
           .enum(["approve", "request-changes", "comment"])

--- a/packages/server-github/src/tools/pr-update.ts
+++ b/packages/server-github/src/tools/pr-update.ts
@@ -15,9 +15,9 @@ export function registerPrUpdateTool(server: McpServer) {
       description:
         "Updates pull request metadata (title, body, labels, assignees, reviewers, milestone, base branch, projects). Returns structured data with PR number and URL. Use instead of running `gh pr edit` in the terminal.",
       inputSchema: {
-        // S-gap P1: Accept PR by number, URL, or branch via union
         number: z
-          .union([z.number(), z.string().max(INPUT_LIMITS.STRING_MAX)])
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
           .describe("Pull request number, URL, or branch name"),
         path: z
           .string()

--- a/packages/server-github/src/tools/pr-view.ts
+++ b/packages/server-github/src/tools/pr-view.ts
@@ -20,9 +20,9 @@ export function registerPrViewTool(server: McpServer) {
       description:
         "Views a pull request by number, URL, or branch. Returns structured data with state, checks, review decision, diff stats, author, labels, draft status, assignees, milestone, and timestamps. Use instead of running `gh pr view` in the terminal.",
       inputSchema: {
-        // S-gap P1: Accept PR by number, URL, branch, or current branch via union
         number: z
-          .union([z.number(), z.string().max(INPUT_LIMITS.STRING_MAX)])
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
           .describe("Pull request number, URL, or branch name"),
         comments: z.boolean().optional().describe("Include PR comments in output (-c/--comments)"),
         // S-gap P1: Add repo for cross-repo inspection


### PR DESCRIPTION
## Summary
- Replaces `z.union([z.number(), z.string()])` with `z.string()` in 11 GitHub tool schemas
- Fixes MCP SDK input validation failure when string values are passed to union-typed params
- All handlers already call `String(number)`, so this is a safe change

Fixes #505

## Test plan
- [ ] Build passes
- [ ] Existing tests pass
- [ ] pr-view can be called with string number values

🤖 Generated with [Claude Code](https://claude.com/claude-code)