### PR TITLE
fix(git): worktree list fails with Zod error

### DIFF
--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -182,20 +182,17 @@ describe("@paretools/git integration", () => {
       expect(result.content).toBeDefined();
       expect(Array.isArray(result.content)).toBe(true);
 
-      // worktree tool uses z.union for outputSchema which may not return
-      // structuredContent via MCP SDK; verify text content instead
       const textContent = result.content as Array<{ type: string; text: string }>;
       expect(textContent.length).toBeGreaterThan(0);
       expect(textContent[0].type).toBe("text");
       // The text output should contain at least one worktree path
       expect(textContent[0].text.length).toBeGreaterThan(0);
 
-      // If structuredContent is available, verify its shape
-      if (result.structuredContent) {
-        const sc = result.structuredContent as Record<string, unknown>;
-        expect(Array.isArray(sc.worktrees)).toBe(true);
-        expect(sc.total).toEqual(expect.any(Number));
-      }
+      // structuredContent is now always returned (unified output schema)
+      expect(result.structuredContent).toBeDefined();
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(Array.isArray(sc.worktrees)).toBe(true);
+      expect(sc.total).toEqual(expect.any(Number));
     });
   });
 

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -655,6 +655,28 @@ export const GitWorktreeSchema = z.object({
 
 export type GitWorktree = z.infer<typeof GitWorktreeSchema>;
 
+/** Unified Zod schema for all worktree tool output (list + mutate actions).
+ *  Uses a single z.object() with optional fields instead of z.union(),
+ *  which is not supported by the MCP SDK for outputSchema. */
+export const GitWorktreeOutputSchema = z.object({
+  /** Present for list action. */
+  worktrees: z.union([z.array(GitWorktreeEntrySchema), z.array(z.string())]).optional(),
+  /** Present for list action. */
+  total: z.number().optional(),
+  /** Present for mutate actions. */
+  success: z.boolean().optional(),
+  /** Action performed (only present for mutate operations). */
+  action: z.enum(["add", "remove", "lock", "unlock", "prune", "move", "repair"]).optional(),
+  /** Worktree path (present for mutate actions). */
+  path: z.string().optional(),
+  /** Target path (only present for move action). */
+  targetPath: z.string().optional(),
+  /** Branch name (present for mutate actions). */
+  branch: z.string().optional(),
+  /** HEAD commit (present for mutate actions). */
+  head: z.string().optional(),
+});
+
 /** Type alias for remote mutate results (uses unified GitRemoteSchema). */
 export type GitRemoteMutate = {
   success: boolean;

--- a/packages/server-git/src/tools/worktree.ts
+++ b/packages/server-git/src/tools/worktree.ts
@@ -14,7 +14,7 @@ import {
   formatWorktreeListCompact,
   formatWorktree,
 } from "../lib/formatters.js";
-import { GitWorktreeListSchema, GitWorktreeSchema } from "../schemas/index.js";
+import { GitWorktreeOutputSchema } from "../schemas/index.js";
 
 /** Registers the `worktree` tool on the given MCP server. */
 export function registerWorktreeTool(server: McpServer) {
@@ -88,7 +88,7 @@ export function registerWorktreeTool(server: McpServer) {
           .describe("Optional worktree paths to repair (used with action=repair)"),
         compact: z.boolean().optional().default(true).describe("Prefer compact output"),
       },
-      outputSchema: z.union([GitWorktreeListSchema, GitWorktreeSchema]),
+      outputSchema: GitWorktreeOutputSchema,
     },
     async (params) => {
       const cwd = params.path || process.cwd();


### PR DESCRIPTION
## Summary
- Fixes #512: `worktree list` returned `Cannot read properties of undefined (reading '_zod')` because the `outputSchema` used `z.union()`, which the MCP SDK does not support for output schemas
- Replaced `z.union([GitWorktreeListSchema, GitWorktreeSchema])` with a unified `GitWorktreeOutputSchema` that merges all fields into a single `z.object()` with optional fields, matching the pattern used by `GitTagSchema` and `GitRemoteSchema`
- Updated integration test to assert `structuredContent` is always returned (no longer conditional)

## Test plan
- [x] All 396 unit tests pass (parsers, formatters, compact, fidelity, p2-gaps)
- [x] All 54 integration tests pass, including the worktree test which now validates `structuredContent`
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)