### PR TITLE
feat(infra): add vagrant tool

### DIFF
--- a/.changeset/vagrant-tool.md
+++ b/.changeset/vagrant-tool.md
@@ -1,0 +1,5 @@
+---
+"@paretools/infra": minor
+---
+
+Add vagrant tool with status, global-status, up, halt, and destroy actions

--- a/packages/server-infra/__tests__/vagrant-formatters.test.ts
+++ b/packages/server-infra/__tests__/vagrant-formatters.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatVagrantStatus,
+  formatVagrantGlobalStatus,
+  formatVagrantUp,
+  formatVagrantLifecycle,
+  compactVagrantStatusMap,
+  formatVagrantStatusCompact,
+  compactVagrantGlobalStatusMap,
+  formatVagrantGlobalStatusCompact,
+  compactVagrantUpMap,
+  formatVagrantUpCompact,
+  compactVagrantLifecycleMap,
+  formatVagrantLifecycleCompact,
+} from "../src/lib/vagrant-formatters.js";
+import type {
+  VagrantStatusResult,
+  VagrantGlobalStatusResult,
+  VagrantUpResult,
+  VagrantLifecycleResult,
+} from "../src/schemas/vagrant.js";
+
+// ── Full formatters ────────────────────────────────────────────────
+
+describe("formatVagrantStatus", () => {
+  it("formats single machine status", () => {
+    const data: VagrantStatusResult = {
+      action: "status",
+      success: true,
+      machines: [{ name: "default", state: "running", provider: "virtualbox" }],
+      count: 1,
+      exitCode: 0,
+    };
+    const result = formatVagrantStatus(data);
+    expect(result).toContain("vagrant status: 1 machine(s)");
+    expect(result).toContain("default: running (virtualbox)");
+  });
+
+  it("formats multi-machine status", () => {
+    const data: VagrantStatusResult = {
+      action: "status",
+      success: true,
+      machines: [
+        { name: "web", state: "running", provider: "virtualbox" },
+        { name: "db", state: "poweroff", provider: "virtualbox" },
+      ],
+      count: 2,
+      exitCode: 0,
+    };
+    const result = formatVagrantStatus(data);
+    expect(result).toContain("2 machine(s)");
+    expect(result).toContain("web: running");
+    expect(result).toContain("db: poweroff");
+  });
+});
+
+describe("formatVagrantGlobalStatus", () => {
+  it("formats global status", () => {
+    const data: VagrantGlobalStatusResult = {
+      action: "global-status",
+      success: true,
+      machines: [
+        {
+          id: "abc123",
+          name: "default",
+          provider: "virtualbox",
+          state: "running",
+          directory: "/home/user/project",
+        },
+      ],
+      count: 1,
+      exitCode: 0,
+    };
+    const result = formatVagrantGlobalStatus(data);
+    expect(result).toContain("vagrant global-status: 1 machine(s)");
+    expect(result).toContain("abc123");
+    expect(result).toContain("/home/user/project");
+  });
+});
+
+describe("formatVagrantUp", () => {
+  it("formats successful up", () => {
+    const data: VagrantUpResult = {
+      action: "up",
+      success: true,
+      machines: [{ name: "default", state: "running", provider: "virtualbox" }],
+      exitCode: 0,
+    };
+    const result = formatVagrantUp(data);
+    expect(result).toContain("vagrant up: success");
+    expect(result).toContain("default: running");
+  });
+
+  it("formats up with warnings", () => {
+    const data: VagrantUpResult = {
+      action: "up",
+      success: true,
+      machines: [{ name: "default", state: "running", provider: "virtualbox" }],
+      warnings: ["Some warning"],
+      exitCode: 0,
+    };
+    const result = formatVagrantUp(data);
+    expect(result).toContain("warning: Some warning");
+  });
+
+  it("formats failed up", () => {
+    const data: VagrantUpResult = {
+      action: "up",
+      success: false,
+      machines: [],
+      exitCode: 1,
+    };
+    const result = formatVagrantUp(data);
+    expect(result).toContain("vagrant up: failed");
+  });
+});
+
+describe("formatVagrantLifecycle", () => {
+  it("formats halt", () => {
+    const data: VagrantLifecycleResult = {
+      action: "halt",
+      success: true,
+      machines: [{ name: "default", newState: "poweroff" }],
+      exitCode: 0,
+    };
+    const result = formatVagrantLifecycle(data);
+    expect(result).toContain("vagrant halt: success");
+    expect(result).toContain("default: poweroff");
+  });
+
+  it("formats destroy", () => {
+    const data: VagrantLifecycleResult = {
+      action: "destroy",
+      success: true,
+      machines: [{ name: "default", newState: "not_created" }],
+      exitCode: 0,
+    };
+    const result = formatVagrantLifecycle(data);
+    expect(result).toContain("vagrant destroy: success");
+    expect(result).toContain("default: not_created");
+  });
+});
+
+// ── Compact formatters ─────────────────────────────────────────────
+
+describe("compact vagrant status", () => {
+  it("maps and formats compact status", () => {
+    const data: VagrantStatusResult = {
+      action: "status",
+      success: true,
+      machines: [{ name: "default", state: "running", provider: "virtualbox" }],
+      count: 1,
+      exitCode: 0,
+    };
+    const compact = compactVagrantStatusMap(data);
+    expect(compact.success).toBe(true);
+    expect(compact.count).toBe(1);
+
+    const text = formatVagrantStatusCompact(compact);
+    expect(text).toBe("vagrant status: 1 machine(s)");
+  });
+});
+
+describe("compact vagrant global-status", () => {
+  it("maps and formats compact global-status", () => {
+    const data: VagrantGlobalStatusResult = {
+      action: "global-status",
+      success: true,
+      machines: [
+        {
+          id: "abc",
+          name: "",
+          provider: "virtualbox",
+          state: "running",
+          directory: "/tmp",
+        },
+      ],
+      count: 1,
+      exitCode: 0,
+    };
+    const compact = compactVagrantGlobalStatusMap(data);
+    expect(compact.count).toBe(1);
+
+    const text = formatVagrantGlobalStatusCompact(compact);
+    expect(text).toBe("vagrant global-status: 1 machine(s)");
+  });
+});
+
+describe("compact vagrant up", () => {
+  it("maps and formats compact up", () => {
+    const data: VagrantUpResult = {
+      action: "up",
+      success: true,
+      machines: [{ name: "default", state: "running", provider: "virtualbox" }],
+      warnings: ["warn1"],
+      exitCode: 0,
+    };
+    const compact = compactVagrantUpMap(data);
+    expect(compact.machineCount).toBe(1);
+    expect(compact.warningCount).toBe(1);
+
+    const text = formatVagrantUpCompact(compact);
+    expect(text).toBe("vagrant up: 1 machine(s) started (1 warnings)");
+  });
+
+  it("formats compact failed up", () => {
+    const compact = { success: false, machineCount: 0, warningCount: 0 };
+    expect(formatVagrantUpCompact(compact)).toBe("vagrant up: failed");
+  });
+});
+
+describe("compact vagrant lifecycle", () => {
+  it("maps and formats compact halt", () => {
+    const data: VagrantLifecycleResult = {
+      action: "halt",
+      success: true,
+      machines: [{ name: "default", newState: "poweroff" }],
+      exitCode: 0,
+    };
+    const compact = compactVagrantLifecycleMap(data);
+    expect(compact.action).toBe("halt");
+    expect(compact.machineCount).toBe(1);
+
+    const text = formatVagrantLifecycleCompact(compact);
+    expect(text).toBe("vagrant halt: 1 machine(s)");
+  });
+
+  it("formats compact failed destroy", () => {
+    const compact = { success: false, action: "destroy", machineCount: 0 };
+    expect(formatVagrantLifecycleCompact(compact)).toBe("vagrant destroy: failed");
+  });
+});

--- a/packages/server-infra/__tests__/vagrant-parsers.test.ts
+++ b/packages/server-infra/__tests__/vagrant-parsers.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseVagrantStatusOutput,
+  parseVagrantGlobalStatusOutput,
+  parseVagrantUpOutput,
+  parseVagrantLifecycleOutput,
+} from "../src/lib/vagrant-parsers.js";
+
+describe("parseVagrantStatusOutput", () => {
+  it("parses single machine status", () => {
+    const stdout = [
+      "1234567890,default,metadata,provider,virtualbox",
+      "1234567890,default,provider-name,virtualbox",
+      "1234567890,default,state,running",
+      "1234567890,default,state-human-short,running",
+      "1234567890,default,state-human-long,The VM is running.",
+    ].join("\n");
+
+    const result = parseVagrantStatusOutput(stdout, "", 0);
+
+    expect(result.action).toBe("status");
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(1);
+    expect(result.machines).toEqual([
+      { name: "default", state: "running", provider: "virtualbox" },
+    ]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("parses multi-machine status", () => {
+    const stdout = [
+      "1234567890,web,provider-name,virtualbox",
+      "1234567890,web,state,running",
+      "1234567890,db,provider-name,virtualbox",
+      "1234567890,db,state,poweroff",
+    ].join("\n");
+
+    const result = parseVagrantStatusOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(2);
+    expect(result.machines).toEqual([
+      { name: "web", state: "running", provider: "virtualbox" },
+      { name: "db", state: "poweroff", provider: "virtualbox" },
+    ]);
+  });
+
+  it("handles empty output on error", () => {
+    const result = parseVagrantStatusOutput("", "Error occurred", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.count).toBe(0);
+    expect(result.machines).toEqual([]);
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe("parseVagrantGlobalStatusOutput", () => {
+  it("parses global status with multiple VMs", () => {
+    const stdout = [
+      "1234567890,,machine-id,abc123",
+      "1234567890,,provider-name,virtualbox",
+      "1234567890,,machine-home,/home/user/project",
+      "1234567890,,state,running",
+      "1234567890,,machine-id,def456",
+      "1234567890,,provider-name,virtualbox",
+      "1234567890,,machine-home,/home/user/other",
+      "1234567890,,state,poweroff",
+    ].join("\n");
+
+    const result = parseVagrantGlobalStatusOutput(stdout, "", 0);
+
+    expect(result.action).toBe("global-status");
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(2);
+    expect(result.machines).toEqual([
+      {
+        id: "abc123",
+        name: "",
+        provider: "virtualbox",
+        state: "running",
+        directory: "/home/user/project",
+      },
+      {
+        id: "def456",
+        name: "",
+        provider: "virtualbox",
+        state: "poweroff",
+        directory: "/home/user/other",
+      },
+    ]);
+  });
+
+  it("handles empty output on error", () => {
+    const result = parseVagrantGlobalStatusOutput("", "Error", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.count).toBe(0);
+    expect(result.machines).toEqual([]);
+  });
+});
+
+describe("parseVagrantUpOutput", () => {
+  it("parses up output with warnings", () => {
+    const stdout = [
+      "1234567890,default,ui,info,Bringing machine 'default' up with 'virtualbox' provider...",
+      "1234567890,default,provider-name,virtualbox",
+      "1234567890,default,state,running",
+      "1234567890,,ui,warn,Some warning message",
+    ].join("\n");
+
+    const result = parseVagrantUpOutput(stdout, "", 0);
+
+    expect(result.action).toBe("up");
+    expect(result.success).toBe(true);
+    expect(result.machines).toEqual([
+      { name: "default", state: "running", provider: "virtualbox" },
+    ]);
+    expect(result.warnings).toEqual(["Some warning message"]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("parses up output without warnings", () => {
+    const stdout = [
+      "1234567890,default,provider-name,virtualbox",
+      "1234567890,default,state,running",
+    ].join("\n");
+
+    const result = parseVagrantUpOutput(stdout, "", 0);
+
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it("handles failed up", () => {
+    const result = parseVagrantUpOutput("", "Error starting VM", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.machines).toEqual([]);
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe("parseVagrantLifecycleOutput", () => {
+  it("parses halt output", () => {
+    const stdout = [
+      "1234567890,default,ui,info,Attempting graceful shutdown of VM...",
+      "1234567890,default,state,poweroff",
+    ].join("\n");
+
+    const result = parseVagrantLifecycleOutput(stdout, "", 0, "halt");
+
+    expect(result.action).toBe("halt");
+    expect(result.success).toBe(true);
+    expect(result.machines).toEqual([{ name: "default", newState: "poweroff" }]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("parses destroy output", () => {
+    const stdout = [
+      "1234567890,default,ui,info,Destroying VM and associated drives...",
+      "1234567890,default,state,not_created",
+    ].join("\n");
+
+    const result = parseVagrantLifecycleOutput(stdout, "", 0, "destroy");
+
+    expect(result.action).toBe("destroy");
+    expect(result.success).toBe(true);
+    expect(result.machines).toEqual([{ name: "default", newState: "not_created" }]);
+  });
+
+  it("handles error output", () => {
+    const result = parseVagrantLifecycleOutput("", "Error", 1, "halt");
+
+    expect(result.success).toBe(false);
+    expect(result.machines).toEqual([]);
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/packages/server-infra/__tests__/vagrant-security.test.ts
+++ b/packages/server-infra/__tests__/vagrant-security.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+
+/** Malicious inputs that must be rejected. */
+const MALICIOUS_INPUTS = [
+  "--evil",
+  "-destroy",
+  "--machine=hack",
+  "-f",
+  "--force",
+  " --evil",
+  "\t-flag",
+];
+
+/** Safe machine names that must be accepted. */
+const SAFE_INPUTS = ["default", "web-server", "db_primary", "app01", "my-vm"];
+
+describe("security: vagrant machine name — flag injection", () => {
+  it("rejects flag-like machine names", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "machine")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe machine names", () => {
+    for (const safe of SAFE_INPUTS) {
+      expect(() => assertNoFlagInjection(safe, "machine")).not.toThrow();
+    }
+  });
+});
+
+describe("Zod .max() constraints — Vagrant machine name", () => {
+  const schema = z.string().max(INPUT_LIMITS.SHORT_STRING_MAX);
+
+  it("accepts a name within the limit", () => {
+    expect(schema.safeParse("default").success).toBe(true);
+  });
+
+  it("rejects a name exceeding SHORT_STRING_MAX", () => {
+    const oversized = "m".repeat(INPUT_LIMITS.SHORT_STRING_MAX + 1);
+    expect(schema.safeParse(oversized).success).toBe(false);
+  });
+});

--- a/packages/server-infra/src/index.ts
+++ b/packages/server-infra/src/index.ts
@@ -8,7 +8,7 @@ const server = new McpServer(
   { name: "@paretools/infra", version: "0.1.0" },
   {
     instructions:
-      "Structured infrastructure-as-code operations (Terraform init, plan, validate, fmt, output, state, workspace, show). Returns typed JSON.",
+      "Structured infrastructure-as-code operations (Terraform init, plan, validate, fmt, output, state, workspace, show; Vagrant status, up, halt, destroy, global-status). Returns typed JSON.",
   },
 );
 

--- a/packages/server-infra/src/lib/vagrant-formatters.ts
+++ b/packages/server-infra/src/lib/vagrant-formatters.ts
@@ -1,0 +1,117 @@
+import type {
+  VagrantStatusResult,
+  VagrantGlobalStatusResult,
+  VagrantUpResult,
+  VagrantLifecycleResult,
+} from "../schemas/vagrant.js";
+
+// ── Full formatters ────────────────────────────────────────────────
+
+export function formatVagrantStatus(data: VagrantStatusResult): string {
+  const lines: string[] = [`vagrant status: ${data.count} machine(s)`];
+  for (const m of data.machines) {
+    lines.push(`  ${m.name}: ${m.state} (${m.provider})`);
+  }
+  return lines.join("\n");
+}
+
+export function formatVagrantGlobalStatus(data: VagrantGlobalStatusResult): string {
+  const lines: string[] = [`vagrant global-status: ${data.count} machine(s)`];
+  for (const m of data.machines) {
+    lines.push(`  ${m.id} ${m.name}: ${m.state} (${m.provider}) ${m.directory}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatVagrantUp(data: VagrantUpResult): string {
+  const lines: string[] = [data.success ? "vagrant up: success" : "vagrant up: failed"];
+  for (const m of data.machines) {
+    lines.push(`  ${m.name}: ${m.state} (${m.provider})`);
+  }
+  if (data.warnings) {
+    for (const w of data.warnings) lines.push(`warning: ${w}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatVagrantLifecycle(data: VagrantLifecycleResult): string {
+  const lines: string[] = [
+    data.success ? `vagrant ${data.action}: success` : `vagrant ${data.action}: failed`,
+  ];
+  for (const m of data.machines) {
+    lines.push(`  ${m.name}: ${m.newState}`);
+  }
+  return lines.join("\n");
+}
+
+// ── Compact types, mappers, and formatters ─────────────────────────
+
+export interface VagrantStatusCompact {
+  [key: string]: unknown;
+  success: boolean;
+  count: number;
+}
+
+export function compactVagrantStatusMap(data: VagrantStatusResult): VagrantStatusCompact {
+  return { success: data.success, count: data.count };
+}
+
+export function formatVagrantStatusCompact(data: VagrantStatusCompact): string {
+  return `vagrant status: ${data.count} machine(s)`;
+}
+
+export interface VagrantGlobalStatusCompact {
+  [key: string]: unknown;
+  success: boolean;
+  count: number;
+}
+
+export function compactVagrantGlobalStatusMap(
+  data: VagrantGlobalStatusResult,
+): VagrantGlobalStatusCompact {
+  return { success: data.success, count: data.count };
+}
+
+export function formatVagrantGlobalStatusCompact(data: VagrantGlobalStatusCompact): string {
+  return `vagrant global-status: ${data.count} machine(s)`;
+}
+
+export interface VagrantUpCompact {
+  [key: string]: unknown;
+  success: boolean;
+  machineCount: number;
+  warningCount: number;
+}
+
+export function compactVagrantUpMap(data: VagrantUpResult): VagrantUpCompact {
+  return {
+    success: data.success,
+    machineCount: data.machines.length,
+    warningCount: data.warnings?.length ?? 0,
+  };
+}
+
+export function formatVagrantUpCompact(data: VagrantUpCompact): string {
+  if (!data.success) return "vagrant up: failed";
+  return `vagrant up: ${data.machineCount} machine(s) started${data.warningCount > 0 ? ` (${data.warningCount} warnings)` : ""}`;
+}
+
+export interface VagrantLifecycleCompact {
+  [key: string]: unknown;
+  success: boolean;
+  action: string;
+  machineCount: number;
+}
+
+export function compactVagrantLifecycleMap(data: VagrantLifecycleResult): VagrantLifecycleCompact {
+  return {
+    success: data.success,
+    action: data.action,
+    machineCount: data.machines.length,
+  };
+}
+
+export function formatVagrantLifecycleCompact(data: VagrantLifecycleCompact): string {
+  if (!data.success) return `vagrant ${data.action}: failed`;
+  return `vagrant ${data.action}: ${data.machineCount} machine(s)`;
+}

--- a/packages/server-infra/src/lib/vagrant-parsers.ts
+++ b/packages/server-infra/src/lib/vagrant-parsers.ts
@@ -1,0 +1,208 @@
+import type {
+  VagrantStatusResult,
+  VagrantGlobalStatusResult,
+  VagrantUpResult,
+  VagrantLifecycleResult,
+} from "../schemas/vagrant.js";
+
+// ── CSV line parser ────────────────────────────────────────────────
+
+interface MachineReadableLine {
+  timestamp: string;
+  target: string;
+  type: string;
+  data: string;
+}
+
+function parseMachineReadableLines(stdout: string): MachineReadableLine[] {
+  return stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      // Vagrant CSV: timestamp,target,type,data (data may contain commas)
+      const parts = line.split(",");
+      if (parts.length < 4) return null;
+      return {
+        timestamp: parts[0],
+        target: parts[1],
+        type: parts[2],
+        data: parts.slice(3).join(","),
+      };
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null);
+}
+
+// ── vagrant status ─────────────────────────────────────────────────
+
+export function parseVagrantStatusOutput(
+  stdout: string,
+  _stderr: string,
+  exitCode: number,
+): VagrantStatusResult {
+  const success = exitCode === 0;
+  const lines = parseMachineReadableLines(stdout);
+
+  // Collect machines: group by target name, pick up state and provider-name
+  const machineMap = new Map<string, { state: string; provider: string }>();
+
+  for (const line of lines) {
+    if (!line.target) continue;
+
+    if (line.type === "state") {
+      const entry = machineMap.get(line.target) ?? { state: "", provider: "" };
+      entry.state = line.data;
+      machineMap.set(line.target, entry);
+    } else if (line.type === "provider-name") {
+      const entry = machineMap.get(line.target) ?? { state: "", provider: "" };
+      entry.provider = line.data;
+      machineMap.set(line.target, entry);
+    }
+  }
+
+  const machines = Array.from(machineMap.entries()).map(([name, info]) => ({
+    name,
+    state: info.state,
+    provider: info.provider,
+  }));
+
+  return {
+    action: "status",
+    success,
+    machines,
+    count: machines.length,
+    exitCode,
+  };
+}
+
+// ── vagrant global-status ──────────────────────────────────────────
+
+export function parseVagrantGlobalStatusOutput(
+  stdout: string,
+  _stderr: string,
+  exitCode: number,
+): VagrantGlobalStatusResult {
+  const success = exitCode === 0;
+  const lines = parseMachineReadableLines(stdout);
+
+  // Global status emits sequential groups of: machine-id, provider-name, machine-home, state
+  const machines: VagrantGlobalStatusResult["machines"] = [];
+  let current: { id: string; name: string; provider: string; state: string; directory: string } = {
+    id: "",
+    name: "",
+    provider: "",
+    state: "",
+    directory: "",
+  };
+
+  for (const line of lines) {
+    switch (line.type) {
+      case "machine-id":
+        // Start of a new machine entry
+        if (current.id) {
+          machines.push({ ...current });
+        }
+        current = { id: line.data, name: "", provider: "", state: "", directory: "" };
+        break;
+      case "provider-name":
+        current.provider = line.data;
+        break;
+      case "machine-home":
+        current.directory = line.data;
+        break;
+      case "state":
+        current.state = line.data;
+        break;
+      case "machine-name":
+        current.name = line.data;
+        break;
+    }
+  }
+
+  // Push the last machine if it has an id
+  if (current.id) {
+    machines.push({ ...current });
+  }
+
+  return {
+    action: "global-status",
+    success,
+    machines,
+    count: machines.length,
+    exitCode,
+  };
+}
+
+// ── vagrant up ─────────────────────────────────────────────────────
+
+export function parseVagrantUpOutput(
+  stdout: string,
+  _stderr: string,
+  exitCode: number,
+): VagrantUpResult {
+  const success = exitCode === 0;
+  const lines = parseMachineReadableLines(stdout);
+
+  const machineMap = new Map<string, { state: string; provider: string }>();
+  const warnings: string[] = [];
+
+  for (const line of lines) {
+    if (line.type === "state" && line.target) {
+      const entry = machineMap.get(line.target) ?? { state: "", provider: "" };
+      entry.state = line.data;
+      machineMap.set(line.target, entry);
+    } else if (line.type === "provider-name" && line.target) {
+      const entry = machineMap.get(line.target) ?? { state: "", provider: "" };
+      entry.provider = line.data;
+      machineMap.set(line.target, entry);
+    } else if (line.type === "ui" && line.data.startsWith("warn,")) {
+      warnings.push(line.data.slice(5));
+    }
+  }
+
+  const machines = Array.from(machineMap.entries()).map(([name, info]) => ({
+    name,
+    state: info.state,
+    provider: info.provider,
+  }));
+
+  return {
+    action: "up",
+    success,
+    machines,
+    warnings: warnings.length > 0 ? warnings : undefined,
+    exitCode,
+  };
+}
+
+// ── vagrant halt / destroy ─────────────────────────────────────────
+
+export function parseVagrantLifecycleOutput(
+  stdout: string,
+  _stderr: string,
+  exitCode: number,
+  action: "halt" | "destroy",
+): VagrantLifecycleResult {
+  const success = exitCode === 0;
+  const lines = parseMachineReadableLines(stdout);
+
+  const machineMap = new Map<string, string>();
+
+  for (const line of lines) {
+    if (line.type === "state" && line.target) {
+      machineMap.set(line.target, line.data);
+    }
+  }
+
+  const machines = Array.from(machineMap.entries()).map(([name, newState]) => ({
+    name,
+    newState,
+  }));
+
+  return {
+    action,
+    success,
+    machines,
+    exitCode,
+  };
+}

--- a/packages/server-infra/src/lib/vagrant-runner.ts
+++ b/packages/server-infra/src/lib/vagrant-runner.ts
@@ -1,0 +1,6 @@
+import { run, type RunResult } from "@paretools/shared";
+
+/** Runs a `vagrant` command with the given arguments. */
+export async function vagrantCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("vagrant", args, { cwd, timeout: 300_000 });
+}

--- a/packages/server-infra/src/schemas/vagrant.ts
+++ b/packages/server-infra/src/schemas/vagrant.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+// ── vagrant status ─────────────────────────────────────────────────
+
+export const VagrantStatusResultSchema = z.object({
+  action: z.literal("status"),
+  success: z.boolean(),
+  machines: z.array(
+    z.object({
+      name: z.string(),
+      state: z.string(),
+      provider: z.string(),
+    }),
+  ),
+  count: z.number(),
+  exitCode: z.number(),
+});
+
+export type VagrantStatusResult = z.infer<typeof VagrantStatusResultSchema>;
+
+// ── vagrant up ─────────────────────────────────────────────────────
+
+export const VagrantUpResultSchema = z.object({
+  action: z.literal("up"),
+  success: z.boolean(),
+  machines: z.array(
+    z.object({
+      name: z.string(),
+      state: z.string(),
+      provider: z.string(),
+    }),
+  ),
+  warnings: z.array(z.string()).optional(),
+  exitCode: z.number(),
+});
+
+export type VagrantUpResult = z.infer<typeof VagrantUpResultSchema>;
+
+// ── vagrant halt / destroy ─────────────────────────────────────────
+
+export const VagrantLifecycleResultSchema = z.object({
+  action: z.enum(["halt", "destroy"]),
+  success: z.boolean(),
+  machines: z.array(
+    z.object({
+      name: z.string(),
+      newState: z.string(),
+    }),
+  ),
+  exitCode: z.number(),
+});
+
+export type VagrantLifecycleResult = z.infer<typeof VagrantLifecycleResultSchema>;
+
+// ── vagrant global-status ──────────────────────────────────────────
+
+export const VagrantGlobalStatusResultSchema = z.object({
+  action: z.literal("global-status"),
+  success: z.boolean(),
+  machines: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      provider: z.string(),
+      state: z.string(),
+      directory: z.string(),
+    }),
+  ),
+  count: z.number(),
+  exitCode: z.number(),
+});
+
+export type VagrantGlobalStatusResult = z.infer<typeof VagrantGlobalStatusResultSchema>;
+
+// ── Union result schema ────────────────────────────────────────────
+
+export const VagrantResultSchema = z.discriminatedUnion("action", [
+  VagrantStatusResultSchema,
+  VagrantUpResultSchema,
+  VagrantLifecycleResultSchema,
+  VagrantGlobalStatusResultSchema,
+]);
+
+export type VagrantResult = z.infer<typeof VagrantResultSchema>;

--- a/packages/server-infra/src/tools/index.ts
+++ b/packages/server-infra/src/tools/index.ts
@@ -8,6 +8,7 @@ import { registerOutputTool } from "./output.js";
 import { registerStateListTool } from "./state-list.js";
 import { registerWorkspaceTool } from "./workspace.js";
 import { registerShowTool } from "./show.js";
+import { registerVagrantTool } from "./vagrant.js";
 
 /** Registers all Infra tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
@@ -20,4 +21,5 @@ export function registerAllTools(server: McpServer) {
   if (s("state-list")) registerStateListTool(server);
   if (s("workspace")) registerWorkspaceTool(server);
   if (s("show")) registerShowTool(server);
+  if (s("vagrant")) registerVagrantTool(server);
 }

--- a/packages/server-infra/src/tools/vagrant.ts
+++ b/packages/server-infra/src/tools/vagrant.ts
@@ -1,0 +1,163 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  compactDualOutput,
+  assertNoFlagInjection,
+  assertAllowedByPolicy,
+  INPUT_LIMITS,
+  compactInput,
+  projectPathInput,
+} from "@paretools/shared";
+import { z } from "zod";
+import { vagrantCmd } from "../lib/vagrant-runner.js";
+import {
+  parseVagrantStatusOutput,
+  parseVagrantGlobalStatusOutput,
+  parseVagrantUpOutput,
+  parseVagrantLifecycleOutput,
+} from "../lib/vagrant-parsers.js";
+import {
+  formatVagrantStatus,
+  compactVagrantStatusMap,
+  formatVagrantStatusCompact,
+  formatVagrantGlobalStatus,
+  compactVagrantGlobalStatusMap,
+  formatVagrantGlobalStatusCompact,
+  formatVagrantUp,
+  compactVagrantUpMap,
+  formatVagrantUpCompact,
+  formatVagrantLifecycle,
+  compactVagrantLifecycleMap,
+  formatVagrantLifecycleCompact,
+} from "../lib/vagrant-formatters.js";
+import { VagrantResultSchema } from "../schemas/vagrant.js";
+
+/** Registers the `vagrant` tool on the given MCP server. */
+export function registerVagrantTool(server: McpServer) {
+  server.registerTool(
+    "vagrant",
+    {
+      title: "Vagrant",
+      description: "Manages Vagrant VMs: status, global-status, up, halt, destroy.",
+      inputSchema: {
+        action: z
+          .enum(["status", "global-status", "up", "halt", "destroy"])
+          .describe("Vagrant action to perform"),
+        machine: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Target machine name"),
+        workDir: projectPathInput,
+        compact: compactInput,
+      },
+      outputSchema: VagrantResultSchema,
+    },
+    async ({ action, machine, workDir, compact }) => {
+      const cwd = workDir || process.cwd();
+      if (machine) assertNoFlagInjection(machine, "machine");
+
+      // destroy requires policy gate
+      if (action === "destroy") {
+        assertAllowedByPolicy("vagrant", "infra");
+      }
+
+      // Build args: always --machine-readable --no-color --no-tty
+      const baseFlags = ["--machine-readable", "--no-color", "--no-tty"];
+
+      switch (action) {
+        case "status": {
+          const args = ["status", ...baseFlags];
+          if (machine) args.push(machine);
+          const result = await vagrantCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseVagrantStatusOutput(result.stdout, result.stderr, result.exitCode);
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatVagrantStatus,
+            compactVagrantStatusMap,
+            formatVagrantStatusCompact,
+            compact === false,
+          );
+        }
+
+        case "global-status": {
+          const args = ["global-status", ...baseFlags];
+          const result = await vagrantCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseVagrantGlobalStatusOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+          );
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatVagrantGlobalStatus,
+            compactVagrantGlobalStatusMap,
+            formatVagrantGlobalStatusCompact,
+            compact === false,
+          );
+        }
+
+        case "up": {
+          const args = ["up", ...baseFlags];
+          if (machine) args.push(machine);
+          const result = await vagrantCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseVagrantUpOutput(result.stdout, result.stderr, result.exitCode);
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatVagrantUp,
+            compactVagrantUpMap,
+            formatVagrantUpCompact,
+            compact === false,
+          );
+        }
+
+        case "halt": {
+          const args = ["halt", ...baseFlags];
+          if (machine) args.push(machine);
+          const result = await vagrantCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseVagrantLifecycleOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            "halt",
+          );
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatVagrantLifecycle,
+            compactVagrantLifecycleMap,
+            formatVagrantLifecycleCompact,
+            compact === false,
+          );
+        }
+
+        case "destroy": {
+          const args = ["destroy", "-f", ...baseFlags];
+          if (machine) args.push(machine);
+          const result = await vagrantCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseVagrantLifecycleOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            "destroy",
+          );
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatVagrantLifecycle,
+            compactVagrantLifecycleMap,
+            formatVagrantLifecycleCompact,
+            compact === false,
+          );
+        }
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a `vagrant` tool to the `@paretools/infra` server with 5 actions: `status`, `global-status`, `up`, `halt`, `destroy`
- Parses Vagrant's `--machine-readable` CSV format into structured JSON with dual output (human-readable + structured)
- Implements policy gate for `destroy` action via `assertAllowedByPolicy`
- Includes full and compact formatters following existing package patterns

## Files Added
- `src/lib/vagrant-runner.ts` — command runner
- `src/schemas/vagrant.ts` — Zod schemas for all result types (discriminated union)
- `src/lib/vagrant-parsers.ts` — CSV parser for machine-readable output
- `src/lib/vagrant-formatters.ts` — full + compact formatters
- `src/tools/vagrant.ts` — tool registration with action dispatch
- `__tests__/vagrant-parsers.test.ts` — 11 parser tests
- `__tests__/vagrant-formatters.test.ts` — 14 formatter tests
- `__tests__/vagrant-security.test.ts` — 4 security tests

## Files Modified
- `src/tools/index.ts` — register vagrant tool
- `src/index.ts` — update instructions string

## Test plan
- [x] All 29 new tests pass (parsers, formatters, security)
- [x] All 101 total tests pass (including existing Terraform tests)
- [x] Build succeeds
- [x] Lint passes
- [x] Prettier formatting verified

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)