### PR TITLE
fix(github): remove unsupported fields and fix pr param inconsistency

### DIFF
--- a/.changeset/fix-pr-checks-bugs.md
+++ b/.changeset/fix-pr-checks-bugs.md
@@ -1,0 +1,5 @@
+---
+"@paretools/github": patch
+---
+
+Fix pr-checks failing due to unsupported `isRequired` and `conclusion` JSON fields, and rename `pr` parameter to `number` in pr-checks and pr-diff for consistency with other PR tools.

--- a/packages/server-github/__tests__/integration.test.ts
+++ b/packages/server-github/__tests__/integration.test.ts
@@ -71,7 +71,7 @@ describe("@paretools/github integration", () => {
       const result = await client.callTool(
         {
           name: "pr-view",
-          arguments: { pr: 999999, repo: "paretools/nonexistent-repo-xyz" },
+          arguments: { number: "999999", repo: "paretools/nonexistent-repo-xyz" },
         },
         undefined,
         { timeout: CALL_TIMEOUT },
@@ -114,7 +114,7 @@ describe("@paretools/github integration", () => {
       const result = await client.callTool(
         {
           name: "pr-checks",
-          arguments: { pr: 999999, repo: "paretools/nonexistent-repo-xyz" },
+          arguments: { number: "999999", repo: "paretools/nonexistent-repo-xyz" },
         },
         undefined,
         { timeout: CALL_TIMEOUT },
@@ -132,7 +132,7 @@ describe("@paretools/github integration", () => {
       const result = await client.callTool(
         {
           name: "pr-diff",
-          arguments: { pr: 999999, repo: "paretools/nonexistent-repo-xyz" },
+          arguments: { number: "999999", repo: "paretools/nonexistent-repo-xyz" },
         },
         undefined,
         { timeout: CALL_TIMEOUT },
@@ -332,7 +332,7 @@ describe("@paretools/github integration", () => {
         {
           name: "pr-comment",
           arguments: {
-            pr: 1,
+            number: "1",
             body: "--exec=malicious",
           },
         },
@@ -396,7 +396,7 @@ describe("@paretools/github integration", () => {
         {
           name: "pr-review",
           arguments: {
-            pr: 1,
+            number: "1",
             event: "comment",
             body: "--exec=malicious",
           },
@@ -413,7 +413,7 @@ describe("@paretools/github integration", () => {
         {
           name: "pr-update",
           arguments: {
-            pr: 1,
+            number: "1",
             title: "--exec=malicious",
           },
         },
@@ -429,7 +429,7 @@ describe("@paretools/github integration", () => {
         {
           name: "pr-update",
           arguments: {
-            pr: 1,
+            number: "1",
             addLabels: ["--exec=malicious"],
           },
         },
@@ -507,7 +507,7 @@ describe("@paretools/github integration", () => {
         {
           name: "pr-diff",
           arguments: {
-            pr: 1,
+            number: "1",
             repo: "--exec=malicious",
           },
         },

--- a/packages/server-github/__tests__/pr-checks.test.ts
+++ b/packages/server-github/__tests__/pr-checks.test.ts
@@ -85,30 +85,6 @@ describe("parsePrChecks (exit code 8 — pending checks)", () => {
     expect(result.summary.failed).toBe(0);
   });
 
-  it("includes required and conclusion fields when present", () => {
-    const json = JSON.stringify([
-      {
-        name: "required-check",
-        state: "PENDING",
-        bucket: "pending",
-        description: "",
-        event: "pull_request",
-        workflow: "CI",
-        link: "",
-        startedAt: "",
-        completedAt: "",
-        isRequired: true,
-        conclusion: null,
-      },
-    ]);
-
-    const result = parsePrChecks(json, 1);
-
-    expect(result.checks[0].required).toBe(true);
-    // null conclusion maps to undefined via the ?? operator in the parser
-    expect(result.checks[0].conclusion).toBeUndefined();
-  });
-
   it("deduplicates checks by name, keeping the most recent run", () => {
     const json = JSON.stringify([
       {

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -135,8 +135,7 @@ export function formatPrChecks(data: PrChecksResult): string {
   ];
   for (const c of data.checks ?? []) {
     const workflow = c.workflow ? ` [${c.workflow}]` : "";
-    const required = c.required ? " *required*" : "";
-    lines.push(`  ${c.name}: ${c.state} (${c.bucket})${workflow}${required}`);
+    lines.push(`  ${c.name}: ${c.state} (${c.bucket})${workflow}`);
   }
   return lines.join("\n");
 }

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -310,8 +310,6 @@ export function parsePrChecks(json: string, pr: number): PrChecksResult {
       link?: string;
       startedAt?: string;
       completedAt?: string;
-      isRequired?: boolean;
-      conclusion?: string;
     }) => ({
       name: c.name ?? "",
       state: c.state ?? "",
@@ -322,9 +320,6 @@ export function parsePrChecks(json: string, pr: number): PrChecksResult {
       link: c.link ?? "",
       startedAt: c.startedAt ?? "",
       completedAt: c.completedAt ?? "",
-      // S-gap fields
-      required: c.isRequired ?? undefined,
-      conclusion: c.conclusion ?? undefined,
     }),
   );
 

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -254,9 +254,6 @@ export const PrChecksItemSchema = z.object({
   link: z.string(),
   startedAt: z.string(),
   completedAt: z.string(),
-  // S-gap: Add per-check required field and conclusion
-  required: z.boolean().optional(),
-  conclusion: z.string().optional(),
 });
 
 /** Zod schema for summary counts of PR checks. */

--- a/packages/server-github/src/tools/pr-checks.ts
+++ b/packages/server-github/src/tools/pr-checks.ts
@@ -6,9 +6,7 @@ import { parsePrChecks } from "../lib/parsers.js";
 import { formatPrChecks, compactPrChecksMap, formatPrChecksCompact } from "../lib/formatters.js";
 import { PrChecksResultSchema } from "../schemas/index.js";
 
-// S-gap P1: Add isRequired and conclusion to checks fields
-const PR_CHECKS_FIELDS =
-  "name,state,bucket,description,event,workflow,link,startedAt,completedAt,isRequired,conclusion";
+const PR_CHECKS_FIELDS = "name,state,bucket,description,event,workflow,link,startedAt,completedAt";
 
 /** Registers the `pr-checks` tool on the given MCP server. */
 export function registerPrChecksTool(server: McpServer) {
@@ -17,9 +15,9 @@ export function registerPrChecksTool(server: McpServer) {
     {
       title: "PR Checks",
       description:
-        "Lists check/status results for a pull request. Returns structured data with check names, states, conclusions, required status, URLs, and summary counts (passed, failed, pending). Use instead of running `gh pr checks` in the terminal.",
+        "Lists check/status results for a pull request. Returns structured data with check names, states, URLs, and summary counts (passed, failed, pending). Use instead of running `gh pr checks` in the terminal.",
       inputSchema: {
-        pr: z
+        number: z
           .string()
           .max(INPUT_LIMITS.STRING_MAX)
           .describe("Pull request number, URL, or branch name"),
@@ -44,12 +42,12 @@ export function registerPrChecksTool(server: McpServer) {
       },
       outputSchema: PrChecksResultSchema,
     },
-    async ({ pr, repo, watch, required, compact }) => {
+    async ({ number, repo, watch, required, compact }) => {
       if (repo) assertNoFlagInjection(repo, "repo");
-      if (typeof pr === "string") assertNoFlagInjection(pr, "pr");
+      if (typeof number === "string") assertNoFlagInjection(number, "number");
 
-      const selector = String(pr);
-      const prNum = typeof pr === "number" ? pr : 0;
+      const selector = String(number);
+      const prNum = typeof number === "number" ? number : 0;
 
       const args = ["pr", "checks", selector, "--json", PR_CHECKS_FIELDS];
       if (repo) {

--- a/packages/server-github/src/tools/pr-diff.ts
+++ b/packages/server-github/src/tools/pr-diff.ts
@@ -18,7 +18,7 @@ export function registerPrDiffTool(server: McpServer) {
       description:
         "Returns file-level diff statistics for a pull request. Use full=true for patch content. Use instead of running `gh pr diff` in the terminal.",
       inputSchema: {
-        pr: z
+        number: z
           .string()
           .max(INPUT_LIMITS.STRING_MAX)
           .describe("Pull request number, URL, or branch name"),
@@ -43,15 +43,15 @@ export function registerPrDiffTool(server: McpServer) {
       },
       outputSchema: PrDiffResultSchema,
     },
-    async ({ pr, repo, full, nameOnly, compact }) => {
+    async ({ number, repo, full, nameOnly, compact }) => {
       if (repo) {
         assertNoFlagInjection(repo, "repo");
       }
-      if (typeof pr === "string") {
-        assertNoFlagInjection(pr, "pr");
+      if (typeof number === "string") {
+        assertNoFlagInjection(number, "number");
       }
 
-      const selector = String(pr);
+      const selector = String(number);
 
       // Get numstat for structured file-level stats
       const numstatArgs = ["pr", "diff", selector, "--patch=false"];


### PR DESCRIPTION
## Summary
- **Bug 1**: `pr-checks` tool was failing because `gh pr checks --json` does not support `isRequired` or `conclusion` fields. Removed these from the fields constant, parser, schema, and formatter.
- **Bug 2**: `pr-checks` and `pr-diff` used `pr` as their input parameter name while all other PR tools use `number`. Renamed to `number` for consistency.
- Fixed stale `pr:` parameter references in integration tests across all PR tools.

## Test plan
- [x] `pnpm --filter @paretools/github build` — builds cleanly (0 errors)
- [x] `pnpm --filter @paretools/github test` — 315/315 tests pass
- [ ] After MCP server restart, call `pr-checks` with `number: "441"` to confirm structured output

🤖 Generated with [Claude Code](https://claude.com/claude-code)