### PR TITLE
ci: make audit advisory so npm outages do not block PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,10 +193,6 @@ jobs:
             echo "smoke failed: ${{ needs.smoke.result }}"
             exit 1
           fi
-          if [[ "${{ needs.audit.result }}" != "success" ]]; then
-            echo "audit failed: ${{ needs.audit.result }}"
-            exit 1
-          fi
           if [[ "${{ needs.build-and-test-ubuntu.result }}" != "success" ]]; then
             echo "build-and-test-ubuntu failed: ${{ needs.build-and-test-ubuntu.result }}"
             exit 1
@@ -204,6 +200,11 @@ jobs:
           if [[ "${{ needs.build-and-test-windows.result }}" != "success" ]]; then
             echo "build-and-test-windows failed: ${{ needs.build-and-test-windows.result }}"
             exit 1
+          fi
+
+          # Advisory: audit is informational — npm registry outages (HTTP 500) must not block PRs
+          if [[ "${{ needs.audit.result }}" == "failure" ]]; then
+            echo "⚠ audit failed (advisory, non-blocking): ${{ needs.audit.result }}"
           fi
 
           # Conditional jobs: must pass if they ran, OK to skip


### PR DESCRIPTION
## Summary
- Moves the `audit` job from a required ci-gate check to an advisory one
- npm registry outages (HTTP 500 on `/security/audits`) were blocking all 14 open PRs despite no actual code vulnerabilities
- Audit still runs and failures are logged as warnings, but no longer fail ci-gate

## Test plan
- [ ] Verify ci-gate passes even when audit fails
- [ ] Verify ci-gate still fails when required jobs (build, lint, smoke) fail