### PR TITLE
chore(ci): add restrictive top-level permissions to all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -7,12 +7,13 @@ on:
       - "pnpm-lock.yaml"
       - "**/package.json"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   sbom:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
## Summary  Fixes OpenSSF Scorecard Token-Permissions alerts by adding restrictive top-level `permissions:` blocks to all workflow files.  **Changes:** - **ci.yml**: Add `permissions: { contents: read }` — all jobs only read the repo - **release.yml**: Add `permissions: {}` top-level default — job-level already declares `contents: write`, `pull-requests: write`, `id-token: write` - **sbom.yml**: Change top-level `contents: write` to `permissions: {}` with job-level `contents: read` (only uploads artifacts, doesn't write to repo) - **scorecard.yml**: Already had `permissions: read-all` — no change needed  ## Test plan  - [x] No functional changes — only tightens permissions - [ ] CI passes with restricted permissions - [ ] Scorecard re-scan shows resolved Token-Permissions alerts