### PR TITLE
fix: correct flag injection guards per #434 audit

### DIFF
--- a/.changeset/fix-flag-injection-audit-434.md
+++ b/.changeset/fix-flag-injection-audit-434.md
@@ -1,0 +1,8 @@
+---
+"@paretools/shared": patch
+"@paretools/git": patch
+"@paretools/security": patch
+"@paretools/build": patch
+---
+
+Fix flag injection guards that incorrectly blocked legitimate values: git sort keys (e.g. `-creatordate`), gitleaks `logOpts` (e.g. `--since=2024-01-01`), and remove misleading validation claim from turbo `args` description.

--- a/packages/server-build/src/tools/turbo.ts
+++ b/packages/server-build/src/tools/turbo.ts
@@ -82,7 +82,7 @@ export function registerTurboTool(server: McpServer) {
           .max(INPUT_LIMITS.ARRAY_MAX)
           .optional()
           .describe(
-            "Additional turbo flags (e.g., ['--env-mode=strict']). Each arg is validated with assertNoFlagInjection.",
+            "Additional turbo flags passed directly to turbo (e.g., ['--env-mode=strict']).",
           ),
         path: z.string().max(INPUT_LIMITS.PATH_MAX).optional().describe("Project root path"),
         compact: z.boolean().optional().default(true).describe("Prefer compact output"),

--- a/packages/server-git/src/tools/branch.ts
+++ b/packages/server-git/src/tools/branch.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { compactDualOutput, INPUT_LIMITS } from "@paretools/shared";
-import { assertNoFlagInjection } from "@paretools/shared";
+import { assertNoFlagInjection, assertValidSortKey } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseBranch } from "../lib/parsers.js";
 import { formatBranch, compactBranchMap, formatBranchCompact } from "../lib/formatters.js";
@@ -156,7 +156,7 @@ export function registerBranchTool(server: McpServer) {
       if (noMerged) args.push("--no-merged");
       if (verbose) args.push("-v");
       if (sort) {
-        assertNoFlagInjection(sort, "sort");
+        assertValidSortKey(sort, "sort");
         args.push(`--sort=${sort}`);
       }
       if (contains) {

--- a/packages/server-git/src/tools/tag.ts
+++ b/packages/server-git/src/tools/tag.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { compactDualOutput, dualOutput, INPUT_LIMITS } from "@paretools/shared";
-import { assertNoFlagInjection } from "@paretools/shared";
+import { assertNoFlagInjection, assertValidSortKey } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseTagOutput } from "../lib/parsers.js";
 import { formatTag, compactTagMap, formatTagCompact, formatTagMutate } from "../lib/formatters.js";
@@ -153,7 +153,7 @@ export function registerTagTool(server: McpServer) {
 
       // Default: list
       const sortFlag = sortBy || "-creatordate";
-      if (sortBy) assertNoFlagInjection(sortBy, "sortBy");
+      if (sortBy) assertValidSortKey(sortBy, "sortBy");
 
       const args = [
         "tag",

--- a/packages/server-security/src/tools/gitleaks.ts
+++ b/packages/server-security/src/tools/gitleaks.ts
@@ -6,6 +6,7 @@ import {
   INPUT_LIMITS,
   assertAllowedRoot,
   assertNoFlagInjection,
+  assertValidLogOpts,
 } from "@paretools/shared";
 import { parseGitleaksJson } from "../lib/parsers.js";
 import {
@@ -107,7 +108,7 @@ export function registerGitleaksTool(server: McpServer) {
     }) => {
       if (config) assertNoFlagInjection(config, "config");
       if (baselinePath) assertNoFlagInjection(baselinePath, "baselinePath");
-      if (logOpts) assertNoFlagInjection(logOpts, "logOpts");
+      if (logOpts) assertValidLogOpts(logOpts, "logOpts");
       if (logLevel) assertNoFlagInjection(logLevel, "logLevel");
       for (const r of enableRule ?? []) {
         assertNoFlagInjection(r, "enableRule");

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,7 +1,12 @@
 export { dualOutput, estimateTokens, compactDualOutput } from "./output.js";
 export { run, escapeCmdArg, type RunResult, type RunOptions } from "./runner.js";
 export { stripAnsi } from "./ansi.js";
-export { assertNoFlagInjection, assertAllowedCommand } from "./validation.js";
+export {
+  assertNoFlagInjection,
+  assertValidSortKey,
+  assertValidLogOpts,
+  assertAllowedCommand,
+} from "./validation.js";
 export { INPUT_LIMITS } from "./limits.js";
 export { sanitizeErrorOutput } from "./sanitize.js";
 export { shouldRegisterTool, _resetProfileCache } from "./tool-filter.js";

--- a/packages/shared/src/validation.ts
+++ b/packages/shared/src/validation.ts
@@ -12,6 +12,35 @@ export function assertNoFlagInjection(value: string, paramName: string): void {
 }
 
 /**
+ * Validates that a git sort key is safe. Git sort keys may start with `-` (meaning
+ * descending order), e.g. `-creatordate`, `-committerdate`, `version:refname`.
+ * Only allows alphanumeric chars, colons, dots, and underscores (with optional leading `-`).
+ */
+export function assertValidSortKey(value: string, paramName: string): void {
+  if (!/^-?[a-zA-Z][a-zA-Z0-9:._-]*$/.test(value)) {
+    throw new Error(
+      `Invalid ${paramName}: "${value}". Sort keys must match /^-?[a-zA-Z][a-zA-Z0-9:._-]*$/.`,
+    );
+  }
+}
+
+/**
+ * Validates that a git log option string is safe. Log options are `--`-prefixed flags
+ * with optional values, e.g. `--since=2024-01-01`, `--author=foo`, `--all`.
+ * Each space-separated token must be a long-form flag (`--name` or `--name=value`).
+ */
+export function assertValidLogOpts(value: string, paramName: string): void {
+  const tokens = value.split(/\s+/).filter(Boolean);
+  for (const token of tokens) {
+    if (!/^--[a-zA-Z][\w-]*(=.*)?$/.test(token)) {
+      throw new Error(
+        `Invalid ${paramName} token: "${token}". Log options must be long-form flags (--name or --name=value).`,
+      );
+    }
+  }
+}
+
+/**
  * Allowlist of known safe build commands.
  * Prevents arbitrary command execution via the build tool's command parameter.
  */


### PR DESCRIPTION
## Summary
- **Fix 1 & 2 (git sort keys)**: Replace `assertNoFlagInjection` with new `assertValidSortKey` validator for `tag sortBy` and `branch sort` params. Git sort keys like `-creatordate` and `-version:refname` legitimately start with `-` (descending order prefix) and were incorrectly blocked. The new validator allows `^-?[a-zA-Z][a-zA-Z0-9:._-]*$`.
- **Fix 3 (gitleaks logOpts)**: Replace `assertNoFlagInjection` with new `assertValidLogOpts` validator. The `logOpts` parameter exists to pass git log flags like `--since=2024-01-01` and `--author=foo`, which all start with `--` and were blocked. The new validator ensures each token is a long-form flag matching `^--[a-zA-Z][\w-]*(=.*)?$`.
- **Fix 4 (turbo args description)**: Remove false claim that "Each arg is validated with assertNoFlagInjection" from the `args` parameter description — the code does not actually perform this validation.

Both new validators (`assertValidSortKey`, `assertValidLogOpts`) are added to `@paretools/shared` and exported for reuse.

Related: #434

## Test plan
- [x] `pnpm build` passes (all 17 packages)
- [x] `pnpm --filter @paretools/shared test` passes (207 tests)
- [x] `pnpm --filter @paretools/git test` passes (663/664 — 1 pre-existing fidelity failure unrelated to this change)
- [x] `pnpm --filter @paretools/security test` passes (73 tests)
- [x] `pnpm --filter @paretools/build test` passes (220 tests)
- [x] Smoke tests pass (1287 tests)