### PR TITLE
chore: align new server package versions to 0.10.2

### DIFF
--- a/packages/server-bun/package.json
+++ b/packages/server-bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paretools/bun",
-  "version": "0.1.0",
+  "version": "0.10.2",
   "mcpName": "io.github.Dave-London/pare-bun",
   "description": "MCP server for Bun runtime operations with structured, token-efficient output",
   "license": "MIT",

--- a/packages/server-bun/server.json
+++ b/packages/server-bun/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.1.0",
+  "version": "0.10.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/bun",
-      "version": "0.1.0",
+      "version": "0.10.2",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-db/package.json
+++ b/packages/server-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paretools/db",
-  "version": "0.1.0",
+  "version": "0.10.2",
   "mcpName": "io.github.Dave-London/pare-db",
   "description": "MCP server for database CLI operations with structured, token-efficient output",
   "license": "MIT",

--- a/packages/server-db/server.json
+++ b/packages/server-db/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.1.0",
+  "version": "0.10.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/db",
-      "version": "0.1.0",
+      "version": "0.10.2",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-deno/package.json
+++ b/packages/server-deno/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paretools/deno",
-  "version": "0.1.0",
+  "version": "0.10.2",
   "mcpName": "io.github.Dave-London/pare-deno",
   "description": "MCP server for Deno runtime operations with structured, token-efficient output",
   "license": "MIT",

--- a/packages/server-deno/server.json
+++ b/packages/server-deno/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.Dave-London/pare-deno",
   "description": "Pare Deno — Structured Deno runtime operations as typed JSON.",
   "repository": { "url": "https://github.com/Dave-London/Pare", "source": "github" },
-  "version": "0.1.0",
+  "version": "0.10.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/deno",
-      "version": "0.1.0",
+      "version": "0.10.2",
       "transport": { "type": "stdio" }
     }
   ]

--- a/packages/server-dotnet/package.json
+++ b/packages/server-dotnet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paretools/dotnet",
-  "version": "0.1.0",
+  "version": "0.10.2",
   "mcpName": "io.github.Dave-London/pare-dotnet",
   "description": "MCP server for .NET CLI operations with structured, token-efficient output",
   "license": "MIT",

--- a/packages/server-dotnet/server.json
+++ b/packages/server-dotnet/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.Dave-London/pare-dotnet",
   "description": "Pare .NET — Structured .NET CLI operations as typed JSON.",
   "repository": { "url": "https://github.com/Dave-London/Pare", "source": "github" },
-  "version": "0.1.0",
+  "version": "0.10.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/dotnet",
-      "version": "0.1.0",
+      "version": "0.10.2",
       "transport": { "type": "stdio" }
     }
   ]

--- a/packages/server-infra/package.json
+++ b/packages/server-infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paretools/infra",
-  "version": "0.1.0",
+  "version": "0.10.2",
   "mcpName": "io.github.Dave-London/pare-infra",
   "description": "MCP server for infrastructure-as-code operations with structured, token-efficient output",
   "license": "MIT",

--- a/packages/server-infra/server.json
+++ b/packages/server-infra/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.1.0",
+  "version": "0.10.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/infra",
-      "version": "0.1.0",
+      "version": "0.10.2",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-jvm/package.json
+++ b/packages/server-jvm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paretools/jvm",
-  "version": "0.1.0",
+  "version": "0.10.2",
   "mcpName": "io.github.Dave-London/pare-jvm",
   "description": "MCP server for JVM build tool operations (Gradle, Maven) with structured, token-efficient output",
   "license": "MIT",

--- a/packages/server-jvm/server.json
+++ b/packages/server-jvm/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.1.0",
+  "version": "0.10.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/jvm",
-      "version": "0.1.0",
+      "version": "0.10.2",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-remote/package.json
+++ b/packages/server-remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paretools/remote",
-  "version": "0.1.0",
+  "version": "0.10.2",
   "mcpName": "io.github.Dave-London/pare-remote",
   "description": "MCP server for remote operations (SSH, rsync) with structured, token-efficient output",
   "license": "MIT",

--- a/packages/server-remote/server.json
+++ b/packages/server-remote/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.1.0",
+  "version": "0.10.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/remote",
-      "version": "0.1.0",
+      "version": "0.10.2",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-ruby/package.json
+++ b/packages/server-ruby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paretools/ruby",
-  "version": "0.1.0",
+  "version": "0.10.2",
   "mcpName": "io.github.Dave-London/pare-ruby",
   "description": "MCP server for Ruby and Bundler operations with structured, token-efficient output",
   "license": "MIT",

--- a/packages/server-ruby/server.json
+++ b/packages/server-ruby/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.1.0",
+  "version": "0.10.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/ruby",
-      "version": "0.1.0",
+      "version": "0.10.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Aligns all 8 new server packages (bun, db, deno, dotnet, infra, jvm, remote, ruby) from 0.1.0 to 0.10.2 to match existing packages.