### PR TITLE
chore: add bugs URL to all package.json files

### DIFF
--- a/.changeset/add-bugs-url.md
+++ b/.changeset/add-bugs-url.md
@@ -1,0 +1,21 @@
+---
+"@paretools/shared": patch
+"@paretools/build": patch
+"@paretools/cargo": patch
+"@paretools/docker": patch
+"@paretools/git": patch
+"@paretools/github": patch
+"@paretools/go": patch
+"@paretools/http": patch
+"@paretools/k8s": patch
+"@paretools/lint": patch
+"@paretools/make": patch
+"@paretools/npm": patch
+"@paretools/process": patch
+"@paretools/python": patch
+"@paretools/search": patch
+"@paretools/security": patch
+"@paretools/test": patch
+---
+
+Add `bugs` URL to package.json for all packages, linking to the GitHub issues page.

--- a/packages/server-build/package.json
+++ b/packages/server-build/package.json
@@ -46,6 +46,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-build"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-cargo/package.json
+++ b/packages/server-cargo/package.json
@@ -45,6 +45,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-cargo"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-docker/package.json
+++ b/packages/server-docker/package.json
@@ -44,6 +44,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-docker"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-git/package.json
+++ b/packages/server-git/package.json
@@ -43,6 +43,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-git"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-github/package.json
+++ b/packages/server-github/package.json
@@ -45,6 +45,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-github"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-go/package.json
+++ b/packages/server-go/package.json
@@ -44,6 +44,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-go"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-http/package.json
+++ b/packages/server-http/package.json
@@ -45,6 +45,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-http"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-k8s/package.json
+++ b/packages/server-k8s/package.json
@@ -45,6 +45,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-k8s"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-lint/package.json
+++ b/packages/server-lint/package.json
@@ -45,6 +45,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-lint"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-make/package.json
+++ b/packages/server-make/package.json
@@ -45,6 +45,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-make"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-npm/package.json
+++ b/packages/server-npm/package.json
@@ -44,6 +44,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-npm"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-process/package.json
+++ b/packages/server-process/package.json
@@ -45,6 +45,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-process"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-python/package.json
+++ b/packages/server-python/package.json
@@ -47,6 +47,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-python"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-search/package.json
+++ b/packages/server-search/package.json
@@ -46,6 +46,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-search"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-security/package.json
+++ b/packages/server-security/package.json
@@ -51,6 +51,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-security"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server-test/package.json
+++ b/packages/server-test/package.json
@@ -46,6 +46,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/server-test"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/Dave-London/Pare.git",
     "directory": "packages/shared"
   },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary
- Adds the `bugs` field (`https://github.com/Dave-London/Pare/issues`) to all 17 published packages
- Enables the "Report a bug" link on each npm package page

## Test plan
- [ ] Verify CI passes (light suite — no code changes)
- [ ] Merge and confirm Version Packages PR bumps to 0.10.2