### PR TITLE
feat(shared): add PARE_PROFILE env var for preset tool profiles

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,9 +25,38 @@ PARE_GIT_TOOLS=status,log,diff
 PARE_NPM_TOOLS=install,run,test
 ```
 
-`PARE_TOOLS` (global) takes precedence over per-server variables when both are set.
+`PARE_TOOLS` (global) takes precedence over profiles and per-server variables when both are set.
 
 When neither is set, all tools are enabled (default).
+
+---
+
+## Tool Profiles (`PARE_PROFILE`)
+
+Activate a preset collection of tools for common workflows instead of listing individual tools.
+
+```bash
+PARE_PROFILE=python
+```
+
+| Profile   | Tools | Description                                      |
+| --------- | ----- | ------------------------------------------------ |
+| `minimal` | 18    | Core git, build, test, search, and GitHub basics |
+| `web`     | ~65   | Full-stack web dev: npm, build, lint, test, HTTP |
+| `python`  | ~48   | Python ecosystem: pip, ruff, mypy, pytest, uv    |
+| `devops`  | ~59   | Docker, K8s, security scanning, CI/CD, releases  |
+| `rust`    | ~44   | Cargo toolchain: build, test, clippy, audit      |
+| `go`      | ~44   | Go toolchain: build, test, vet, lint             |
+| `full`    | all   | No filtering (default when unset)                |
+
+### Precedence
+
+1. `PARE_TOOLS` — highest priority (explicit tool list)
+2. `PARE_PROFILE` — preset profile
+3. `PARE_{SERVER}_TOOLS` — per-server filter
+4. No env vars — all tools enabled
+
+`PARE_PROFILE` overrides per-server variables but is itself overridden by `PARE_TOOLS`. Profile names are case-insensitive.
 
 ---
 
@@ -130,6 +159,7 @@ Server names in env vars use uppercase with hyphens replaced by underscores:
 | Variable                         | Type              | Default      | Description                          |
 | -------------------------------- | ----------------- | ------------ | ------------------------------------ |
 | `PARE_TOOLS`                     | `server:tool,...` | all enabled  | Global tool filter                   |
+| `PARE_PROFILE`                   | profile name      | `full`       | Preset tool profile                  |
 | `PARE_{SERVER}_TOOLS`            | `tool,...`        | all enabled  | Per-server tool filter               |
 | `PARE_ALLOWED_COMMANDS`          | `cmd,...`         | unrestricted | Global command allowlist             |
 | `PARE_{SERVER}_ALLOWED_COMMANDS` | `cmd,...`         | unrestricted | Per-server command allowlist         |

--- a/packages/shared/__tests__/profiles.test.ts
+++ b/packages/shared/__tests__/profiles.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PROFILES, resolveProfile, _resetProfileCache } from "../src/profiles.js";
+import { shouldRegisterTool } from "../src/tool-filter.js";
+import type { ProfileName } from "../src/profiles.js";
+
+describe("profiles", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    savedEnv.PARE_PROFILE = process.env.PARE_PROFILE;
+    savedEnv.PARE_TOOLS = process.env.PARE_TOOLS;
+    savedEnv.PARE_GIT_TOOLS = process.env.PARE_GIT_TOOLS;
+    savedEnv.PARE_NPM_TOOLS = process.env.PARE_NPM_TOOLS;
+    delete process.env.PARE_PROFILE;
+    delete process.env.PARE_TOOLS;
+    delete process.env.PARE_GIT_TOOLS;
+    delete process.env.PARE_NPM_TOOLS;
+    _resetProfileCache();
+  });
+
+  afterEach(() => {
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = val;
+      }
+    }
+    _resetProfileCache();
+  });
+
+  describe("resolveProfile()", () => {
+    it("returns null when no env var is set", () => {
+      expect(resolveProfile()).toBeNull();
+    });
+
+    it("returns null when env var is empty string", () => {
+      process.env.PARE_PROFILE = "";
+      expect(resolveProfile()).toBeNull();
+    });
+
+    it("returns null when env var is whitespace only", () => {
+      process.env.PARE_PROFILE = "   ";
+      expect(resolveProfile()).toBeNull();
+    });
+
+    it('returns null for "full" profile', () => {
+      process.env.PARE_PROFILE = "full";
+      expect(resolveProfile()).toBeNull();
+    });
+
+    it("returns Set for valid profiles", () => {
+      for (const name of ["minimal", "web", "python", "devops", "rust", "go"] as ProfileName[]) {
+        _resetProfileCache();
+        process.env.PARE_PROFILE = name;
+        const result = resolveProfile();
+        expect(result).toBeInstanceOf(Set);
+        expect(result!.size).toBeGreaterThan(0);
+      }
+    });
+
+    it("logs warning and returns null for unknown profile", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      process.env.PARE_PROFILE = "nonexistent";
+      const result = resolveProfile();
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown profile "nonexistent"'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("is case-insensitive", () => {
+      process.env.PARE_PROFILE = "MINIMAL";
+      const upper = resolveProfile();
+      expect(upper).toBeInstanceOf(Set);
+
+      _resetProfileCache();
+      process.env.PARE_PROFILE = "Minimal";
+      const mixed = resolveProfile();
+      expect(mixed).toBeInstanceOf(Set);
+
+      _resetProfileCache();
+      process.env.PARE_PROFILE = "minimal";
+      const lower = resolveProfile();
+      expect(lower).toBeInstanceOf(Set);
+
+      // All should contain the same tools
+      expect(upper!.size).toBe(lower!.size);
+      expect(mixed!.size).toBe(lower!.size);
+    });
+
+    it("caches the result across calls", () => {
+      process.env.PARE_PROFILE = "minimal";
+      const first = resolveProfile();
+      const second = resolveProfile();
+      expect(first).toBe(second); // Same reference
+    });
+  });
+
+  describe("PROFILES definitions", () => {
+    it('all entries match "server:tool" format', () => {
+      const pattern = /^[a-z][a-z0-9]*:[a-z][a-z0-9-]*$/;
+      for (const [name, tools] of Object.entries(PROFILES)) {
+        if (tools === null) continue; // "full"
+        for (const entry of tools) {
+          expect(entry, `${name}: "${entry}" must match server:tool`).toMatch(pattern);
+        }
+      }
+    });
+
+    it('"full" profile is null', () => {
+      expect(PROFILES.full).toBeNull();
+    });
+
+    it('"minimal" is a subset of "web"', () => {
+      const minimal = new Set(PROFILES.minimal!);
+      const web = new Set(PROFILES.web!);
+      for (const tool of minimal) {
+        expect(web.has(tool), `web should contain ${tool}`).toBe(true);
+      }
+    });
+
+    it("all profiles contain git:status and git:commit", () => {
+      for (const [name, tools] of Object.entries(PROFILES)) {
+        if (tools === null) continue;
+        const set = new Set(tools);
+        expect(set.has("git:status"), `${name} should have git:status`).toBe(true);
+        expect(set.has("git:commit"), `${name} should have git:commit`).toBe(true);
+      }
+    });
+
+    it("has expected profile count", () => {
+      expect(Object.keys(PROFILES)).toHaveLength(7);
+    });
+  });
+
+  describe("shouldRegisterTool with PARE_PROFILE", () => {
+    it("filters tools by profile", () => {
+      process.env.PARE_PROFILE = "minimal";
+      expect(shouldRegisterTool("git", "status")).toBe(true);
+      expect(shouldRegisterTool("git", "log")).toBe(true);
+      expect(shouldRegisterTool("docker", "ps")).toBe(false);
+      expect(shouldRegisterTool("cargo", "build")).toBe(false);
+    });
+
+    it("PARE_TOOLS overrides PARE_PROFILE", () => {
+      process.env.PARE_TOOLS = "git:status";
+      process.env.PARE_PROFILE = "web";
+      // PARE_TOOLS wins — only git:status allowed
+      expect(shouldRegisterTool("git", "status")).toBe(true);
+      expect(shouldRegisterTool("git", "log")).toBe(false);
+      expect(shouldRegisterTool("npm", "install")).toBe(false);
+    });
+
+    it("PARE_PROFILE overrides per-server PARE_{SERVER}_TOOLS", () => {
+      process.env.PARE_PROFILE = "minimal";
+      process.env.PARE_GIT_TOOLS = "status,log,diff,show,blame";
+      // Profile wins — blame is not in minimal
+      expect(shouldRegisterTool("git", "status")).toBe(true);
+      expect(shouldRegisterTool("git", "blame")).toBe(false);
+    });
+
+    it('"full" profile enables all tools (same as no profile)', () => {
+      process.env.PARE_PROFILE = "full";
+      expect(shouldRegisterTool("git", "status")).toBe(true);
+      expect(shouldRegisterTool("docker", "ps")).toBe(true);
+      expect(shouldRegisterTool("cargo", "build")).toBe(true);
+    });
+  });
+});

--- a/packages/shared/__tests__/tool-filter.test.ts
+++ b/packages/shared/__tests__/tool-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { shouldRegisterTool } from "../src/tool-filter.js";
+import { shouldRegisterTool, _resetProfileCache } from "../src/tool-filter.js";
 
 describe("shouldRegisterTool", () => {
   const savedEnv: Record<string, string | undefined> = {};
@@ -7,14 +7,17 @@ describe("shouldRegisterTool", () => {
   beforeEach(() => {
     // Save current env vars
     savedEnv.PARE_TOOLS = process.env.PARE_TOOLS;
+    savedEnv.PARE_PROFILE = process.env.PARE_PROFILE;
     savedEnv.PARE_GIT_TOOLS = process.env.PARE_GIT_TOOLS;
     savedEnv.PARE_NPM_TOOLS = process.env.PARE_NPM_TOOLS;
     savedEnv.PARE_DOCKER_TOOLS = process.env.PARE_DOCKER_TOOLS;
     // Clean slate
     delete process.env.PARE_TOOLS;
+    delete process.env.PARE_PROFILE;
     delete process.env.PARE_GIT_TOOLS;
     delete process.env.PARE_NPM_TOOLS;
     delete process.env.PARE_DOCKER_TOOLS;
+    _resetProfileCache();
   });
 
   afterEach(() => {
@@ -26,6 +29,7 @@ describe("shouldRegisterTool", () => {
         process.env[key] = val;
       }
     }
+    _resetProfileCache();
   });
 
   describe("default behavior (no env vars)", () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,7 +4,9 @@ export { stripAnsi } from "./ansi.js";
 export { assertNoFlagInjection, assertAllowedCommand } from "./validation.js";
 export { INPUT_LIMITS } from "./limits.js";
 export { sanitizeErrorOutput } from "./sanitize.js";
-export { shouldRegisterTool } from "./tool-filter.js";
+export { shouldRegisterTool, _resetProfileCache } from "./tool-filter.js";
+export { PROFILES, resolveProfile } from "./profiles.js";
+export type { ProfileName } from "./profiles.js";
 export {
   assertAllowedByPolicy,
   assertAllowedRoot,

--- a/packages/shared/src/profiles.ts
+++ b/packages/shared/src/profiles.ts
@@ -1,0 +1,370 @@
+/**
+ * Preset tool profiles — allows users to activate a curated set of tools
+ * via the `PARE_PROFILE` environment variable.
+ *
+ * Profiles provide a convenient shorthand for `PARE_TOOLS` lists tuned to
+ * common workflows (web dev, Python, DevOps, Rust, Go, or a minimal core set).
+ *
+ * Setting `PARE_PROFILE=full` (or leaving it unset) enables all tools.
+ */
+
+/** Valid profile names. */
+export type ProfileName = "minimal" | "web" | "python" | "devops" | "rust" | "go" | "full";
+
+/**
+ * Maps each profile name to an array of `server:tool` strings, or `null`
+ * for the "full" profile (no filtering).
+ */
+export const PROFILES: Record<ProfileName, readonly string[] | null> = {
+  minimal: [
+    "git:status",
+    "git:log",
+    "git:diff",
+    "git:add",
+    "git:commit",
+    "git:push",
+    "git:pull",
+    "git:checkout",
+    "git:branch",
+    "test:run",
+    "build:build",
+    "build:tsc",
+    "search:search",
+    "search:find",
+    "github:pr-view",
+    "github:pr-list",
+    "github:pr-create",
+    "process:run",
+  ],
+
+  web: [
+    "git:status",
+    "git:log",
+    "git:log-graph",
+    "git:diff",
+    "git:branch",
+    "git:show",
+    "git:add",
+    "git:commit",
+    "git:push",
+    "git:pull",
+    "git:checkout",
+    "git:merge",
+    "git:rebase",
+    "git:stash",
+    "git:stash-list",
+    "git:reset",
+    "git:restore",
+    "github:pr-view",
+    "github:pr-list",
+    "github:pr-create",
+    "github:pr-merge",
+    "github:pr-comment",
+    "github:pr-review",
+    "github:pr-update",
+    "github:pr-checks",
+    "github:pr-diff",
+    "github:issue-view",
+    "github:issue-list",
+    "github:issue-create",
+    "github:issue-close",
+    "github:issue-comment",
+    "github:run-view",
+    "github:run-list",
+    "npm:install",
+    "npm:audit",
+    "npm:outdated",
+    "npm:list",
+    "npm:run",
+    "npm:test",
+    "npm:info",
+    "npm:search",
+    "npm:nvm",
+    "build:tsc",
+    "build:build",
+    "build:esbuild",
+    "build:vite-build",
+    "build:webpack",
+    "build:turbo",
+    "build:nx",
+    "test:run",
+    "test:coverage",
+    "test:playwright",
+    "lint:lint",
+    "lint:format-check",
+    "lint:prettier-format",
+    "lint:biome-check",
+    "lint:biome-format",
+    "lint:oxlint",
+    "lint:stylelint",
+    "search:search",
+    "search:find",
+    "search:count",
+    "search:jq",
+    "http:get",
+    "http:post",
+    "http:request",
+    "http:head",
+    "process:run",
+  ],
+
+  python: [
+    "git:status",
+    "git:log",
+    "git:log-graph",
+    "git:diff",
+    "git:branch",
+    "git:show",
+    "git:add",
+    "git:commit",
+    "git:push",
+    "git:pull",
+    "git:checkout",
+    "git:merge",
+    "git:rebase",
+    "git:stash",
+    "git:stash-list",
+    "git:reset",
+    "git:restore",
+    "github:pr-view",
+    "github:pr-list",
+    "github:pr-create",
+    "github:pr-merge",
+    "github:pr-checks",
+    "github:issue-view",
+    "github:issue-list",
+    "github:issue-create",
+    "github:run-view",
+    "github:run-list",
+    "python:pip-install",
+    "python:pip-list",
+    "python:pip-show",
+    "python:mypy",
+    "python:ruff-check",
+    "python:ruff-format",
+    "python:pip-audit",
+    "python:pytest",
+    "python:uv-install",
+    "python:uv-run",
+    "python:black",
+    "python:poetry",
+    "python:pyenv",
+    "python:conda",
+    "test:run",
+    "test:coverage",
+    "search:search",
+    "search:find",
+    "search:count",
+    "make:run",
+    "make:list",
+    "process:run",
+  ],
+
+  devops: [
+    "git:status",
+    "git:log",
+    "git:diff",
+    "git:branch",
+    "git:show",
+    "git:add",
+    "git:commit",
+    "git:push",
+    "git:pull",
+    "git:checkout",
+    "git:tag",
+    "git:remote",
+    "git:merge",
+    "github:pr-view",
+    "github:pr-list",
+    "github:pr-create",
+    "github:pr-merge",
+    "github:pr-checks",
+    "github:issue-view",
+    "github:issue-list",
+    "github:run-view",
+    "github:run-list",
+    "github:run-rerun",
+    "github:release-create",
+    "github:release-list",
+    "docker:ps",
+    "docker:build",
+    "docker:logs",
+    "docker:images",
+    "docker:run",
+    "docker:exec",
+    "docker:compose-up",
+    "docker:compose-down",
+    "docker:pull",
+    "docker:inspect",
+    "docker:network-ls",
+    "docker:volume-ls",
+    "docker:compose-ps",
+    "docker:compose-logs",
+    "docker:compose-build",
+    "docker:stats",
+    "k8s:get",
+    "k8s:describe",
+    "k8s:logs",
+    "k8s:apply",
+    "k8s:helm",
+    "security:trivy",
+    "security:semgrep",
+    "security:gitleaks",
+    "make:run",
+    "make:list",
+    "lint:shellcheck",
+    "lint:hadolint",
+    "http:get",
+    "http:post",
+    "http:request",
+    "http:head",
+    "search:search",
+    "search:find",
+    "process:run",
+  ],
+
+  rust: [
+    "git:status",
+    "git:log",
+    "git:log-graph",
+    "git:diff",
+    "git:branch",
+    "git:show",
+    "git:add",
+    "git:commit",
+    "git:push",
+    "git:pull",
+    "git:checkout",
+    "git:merge",
+    "git:rebase",
+    "git:stash",
+    "git:stash-list",
+    "git:reset",
+    "git:restore",
+    "github:pr-view",
+    "github:pr-list",
+    "github:pr-create",
+    "github:pr-merge",
+    "github:pr-checks",
+    "github:issue-view",
+    "github:issue-list",
+    "github:issue-create",
+    "github:run-view",
+    "github:run-list",
+    "cargo:build",
+    "cargo:test",
+    "cargo:clippy",
+    "cargo:run",
+    "cargo:add",
+    "cargo:remove",
+    "cargo:fmt",
+    "cargo:doc",
+    "cargo:check",
+    "cargo:update",
+    "cargo:tree",
+    "cargo:audit",
+    "test:run",
+    "test:coverage",
+    "search:search",
+    "search:find",
+    "search:count",
+    "process:run",
+  ],
+
+  go: [
+    "git:status",
+    "git:log",
+    "git:log-graph",
+    "git:diff",
+    "git:branch",
+    "git:show",
+    "git:add",
+    "git:commit",
+    "git:push",
+    "git:pull",
+    "git:checkout",
+    "git:merge",
+    "git:rebase",
+    "git:stash",
+    "git:stash-list",
+    "git:reset",
+    "git:restore",
+    "github:pr-view",
+    "github:pr-list",
+    "github:pr-create",
+    "github:pr-merge",
+    "github:pr-checks",
+    "github:issue-view",
+    "github:issue-list",
+    "github:issue-create",
+    "github:run-view",
+    "github:run-list",
+    "go:build",
+    "go:test",
+    "go:vet",
+    "go:run",
+    "go:mod-tidy",
+    "go:fmt",
+    "go:generate",
+    "go:env",
+    "go:list",
+    "go:get",
+    "go:golangci-lint",
+    "test:run",
+    "test:coverage",
+    "search:search",
+    "search:find",
+    "search:count",
+    "process:run",
+  ],
+
+  full: null,
+};
+
+/** Module-level cache for the resolved profile Set. */
+let profileCache: Set<string> | null | undefined;
+
+/**
+ * Reads `PARE_PROFILE` and returns a `Set<string>` of allowed `server:tool`
+ * entries, or `null` if all tools should be enabled.
+ *
+ * Results are cached at the module level since the env var is read once at
+ * startup and does not change.
+ */
+export function resolveProfile(): Set<string> | null {
+  if (profileCache !== undefined) return profileCache;
+
+  const raw = process.env.PARE_PROFILE;
+  if (raw === undefined || raw.trim() === "") {
+    profileCache = null;
+    return null;
+  }
+
+  const name = raw.trim().toLowerCase() as ProfileName;
+  const tools = PROFILES[name];
+
+  if (tools === undefined) {
+    // Unknown profile — warn and fall back to no filtering.
+    console.warn(
+      `[pare] Unknown profile "${raw.trim()}". Valid profiles: ${Object.keys(PROFILES).join(", ")}. Ignoring.`,
+    );
+    profileCache = null;
+    return null;
+  }
+
+  if (tools === null) {
+    // "full" profile — no filtering.
+    profileCache = null;
+    return null;
+  }
+
+  profileCache = new Set(tools);
+  return profileCache;
+}
+
+/**
+ * Resets the module-level profile cache. Intended for test cleanup only.
+ */
+export function _resetProfileCache(): void {
+  profileCache = undefined;
+}

--- a/packages/shared/src/tool-filter.ts
+++ b/packages/shared/src/tool-filter.ts
@@ -7,14 +7,23 @@
  *      Format: comma-separated `server:tool` pairs.
  *      Example: `PARE_TOOLS=git:status,git:log,npm:install`
  *
- *   2. `PARE_{SERVER}_TOOLS` — per-server filter.
+ *   2. `PARE_PROFILE` — preset tool profile.
+ *      Format: profile name (minimal, web, python, devops, rust, go, full).
+ *      Example: `PARE_PROFILE=python`
+ *
+ *   3. `PARE_{SERVER}_TOOLS` — per-server filter.
  *      Format: comma-separated tool names.
  *      Example: `PARE_GIT_TOOLS=status,log`
  *
- *   3. No env vars → all tools enabled (default).
+ *   4. No env vars → all tools enabled (default).
  *
- * Universal (`PARE_TOOLS`) takes precedence over per-server env vars.
+ * Universal (`PARE_TOOLS`) takes precedence over profiles,
+ * which take precedence over per-server env vars.
  */
+
+import { resolveProfile, _resetProfileCache } from "./profiles.js";
+
+export { _resetProfileCache };
 
 /**
  * Determines whether a tool should be registered based on environment variables.
@@ -24,6 +33,7 @@
  * @returns `true` if the tool should be registered, `false` if filtered out.
  */
 export function shouldRegisterTool(serverName: string, toolName: string): boolean {
+  // 1. PARE_TOOLS — highest priority universal filter.
   const universal = process.env.PARE_TOOLS;
   if (universal !== undefined) {
     if (universal.trim() === "") return false;
@@ -31,6 +41,13 @@ export function shouldRegisterTool(serverName: string, toolName: string): boolea
     return allowed.includes(`${serverName}:${toolName}`);
   }
 
+  // 2. PARE_PROFILE — preset profile filter.
+  const profileSet = resolveProfile();
+  if (profileSet !== null) {
+    return profileSet.has(`${serverName}:${toolName}`);
+  }
+
+  // 3. PARE_{SERVER}_TOOLS — per-server filter.
   const envKey = `PARE_${serverName.toUpperCase().replace(/-/g, "_")}_TOOLS`;
   const perServer = process.env[envKey];
   if (perServer !== undefined) {
@@ -39,5 +56,6 @@ export function shouldRegisterTool(serverName: string, toolName: string): boolea
     return allowed.includes(toolName);
   }
 
+  // 4. Default: all enabled.
   return true;
 }


### PR DESCRIPTION
## Summary  - Adds `PARE_PROFILE` environment variable that activates preset tool collections for common workflows - Seven profiles: `minimal` (18 tools), `web` (~65), `python` (~48), `devops` (~59), `rust` (~44), `go` (~44), `full` (all) - Integrates into existing tool filter with clear precedence: `PARE_TOOLS` > `PARE_PROFILE` > `PARE_{SERVER}_TOOLS` > default  ## Changes  - **New**: `packages/shared/src/profiles.ts` — `ProfileName` type, `PROFILES` record, `resolveProfile()` with module-level caching - **Modified**: `packages/shared/src/tool-filter.ts` — profile resolution as priority 2 in `shouldRegisterTool()` - **Modified**: `packages/shared/src/index.ts` — exports for profiles API - **New**: `packages/shared/__tests__/profiles.test.ts` — 17 tests covering resolution, caching, case-insensitivity, precedence, subset validation - **Modified**: `packages/shared/__tests__/tool-filter.test.ts` — added `PARE_PROFILE` cleanup and cache reset - **Modified**: `docs/configuration.md` — profile documentation and quick reference table entry  ## Test plan  - [x] All 195 shared package tests pass (including 17 new profile tests) - [x] TypeScript builds cleanly across all 17 packages - [ ] Verify `PARE_PROFILE=minimal` limits tools when running a server - [ ] Verify `PARE_TOOLS` overrides `PARE_PROFILE` when both are set  Closes #518  🤖 Generated with [Claude Code](https://claude.com/claude-code)