### PR TITLE
fix(git): handle '+' worktree marker in branch parser

### DIFF
--- a/packages/server-git/__tests__/parsers.test.ts
+++ b/packages/server-git/__tests__/parsers.test.ts
@@ -244,6 +244,38 @@ describe("parseBranch", () => {
       lastCommit: "1234567",
     });
   });
+
+  it("handles '+' worktree marker without garbling branch names", () => {
+    // Git marks branches checked out in linked worktrees with '+' instead of '*'
+    const stdout = [
+      "* main         abc1234 [origin/main] Latest commit",
+      "+ feat/go-http  def5678 [origin/feat/go-http] Add HTTP support",
+      "  dev           1234567 Fix bug",
+    ].join("\n");
+
+    const result = parseBranch(stdout);
+
+    expect(result.current).toBe("main");
+    expect(result.branches).toHaveLength(3);
+    expect(result.branches[0]).toEqual({
+      name: "main",
+      current: true,
+      upstream: "origin/main",
+      lastCommit: "abc1234",
+    });
+    // The '+' marker must NOT become the branch name
+    expect(result.branches[1]).toEqual({
+      name: "feat/go-http",
+      current: false,
+      upstream: "origin/feat/go-http",
+      lastCommit: "def5678",
+    });
+    expect(result.branches[2]).toEqual({
+      name: "dev",
+      current: false,
+      lastCommit: "1234567",
+    });
+  });
 });
 
 describe("parseShow", () => {

--- a/packages/server-git/src/lib/parsers.ts
+++ b/packages/server-git/src/lib/parsers.ts
@@ -315,7 +315,9 @@ export function parseBranch(stdout: string): GitBranchFull {
   let current = "";
   const branches = lines.map((line) => {
     const isCurrent = line.startsWith("* ");
-    const stripped = line.replace(/^\*?\s+/, "");
+    // Git uses '*' for the current branch and '+' for branches checked out
+    // in linked worktrees. Strip both markers before parsing the name.
+    const stripped = line.replace(/^[*+]?\s+/, "");
     const name = stripped.split(/\s+/)[0];
     if (isCurrent) current = name;
 


### PR DESCRIPTION
## Summary

- Fixes branch parser regex to strip `+` worktree markers in addition to `*` current-branch markers, preventing garbled branch names (`"+"` instead of actual name) in compact mode
- Adds test case verifying branches with `+` worktree markers are parsed correctly

Fixes #513

## Test plan

- [x] New unit test: `parseBranch` handles `+` worktree marker without garbling branch names
- [x] All 158 parser tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)