### PR TITLE
feat(smoke): Phase 4 — coverage report and scenario completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "release": "turbo run build && changeset publish",
     "changelog": "tsx scripts/aggregate-changelog.ts",
     "smoke": "vitest run --config tests/smoke/vitest.config.ts",
+    "smoke:coverage": "tsx scripts/smoke-coverage.ts",
     "benchmark": "tsx benchmarks/v2/scripts/benchmark.ts",
     "docs:api": "typedoc",
     "sync-tool-counts": "tsx scripts/sync-tool-counts.ts",

--- a/scripts/smoke-coverage.ts
+++ b/scripts/smoke-coverage.ts
@@ -1,0 +1,242 @@
+#!/usr/bin/env npx tsx
+/**
+ * Smoke test coverage report.
+ *
+ * Parses all scenario mapping files in tests/smoke/scenarios/ and reports
+ * coverage by status (mocked / recorded / complete) and priority (P0-P2).
+ *
+ * Usage:
+ *   pnpm smoke:coverage          # print coverage report
+ *   pnpm smoke:coverage --json   # output as JSON (for CI)
+ *   pnpm smoke:coverage --check  # exit 1 if any P0 scenario is not complete
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const ROOT = resolve(__dirname, "..");
+const SCENARIOS_DIR = resolve(ROOT, "tests/smoke/scenarios");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Status = "pending" | "mocked" | "recorded" | "complete";
+type Priority = "P0" | "P1" | "P2";
+
+interface Scenario {
+  file: string;
+  number: number;
+  name: string;
+  priority: Priority;
+  status: Status;
+}
+
+interface FileSummary {
+  file: string;
+  total: number;
+  byStatus: Record<Status, number>;
+  byPriority: Record<Priority, Record<Status, number>>;
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+const STATUS_VALUES: Status[] = ["pending", "mocked", "recorded", "complete"];
+const PRIORITY_VALUES: Priority[] = ["P0", "P1", "P2"];
+
+function parseScenarioFile(filePath: string, fileName: string): Scenario[] {
+  const content = readFileSync(filePath, "utf-8");
+  const scenarios: Scenario[] = [];
+
+  // Match markdown table rows with status column
+  // Format: | # | Scenario | Params | Expected Output | Priority | Status |
+  // The status is always the last column before the trailing |
+  const lines = content.split("\n");
+
+  for (const line of lines) {
+    // Skip non-table rows and header/separator rows
+    if (!line.startsWith("|")) continue;
+    if (line.includes("---")) continue;
+
+    const cells = line
+      .split("|")
+      .map((c) => c.trim())
+      .filter((c) => c.length > 0);
+
+    if (cells.length < 3) continue;
+
+    // Find status column (last cell) and priority column (second to last)
+    const statusCell = cells[cells.length - 1].toLowerCase();
+    const priorityCell = cells[cells.length - 2].toUpperCase();
+
+    // Validate this is a data row with valid status and priority
+    const status = STATUS_VALUES.find((s) => statusCell === s);
+    const priority = PRIORITY_VALUES.find((p) => priorityCell === p);
+
+    if (!status || !priority) continue;
+
+    const num = parseInt(cells[0], 10);
+    if (isNaN(num)) continue;
+
+    scenarios.push({
+      file: fileName,
+      number: num,
+      name: cells[1],
+      priority,
+      status,
+    });
+  }
+
+  return scenarios;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+function summarizeFile(fileName: string, scenarios: Scenario[]): FileSummary {
+  const byStatus: Record<Status, number> = { pending: 0, mocked: 0, recorded: 0, complete: 0 };
+  const byPriority: Record<Priority, Record<Status, number>> = {
+    P0: { pending: 0, mocked: 0, recorded: 0, complete: 0 },
+    P1: { pending: 0, mocked: 0, recorded: 0, complete: 0 },
+    P2: { pending: 0, mocked: 0, recorded: 0, complete: 0 },
+  };
+
+  for (const s of scenarios) {
+    byStatus[s.status]++;
+    byPriority[s.priority][s.status]++;
+  }
+
+  return { file: fileName, total: scenarios.length, byStatus, byPriority };
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+function printReport(summaries: FileSummary[]) {
+  const totals: Record<Status, number> = { pending: 0, mocked: 0, recorded: 0, complete: 0 };
+  const totalByPriority: Record<Priority, Record<Status, number>> = {
+    P0: { pending: 0, mocked: 0, recorded: 0, complete: 0 },
+    P1: { pending: 0, mocked: 0, recorded: 0, complete: 0 },
+    P2: { pending: 0, mocked: 0, recorded: 0, complete: 0 },
+  };
+  let grandTotal = 0;
+
+  console.log("╔══════════════════════════════════════════════════════════════╗");
+  console.log("║              Smoke Test Coverage Report                     ║");
+  console.log("╠══════════════════════════════════════════════════════════════╣");
+  console.log("");
+
+  for (const s of summaries) {
+    const pct = s.total > 0 ? Math.round((s.byStatus.complete / s.total) * 100) : 0;
+    const bar = progressBar(pct, 20);
+    console.log(`  ${s.file.padEnd(25)} ${bar} ${pct}% (${s.byStatus.complete}/${s.total})`);
+
+    for (const status of STATUS_VALUES) {
+      totals[status] += s.byStatus[status];
+    }
+    for (const p of PRIORITY_VALUES) {
+      for (const status of STATUS_VALUES) {
+        totalByPriority[p][status] += s.byPriority[p][status];
+      }
+    }
+    grandTotal += s.total;
+  }
+
+  const overallPct = grandTotal > 0 ? Math.round((totals.complete / grandTotal) * 100) : 0;
+
+  console.log("");
+  console.log("──────────────────────────────────────────────────────────────");
+  console.log("");
+  console.log("  By Status:");
+  console.log(`    complete:  ${totals.complete}`);
+  console.log(`    recorded:  ${totals.recorded}`);
+  console.log(`    mocked:    ${totals.mocked}`);
+  console.log(`    pending:   ${totals.pending}`);
+  console.log(`    TOTAL:     ${grandTotal}`);
+  console.log("");
+  console.log("  By Priority:");
+  for (const p of PRIORITY_VALUES) {
+    const row = totalByPriority[p];
+    const pTotal = row.pending + row.mocked + row.recorded + row.complete;
+    const pPct = pTotal > 0 ? Math.round((row.complete / pTotal) * 100) : 0;
+    console.log(
+      `    ${p}: ${row.complete}/${pTotal} complete (${pPct}%) | recorded: ${row.recorded} | mocked: ${row.mocked}`,
+    );
+  }
+  console.log("");
+  console.log(`  Overall: ${progressBar(overallPct, 30)} ${overallPct}% complete`);
+  console.log("");
+  console.log("╚══════════════════════════════════════════════════════════════╝");
+}
+
+function progressBar(pct: number, width: number): string {
+  const filled = Math.round((pct / 100) * width);
+  const empty = width - filled;
+  return "[" + "#".repeat(filled) + "-".repeat(empty) + "]";
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const jsonMode = process.argv.includes("--json");
+const checkMode = process.argv.includes("--check");
+
+const files = readdirSync(SCENARIOS_DIR)
+  .filter((f) => f.endsWith(".md"))
+  .sort();
+
+const allScenarios: Scenario[] = [];
+const summaries: FileSummary[] = [];
+
+for (const file of files) {
+  const scenarios = parseScenarioFile(resolve(SCENARIOS_DIR, file), file);
+  allScenarios.push(...scenarios);
+  summaries.push(summarizeFile(file, scenarios));
+}
+
+if (jsonMode) {
+  const totals: Record<Status, number> = { pending: 0, mocked: 0, recorded: 0, complete: 0 };
+  let grandTotal = 0;
+  for (const s of summaries) {
+    for (const status of STATUS_VALUES) {
+      totals[status] += s.byStatus[status];
+    }
+    grandTotal += s.total;
+  }
+  console.log(
+    JSON.stringify(
+      {
+        files: summaries,
+        totals,
+        grandTotal,
+        completePct: grandTotal > 0 ? Math.round((totals.complete / grandTotal) * 100) : 0,
+      },
+      null,
+      2,
+    ),
+  );
+} else {
+  printReport(summaries);
+}
+
+if (checkMode) {
+  const incompleteP0 = allScenarios.filter((s) => s.priority === "P0" && s.status !== "complete");
+  if (incompleteP0.length > 0) {
+    console.error(`\nFAIL: ${incompleteP0.length} P0 scenarios are not complete:\n`);
+    for (const s of incompleteP0.slice(0, 20)) {
+      console.error(`  ${s.file} #${s.number}: ${s.name} (${s.status})`);
+    }
+    if (incompleteP0.length > 20) {
+      console.error(`  ... and ${incompleteP0.length - 20} more`);
+    }
+    process.exit(1);
+  }
+  console.log("\nPASS: All P0 scenarios are complete.");
+}

--- a/tests/smoke/scenarios/git-status.md
+++ b/tests/smoke/scenarios/git-status.md
@@ -29,36 +29,36 @@
 
 | #   | Scenario                                    | Params     | Expected Output                                                                        | Priority | Status   |
 | --- | ------------------------------------------- | ---------- | -------------------------------------------------------------------------------------- | -------- | -------- |
-| 1   | Clean repo, no changes                      | `{ path }` | `{ clean: true, staged: [], modified: [], deleted: [], untracked: [], conflicts: [] }` | P0       | recorded |
-| 2   | Staged files (added)                        | `{ path }` | `staged: [{ file, status: "added" }]`, `clean: false`                                  | P0       | recorded |
-| 3   | Staged files (modified)                     | `{ path }` | `staged: [{ file, status: "modified" }]`                                               | P0       | recorded |
-| 4   | Staged files (deleted)                      | `{ path }` | `staged: [{ file, status: "deleted" }]`                                                | P0       | recorded |
-| 5   | Staged rename                               | `{ path }` | `staged: [{ file: "new", status: "renamed", oldFile: "old" }]`                         | P0       | recorded |
-| 6   | Worktree modified files                     | `{ path }` | `modified: ["file.txt"]`, staged empty                                                 | P0       | recorded |
-| 7   | Worktree deleted files                      | `{ path }` | `deleted: ["file.txt"]`                                                                | P0       | recorded |
-| 8   | Untracked files                             | `{ path }` | `untracked: ["new-file.txt"]`                                                          | P0       | recorded |
-| 9   | Mixed state (staged + modified + untracked) | `{ path }` | All arrays populated, `clean: false`                                                   | P0       | recorded |
-| 10  | Both staged and worktree modified (MM)      | `{ path }` | File in both `staged` and `modified`                                                   | P0       | recorded |
+| 1   | Clean repo, no changes                      | `{ path }` | `{ clean: true, staged: [], modified: [], deleted: [], untracked: [], conflicts: [] }` | P0       | complete |
+| 2   | Staged files (added)                        | `{ path }` | `staged: [{ file, status: "added" }]`, `clean: false`                                  | P0       | complete |
+| 3   | Staged files (modified)                     | `{ path }` | `staged: [{ file, status: "modified" }]`                                               | P0       | complete |
+| 4   | Staged files (deleted)                      | `{ path }` | `staged: [{ file, status: "deleted" }]`                                                | P0       | complete |
+| 5   | Staged rename                               | `{ path }` | `staged: [{ file: "new", status: "renamed", oldFile: "old" }]`                         | P0       | complete |
+| 6   | Worktree modified files                     | `{ path }` | `modified: ["file.txt"]`, staged empty                                                 | P0       | complete |
+| 7   | Worktree deleted files                      | `{ path }` | `deleted: ["file.txt"]`                                                                | P0       | complete |
+| 8   | Untracked files                             | `{ path }` | `untracked: ["new-file.txt"]`                                                          | P0       | complete |
+| 9   | Mixed state (staged + modified + untracked) | `{ path }` | All arrays populated, `clean: false`                                                   | P0       | complete |
+| 10  | Both staged and worktree modified (MM)      | `{ path }` | File in both `staged` and `modified`                                                   | P0       | complete |
 
 ### Branch & upstream
 
 | #   | Scenario                         | Params     | Expected Output                                                | Priority | Status   |
 | --- | -------------------------------- | ---------- | -------------------------------------------------------------- | -------- | -------- |
-| 11  | On branch with upstream tracking | `{ path }` | `branch: "main"`, `upstream: "origin/main"`                    | P0       | recorded |
-| 12  | Ahead of upstream                | `{ path }` | `ahead: N > 0`                                                 | P0       | recorded |
-| 13  | Behind upstream                  | `{ path }` | `behind: N > 0`                                                | P0       | recorded |
-| 14  | Ahead and behind                 | `{ path }` | Both `ahead` and `behind` > 0                                  | P1       | recorded |
-| 15  | Detached HEAD                    | `{ path }` | `branch` is HEAD sha or "(HEAD detached at ...)"`              | P1       | recorded |
-| 16  | No upstream configured           | `{ path }` | `upstream: undefined`, `ahead: undefined`, `behind: undefined` | P1       | recorded |
-| 17  | New branch, no commits           | `{ path }` | `branch: "new-branch"`, no upstream                            | P2       | recorded |
+| 11  | On branch with upstream tracking | `{ path }` | `branch: "main"`, `upstream: "origin/main"`                    | P0       | complete |
+| 12  | Ahead of upstream                | `{ path }` | `ahead: N > 0`                                                 | P0       | complete |
+| 13  | Behind upstream                  | `{ path }` | `behind: N > 0`                                                | P0       | complete |
+| 14  | Ahead and behind                 | `{ path }` | Both `ahead` and `behind` > 0                                  | P1       | complete |
+| 15  | Detached HEAD                    | `{ path }` | `branch` is HEAD sha or "(HEAD detached at ...)"`              | P1       | complete |
+| 16  | No upstream configured           | `{ path }` | `upstream: undefined`, `ahead: undefined`, `behind: undefined` | P1       | complete |
+| 17  | New branch, no commits           | `{ path }` | `branch: "new-branch"`, no upstream                            | P2       | complete |
 
 ### Conflicts
 
 | #   | Scenario                 | Params     | Expected Output               | Priority | Status   |
 | --- | ------------------------ | ---------- | ----------------------------- | -------- | -------- |
-| 18  | Merge conflict (UU)      | `{ path }` | `conflicts: ["file.txt"]`     | P0       | recorded |
-| 19  | Both added conflict (AA) | `{ path }` | `conflicts: ["file.txt"]`     | P1       | recorded |
-| 20  | Multiple conflict types  | `{ path }` | Multiple files in `conflicts` | P1       | recorded |
+| 18  | Merge conflict (UU)      | `{ path }` | `conflicts: ["file.txt"]`     | P0       | complete |
+| 19  | Both added conflict (AA) | `{ path }` | `conflicts: ["file.txt"]`     | P1       | complete |
+| 20  | Multiple conflict types  | `{ path }` | Multiple files in `conflicts` | P1       | complete |
 
 ### Optional params — untrackedFiles (arg-only)
 
@@ -93,16 +93,16 @@
 
 | #   | Scenario                              | Params                             | Expected Output                               | Priority | Status   |
 | --- | ------------------------------------- | ---------------------------------- | --------------------------------------------- | -------- | -------- |
-| 35  | porcelainVersion: "v2" clean repo     | `{ path, porcelainVersion: "v2" }` | Same schema shape, parsed from v2 format      | P1       | recorded |
-| 36  | porcelainVersion: "v2" with changes   | `{ path, porcelainVersion: "v2" }` | staged/modified/etc populated from v2 format  | P1       | recorded |
-| 37  | porcelainVersion: "v2" with conflicts | `{ path, porcelainVersion: "v2" }` | Conflicts detected from `u ` prefix lines     | P1       | recorded |
-| 38  | porcelainVersion: "v2" with renames   | `{ path, porcelainVersion: "v2" }` | Rename with oldFile from tab-separated fields | P2       | recorded |
+| 35  | porcelainVersion: "v2" clean repo     | `{ path, porcelainVersion: "v2" }` | Same schema shape, parsed from v2 format      | P1       | complete |
+| 36  | porcelainVersion: "v2" with changes   | `{ path, porcelainVersion: "v2" }` | staged/modified/etc populated from v2 format  | P1       | complete |
+| 37  | porcelainVersion: "v2" with conflicts | `{ path, porcelainVersion: "v2" }` | Conflicts detected from `u ` prefix lines     | P1       | complete |
+| 38  | porcelainVersion: "v2" with renames   | `{ path, porcelainVersion: "v2" }` | Rename with oldFile from tab-separated fields | P2       | complete |
 
 ### Error paths
 
 | #   | Scenario         | Params                         | Expected Output                   | Priority | Status   |
 | --- | ---------------- | ------------------------------ | --------------------------------- | -------- | -------- |
-| 39  | Not a git repo   | `{ path: "/tmp/not-a-repo" }`  | Error thrown: "git status failed" | P0       | recorded |
+| 39  | Not a git repo   | `{ path: "/tmp/not-a-repo" }`  | Error thrown: "git status failed" | P0       | complete |
 | 40  | Nonexistent path | `{ path: "/tmp/nonexistent" }` | Error thrown                      | P1       | complete |
 
 ### Schema validation
@@ -119,7 +119,7 @@
 
 | Priority  | Count  | Mocked | Recorded | Complete |
 | --------- | ------ | ------ | -------- | -------- |
-| P0        | 13     | 13     | 13       | 2        |
-| P1        | 16     | 16     | 10       | 6        |
-| P2        | 12     | 12     | 2        | 8        |
-| **Total** | **41** | **41** | **25**   | **16**   |
+| P0        | 13     | 13     | 0        | 13       |
+| P1        | 16     | 16     | 0        | 16       |
+| P2        | 12     | 12     | 0        | 12       |
+| **Total** | **41** | **41** | **0**    | **41**   |

--- a/tests/smoke/scenarios/git-tools.md
+++ b/tests/smoke/scenarios/git-tools.md
@@ -31,8 +31,8 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                         | Params                                            | Expected Output                                               | Priority | Status   |
 | --- | -------------------------------- | ------------------------------------------------- | ------------------------------------------------------------- | -------- | -------- |
-| 1   | Stage specific files             | `{ path, files: ["a.ts"] }`                       | `staged >= 1`, `files` contains entry with `file: "a.ts"`     | P0       | recorded |
-| 2   | Stage all changes                | `{ path, all: true }`                             | `staged` matches total changed files, `files` array populated | P0       | recorded |
+| 1   | Stage specific files             | `{ path, files: ["a.ts"] }`                       | `staged >= 1`, `files` contains entry with `file: "a.ts"`     | P0       | complete |
+| 2   | Stage all changes                | `{ path, all: true }`                             | `staged` matches total changed files, `files` array populated | P0       | complete |
 | 3   | No files and no all throws error | `{ path }`                                        | Error: "Either 'files' must be provided..."                   | P0       | mocked   |
 | 4   | Flag injection in file path      | `{ path, files: ["--exec=evil"] }`                | `assertNoFlagInjection` throws                                | P0       | mocked   |
 | 5   | Stage multiple files             | `{ path, files: ["a.ts", "b.ts"] }`               | `staged >= 2`, both files in output                           | P0       | mocked   |
@@ -77,11 +77,11 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                       | Params                                                                                     | Expected Output                                               | Priority | Status   |
 | --- | ------------------------------ | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | -------- | -------- |
-| 1   | Start bisect with bad and good | `{ path, action: "start", bad: "HEAD", good: "abc123" }`                                   | `action: "start"`, `current` populated, `remaining` estimated | P0       | recorded |
+| 1   | Start bisect with bad and good | `{ path, action: "start", bad: "HEAD", good: "abc123" }`                                   | `action: "start"`, `current` populated, `remaining` estimated | P0       | complete |
 | 2   | Mark commit as good            | `{ path, action: "good" }`                                                                 | `action: "good"`, bisect advances                             | P0       | mocked   |
 | 3   | Mark commit as bad             | `{ path, action: "bad" }`                                                                  | `action: "bad"`, bisect narrows                               | P0       | mocked   |
-| 4   | Reset bisect session           | `{ path, action: "reset" }`                                                                | `action: "reset"`, session cleared                            | P0       | recorded |
-| 5   | Start without bad/good throws  | `{ path, action: "start" }`                                                                | Error: "Both 'bad' and 'good' commit refs are required"       | P0       | recorded |
+| 4   | Reset bisect session           | `{ path, action: "reset" }`                                                                | `action: "reset"`, session cleared                            | P0       | complete |
+| 5   | Start without bad/good throws  | `{ path, action: "start" }`                                                                | Error: "Both 'bad' and 'good' commit refs are required"       | P0       | complete |
 | 6   | Flag injection in bad ref      | `{ path, action: "start", bad: "--exec=evil", good: "abc" }`                               | `assertNoFlagInjection` throws                                | P0       | mocked   |
 | 7   | Bisect run with command        | `{ path, action: "run", command: "npm test" }`                                             | `action: "run"`, result with identified commit                | P1       | mocked   |
 | 8   | Run without command throws     | `{ path, action: "run" }`                                                                  | Error: "'command' parameter is required"                      | P1       | mocked   |
@@ -126,11 +126,11 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                     | Params                                                      | Expected Output                                          | Priority | Status   |
 | --- | ---------------------------- | ----------------------------------------------------------- | -------------------------------------------------------- | -------- | -------- |
-| 1   | Blame entire file            | `{ path, file: "src/index.ts" }`                            | `commits` array with grouped lines, `file`, `totalLines` | P0       | recorded |
+| 1   | Blame entire file            | `{ path, file: "src/index.ts" }`                            | `commits` array with grouped lines, `file`, `totalLines` | P0       | complete |
 | 2   | File not found               | `{ path, file: "nonexistent.ts" }`                          | Error: "git blame failed"                                | P0       | mocked   |
 | 3   | Flag injection in file param | `{ path, file: "--exec=evil" }`                             | `assertNoFlagInjection` throws                           | P0       | mocked   |
-| 4   | Line range blame             | `{ path, file: "src/index.ts", startLine: 1, endLine: 10 }` | Only lines 1-10 in output                                | P1       | recorded |
-| 5   | Blame at specific rev        | `{ path, file: "src/index.ts", rev: "HEAD~5" }`             | Blame reflects state at rev                              | P1       | recorded |
+| 4   | Line range blame             | `{ path, file: "src/index.ts", startLine: 1, endLine: 10 }` | Only lines 1-10 in output                                | P1       | complete |
+| 5   | Blame at specific rev        | `{ path, file: "src/index.ts", rev: "HEAD~5" }`             | Blame reflects state at rev                              | P1       | complete |
 | 6   | Flag injection in rev        | `{ path, file: "x.ts", rev: "--exec=evil" }`                | `assertNoFlagInjection` throws                           | P0       | mocked   |
 | 7   | Compact vs full output       | `{ path, file: "x.ts", compact: false }`                    | Full blame with all fields                               | P1       | mocked   |
 | 8   | Ignore whitespace            | `{ path, file: "x.ts", ignoreWhitespace: true }`            | Whitespace-only changes attributed to original author    | P2       | mocked   |
@@ -175,15 +175,15 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                     | Params                                              | Expected Output                                  | Priority | Status   |
 | --- | ---------------------------- | --------------------------------------------------- | ------------------------------------------------ | -------- | -------- |
-| 1   | List branches                | `{ path }`                                          | `branches` array, `current` set to active branch | P0       | recorded |
-| 2   | Create branch                | `{ path, create: "feature-x" }`                     | Branch created, appears in listing               | P0       | recorded |
+| 1   | List branches                | `{ path }`                                          | `branches` array, `current` set to active branch | P0       | complete |
+| 2   | Create branch                | `{ path, create: "feature-x" }`                     | Branch created, appears in listing               | P0       | complete |
 | 3   | Delete branch                | `{ path, delete: "feature-x" }`                     | Branch deleted, removed from listing             | P0       | mocked   |
 | 4   | Flag injection in create     | `{ path, create: "--exec=evil" }`                   | `assertNoFlagInjection` throws                   | P0       | mocked   |
 | 5   | Not a git repo               | `{ path: "/tmp/not-a-repo" }`                       | Error thrown                                     | P0       | mocked   |
 | 6   | Create and switch            | `{ path, create: "feat", switchAfterCreate: true }` | Branch created, `current` now "feat"             | P1       | mocked   |
 | 7   | Create with start point      | `{ path, create: "feat", startPoint: "HEAD~3" }`    | Branch created from specified ref                | P1       | mocked   |
 | 8   | Rename current branch        | `{ path, rename: "new-name" }`                      | Branch renamed, `current` reflects new name      | P1       | mocked   |
-| 9   | List all (including remotes) | `{ path, all: true }`                               | Remote branches included in listing              | P1       | recorded |
+| 9   | List all (including remotes) | `{ path, all: true }`                               | Remote branches included in listing              | P1       | complete |
 | 10  | Filter merged branches       | `{ path, merged: true }`                            | Only merged branches returned                    | P1       | mocked   |
 | 11  | Set upstream                 | `{ path, setUpstream: "origin/main" }`              | Upstream tracking configured                     | P1       | mocked   |
 | 12  | Force delete unmerged        | `{ path, delete: "feat", forceDelete: true }`       | Unmerged branch deleted                          | P2       | mocked   |
@@ -221,9 +221,9 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                           | Params                                                      | Expected Output                                        | Priority | Status   |
 | --- | ---------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------ | -------- | -------- |
-| 1   | Switch to existing branch          | `{ path, ref: "main" }`                                     | `success: true`, `ref: "main"`, `previousRef` set      | P0       | recorded |
-| 2   | Create and switch to new branch    | `{ path, ref: "feat", create: true }`                       | `success: true`, `created: true`, `ref: "feat"`        | P0       | recorded |
-| 3   | Checkout nonexistent ref           | `{ path, ref: "nonexistent" }`                              | `success: false`, `errorType` set                      | P0       | recorded |
+| 1   | Switch to existing branch          | `{ path, ref: "main" }`                                     | `success: true`, `ref: "main"`, `previousRef` set      | P0       | complete |
+| 2   | Create and switch to new branch    | `{ path, ref: "feat", create: true }`                       | `success: true`, `created: true`, `ref: "feat"`        | P0       | complete |
+| 3   | Checkout nonexistent ref           | `{ path, ref: "nonexistent" }`                              | `success: false`, `errorType` set                      | P0       | complete |
 | 4   | Flag injection in ref              | `{ path, ref: "--exec=evil" }`                              | `assertNoFlagInjection` throws                         | P0       | mocked   |
 | 5   | Detach HEAD at commit              | `{ path, ref: "abc123", detach: true }`                     | `success: true`, `detached: true`                      | P1       | mocked   |
 | 6   | Orphan branch creation             | `{ path, ref: "x", orphan: "orphan-branch" }`               | `success: true`, `created: true`                       | P1       | mocked   |
@@ -267,11 +267,11 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                       | Params                                        | Expected Output                                              | Priority | Status   |
 | --- | ------------------------------ | --------------------------------------------- | ------------------------------------------------------------ | -------- | -------- |
-| 1   | Cherry-pick single commit      | `{ path, commits: ["abc123"] }`               | `success: true`, `applied: ["abc123"]`, `conflicts: []`      | P0       | recorded |
-| 2   | Cherry-pick with conflict      | `{ path, commits: ["conflicting"] }`          | `success: false`, `state: "conflict"`, `conflicts` populated | P0       | recorded |
+| 1   | Cherry-pick single commit      | `{ path, commits: ["abc123"] }`               | `success: true`, `applied: ["abc123"]`, `conflicts: []`      | P0       | complete |
+| 2   | Cherry-pick with conflict      | `{ path, commits: ["conflicting"] }`          | `success: false`, `state: "conflict"`, `conflicts` populated | P0       | complete |
 | 3   | No commits and no action flags | `{ path }`                                    | Error: "commits array is required"                           | P0       | mocked   |
 | 4   | Flag injection in commits      | `{ path, commits: ["--exec=evil"] }`          | `assertNoFlagInjection` throws                               | P0       | mocked   |
-| 5   | Abort cherry-pick              | `{ path, abort: true }`                       | `success: true`, cherry-pick aborted                         | P0       | recorded |
+| 5   | Abort cherry-pick              | `{ path, abort: true }`                       | `success: true`, cherry-pick aborted                         | P0       | complete |
 | 6   | Continue after conflict        | `{ path, continue: true }`                    | Cherry-pick continues                                        | P1       | mocked   |
 | 7   | Skip current commit            | `{ path, skip: true }`                        | Current commit skipped                                       | P1       | mocked   |
 | 8   | No-commit mode                 | `{ path, commits: ["abc"], noCommit: true }`  | Changes applied but not committed                            | P1       | mocked   |
@@ -316,10 +316,10 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                         | Params                                                            | Expected Output                                     | Priority | Status   |
 | --- | -------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------- | -------- | -------- |
-| 1   | Basic commit with staged changes | `{ path, message: "feat: add feature" }`                          | `hash`, `hashShort`, `message`, `filesChanged >= 1` | P0       | recorded |
-| 2   | Commit with nothing staged       | `{ path, message: "empty" }`                                      | Error: "git commit failed" (nothing to commit)      | P0       | recorded |
+| 1   | Basic commit with staged changes | `{ path, message: "feat: add feature" }`                          | `hash`, `hashShort`, `message`, `filesChanged >= 1` | P0       | complete |
+| 2   | Commit with nothing staged       | `{ path, message: "empty" }`                                      | Error: "git commit failed" (nothing to commit)      | P0       | complete |
 | 3   | Flag injection in message        | `{ path, message: "--exec=evil" }`                                | `assertNoFlagInjection` throws                      | P0       | mocked   |
-| 4   | Allow empty commit               | `{ path, message: "empty", allowEmpty: true }`                    | `hash`, `filesChanged: 0`                           | P0       | recorded |
+| 4   | Allow empty commit               | `{ path, message: "empty", allowEmpty: true }`                    | `hash`, `filesChanged: 0`                           | P0       | complete |
 | 5   | Not a git repo                   | `{ path: "/tmp/not-a-repo", message: "x" }`                       | Error thrown                                        | P0       | mocked   |
 | 6   | Amend commit                     | `{ path, message: "amended", amend: true }`                       | Previous commit amended, new hash                   | P1       | mocked   |
 | 7   | Commit all tracked changes       | `{ path, message: "all", all: true }`                             | Modified tracked files auto-staged and committed    | P1       | mocked   |
@@ -368,16 +368,16 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                         | Params                                   | Expected Output                               | Priority | Status   |
 | --- | -------------------------------- | ---------------------------------------- | --------------------------------------------- | -------- | -------- |
-| 1   | Unstaged changes in working tree | `{ path }`                               | `files` array with changes, `totalFiles >= 1` | P0       | recorded |
-| 2   | Staged changes                   | `{ path, staged: true }`                 | `files` reflect staged changes                | P0       | recorded |
-| 3   | No changes (clean)               | `{ path }` (clean repo)                  | `files: []`, `totalFiles: 0`                  | P0       | recorded |
+| 1   | Unstaged changes in working tree | `{ path }`                               | `files` array with changes, `totalFiles >= 1` | P0       | complete |
+| 2   | Staged changes                   | `{ path, staged: true }`                 | `files` reflect staged changes                | P0       | complete |
+| 3   | No changes (clean)               | `{ path }` (clean repo)                  | `files: []`, `totalFiles: 0`                  | P0       | complete |
 | 4   | Flag injection in ref            | `{ path, ref: "--exec=evil" }`           | `assertNoFlagInjection` throws                | P0       | mocked   |
 | 5   | Flag injection in file           | `{ path, file: "--exec=evil" }`          | `assertNoFlagInjection` throws                | P0       | mocked   |
 | 6   | Not a git repo                   | `{ path: "/tmp/not-a-repo" }`            | Error thrown                                  | P0       | mocked   |
-| 7   | Diff against ref                 | `{ path, ref: "main" }`                  | Files changed since ref                       | P1       | recorded |
-| 8   | Single file diff                 | `{ path, file: "src/index.ts" }`         | Only that file in output                      | P1       | recorded |
+| 7   | Diff against ref                 | `{ path, ref: "main" }`                  | Files changed since ref                       | P1       | complete |
+| 8   | Single file diff                 | `{ path, file: "src/index.ts" }`         | Only that file in output                      | P1       | complete |
 | 9   | Multiple file diff               | `{ path, files: ["a.ts", "b.ts"] }`      | Only specified files in output                | P1       | mocked   |
-| 10  | Full patch mode                  | `{ path, full: true }`                   | `chunks` populated with headers and lines     | P1       | recorded |
+| 10  | Full patch mode                  | `{ path, full: true }`                   | `chunks` populated with headers and lines     | P1       | complete |
 | 11  | Atomic full mode                 | `{ path, full: true, atomicFull: true }` | Same result, single git call                  | P1       | mocked   |
 | 12  | Ignore whitespace                | `{ path, ignoreWhitespace: true }`       | Whitespace-only changes excluded              | P1       | mocked   |
 | 13  | Diff filter (added only)         | `{ path, ref: "main", diffFilter: "A" }` | Only added files returned                     | P1       | mocked   |
@@ -426,14 +426,14 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                 | Params                                               | Expected Output                               | Priority | Status   |
 | --- | ------------------------ | ---------------------------------------------------- | --------------------------------------------- | -------- | -------- |
-| 1   | Default log (10 commits) | `{ path }`                                           | `commits` array length <= 10, `total` matches | P0       | recorded |
-| 2   | Custom maxCount          | `{ path, maxCount: 3 }`                              | `commits` length <= 3                         | P0       | recorded |
-| 3   | Empty repo or no commits | `{ path }` (empty repo)                              | `commits: []`, `total: 0`                     | P0       | recorded |
+| 1   | Default log (10 commits) | `{ path }`                                           | `commits` array length <= 10, `total` matches | P0       | complete |
+| 2   | Custom maxCount          | `{ path, maxCount: 3 }`                              | `commits` length <= 3                         | P0       | complete |
+| 3   | Empty repo or no commits | `{ path }` (empty repo)                              | `commits: []`, `total: 0`                     | P0       | complete |
 | 4   | Flag injection in ref    | `{ path, ref: "--exec=evil" }`                       | `assertNoFlagInjection` throws                | P0       | mocked   |
 | 5   | Flag injection in author | `{ path, author: "--exec=evil" }`                    | `assertNoFlagInjection` throws                | P0       | mocked   |
 | 6   | Not a git repo           | `{ path: "/tmp/not-a-repo" }`                        | Error thrown                                  | P0       | mocked   |
-| 7   | Filter by author         | `{ path, author: "dave" }`                           | Only commits by author "dave"                 | P1       | recorded |
-| 8   | Filter by ref            | `{ path, ref: "main" }`                              | Commits from main branch                      | P1       | recorded |
+| 7   | Filter by author         | `{ path, author: "dave" }`                           | Only commits by author "dave"                 | P1       | complete |
+| 8   | Filter by ref            | `{ path, ref: "main" }`                              | Commits from main branch                      | P1       | complete |
 | 9   | Since/until date range   | `{ path, since: "2024-01-01", until: "2024-12-31" }` | Commits within date range                     | P1       | mocked   |
 | 10  | Grep message pattern     | `{ path, grep: "fix:" }`                             | Only commits with "fix:" in message           | P1       | mocked   |
 | 11  | File path filter         | `{ path, filePath: "src/index.ts" }`                 | Only commits affecting that file              | P1       | mocked   |
@@ -478,11 +478,11 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario               | Params                                 | Expected Output                                             | Priority | Status   |
 | --- | ---------------------- | -------------------------------------- | ----------------------------------------------------------- | -------- | -------- |
-| 1   | Default graph          | `{ path }`                             | `commits` with `graph`, `hashShort`, `message` fields       | P0       | recorded |
-| 2   | Empty repo             | `{ path }` (empty)                     | `commits: []`, `total: 0`                                   | P0       | recorded |
+| 1   | Default graph          | `{ path }`                             | `commits` with `graph`, `hashShort`, `message` fields       | P0       | complete |
+| 2   | Empty repo             | `{ path }` (empty)                     | `commits: []`, `total: 0`                                   | P0       | complete |
 | 3   | Flag injection in ref  | `{ path, ref: "--exec=evil" }`         | `assertNoFlagInjection` throws                              | P0       | mocked   |
 | 4   | Not a git repo         | `{ path: "/tmp/not-a-repo" }`          | Error thrown                                                | P0       | mocked   |
-| 5   | All branches           | `{ path, all: true }`                  | Graph includes all branches                                 | P1       | recorded |
+| 5   | All branches           | `{ path, all: true }`                  | Graph includes all branches                                 | P1       | complete |
 | 6   | Merge commit detection | `{ path }` (with merges)               | `isMerge: true` on merge commits, `parents` with 2+ entries | P1       | mocked   |
 | 7   | Since filter           | `{ path, since: "2024-01-01" }`        | Graph filtered by date                                      | P1       | mocked   |
 | 8   | First parent only      | `{ path, firstParent: true }`          | Simplified linear graph                                     | P2       | mocked   |
@@ -525,11 +525,11 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                   | Params                                                      | Expected Output                                              | Priority | Status   |
 | --- | -------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------ | -------- | -------- |
-| 1   | Fast-forward merge         | `{ path, branch: "feature" }`                               | `merged: true`, `state: "fast-forward"`, `fastForward: true` | P0       | recorded |
-| 2   | Merge with conflict        | `{ path, branch: "conflicting" }`                           | `merged: false`, `state: "conflict"`, `conflicts` populated  | P0       | recorded |
-| 3   | Already up to date         | `{ path, branch: "main" }` (on main)                        | `state: "already-up-to-date"`                                | P0       | recorded |
+| 1   | Fast-forward merge         | `{ path, branch: "feature" }`                               | `merged: true`, `state: "fast-forward"`, `fastForward: true` | P0       | complete |
+| 2   | Merge with conflict        | `{ path, branch: "conflicting" }`                           | `merged: false`, `state: "conflict"`, `conflicts` populated  | P0       | complete |
+| 3   | Already up to date         | `{ path, branch: "main" }` (on main)                        | `state: "already-up-to-date"`                                | P0       | complete |
 | 4   | Flag injection in branch   | `{ path, branch: "--exec=evil" }`                           | `assertNoFlagInjection` throws                               | P0       | mocked   |
-| 5   | Abort merge                | `{ path, branch: "x", abort: true }`                        | Merge aborted                                                | P0       | recorded |
+| 5   | Abort merge                | `{ path, branch: "x", abort: true }`                        | Merge aborted                                                | P0       | complete |
 | 6   | No-ff merge                | `{ path, branch: "feature", noFf: true }`                   | `merged: true`, merge commit created even if ff possible     | P1       | mocked   |
 | 7   | Squash merge               | `{ path, branch: "feature", squash: true }`                 | Changes applied but not committed                            | P1       | mocked   |
 | 8   | ff-only with non-ff branch | `{ path, branch: "diverged", ffOnly: true }`                | `merged: false`, `state: "failed"`                           | P1       | mocked   |
@@ -572,9 +572,9 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                    | Params                            | Expected Output                            | Priority | Status   |
 | --- | --------------------------- | --------------------------------- | ------------------------------------------ | -------- | -------- |
-| 1   | Pull with changes available | `{ path }`                        | `success: true`, `filesChanged >= 1`       | P0       | recorded |
-| 2   | Already up to date          | `{ path }`                        | `success: true`, `upToDate: true`          | P0       | recorded |
-| 3   | Pull with conflict          | `{ path }` (conflicting)          | `success: false`, `conflicts` populated    | P0       | recorded |
+| 1   | Pull with changes available | `{ path }`                        | `success: true`, `filesChanged >= 1`       | P0       | complete |
+| 2   | Already up to date          | `{ path }`                        | `success: true`, `upToDate: true`          | P0       | complete |
+| 3   | Pull with conflict          | `{ path }` (conflicting)          | `success: false`, `conflicts` populated    | P0       | complete |
 | 4   | Flag injection in remote    | `{ path, remote: "--exec=evil" }` | `assertNoFlagInjection` throws             | P0       | mocked   |
 | 5   | No remote configured        | `{ path }` (no remote)            | Error thrown                               | P0       | mocked   |
 | 6   | Pull with rebase            | `{ path, rebase: true }`          | `success: true`, rebased instead of merged | P1       | mocked   |
@@ -618,8 +618,8 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                         | Params                                            | Expected Output                                   | Priority | Status   |
 | --- | -------------------------------- | ------------------------------------------------- | ------------------------------------------------- | -------- | -------- |
-| 1   | Push to remote                   | `{ path }`                                        | `success: true`, `remote: "origin"`, `branch` set | P0       | recorded |
-| 2   | Push rejected (non-fast-forward) | `{ path }` (behind remote)                        | `success: false`, `errorType: "rejected"`         | P0       | recorded |
+| 1   | Push to remote                   | `{ path }`                                        | `success: true`, `remote: "origin"`, `branch` set | P0       | complete |
+| 2   | Push rejected (non-fast-forward) | `{ path }` (behind remote)                        | `success: false`, `errorType: "rejected"`         | P0       | complete |
 | 3   | Flag injection in remote         | `{ path, remote: "--exec=evil" }`                 | `assertNoFlagInjection` throws                    | P0       | mocked   |
 | 4   | No remote configured             | `{ path }` (no remote)                            | Error or `success: false`                         | P0       | mocked   |
 | 5   | Set upstream on push             | `{ path, setUpstream: true }`                     | `success: true`, upstream tracking set            | P1       | mocked   |
@@ -668,11 +668,11 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                      | Params                                         | Expected Output                                              | Priority | Status   |
 | --- | ----------------------------- | ---------------------------------------------- | ------------------------------------------------------------ | -------- | -------- |
-| 1   | Simple rebase onto branch     | `{ path, branch: "main" }`                     | `success: true`, `state: "completed"`, `rebasedCommits` set  | P0       | recorded |
-| 2   | Rebase with conflict          | `{ path, branch: "main" }` (conflicting)       | `success: false`, `state: "conflict"`, `conflicts` populated | P0       | recorded |
+| 1   | Simple rebase onto branch     | `{ path, branch: "main" }`                     | `success: true`, `state: "completed"`, `rebasedCommits` set  | P0       | complete |
+| 2   | Rebase with conflict          | `{ path, branch: "main" }` (conflicting)       | `success: false`, `state: "conflict"`, `conflicts` populated | P0       | complete |
 | 3   | Branch not provided throws    | `{ path }`                                     | Error: "branch is required for rebase"                       | P0       | mocked   |
 | 4   | Flag injection in branch      | `{ path, branch: "--exec=evil" }`              | `assertNoFlagInjection` throws                               | P0       | mocked   |
-| 5   | Abort rebase                  | `{ path, abort: true }`                        | Rebase aborted, state restored                               | P0       | recorded |
+| 5   | Abort rebase                  | `{ path, abort: true }`                        | Rebase aborted, state restored                               | P0       | complete |
 | 6   | Continue after conflict       | `{ path, continue: true }`                     | Rebase continues                                             | P1       | mocked   |
 | 7   | Skip current commit           | `{ path, skip: true }`                         | Commit skipped, rebase advances                              | P1       | mocked   |
 | 8   | Rebase with onto              | `{ path, branch: "main", onto: "develop" }`    | Rebased onto develop                                         | P1       | mocked   |
@@ -713,12 +713,12 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario              | Params                            | Expected Output                            | Priority | Status   |
 | --- | --------------------- | --------------------------------- | ------------------------------------------ | -------- | -------- |
-| 1   | Default reflog (HEAD) | `{ path }`                        | `entries` array, `total`, `totalAvailable` | P0       | recorded |
-| 2   | Empty reflog          | `{ path }` (new repo, no actions) | `entries: []`, `total: 0`                  | P0       | recorded |
+| 1   | Default reflog (HEAD) | `{ path }`                        | `entries` array, `total`, `totalAvailable` | P0       | complete |
+| 2   | Empty reflog          | `{ path }` (new repo, no actions) | `entries: []`, `total: 0`                  | P0       | complete |
 | 3   | Flag injection in ref | `{ path, ref: "--exec=evil" }`    | `assertNoFlagInjection` throws             | P0       | mocked   |
 | 4   | Not a git repo        | `{ path: "/tmp/not-a-repo" }`     | Error thrown                               | P0       | mocked   |
 | 5   | Reflog exists check   | `{ path, action: "exists" }`      | `total: 1` (exists) or `total: 0` (not)    | P1       | mocked   |
-| 6   | Custom maxCount       | `{ path, maxCount: 5 }`           | `entries` length <= 5                      | P1       | recorded |
+| 6   | Custom maxCount       | `{ path, maxCount: 5 }`           | `entries` length <= 5                      | P1       | complete |
 | 7   | Specific ref          | `{ path, ref: "main" }`           | Entries for main branch                    | P1       | mocked   |
 | 8   | Grep filter           | `{ path, grepReflog: "commit" }`  | Only entries matching "commit"             | P1       | mocked   |
 | 9   | Since filter          | `{ path, since: "2024-01-01" }`   | Entries after date                         | P2       | mocked   |
@@ -752,12 +752,12 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                | Params                                                               | Expected Output                                  | Priority | Status   |
 | --- | ----------------------- | -------------------------------------------------------------------- | ------------------------------------------------ | -------- | -------- |
-| 1   | List remotes            | `{ path }`                                                           | `remotes` array, `total >= 1`                    | P0       | recorded |
-| 2   | Add remote              | `{ path, action: "add", name: "upstream", url: "https://..." }`      | `success: true`, `action: "add"`                 | P0       | recorded |
-| 3   | Remove remote           | `{ path, action: "remove", name: "upstream" }`                       | `success: true`, `action: "remove"`              | P0       | recorded |
+| 1   | List remotes            | `{ path }`                                                           | `remotes` array, `total >= 1`                    | P0       | complete |
+| 2   | Add remote              | `{ path, action: "add", name: "upstream", url: "https://..." }`      | `success: true`, `action: "add"`                 | P0       | complete |
+| 3   | Remove remote           | `{ path, action: "remove", name: "upstream" }`                       | `success: true`, `action: "remove"`              | P0       | complete |
 | 4   | Add without name throws | `{ path, action: "add", url: "https://..." }`                        | Error: "name parameter is required"              | P0       | mocked   |
 | 5   | Flag injection in name  | `{ path, action: "add", name: "--exec=evil", url: "x" }`             | `assertNoFlagInjection` throws                   | P0       | mocked   |
-| 6   | Show remote details     | `{ path, action: "show", name: "origin" }`                           | `showDetails` with fetchUrl, pushUrl, headBranch | P1       | recorded |
+| 6   | Show remote details     | `{ path, action: "show", name: "origin" }`                           | `showDetails` with fetchUrl, pushUrl, headBranch | P1       | complete |
 | 7   | Rename remote           | `{ path, action: "rename", oldName: "origin", newName: "upstream" }` | `success: true`, `action: "rename"`              | P1       | mocked   |
 | 8   | Set-url                 | `{ path, action: "set-url", name: "origin", url: "https://new" }`    | `success: true`, `action: "set-url"`             | P1       | mocked   |
 | 9   | Prune remote            | `{ path, action: "prune", name: "origin" }`                          | `success: true`, `prunedBranches` array          | P1       | mocked   |
@@ -793,9 +793,9 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                          | Params                                                 | Expected Output                                               | Priority | Status   |
 | --- | --------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------- | -------- | -------- |
-| 1   | Unstage files (mixed reset HEAD)  | `{ path, files: ["a.ts"] }`                            | `success: true`, `ref: "HEAD"`, `filesAffected` contains file | P0       | recorded |
-| 2   | Soft reset                        | `{ path, ref: "HEAD~1", mode: "soft" }`                | `mode: "soft"`, HEAD moved back, changes kept staged          | P0       | recorded |
-| 3   | Hard reset without confirm throws | `{ path, ref: "HEAD~1", mode: "hard" }`                | Error: "Safety guard..."                                      | P0       | recorded |
+| 1   | Unstage files (mixed reset HEAD)  | `{ path, files: ["a.ts"] }`                            | `success: true`, `ref: "HEAD"`, `filesAffected` contains file | P0       | complete |
+| 2   | Soft reset                        | `{ path, ref: "HEAD~1", mode: "soft" }`                | `mode: "soft"`, HEAD moved back, changes kept staged          | P0       | complete |
+| 3   | Hard reset without confirm throws | `{ path, ref: "HEAD~1", mode: "hard" }`                | Error: "Safety guard..."                                      | P0       | complete |
 | 4   | Hard reset with confirm           | `{ path, ref: "HEAD~1", mode: "hard", confirm: true }` | `success: true`, `mode: "hard"`, changes discarded            | P0       | mocked   |
 | 5   | Flag injection in ref             | `{ path, ref: "--exec=evil" }`                         | `assertNoFlagInjection` throws                                | P0       | mocked   |
 | 6   | Invalid ref                       | `{ path, ref: "nonexistent" }`                         | `errorType: "invalid-ref"`                                    | P0       | mocked   |
@@ -838,8 +838,8 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                       | Params                                             | Expected Output                                             | Priority | Status   |
 | --- | ------------------------------ | -------------------------------------------------- | ----------------------------------------------------------- | -------- | -------- |
-| 1   | Restore working tree file      | `{ path, files: ["modified.ts"] }`                 | `restored` contains file, `staged: false`, `source: "HEAD"` | P0       | recorded |
-| 2   | Restore staged file            | `{ path, files: ["staged.ts"], staged: true }`     | `staged: true`, file unstaged                               | P0       | recorded |
+| 1   | Restore working tree file      | `{ path, files: ["modified.ts"] }`                 | `restored` contains file, `staged: false`, `source: "HEAD"` | P0       | complete |
+| 2   | Restore staged file            | `{ path, files: ["staged.ts"], staged: true }`     | `staged: true`, file unstaged                               | P0       | complete |
 | 3   | No files provided throws       | `{ path, files: [] }`                              | Error: "'files' must be provided"                           | P0       | mocked   |
 | 4   | Flag injection in files        | `{ path, files: ["--exec=evil"] }`                 | `assertNoFlagInjection` throws                              | P0       | mocked   |
 | 5   | Nonexistent file               | `{ path, files: ["nonexistent.ts"] }`              | `errorType: "pathspec"`                                     | P0       | mocked   |
@@ -879,11 +879,11 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario               | Params                            | Expected Output                                        | Priority | Status   |
 | --- | ---------------------- | --------------------------------- | ------------------------------------------------------ | -------- | -------- |
-| 1   | Show HEAD commit       | `{ path }`                        | `hash`, `author`, `date`, `message`, `diff` with files | P0       | recorded |
-| 2   | Show specific commit   | `{ path, ref: "abc123" }`         | Commit details for specified ref                       | P0       | recorded |
-| 3   | Invalid ref            | `{ path, ref: "nonexistent" }`    | Error thrown                                           | P0       | recorded |
+| 1   | Show HEAD commit       | `{ path }`                        | `hash`, `author`, `date`, `message`, `diff` with files | P0       | complete |
+| 2   | Show specific commit   | `{ path, ref: "abc123" }`         | Commit details for specified ref                       | P0       | complete |
+| 3   | Invalid ref            | `{ path, ref: "nonexistent" }`    | Error thrown                                           | P0       | complete |
 | 4   | Flag injection in ref  | `{ path, ref: "--exec=evil" }`    | `assertNoFlagInjection` throws                         | P0       | mocked   |
-| 5   | Show tag object        | `{ path, ref: "v1.0" }`           | `objectType: "tag"`, tag metadata                      | P1       | recorded |
+| 5   | Show tag object        | `{ path, ref: "v1.0" }`           | `objectType: "tag"`, tag metadata                      | P1       | complete |
 | 6   | Show tree object       | `{ path, ref: "HEAD^{tree}" }`    | `objectType: "tree"`, tree content                     | P1       | mocked   |
 | 7   | Show blob object       | `{ path, ref: "HEAD:README.md" }` | `objectType: "blob"`, file content                     | P1       | mocked   |
 | 8   | Include patch          | `{ path, patch: true }`           | Diff includes full patch content                       | P1       | mocked   |
@@ -923,14 +923,14 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                  | Params                                                   | Expected Output                                   | Priority | Status   |
 | --- | ------------------------- | -------------------------------------------------------- | ------------------------------------------------- | -------- | -------- |
-| 1   | Push (stash changes)      | `{ path, action: "push" }`                               | `action: "push"`, `success: true`, `stashRef` set | P0       | recorded |
-| 2   | Pop stash                 | `{ path, action: "pop" }`                                | `action: "pop"`, `success: true`                  | P0       | recorded |
-| 3   | Push with no changes      | `{ path, action: "push" }` (clean)                       | `success: false`, no changes to stash             | P0       | recorded |
+| 1   | Push (stash changes)      | `{ path, action: "push" }`                               | `action: "push"`, `success: true`, `stashRef` set | P0       | complete |
+| 2   | Pop stash                 | `{ path, action: "pop" }`                                | `action: "pop"`, `success: true`                  | P0       | complete |
+| 3   | Push with no changes      | `{ path, action: "push" }` (clean)                       | `success: false`, no changes to stash             | P0       | complete |
 | 4   | Flag injection in message | `{ path, action: "push", message: "--exec=evil" }`       | `assertNoFlagInjection` throws                    | P0       | mocked   |
-| 5   | Apply stash               | `{ path, action: "apply" }`                              | `action: "apply"`, `success: true`                | P0       | recorded |
+| 5   | Apply stash               | `{ path, action: "apply" }`                              | `action: "apply"`, `success: true`                | P0       | complete |
 | 6   | Drop stash                | `{ path, action: "drop", index: 0 }`                     | `action: "drop"`, `success: true`                 | P1       | mocked   |
 | 7   | Clear all stashes         | `{ path, action: "clear" }`                              | `action: "clear"`, `success: true`                | P1       | mocked   |
-| 8   | Show stash                | `{ path, action: "show", index: 0 }`                     | `action: "show"`, `diffStat` populated            | P1       | recorded |
+| 8   | Show stash                | `{ path, action: "show", index: 0 }`                     | `action: "show"`, `diffStat` populated            | P1       | complete |
 | 9   | Push with message         | `{ path, action: "push", message: "WIP: feature" }`      | Stash created with message                        | P1       | mocked   |
 | 10  | Push include untracked    | `{ path, action: "push", includeUntracked: true }`       | Untracked files stashed                           | P1       | mocked   |
 | 11  | Push staged only          | `{ path, action: "push", staged: true }`                 | Only staged changes stashed                       | P1       | mocked   |
@@ -966,8 +966,8 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                    | Params                           | Expected Output                               | Priority | Status   |
 | --- | --------------------------- | -------------------------------- | --------------------------------------------- | -------- | -------- |
-| 1   | List stashes (with stashes) | `{ path }`                       | `stashes` array, `total >= 1`                 | P0       | recorded |
-| 2   | List stashes (empty)        | `{ path }` (no stashes)          | `stashes: []`, `total: 0`                     | P0       | recorded |
+| 1   | List stashes (with stashes) | `{ path }`                       | `stashes` array, `total >= 1`                 | P0       | complete |
+| 2   | List stashes (empty)        | `{ path }` (no stashes)          | `stashes: []`, `total: 0`                     | P0       | complete |
 | 3   | Not a git repo              | `{ path: "/tmp/not-a-repo" }`    | Error thrown                                  | P0       | mocked   |
 | 4   | Flag injection in grep      | `{ path, grep: "--exec=evil" }`  | `assertNoFlagInjection` throws                | P0       | mocked   |
 | 5   | With maxCount               | `{ path, maxCount: 3 }`          | `stashes` length <= 3                         | P1       | mocked   |
@@ -1012,13 +1012,13 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                   | Params                                                         | Expected Output                                         | Priority | Status   |
 | --- | -------------------------- | -------------------------------------------------------------- | ------------------------------------------------------- | -------- | -------- |
-| 1   | List tags                  | `{ path }`                                                     | `tags` array, `total` count                             | P0       | recorded |
-| 2   | Create lightweight tag     | `{ path, action: "create", name: "v1.0" }`                     | `success: true`, `action: "create"`, `annotated: false` | P0       | recorded |
-| 3   | Create annotated tag       | `{ path, action: "create", name: "v1.0", message: "Release" }` | `success: true`, `annotated: true`                      | P0       | recorded |
-| 4   | Delete tag                 | `{ path, action: "delete", name: "v1.0" }`                     | `success: true`, `action: "delete"`                     | P0       | recorded |
+| 1   | List tags                  | `{ path }`                                                     | `tags` array, `total` count                             | P0       | complete |
+| 2   | Create lightweight tag     | `{ path, action: "create", name: "v1.0" }`                     | `success: true`, `action: "create"`, `annotated: false` | P0       | complete |
+| 3   | Create annotated tag       | `{ path, action: "create", name: "v1.0", message: "Release" }` | `success: true`, `annotated: true`                      | P0       | complete |
+| 4   | Delete tag                 | `{ path, action: "delete", name: "v1.0" }`                     | `success: true`, `action: "delete"`                     | P0       | complete |
 | 5   | Create without name throws | `{ path, action: "create" }`                                   | Error: "name parameter is required"                     | P0       | mocked   |
 | 6   | Flag injection in name     | `{ path, action: "create", name: "--exec=evil" }`              | `assertNoFlagInjection` throws                          | P0       | mocked   |
-| 7   | No tags in repo            | `{ path }` (no tags)                                           | `tags: []`, `total: 0`                                  | P0       | recorded |
+| 7   | No tags in repo            | `{ path }` (no tags)                                           | `tags: []`, `total: 0`                                  | P0       | complete |
 | 8   | Tag at specific commit     | `{ path, action: "create", name: "v1.0", commit: "abc123" }`   | `commit: "abc123"`                                      | P1       | mocked   |
 | 9   | Pattern filter             | `{ path, pattern: "v1.*" }`                                    | Only matching tags                                      | P1       | mocked   |
 | 10  | Contains filter            | `{ path, contains: "abc123" }`                                 | Only tags containing commit                             | P1       | mocked   |
@@ -1063,10 +1063,10 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 | #   | Scenario                       | Params                                                                               | Expected Output                                     | Priority | Status   |
 | --- | ------------------------------ | ------------------------------------------------------------------------------------ | --------------------------------------------------- | -------- | -------- |
-| 1   | List worktrees                 | `{ path }`                                                                           | `worktrees` array, `total >= 1` (main worktree)     | P0       | recorded |
-| 2   | Add worktree                   | `{ path, action: "add", worktreePath: "../wt-test", branch: "main" }`                | `success: true`, `action: "add"`, `path` set        | P0       | recorded |
+| 1   | List worktrees                 | `{ path }`                                                                           | `worktrees` array, `total >= 1` (main worktree)     | P0       | complete |
+| 2   | Add worktree                   | `{ path, action: "add", worktreePath: "../wt-test", branch: "main" }`                | `success: true`, `action: "add"`, `path` set        | P0       | complete |
 | 3   | Remove worktree                | `{ path, action: "remove", worktreePath: "../wt-test" }`                             | `success: true`, `action: "remove"`                 | P0       | mocked   |
-| 4   | Add without path throws        | `{ path, action: "add" }`                                                            | Error: "'worktreePath' is required"                 | P0       | recorded |
+| 4   | Add without path throws        | `{ path, action: "add" }`                                                            | Error: "'worktreePath' is required"                 | P0       | complete |
 | 5   | Flag injection in worktreePath | `{ path, action: "add", worktreePath: "--exec=evil" }`                               | `assertNoFlagInjection` throws                      | P0       | mocked   |
 | 6   | Add with new branch            | `{ path, action: "add", worktreePath: "../wt", branch: "feat", createBranch: true }` | Branch created, worktree added                      | P1       | mocked   |
 | 7   | Lock worktree                  | `{ path, action: "lock", worktreePath: "../wt" }`                                    | `success: true`, `action: "lock"`                   | P1       | mocked   |

--- a/tests/smoke/scenarios/github-pr-checks.md
+++ b/tests/smoke/scenarios/github-pr-checks.md
@@ -24,66 +24,66 @@
 
 | #   | Scenario                | Params              | Expected Output                                                             | Priority | Status   |
 | --- | ----------------------- | ------------------- | --------------------------------------------------------------------------- | -------- | -------- |
-| 1   | All checks passing      | `{ number: "123" }` | `checks` array with all `bucket: "pass"`, `summary.passed == summary.total` | P0       | recorded |
-| 2   | Mixed pass/fail/pending | `{ number: "123" }` | `checks` with various buckets, `summary` counts match                       | P0       | recorded |
-| 3   | All checks pending      | `{ number: "123" }` | All `bucket: "pending"`, `summary.pending == summary.total`                 | P0       | recorded |
-| 4   | Single check only       | `{ number: "123" }` | `checks.length == 1`, `summary.total == 1`                                  | P1       | recorded |
-| 5   | Many checks (10+)       | `{ number: "123" }` | All checks parsed, summary computed correctly                               | P1       | recorded |
+| 1   | All checks passing      | `{ number: "123" }` | `checks` array with all `bucket: "pass"`, `summary.passed == summary.total` | P0       | complete |
+| 2   | Mixed pass/fail/pending | `{ number: "123" }` | `checks` with various buckets, `summary` counts match                       | P0       | complete |
+| 3   | All checks pending      | `{ number: "123" }` | All `bucket: "pending"`, `summary.pending == summary.total`                 | P0       | complete |
+| 4   | Single check only       | `{ number: "123" }` | `checks.length == 1`, `summary.total == 1`                                  | P1       | complete |
+| 5   | Many checks (10+)       | `{ number: "123" }` | All checks parsed, summary computed correctly                               | P1       | complete |
 
 ### Empty / no checks — THE BUG (#529)
 
 | #   | Scenario                        | Params              | Expected Output                                                | Priority | Status   |
 | --- | ------------------------------- | ------------------- | -------------------------------------------------------------- | -------- | -------- |
-| 6   | PR with no CI checks configured | `{ number: "123" }` | `{ checks: [], summary: { total: 0, ... } }` — NOT a Zod crash | P0       | recorded |
-| 7   | Empty JSON array from gh        | `{ number: "123" }` | Same as #6                                                     | P0       | recorded |
-| 8   | Empty string stdout             | `{ number: "123" }` | Graceful error or empty result                                 | P0       | recorded |
+| 6   | PR with no CI checks configured | `{ number: "123" }` | `{ checks: [], summary: { total: 0, ... } }` — NOT a Zod crash | P0       | complete |
+| 7   | Empty JSON array from gh        | `{ number: "123" }` | Same as #6                                                     | P0       | complete |
+| 8   | Empty string stdout             | `{ number: "123" }` | Graceful error or empty result                                 | P0       | complete |
 
 ### Exit code handling
 
 | #   | Scenario                        | Params                                    | Expected Output                                     | Priority | Status   |
 | --- | ------------------------------- | ----------------------------------------- | --------------------------------------------------- | -------- | -------- |
-| 9   | Exit code 0 (all complete)      | `{ number: "123" }`                       | Normal response, no errorType                       | P0       | recorded |
-| 10  | Exit code 8 (checks pending)    | `{ number: "123" }`                       | Valid response with pending checks, no error thrown | P0       | recorded |
-| 11  | Exit code 1 (PR not found)      | `{ number: "999999" }`                    | `errorType: "not-found"`, `errorMessage` populated  | P0       | recorded |
-| 12  | Exit code 1 (permission denied) | `{ number: "123", repo: "private/repo" }` | `errorType: "permission-denied"`                    | P1       | recorded |
+| 9   | Exit code 0 (all complete)      | `{ number: "123" }`                       | Normal response, no errorType                       | P0       | complete |
+| 10  | Exit code 8 (checks pending)    | `{ number: "123" }`                       | Valid response with pending checks, no error thrown | P0       | complete |
+| 11  | Exit code 1 (PR not found)      | `{ number: "999999" }`                    | `errorType: "not-found"`, `errorMessage` populated  | P0       | complete |
+| 12  | Exit code 1 (permission denied) | `{ number: "123", repo: "private/repo" }` | `errorType: "permission-denied"`                    | P1       | complete |
 
 ### Check deduplication
 
 | #   | Scenario                               | Params              | Expected Output                    | Priority | Status   |
 | --- | -------------------------------------- | ------------------- | ---------------------------------- | -------- | -------- |
-| 13  | Duplicate check names (re-runs)        | `{ number: "123" }` | Only most recent run kept per name | P1       | recorded |
-| 14  | Duplicate names, different completedAt | `{ number: "123" }` | Later completedAt wins             | P1       | recorded |
+| 13  | Duplicate check names (re-runs)        | `{ number: "123" }` | Only most recent run kept per name | P1       | complete |
+| 14  | Duplicate names, different completedAt | `{ number: "123" }` | Later completedAt wins             | P1       | complete |
 
 ### Optional params
 
 | #   | Scenario                | Params                                        | Expected Output                                          | Priority | Status   |
 | --- | ----------------------- | --------------------------------------------- | -------------------------------------------------------- | -------- | -------- |
-| 15  | required: true          | `{ number: "123", required: true }`           | `--required` flag in args, only required checks returned | P1       | recorded |
-| 16  | compact: false          | `{ number: "123", compact: false }`           | Full schema output, not compact                          | P1       | recorded |
-| 17  | compact: true (default) | `{ number: "123" }`                           | Compact output                                           | P1       | recorded |
-| 18  | repo: "owner/repo"      | `{ number: "123", repo: "Dave-London/Pare" }` | `--repo` flag in args                                    | P1       | recorded |
+| 15  | required: true          | `{ number: "123", required: true }`           | `--required` flag in args, only required checks returned | P1       | complete |
+| 16  | compact: false          | `{ number: "123", compact: false }`           | Full schema output, not compact                          | P1       | complete |
+| 17  | compact: true (default) | `{ number: "123" }`                           | Compact output                                           | P1       | complete |
+| 18  | repo: "owner/repo"      | `{ number: "123", repo: "Dave-London/Pare" }` | `--repo` flag in args                                    | P1       | complete |
 
 ### Security
 
 | #   | Scenario                   | Params                                   | Expected Output                | Priority | Status   |
 | --- | -------------------------- | ---------------------------------------- | ------------------------------ | -------- | -------- |
-| 19  | repo with flag injection   | `{ number: "123", repo: "--exec=evil" }` | `assertNoFlagInjection` throws | P0       | recorded |
-| 20  | number with flag injection | `{ number: "--exec=evil" }`              | `assertNoFlagInjection` throws | P0       | recorded |
+| 19  | repo with flag injection   | `{ number: "123", repo: "--exec=evil" }` | `assertNoFlagInjection` throws | P0       | complete |
+| 20  | number with flag injection | `{ number: "--exec=evil" }`              | `assertNoFlagInjection` throws | P0       | complete |
 
 ### Check fields / data fidelity
 
 | #   | Scenario                                             | Params              | Expected Output                                                                                | Priority | Status   |
 | --- | ---------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------- | -------- | -------- |
-| 21  | All check fields populated                           | `{ number: "123" }` | Each check has name, state, bucket, description, event, workflow, link, startedAt, completedAt | P1       | recorded |
-| 22  | Check with empty/null fields                         | `{ number: "123" }` | Defaults to empty strings, no crash                                                            | P1       | recorded |
-| 23  | Bucket values: pass, fail, pending, skipping, cancel | `{ number: "123" }` | Summary counts map correctly to bucket values                                                  | P1       | recorded |
+| 21  | All check fields populated                           | `{ number: "123" }` | Each check has name, state, bucket, description, event, workflow, link, startedAt, completedAt | P1       | complete |
+| 22  | Check with empty/null fields                         | `{ number: "123" }` | Defaults to empty strings, no crash                                                            | P1       | complete |
+| 23  | Bucket values: pass, fail, pending, skipping, cancel | `{ number: "123" }` | Summary counts map correctly to bucket values                                                  | P1       | complete |
 
 ### Compact output
 
 | #   | Scenario                    | Params                             | Expected Output                        | Priority | Status   |
 | --- | --------------------------- | ---------------------------------- | -------------------------------------- | -------- | -------- |
-| 24  | Compact output with checks  | `{ number: "123", compact: true }` | `compactPrChecksMap` applied correctly | P2       | recorded |
-| 25  | Compact output empty checks | `{ number: "123", compact: true }` | Compact output doesn't crash on empty  | P0       | recorded |
+| 24  | Compact output with checks  | `{ number: "123", compact: true }` | `compactPrChecksMap` applied correctly | P2       | complete |
+| 25  | Compact output empty checks | `{ number: "123", compact: true }` | Compact output doesn't crash on empty  | P0       | complete |
 
 ### Schema validation
 
@@ -95,15 +95,15 @@
 
 | #   | Scenario                    | Params                                                 | Expected Output                                                    | Priority | Status   |
 | --- | --------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------ | -------- | -------- |
-| 27  | PR number as URL string     | `{ number: "https://github.com/owner/repo/pull/123" }` | Passes URL to gh CLI correctly                                     | P2       | recorded |
-| 28  | PR number as branch name    | `{ number: "feature-branch" }`                         | Passes branch to gh CLI correctly                                  | P2       | recorded |
-| 29  | watch: true (short timeout) | `{ number: "123", watch: true }`                       | `--watch` flag in args (actual watch behavior not tested in smoke) | P2       | recorded |
+| 27  | PR number as URL string     | `{ number: "https://github.com/owner/repo/pull/123" }` | Passes URL to gh CLI correctly                                     | P2       | complete |
+| 28  | PR number as branch name    | `{ number: "feature-branch" }`                         | Passes branch to gh CLI correctly                                  | P2       | complete |
+| 29  | watch: true (short timeout) | `{ number: "123", watch: true }`                       | `--watch` flag in args (actual watch behavior not tested in smoke) | P2       | complete |
 
 ## Summary
 
 | Priority  | Count  | Mocked | Recorded | Complete |
 | --------- | ------ | ------ | -------- | -------- |
-| P0        | 12     | 12     | 11       | 1        |
-| P1        | 12     | 12     | 12       | 0        |
-| P2        | 5      | 5      | 5        | 0        |
-| **Total** | **29** | **29** | **28**   | **1**    |
+| P0        | 12     | 12     | 0        | 12       |
+| P1        | 12     | 12     | 0        | 12       |
+| P2        | 5      | 5      | 0        | 5        |
+| **Total** | **29** | **29** | **0**    | **29**   |


### PR DESCRIPTION
## Summary - Add `scripts/smoke-coverage.ts` — parses all scenario `.md` files and reports coverage by status (mocked/recorded/complete) and priority (P0-P2). Supports `--json` for CI and `--check` to fail if any P0 is not complete - Add `pnpm smoke:coverage` script to package.json - Update 130 scenarios from `recorded` → `complete` across git-tools.md (77), git-status.md (25), and github-pr-checks.md (28) - Add smoke testing guide to CONTRIBUTING.md with directory structure, workflow, and key patterns - CI smoke job already exists from prior work  ## Coverage Report ```   git-status.md             [####################] 100% (41/41)   git-tools.md              [#####---------------] 25% (77/314)   github-pr-checks.md       [####################] 100% (29/29)   Overall:                  [##----------------------------] 7% (147/2112) ```  ## Phase 4 DoD (#544) - [x] `pnpm smoke` runs all recorded fixtures and reports pass/fail - [x] Coverage report shows % of mapped scenarios at `complete` status - [x] CI integration added (recorded mode) - [ ] `pnpm smoke:live` works for local validation (deferred — needs design) - [x] Documentation in CONTRIBUTING.md for adding new smoke tests - [ ] All P0 scenarios at `complete` status (7% — remaining servers need Phase 3 fixtures)  ## Test plan - [x] `pnpm smoke` passes (2245 tests) - [x] `pnpm smoke:coverage` prints report - [x] `pnpm smoke:coverage --json` outputs valid JSON - [x] `pnpm smoke:coverage --check` exits 1 (P0 scenarios incomplete for non-git servers)