### PR TITLE
feat(cmake): add @paretools/cmake server package

### DIFF
--- a/.changeset/cmake-tool.md
+++ b/.changeset/cmake-tool.md
@@ -1,0 +1,5 @@
+---
+"@paretools/cmake": minor
+---
+
+Add cmake tool with configure, build, test, list-presets, install, and clean actions

--- a/packages/server-cmake/package.json
+++ b/packages/server-cmake/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@paretools/cmake",
+  "version": "0.1.0",
+  "mcpName": "io.github.Dave-London/pare-cmake",
+  "description": "MCP server for CMake build system operations with structured, token-efficient output",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "structured-output",
+    "ai",
+    "cmake",
+    "ctest",
+    "build-system",
+    "cpp"
+  ],
+  "homepage": "https://github.com/Dave-London/Pare/tree/main/packages/server-cmake",
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "bin": {
+    "pare-cmake": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/Pare.git",
+    "directory": "packages/server-cmake"
+  },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@paretools/shared": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@paretools/tsconfig": "workspace:*",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/server-cmake/server.json
+++ b/packages/server-cmake/server.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Dave-London/pare-cmake",
+  "description": "Pare CMake — Structured CMake/CTest build system operations as typed JSON.",
+  "repository": { "url": "https://github.com/Dave-London/Pare", "source": "github" },
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@paretools/cmake",
+      "version": "0.1.0",
+      "transport": { "type": "stdio" }
+    }
+  ]
+}

--- a/packages/server-cmake/src/__tests__/formatters.test.ts
+++ b/packages/server-cmake/src/__tests__/formatters.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatConfigure,
+  formatConfigureCompact,
+  compactConfigureMap,
+  formatBuild,
+  formatBuildCompact,
+  compactBuildMap,
+  formatTest,
+  formatTestCompact,
+  compactTestMap,
+  formatPresets,
+  formatPresetsCompact,
+  compactPresetsMap,
+  formatInstall,
+  formatInstallCompact,
+  compactInstallMap,
+  formatClean,
+  formatCleanCompact,
+  compactCleanMap,
+} from "../lib/formatters.js";
+import type {
+  CMakeConfigureResult,
+  CMakeBuildResult,
+  CMakeTestResult,
+  CMakePresetsResult,
+  CMakeInstallResult,
+  CMakeCleanResult,
+} from "../schemas/index.js";
+
+// ── Configure ──────────────────────────────────────────────────────
+
+describe("formatConfigure", () => {
+  it("formats successful configure", () => {
+    const data: CMakeConfigureResult = {
+      action: "configure",
+      success: true,
+      generator: "GNU 11.4.0",
+      buildDir: "build",
+      exitCode: 0,
+    };
+    const output = formatConfigure(data);
+    expect(output).toContain("cmake configure: success");
+    expect(output).toContain("build dir: build");
+    expect(output).toContain("compiler: GNU 11.4.0");
+  });
+
+  it("formats configure with errors", () => {
+    const data: CMakeConfigureResult = {
+      action: "configure",
+      success: false,
+      buildDir: "build",
+      errors: [{ message: "FindFoo.cmake not found", file: "CMakeLists.txt", line: 3 }],
+      exitCode: 1,
+    };
+    const output = formatConfigure(data);
+    expect(output).toContain("cmake configure: failed");
+    expect(output).toContain("error (CMakeLists.txt:3): FindFoo.cmake not found");
+  });
+});
+
+describe("compactConfigureMap + formatConfigureCompact", () => {
+  it("maps and formats compact configure", () => {
+    const data: CMakeConfigureResult = {
+      action: "configure",
+      success: true,
+      buildDir: "build",
+      warnings: [{ message: "unused var" }],
+      exitCode: 0,
+    };
+    const compact = compactConfigureMap(data);
+    expect(compact.success).toBe(true);
+    expect(compact.warningCount).toBe(1);
+    expect(compact.errorCount).toBe(0);
+
+    const output = formatConfigureCompact(compact);
+    expect(output).toContain("cmake configure: success");
+  });
+});
+
+// ── Build ──────────────────────────────────────────────────────────
+
+describe("formatBuild", () => {
+  it("formats successful build", () => {
+    const data: CMakeBuildResult = {
+      action: "build",
+      success: true,
+      summary: { warningCount: 0, errorCount: 0 },
+      exitCode: 0,
+    };
+    expect(formatBuild(data)).toContain("cmake build: success");
+  });
+
+  it("formats build with warnings and errors", () => {
+    const data: CMakeBuildResult = {
+      action: "build",
+      success: false,
+      warnings: [{ message: "unused var", file: "main.cpp", line: 10, column: 5 }],
+      errors: [{ message: "undeclared", file: "utils.cpp", line: 20, column: 3 }],
+      summary: { warningCount: 1, errorCount: 1 },
+      exitCode: 1,
+    };
+    const output = formatBuild(data);
+    expect(output).toContain("cmake build: failed");
+    expect(output).toContain("warning: main.cpp:10:5: unused var");
+    expect(output).toContain("error: utils.cpp:20:3: undeclared");
+  });
+});
+
+describe("compactBuildMap + formatBuildCompact", () => {
+  it("maps and formats compact build", () => {
+    const data: CMakeBuildResult = {
+      action: "build",
+      success: true,
+      summary: { warningCount: 2, errorCount: 0 },
+      exitCode: 0,
+    };
+    const compact = compactBuildMap(data);
+    expect(compact.warningCount).toBe(2);
+    expect(formatBuildCompact(compact)).toContain("2 warnings");
+  });
+});
+
+// ── Test ───────────────────────────────────────────────────────────
+
+describe("formatTest", () => {
+  it("formats test results", () => {
+    const data: CMakeTestResult = {
+      action: "test",
+      success: false,
+      tests: [
+        { name: "test_basic", number: 1, status: "passed", durationSec: 0.01 },
+        { name: "test_advanced", number: 2, status: "failed", durationSec: 0.05 },
+      ],
+      summary: {
+        totalTests: 2,
+        passed: 1,
+        failed: 1,
+        skipped: 0,
+        timeout: 0,
+        totalDurationSec: 0.06,
+      },
+      exitCode: 8,
+    };
+    const output = formatTest(data);
+    expect(output).toContain("ctest: 1/2 failed");
+    expect(output).toContain("#1 test_basic: passed");
+    expect(output).toContain("#2 test_advanced: failed");
+    expect(output).toContain("total time: 0.06s");
+  });
+});
+
+describe("compactTestMap + formatTestCompact", () => {
+  it("maps and formats compact test", () => {
+    const data: CMakeTestResult = {
+      action: "test",
+      success: true,
+      tests: [],
+      summary: { totalTests: 5, passed: 5, failed: 0, skipped: 0, timeout: 0 },
+      exitCode: 0,
+    };
+    const compact = compactTestMap(data);
+    expect(compact.totalTests).toBe(5);
+    expect(formatTestCompact(compact)).toContain("5/5 passed");
+  });
+});
+
+// ── Presets ────────────────────────────────────────────────────────
+
+describe("formatPresets", () => {
+  it("formats presets", () => {
+    const data: CMakePresetsResult = {
+      action: "list-presets",
+      success: true,
+      configurePresets: [{ name: "release", displayName: "Release build" }],
+      buildPresets: [{ name: "release-build" }],
+      exitCode: 0,
+    };
+    const output = formatPresets(data);
+    expect(output).toContain("cmake presets:");
+    expect(output).toContain('"release" - Release build');
+    expect(output).toContain('"release-build"');
+  });
+});
+
+describe("compactPresetsMap + formatPresetsCompact", () => {
+  it("maps and formats compact presets", () => {
+    const data: CMakePresetsResult = {
+      action: "list-presets",
+      success: true,
+      configurePresets: [{ name: "a" }, { name: "b" }],
+      exitCode: 0,
+    };
+    const compact = compactPresetsMap(data);
+    expect(compact.configureCount).toBe(2);
+    expect(compact.buildCount).toBe(0);
+    expect(formatPresetsCompact(compact)).toContain("2 configure");
+  });
+});
+
+// ── Install ────────────────────────────────────────────────────────
+
+describe("formatInstall", () => {
+  it("formats install output", () => {
+    const data: CMakeInstallResult = {
+      action: "install",
+      success: true,
+      prefix: "Release",
+      installedFiles: ["/usr/local/lib/libfoo.a", "/usr/local/bin/foo"],
+      exitCode: 0,
+    };
+    const output = formatInstall(data);
+    expect(output).toContain("cmake install: success");
+    expect(output).toContain("configuration: Release");
+    expect(output).toContain("/usr/local/lib/libfoo.a");
+  });
+});
+
+describe("compactInstallMap + formatInstallCompact", () => {
+  it("maps and formats compact install", () => {
+    const data: CMakeInstallResult = {
+      action: "install",
+      success: true,
+      installedFiles: ["/a", "/b", "/c"],
+      exitCode: 0,
+    };
+    const compact = compactInstallMap(data);
+    expect(compact.fileCount).toBe(3);
+    expect(formatInstallCompact(compact)).toContain("3 files");
+  });
+});
+
+// ── Clean ──────────────────────────────────────────────────────────
+
+describe("formatClean", () => {
+  it("formats successful clean", () => {
+    const data: CMakeCleanResult = { action: "clean", success: true, exitCode: 0 };
+    expect(formatClean(data)).toBe("cmake clean: success");
+  });
+
+  it("formats failed clean", () => {
+    const data: CMakeCleanResult = { action: "clean", success: false, exitCode: 1 };
+    expect(formatClean(data)).toBe("cmake clean: failed");
+  });
+});
+
+describe("compactCleanMap + formatCleanCompact", () => {
+  it("maps and formats compact clean", () => {
+    const data: CMakeCleanResult = { action: "clean", success: true, exitCode: 0 };
+    const compact = compactCleanMap(data);
+    expect(compact.success).toBe(true);
+    expect(formatCleanCompact(compact)).toBe("cmake clean: success");
+  });
+});

--- a/packages/server-cmake/src/__tests__/parsers.test.ts
+++ b/packages/server-cmake/src/__tests__/parsers.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCMakeConfigureOutput,
+  parseCMakeBuildOutput,
+  parseCTestOutput,
+  parseCMakePresetsOutput,
+  parseCMakeInstallOutput,
+  parseCMakeCleanOutput,
+} from "../lib/parsers.js";
+
+// ── Configure ──────────────────────────────────────────────────────
+
+describe("parseCMakeConfigureOutput", () => {
+  it("parses successful configure output", () => {
+    const stdout = [
+      "-- The C compiler identification is GNU 11.4.0",
+      "-- The CXX compiler identification is GNU 11.4.0",
+      "-- Detecting C compiler ABI info",
+      "-- Detecting C compiler ABI info - done",
+      "-- Check for working C compiler: /usr/bin/cc - skipped",
+      "-- Detecting CXX compiler ABI info",
+      "-- Detecting CXX compiler ABI info - done",
+      "-- Configuring done (0.5s)",
+      "-- Generating done (0.1s)",
+      "-- Build files have been written to: /home/user/project/build",
+    ].join("\n");
+
+    const result = parseCMakeConfigureOutput(stdout, "", 0, "build");
+
+    expect(result.action).toBe("configure");
+    expect(result.success).toBe(true);
+    expect(result.generator).toBe("GNU 11.4.0");
+    expect(result.buildDir).toBe("build");
+    expect(result.warnings).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("parses configure with warnings", () => {
+    const stdout = [
+      "CMake Warning at CMakeLists.txt:15:",
+      "  Manually-specified variables were not used by the project:",
+      "",
+      "    UNUSED_VAR",
+      "",
+      "-- Configuring done (0.3s)",
+      "-- Generating done (0.1s)",
+    ].join("\n");
+
+    const result = parseCMakeConfigureOutput(stdout, "", 0, "build");
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.length).toBeGreaterThanOrEqual(1);
+    expect(result.warnings![0].file).toBe("CMakeLists.txt");
+    expect(result.warnings![0].line).toBe(15);
+  });
+
+  it("parses configure with errors", () => {
+    const stderr = [
+      "CMake Error at CMakeLists.txt:3 (find_package):",
+      '  By not providing "FindFoo.cmake" in CMAKE_MODULE_PATH this project has',
+      '  asked CMake to find a package configuration file provided by "Foo", but',
+      "  CMake did not find one.",
+      "",
+      "-- Configuring incomplete, errors occurred!",
+    ].join("\n");
+
+    const result = parseCMakeConfigureOutput("", stderr, 1, "build");
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors!.length).toBeGreaterThanOrEqual(1);
+    expect(result.errors![0].file).toBe("CMakeLists.txt");
+    expect(result.errors![0].line).toBe(3);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("handles empty output", () => {
+    const result = parseCMakeConfigureOutput("", "", 1, "build");
+
+    expect(result.success).toBe(false);
+    expect(result.generator).toBeUndefined();
+    expect(result.warnings).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+  });
+});
+
+// ── Build ──────────────────────────────────────────────────────────
+
+describe("parseCMakeBuildOutput", () => {
+  it("parses build with GCC warnings and errors", () => {
+    const stdout = [
+      "[1/4] Building CXX object CMakeFiles/app.dir/src/main.cpp.o",
+      "/home/user/project/src/main.cpp:10:5: warning: unused variable 'x' [-Wunused-variable]",
+      "   10 |     int x = 5;",
+      "      |     ^",
+      "[2/4] Building CXX object CMakeFiles/app.dir/src/utils.cpp.o",
+      "/home/user/project/src/utils.cpp:20:3: error: use of undeclared identifier 'foo'",
+      "   20 |   foo();",
+      "      |   ^",
+    ].join("\n");
+
+    const result = parseCMakeBuildOutput(stdout, "", 1);
+
+    expect(result.action).toBe("build");
+    expect(result.success).toBe(false);
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.length).toBe(1);
+    expect(result.warnings![0]).toEqual({
+      message: "unused variable 'x' [-Wunused-variable]",
+      file: "/home/user/project/src/main.cpp",
+      line: 10,
+      column: 5,
+    });
+    expect(result.errors).toBeDefined();
+    expect(result.errors!.length).toBe(1);
+    expect(result.errors![0]).toEqual({
+      message: "use of undeclared identifier 'foo'",
+      file: "/home/user/project/src/utils.cpp",
+      line: 20,
+      column: 3,
+    });
+    expect(result.summary).toEqual({ warningCount: 1, errorCount: 1 });
+  });
+
+  it("parses successful build with no warnings or errors", () => {
+    const stdout = [
+      "[1/2] Building CXX object CMakeFiles/app.dir/src/main.cpp.o",
+      "[2/2] Linking CXX executable app",
+    ].join("\n");
+
+    const result = parseCMakeBuildOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+    expect(result.summary).toEqual({ warningCount: 0, errorCount: 0 });
+  });
+
+  it("parses MSVC warnings and errors", () => {
+    const stdout = [
+      "main.cpp(10): warning C4101: 'x': unreferenced local variable",
+      "utils.cpp(20): error C2065: 'foo': undeclared identifier",
+    ].join("\n");
+
+    const result = parseCMakeBuildOutput(stdout, "", 1);
+
+    expect(result.warnings!.length).toBe(1);
+    expect(result.warnings![0].file).toBe("main.cpp");
+    expect(result.warnings![0].line).toBe(10);
+    expect(result.errors!.length).toBe(1);
+    expect(result.errors![0].file).toBe("utils.cpp");
+    expect(result.errors![0].line).toBe(20);
+  });
+
+  it("handles empty output", () => {
+    const result = parseCMakeBuildOutput("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+    expect(result.summary).toEqual({ warningCount: 0, errorCount: 0 });
+  });
+});
+
+// ── CTest ──────────────────────────────────────────────────────────
+
+describe("parseCTestOutput", () => {
+  it("parses ctest with mixed results", () => {
+    const stdout = [
+      "Test project /home/user/project/build",
+      "    Start 1: test_basic",
+      "1/3 Test #1: test_basic ...................   Passed    0.01 sec",
+      "    Start 2: test_advanced",
+      "2/3 Test #2: test_advanced ................***Failed    0.05 sec",
+      "    Start 3: test_edge",
+      "3/3 Test #3: test_edge ....................   Passed    0.02 sec",
+      "",
+      "67% tests passed, 1 tests failed out of 3",
+      "",
+      "Total Test time (real) =   0.08 sec",
+      "",
+      "The following tests FAILED:",
+      "          2 - test_advanced (Failed)",
+    ].join("\n");
+
+    const result = parseCTestOutput(stdout, "", 8);
+
+    expect(result.action).toBe("test");
+    expect(result.success).toBe(false);
+    expect(result.tests).toHaveLength(3);
+    expect(result.tests[0]).toEqual({
+      name: "test_basic",
+      number: 1,
+      status: "passed",
+      durationSec: 0.01,
+    });
+    expect(result.tests[1]).toEqual({
+      name: "test_advanced",
+      number: 2,
+      status: "failed",
+      durationSec: 0.05,
+    });
+    expect(result.tests[2]).toEqual({
+      name: "test_edge",
+      number: 3,
+      status: "passed",
+      durationSec: 0.02,
+    });
+    expect(result.summary).toEqual({
+      totalTests: 3,
+      passed: 2,
+      failed: 1,
+      skipped: 0,
+      timeout: 0,
+      totalDurationSec: 0.08,
+    });
+  });
+
+  it("parses ctest all passing", () => {
+    const stdout = [
+      "Test project /home/user/project/build",
+      "    Start 1: test_one",
+      "1/2 Test #1: test_one .....................   Passed    0.01 sec",
+      "    Start 2: test_two",
+      "2/2 Test #2: test_two .....................   Passed    0.02 sec",
+      "",
+      "100% tests passed, 0 tests failed out of 2",
+      "",
+      "Total Test time (real) =   0.03 sec",
+    ].join("\n");
+
+    const result = parseCTestOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.tests).toHaveLength(2);
+    expect(result.summary.totalTests).toBe(2);
+    expect(result.summary.passed).toBe(2);
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.totalDurationSec).toBe(0.03);
+  });
+
+  it("handles empty ctest output", () => {
+    const result = parseCTestOutput("", "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.tests).toHaveLength(0);
+    expect(result.summary.totalTests).toBe(0);
+  });
+});
+
+// ── Presets ────────────────────────────────────────────────────────
+
+describe("parseCMakePresetsOutput", () => {
+  it("parses presets output", () => {
+    const stdout = [
+      "Available configure presets:",
+      "",
+      '  "release" - Release build',
+      '  "debug"   - Debug build',
+      "",
+      "Available build presets:",
+      "",
+      '  "release-build" - Release build preset',
+    ].join("\n");
+
+    const result = parseCMakePresetsOutput(stdout, "", 0);
+
+    expect(result.action).toBe("list-presets");
+    expect(result.success).toBe(true);
+    expect(result.configurePresets).toEqual([
+      { name: "release", displayName: "Release build" },
+      { name: "debug", displayName: "Debug build" },
+    ]);
+    expect(result.buildPresets).toEqual([
+      { name: "release-build", displayName: "Release build preset" },
+    ]);
+    expect(result.testPresets).toBeUndefined();
+  });
+
+  it("handles empty presets output", () => {
+    const result = parseCMakePresetsOutput("", "", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.configurePresets).toBeUndefined();
+    expect(result.buildPresets).toBeUndefined();
+    expect(result.testPresets).toBeUndefined();
+  });
+});
+
+// ── Install ────────────────────────────────────────────────────────
+
+describe("parseCMakeInstallOutput", () => {
+  it("parses install output", () => {
+    const stdout = [
+      '-- Install configuration: "Release"',
+      "-- Installing: /usr/local/lib/libfoo.a",
+      "-- Installing: /usr/local/include/foo.h",
+      "-- Installing: /usr/local/bin/foo",
+    ].join("\n");
+
+    const result = parseCMakeInstallOutput(stdout, "", 0);
+
+    expect(result.action).toBe("install");
+    expect(result.success).toBe(true);
+    expect(result.prefix).toBe("Release");
+    expect(result.installedFiles).toEqual([
+      "/usr/local/lib/libfoo.a",
+      "/usr/local/include/foo.h",
+      "/usr/local/bin/foo",
+    ]);
+  });
+
+  it("handles empty install output", () => {
+    const result = parseCMakeInstallOutput("", "", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.prefix).toBeUndefined();
+    expect(result.installedFiles).toBeUndefined();
+  });
+});
+
+// ── Clean ──────────────────────────────────────────────────────────
+
+describe("parseCMakeCleanOutput", () => {
+  it("parses successful clean", () => {
+    const result = parseCMakeCleanOutput("", "", 0);
+
+    expect(result.action).toBe("clean");
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("parses failed clean", () => {
+    const result = parseCMakeCleanOutput("", "Error: no build directory", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/packages/server-cmake/src/__tests__/security.test.ts
+++ b/packages/server-cmake/src/__tests__/security.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { assertNoFlagInjection, assertAllowedByPolicy, INPUT_LIMITS } from "@paretools/shared";
+
+// ── Cache variable key validation ──────────────────────────────────
+
+describe("cache variable key validation", () => {
+  const keyRegex = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+  it("accepts valid cache variable keys", () => {
+    expect(keyRegex.test("CMAKE_BUILD_TYPE")).toBe(true);
+    expect(keyRegex.test("MY_VAR")).toBe(true);
+    expect(keyRegex.test("_PRIVATE")).toBe(true);
+    expect(keyRegex.test("foo123")).toBe(true);
+  });
+
+  it("rejects invalid cache variable keys", () => {
+    expect(keyRegex.test("")).toBe(false);
+    expect(keyRegex.test("123ABC")).toBe(false);
+    expect(keyRegex.test("VAR-NAME")).toBe(false);
+    expect(keyRegex.test("VAR.NAME")).toBe(false);
+    expect(keyRegex.test("VAR NAME")).toBe(false);
+  });
+
+  it("rejects injection attempt: CMAKE_C_COMPILER && rm -rf /", () => {
+    expect(keyRegex.test("CMAKE_C_COMPILER && rm -rf /")).toBe(false);
+  });
+
+  it("rejects key with semicolons", () => {
+    expect(keyRegex.test("VAR;rm -rf /")).toBe(false);
+  });
+
+  it("rejects key with special characters", () => {
+    expect(keyRegex.test("VAR=$(whoami)")).toBe(false);
+    expect(keyRegex.test("VAR`id`")).toBe(false);
+    expect(keyRegex.test("VAR|cat /etc/passwd")).toBe(false);
+  });
+});
+
+// ── assertNoFlagInjection on cmake inputs ──────────────────────────
+
+describe("assertNoFlagInjection on cmake inputs", () => {
+  it("allows normal sourceDir", () => {
+    expect(() => assertNoFlagInjection("/home/user/project", "sourceDir")).not.toThrow();
+    expect(() => assertNoFlagInjection(".", "sourceDir")).not.toThrow();
+    expect(() => assertNoFlagInjection("my-project", "sourceDir")).not.toThrow();
+  });
+
+  it("rejects flag-like sourceDir", () => {
+    expect(() => assertNoFlagInjection("--evil", "sourceDir")).toThrow(/must not start with/);
+    expect(() => assertNoFlagInjection("-S", "sourceDir")).toThrow(/must not start with/);
+  });
+
+  it("allows normal buildDir", () => {
+    expect(() => assertNoFlagInjection("build", "buildDir")).not.toThrow();
+    expect(() => assertNoFlagInjection("out/release", "buildDir")).not.toThrow();
+  });
+
+  it("rejects flag-like buildDir", () => {
+    expect(() => assertNoFlagInjection("--build=/etc", "buildDir")).toThrow(/must not start with/);
+  });
+
+  it("allows normal target", () => {
+    expect(() => assertNoFlagInjection("all", "target")).not.toThrow();
+    expect(() => assertNoFlagInjection("my_lib", "target")).not.toThrow();
+  });
+
+  it("rejects flag-like target", () => {
+    expect(() => assertNoFlagInjection("--target=evil", "target")).toThrow(/must not start with/);
+  });
+});
+
+// ── Policy gate for install action ─────────────────────────────────
+
+describe("assertAllowedByPolicy for install", () => {
+  it("allows cmake when no policy is set", () => {
+    // When no PARE_ALLOWED_COMMANDS or PARE_CMAKE_ALLOWED_COMMANDS is set,
+    // assertAllowedByPolicy is a no-op (permissive default)
+    expect(() => assertAllowedByPolicy("cmake", "cmake")).not.toThrow();
+  });
+
+  it("rejects cmake when policy excludes it", () => {
+    const orig = process.env.PARE_CMAKE_ALLOWED_COMMANDS;
+    try {
+      process.env.PARE_CMAKE_ALLOWED_COMMANDS = "git,npm";
+      expect(() => assertAllowedByPolicy("cmake", "cmake")).toThrow(/not allowed/);
+    } finally {
+      if (orig === undefined) delete process.env.PARE_CMAKE_ALLOWED_COMMANDS;
+      else process.env.PARE_CMAKE_ALLOWED_COMMANDS = orig;
+    }
+  });
+
+  it("allows cmake when policy includes it", () => {
+    const orig = process.env.PARE_CMAKE_ALLOWED_COMMANDS;
+    try {
+      process.env.PARE_CMAKE_ALLOWED_COMMANDS = "cmake,ctest";
+      expect(() => assertAllowedByPolicy("cmake", "cmake")).not.toThrow();
+    } finally {
+      if (orig === undefined) delete process.env.PARE_CMAKE_ALLOWED_COMMANDS;
+      else process.env.PARE_CMAKE_ALLOWED_COMMANDS = orig;
+    }
+  });
+});
+
+// ── Zod .max() input-limit constraints ─────────────────────────────
+
+describe("Zod .max() constraints — CMake tool schemas", () => {
+  describe("sourceDir parameter (PATH_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.PATH_MAX);
+
+    it("accepts a path within the limit", () => {
+      expect(schema.safeParse("/home/user/project").success).toBe(true);
+    });
+
+    it("rejects a path exceeding PATH_MAX", () => {
+      const oversized = "p".repeat(INPUT_LIMITS.PATH_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("buildDir parameter (PATH_MAX)", () => {
+    const schema = z.string().max(INPUT_LIMITS.PATH_MAX);
+
+    it("accepts a path within the limit", () => {
+      expect(schema.safeParse("build").success).toBe(true);
+    });
+
+    it("rejects a path exceeding PATH_MAX", () => {
+      const oversized = "b".repeat(INPUT_LIMITS.PATH_MAX + 1);
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+
+  describe("target array (max 20 items, SHORT_STRING_MAX per item)", () => {
+    const schema = z.array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX)).max(20);
+
+    it("accepts array within limits", () => {
+      expect(schema.safeParse(["all", "install"]).success).toBe(true);
+    });
+
+    it("rejects array exceeding max 20 items", () => {
+      const oversized = Array.from({ length: 21 }, () => "target");
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+
+    it("rejects target string exceeding SHORT_STRING_MAX", () => {
+      const oversized = ["t".repeat(INPUT_LIMITS.SHORT_STRING_MAX + 1)];
+      expect(schema.safeParse(oversized).success).toBe(false);
+    });
+  });
+});

--- a/packages/server-cmake/src/index.ts
+++ b/packages/server-cmake/src/index.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerAllTools } from "./tools/index.js";
+
+const server = new McpServer(
+  { name: "@paretools/cmake", version: "0.1.0" },
+  {
+    instructions:
+      "Structured CMake build system operations (configure, build, test, list-presets, install, clean). Returns typed JSON.",
+  },
+);
+
+registerAllTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/server-cmake/src/lib/cmake-runner.ts
+++ b/packages/server-cmake/src/lib/cmake-runner.ts
@@ -1,0 +1,9 @@
+import { run, type RunResult } from "@paretools/shared";
+
+export async function cmakeCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("cmake", args, { cwd, timeout: 300_000 });
+}
+
+export async function ctestCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("ctest", args, { cwd, timeout: 300_000 });
+}

--- a/packages/server-cmake/src/lib/formatters.ts
+++ b/packages/server-cmake/src/lib/formatters.ts
@@ -1,0 +1,227 @@
+import type {
+  CMakeConfigureResult,
+  CMakeBuildResult,
+  CMakeTestResult,
+  CMakePresetsResult,
+  CMakeInstallResult,
+  CMakeCleanResult,
+} from "../schemas/index.js";
+
+// ── Full formatters ────────────────────────────────────────────────
+
+export function formatConfigure(data: CMakeConfigureResult): string {
+  const lines: string[] = [];
+  lines.push(data.success ? "cmake configure: success" : "cmake configure: failed");
+  lines.push(`build dir: ${data.buildDir}`);
+  if (data.generator) lines.push(`compiler: ${data.generator}`);
+  if (data.warnings) {
+    for (const w of data.warnings) {
+      const loc = w.file ? ` (${w.file}${w.line != null ? `:${w.line}` : ""})` : "";
+      lines.push(`warning${loc}: ${w.message}`);
+    }
+  }
+  if (data.errors) {
+    for (const e of data.errors) {
+      const loc = e.file ? ` (${e.file}${e.line != null ? `:${e.line}` : ""})` : "";
+      lines.push(`error${loc}: ${e.message}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+export function formatBuild(data: CMakeBuildResult): string {
+  const lines: string[] = [];
+  lines.push(
+    data.success
+      ? `cmake build: success (${data.summary.warningCount} warnings)`
+      : `cmake build: failed (${data.summary.errorCount} errors, ${data.summary.warningCount} warnings)`,
+  );
+  if (data.warnings) {
+    for (const w of data.warnings) {
+      const loc = w.file ? `${w.file}:${w.line ?? "?"}:${w.column ?? "?"}` : "unknown";
+      lines.push(`  warning: ${loc}: ${w.message}`);
+    }
+  }
+  if (data.errors) {
+    for (const e of data.errors) {
+      const loc = e.file ? `${e.file}:${e.line ?? "?"}:${e.column ?? "?"}` : "unknown";
+      lines.push(`  error: ${loc}: ${e.message}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+export function formatTest(data: CMakeTestResult): string {
+  const lines: string[] = [];
+  const s = data.summary;
+  lines.push(
+    data.success
+      ? `ctest: ${s.passed}/${s.totalTests} passed`
+      : `ctest: ${s.failed}/${s.totalTests} failed`,
+  );
+  for (const t of data.tests) {
+    const dur = t.durationSec != null ? ` (${t.durationSec}s)` : "";
+    lines.push(`  #${t.number} ${t.name}: ${t.status}${dur}`);
+  }
+  if (s.totalDurationSec != null) {
+    lines.push(`total time: ${s.totalDurationSec}s`);
+  }
+  return lines.join("\n");
+}
+
+export function formatPresets(data: CMakePresetsResult): string {
+  const lines: string[] = [];
+  lines.push(data.success ? "cmake presets:" : "cmake presets: failed");
+  if (data.configurePresets) {
+    lines.push("  configure:");
+    for (const p of data.configurePresets) {
+      lines.push(`    "${p.name}"${p.displayName ? ` - ${p.displayName}` : ""}`);
+    }
+  }
+  if (data.buildPresets) {
+    lines.push("  build:");
+    for (const p of data.buildPresets) {
+      lines.push(`    "${p.name}"${p.displayName ? ` - ${p.displayName}` : ""}`);
+    }
+  }
+  if (data.testPresets) {
+    lines.push("  test:");
+    for (const p of data.testPresets) {
+      lines.push(`    "${p.name}"${p.displayName ? ` - ${p.displayName}` : ""}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+export function formatInstall(data: CMakeInstallResult): string {
+  const lines: string[] = [];
+  lines.push(data.success ? "cmake install: success" : "cmake install: failed");
+  if (data.prefix) lines.push(`configuration: ${data.prefix}`);
+  if (data.installedFiles) {
+    for (const f of data.installedFiles) lines.push(`  ${f}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatClean(data: CMakeCleanResult): string {
+  return data.success ? "cmake clean: success" : "cmake clean: failed";
+}
+
+// ── Compact types, mappers, and formatters ─────────────────────────
+
+export interface CMakeConfigureCompact {
+  [key: string]: unknown;
+  success: boolean;
+  buildDir: string;
+  warningCount: number;
+  errorCount: number;
+}
+
+export function compactConfigureMap(data: CMakeConfigureResult): CMakeConfigureCompact {
+  return {
+    success: data.success,
+    buildDir: data.buildDir,
+    warningCount: data.warnings?.length ?? 0,
+    errorCount: data.errors?.length ?? 0,
+  };
+}
+
+export function formatConfigureCompact(data: CMakeConfigureCompact): string {
+  if (data.success) return `cmake configure: success (${data.buildDir})`;
+  return `cmake configure: failed (${data.errorCount} errors, ${data.warningCount} warnings)`;
+}
+
+export interface CMakeBuildCompact {
+  [key: string]: unknown;
+  success: boolean;
+  warningCount: number;
+  errorCount: number;
+}
+
+export function compactBuildMap(data: CMakeBuildResult): CMakeBuildCompact {
+  return {
+    success: data.success,
+    warningCount: data.summary.warningCount,
+    errorCount: data.summary.errorCount,
+  };
+}
+
+export function formatBuildCompact(data: CMakeBuildCompact): string {
+  if (data.success) return `cmake build: success (${data.warningCount} warnings)`;
+  return `cmake build: failed (${data.errorCount} errors, ${data.warningCount} warnings)`;
+}
+
+export interface CMakeTestCompact {
+  [key: string]: unknown;
+  success: boolean;
+  totalTests: number;
+  passed: number;
+  failed: number;
+}
+
+export function compactTestMap(data: CMakeTestResult): CMakeTestCompact {
+  return {
+    success: data.success,
+    totalTests: data.summary.totalTests,
+    passed: data.summary.passed,
+    failed: data.summary.failed,
+  };
+}
+
+export function formatTestCompact(data: CMakeTestCompact): string {
+  if (data.success) return `ctest: ${data.passed}/${data.totalTests} passed`;
+  return `ctest: ${data.failed}/${data.totalTests} failed`;
+}
+
+export interface CMakePresetsCompact {
+  [key: string]: unknown;
+  success: boolean;
+  configureCount: number;
+  buildCount: number;
+  testCount: number;
+}
+
+export function compactPresetsMap(data: CMakePresetsResult): CMakePresetsCompact {
+  return {
+    success: data.success,
+    configureCount: data.configurePresets?.length ?? 0,
+    buildCount: data.buildPresets?.length ?? 0,
+    testCount: data.testPresets?.length ?? 0,
+  };
+}
+
+export function formatPresetsCompact(data: CMakePresetsCompact): string {
+  if (!data.success) return "cmake presets: failed";
+  return `cmake presets: ${data.configureCount} configure, ${data.buildCount} build, ${data.testCount} test`;
+}
+
+export interface CMakeInstallCompact {
+  [key: string]: unknown;
+  success: boolean;
+  fileCount: number;
+}
+
+export function compactInstallMap(data: CMakeInstallResult): CMakeInstallCompact {
+  return {
+    success: data.success,
+    fileCount: data.installedFiles?.length ?? 0,
+  };
+}
+
+export function formatInstallCompact(data: CMakeInstallCompact): string {
+  if (data.success) return `cmake install: success (${data.fileCount} files)`;
+  return "cmake install: failed";
+}
+
+export interface CMakeCleanCompact {
+  [key: string]: unknown;
+  success: boolean;
+}
+
+export function compactCleanMap(data: CMakeCleanResult): CMakeCleanCompact {
+  return { success: data.success };
+}
+
+export function formatCleanCompact(data: CMakeCleanCompact): string {
+  return data.success ? "cmake clean: success" : "cmake clean: failed";
+}

--- a/packages/server-cmake/src/lib/parsers.ts
+++ b/packages/server-cmake/src/lib/parsers.ts
@@ -1,0 +1,345 @@
+import type {
+  CMakeConfigureResult,
+  CMakeBuildResult,
+  CMakeTestResult,
+  CMakePresetsResult,
+  CMakeInstallResult,
+  CMakeCleanResult,
+} from "../schemas/index.js";
+
+// ── cmake configure ────────────────────────────────────────────────
+
+export function parseCMakeConfigureOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  buildDir: string,
+): CMakeConfigureResult {
+  const success = exitCode === 0;
+  const text = stdout + "\n" + stderr;
+
+  // Extract generator from compiler identification lines
+  let generator: string | undefined;
+  const cMatch = text.match(/-- The C compiler identification is (.+)/);
+  const cxxMatch = text.match(/-- The CXX compiler identification is (.+)/);
+  if (cxxMatch) generator = cxxMatch[1].trim();
+  else if (cMatch) generator = cMatch[1].trim();
+
+  // Parse CMake warnings
+  const warnings: { message: string; file?: string; line?: number }[] = [];
+  const warnWithLocRe = /CMake Warning at ([^:]+):(\d+)[^:]*:\s*\n([\s\S]*?)(?=\n(?:--|CMake|$))/g;
+  let match: RegExpExecArray | null;
+  while ((match = warnWithLocRe.exec(text)) !== null) {
+    warnings.push({
+      message: match[3].trim(),
+      file: match[1].trim(),
+      line: parseInt(match[2], 10),
+    });
+  }
+  // Warnings without location
+  const warnNoLocRe = /CMake Warning:\s*\n?([\s\S]*?)(?=\n(?:--|CMake|$))/g;
+  while ((match = warnNoLocRe.exec(text)) !== null) {
+    const msg = match[1].trim();
+    // Avoid duplicates from location-based matches
+    if (msg && !warnings.some((w) => w.message === msg)) {
+      warnings.push({ message: msg });
+    }
+  }
+
+  // Parse CMake errors
+  const errors: { message: string; file?: string; line?: number }[] = [];
+  const errWithLocRe = /CMake Error at ([^:]+):(\d+)[^:]*:\s*\n?([\s\S]*?)(?=\n(?:--|CMake|$))/g;
+  while ((match = errWithLocRe.exec(text)) !== null) {
+    errors.push({
+      message: match[3].trim(),
+      file: match[1].trim(),
+      line: parseInt(match[2], 10),
+    });
+  }
+  // Errors without location
+  const errNoLocRe = /CMake Error:\s*\n?([\s\S]*?)(?=\n(?:--|CMake|$))/g;
+  while ((match = errNoLocRe.exec(text)) !== null) {
+    const msg = match[1].trim();
+    if (msg && !errors.some((e) => e.message === msg)) {
+      errors.push({ message: msg });
+    }
+  }
+
+  return {
+    action: "configure",
+    success,
+    generator,
+    buildDir,
+    warnings: warnings.length > 0 ? warnings : undefined,
+    errors: errors.length > 0 ? errors : undefined,
+    exitCode,
+  };
+}
+
+// ── cmake build ────────────────────────────────────────────────────
+
+export function parseCMakeBuildOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): CMakeBuildResult {
+  const success = exitCode === 0;
+  const text = stdout + "\n" + stderr;
+
+  const warnings: { message: string; file?: string; line?: number; column?: number }[] = [];
+  const errors: { message: string; file?: string; line?: number; column?: number }[] = [];
+
+  // GCC/Clang: file:line:col: warning: message
+  const gccWarnRe = /([^:\s]+):(\d+):(\d+):\s*warning:\s*(.+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = gccWarnRe.exec(text)) !== null) {
+    warnings.push({
+      message: match[4].trim(),
+      file: match[1],
+      line: parseInt(match[2], 10),
+      column: parseInt(match[3], 10),
+    });
+  }
+
+  // GCC/Clang: file:line:col: error: message
+  const gccErrRe = /([^:\s]+):(\d+):(\d+):\s*error:\s*(.+)/g;
+  while ((match = gccErrRe.exec(text)) !== null) {
+    errors.push({
+      message: match[4].trim(),
+      file: match[1],
+      line: parseInt(match[2], 10),
+      column: parseInt(match[3], 10),
+    });
+  }
+
+  // MSVC: file(line): warning C1234: message
+  const msvcWarnRe = /([^(\s]+)\((\d+)\):\s*warning\s+\w+:\s*(.+)/g;
+  while ((match = msvcWarnRe.exec(text)) !== null) {
+    warnings.push({
+      message: match[3].trim(),
+      file: match[1],
+      line: parseInt(match[2], 10),
+    });
+  }
+
+  // MSVC: file(line): error C1234: message
+  const msvcErrRe = /([^(\s]+)\((\d+)\):\s*error\s+\w+:\s*(.+)/g;
+  while ((match = msvcErrRe.exec(text)) !== null) {
+    errors.push({
+      message: match[3].trim(),
+      file: match[1],
+      line: parseInt(match[2], 10),
+    });
+  }
+
+  return {
+    action: "build",
+    success,
+    warnings: warnings.length > 0 ? warnings : undefined,
+    errors: errors.length > 0 ? errors : undefined,
+    summary: {
+      warningCount: warnings.length,
+      errorCount: errors.length,
+    },
+    exitCode,
+  };
+}
+
+// ── ctest ──────────────────────────────────────────────────────────
+
+export function parseCTestOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): CMakeTestResult {
+  const success = exitCode === 0;
+  const text = stdout + "\n" + stderr;
+
+  const tests: {
+    name: string;
+    number: number;
+    status: "passed" | "failed" | "timeout" | "skipped" | "not_run" | "disabled";
+    durationSec?: number;
+    output?: string;
+  }[] = [];
+
+  // Parse individual test results
+  // Pattern: 1/3 Test #1: test_basic ...................   Passed    0.01 sec
+  // or:      2/3 Test #2: test_advanced ................***Failed    0.05 sec
+  const testRe =
+    /\d+\/\d+\s+Test\s+#(\d+):\s+(\S+)\s+\.+\s*(\*{0,3}(?:Passed|Failed|Timeout|Not Run|Disabled))\s+([\d.]+)\s+sec/g;
+  let match: RegExpExecArray | null;
+  while ((match = testRe.exec(text)) !== null) {
+    // Strip leading *** prefix (e.g., "***Failed" -> "Failed")
+    const rawStatus = match[3].replace(/^\*+/, "");
+    let status: "passed" | "failed" | "timeout" | "skipped" | "not_run" | "disabled";
+    switch (rawStatus) {
+      case "Passed":
+        status = "passed";
+        break;
+      case "Failed":
+        status = "failed";
+        break;
+      case "Timeout":
+        status = "timeout";
+        break;
+      case "Not Run":
+        status = "not_run";
+        break;
+      case "Disabled":
+        status = "disabled";
+        break;
+      default:
+        status = "failed";
+    }
+
+    tests.push({
+      name: match[2],
+      number: parseInt(match[1], 10),
+      status,
+      durationSec: parseFloat(match[4]),
+    });
+  }
+
+  // Parse summary
+  let passed = 0;
+  let failed = 0;
+  let totalTests = tests.length;
+  const skipped = tests.filter((t) => t.status === "skipped" || t.status === "not_run").length;
+  const timeout = tests.filter((t) => t.status === "timeout").length;
+
+  const summaryMatch = text.match(
+    /(\d+)%\s+tests\s+passed,\s+(\d+)\s+tests?\s+failed\s+out\s+of\s+(\d+)/,
+  );
+  if (summaryMatch) {
+    failed = parseInt(summaryMatch[2], 10);
+    totalTests = parseInt(summaryMatch[3], 10);
+    passed = totalTests - failed;
+  } else {
+    passed = tests.filter((t) => t.status === "passed").length;
+    failed = tests.filter((t) => t.status === "failed" || t.status === "timeout").length;
+  }
+
+  // Parse total duration
+  let totalDurationSec: number | undefined;
+  const durationMatch = text.match(/Total Test time \(real\)\s*=\s*([\d.]+)\s+sec/);
+  if (durationMatch) {
+    totalDurationSec = parseFloat(durationMatch[1]);
+  }
+
+  return {
+    action: "test",
+    success,
+    tests,
+    summary: {
+      totalTests,
+      passed,
+      failed,
+      skipped,
+      timeout,
+      totalDurationSec,
+    },
+    exitCode,
+  };
+}
+
+// ── cmake list-presets ─────────────────────────────────────────────
+
+export function parseCMakePresetsOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): CMakePresetsResult {
+  const success = exitCode === 0;
+  const text = stdout + "\n" + stderr;
+
+  const configurePresets: { name: string; displayName?: string }[] = [];
+  const buildPresets: { name: string; displayName?: string }[] = [];
+  const testPresets: { name: string; displayName?: string }[] = [];
+
+  // Determine which section we're in
+  let currentTarget: { name: string; displayName?: string }[] | null = null;
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+
+    if (/^Available configure presets?:/i.test(trimmed)) {
+      currentTarget = configurePresets;
+      continue;
+    }
+    if (/^Available build presets?:/i.test(trimmed)) {
+      currentTarget = buildPresets;
+      continue;
+    }
+    if (/^Available test presets?:/i.test(trimmed)) {
+      currentTarget = testPresets;
+      continue;
+    }
+
+    // Parse preset entry: "name" - Display Name  or  "name"
+    const presetMatch = trimmed.match(/^"([^"]+)"(?:\s+-\s+(.+))?$/);
+    if (presetMatch && currentTarget) {
+      currentTarget.push({
+        name: presetMatch[1],
+        displayName: presetMatch[2]?.trim() || undefined,
+      });
+    }
+  }
+
+  return {
+    action: "list-presets",
+    success,
+    configurePresets: configurePresets.length > 0 ? configurePresets : undefined,
+    buildPresets: buildPresets.length > 0 ? buildPresets : undefined,
+    testPresets: testPresets.length > 0 ? testPresets : undefined,
+    exitCode,
+  };
+}
+
+// ── cmake install ──────────────────────────────────────────────────
+
+export function parseCMakeInstallOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): CMakeInstallResult {
+  const success = exitCode === 0;
+  const text = stdout + "\n" + stderr;
+
+  // Parse prefix from "-- Install configuration: ..."
+  let prefix: string | undefined;
+  const prefixMatch = text.match(/-- Install configuration:\s*"([^"]+)"/);
+  if (prefixMatch) {
+    prefix = prefixMatch[1];
+  }
+
+  // Parse installed files: "-- Installing: /path/to/file"
+  const installedFiles: string[] = [];
+  const installRe = /-- Installing:\s*(.+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = installRe.exec(text)) !== null) {
+    installedFiles.push(match[1].trim());
+  }
+
+  return {
+    action: "install",
+    success,
+    prefix,
+    installedFiles: installedFiles.length > 0 ? installedFiles : undefined,
+    exitCode,
+  };
+}
+
+// ── cmake clean ────────────────────────────────────────────────────
+
+export function parseCMakeCleanOutput(
+  _stdout: string,
+  _stderr: string,
+  exitCode: number,
+): CMakeCleanResult {
+  return {
+    action: "clean",
+    success: exitCode === 0,
+    exitCode,
+  };
+}

--- a/packages/server-cmake/src/schemas/index.ts
+++ b/packages/server-cmake/src/schemas/index.ts
@@ -1,0 +1,146 @@
+import { z } from "zod";
+
+// ── cmake configure ────────────────────────────────────────────────
+
+export const CMakeConfigureResultSchema = z.object({
+  action: z.literal("configure"),
+  success: z.boolean(),
+  generator: z.string().optional(),
+  buildDir: z.string(),
+  warnings: z
+    .array(
+      z.object({
+        message: z.string(),
+        file: z.string().optional(),
+        line: z.number().optional(),
+      }),
+    )
+    .optional(),
+  errors: z
+    .array(
+      z.object({
+        message: z.string(),
+        file: z.string().optional(),
+        line: z.number().optional(),
+      }),
+    )
+    .optional(),
+  exitCode: z.number(),
+});
+
+export type CMakeConfigureResult = z.infer<typeof CMakeConfigureResultSchema>;
+
+// ── cmake build ────────────────────────────────────────────────────
+
+export const CMakeBuildResultSchema = z.object({
+  action: z.literal("build"),
+  success: z.boolean(),
+  warnings: z
+    .array(
+      z.object({
+        message: z.string(),
+        file: z.string().optional(),
+        line: z.number().optional(),
+        column: z.number().optional(),
+      }),
+    )
+    .optional(),
+  errors: z
+    .array(
+      z.object({
+        message: z.string(),
+        file: z.string().optional(),
+        line: z.number().optional(),
+        column: z.number().optional(),
+      }),
+    )
+    .optional(),
+  summary: z.object({
+    warningCount: z.number(),
+    errorCount: z.number(),
+  }),
+  exitCode: z.number(),
+});
+
+export type CMakeBuildResult = z.infer<typeof CMakeBuildResultSchema>;
+
+// ── cmake test (ctest) ─────────────────────────────────────────────
+
+export const CMakeTestResultSchema = z.object({
+  action: z.literal("test"),
+  success: z.boolean(),
+  tests: z.array(
+    z.object({
+      name: z.string(),
+      number: z.number(),
+      status: z.enum(["passed", "failed", "timeout", "skipped", "not_run", "disabled"]),
+      durationSec: z.number().optional(),
+      output: z.string().optional(),
+    }),
+  ),
+  summary: z.object({
+    totalTests: z.number(),
+    passed: z.number(),
+    failed: z.number(),
+    skipped: z.number(),
+    timeout: z.number(),
+    totalDurationSec: z.number().optional(),
+  }),
+  exitCode: z.number(),
+});
+
+export type CMakeTestResult = z.infer<typeof CMakeTestResultSchema>;
+
+// ── cmake list-presets ─────────────────────────────────────────────
+
+export const CMakePresetsResultSchema = z.object({
+  action: z.literal("list-presets"),
+  success: z.boolean(),
+  configurePresets: z
+    .array(z.object({ name: z.string(), displayName: z.string().optional() }))
+    .optional(),
+  buildPresets: z
+    .array(z.object({ name: z.string(), displayName: z.string().optional() }))
+    .optional(),
+  testPresets: z
+    .array(z.object({ name: z.string(), displayName: z.string().optional() }))
+    .optional(),
+  exitCode: z.number(),
+});
+
+export type CMakePresetsResult = z.infer<typeof CMakePresetsResultSchema>;
+
+// ── cmake install ──────────────────────────────────────────────────
+
+export const CMakeInstallResultSchema = z.object({
+  action: z.literal("install"),
+  success: z.boolean(),
+  prefix: z.string().optional(),
+  installedFiles: z.array(z.string()).optional(),
+  exitCode: z.number(),
+});
+
+export type CMakeInstallResult = z.infer<typeof CMakeInstallResultSchema>;
+
+// ── cmake clean ────────────────────────────────────────────────────
+
+export const CMakeCleanResultSchema = z.object({
+  action: z.literal("clean"),
+  success: z.boolean(),
+  exitCode: z.number(),
+});
+
+export type CMakeCleanResult = z.infer<typeof CMakeCleanResultSchema>;
+
+// ── Union schema ───────────────────────────────────────────────────
+
+export const CMakeResultSchema = z.discriminatedUnion("action", [
+  CMakeConfigureResultSchema,
+  CMakeBuildResultSchema,
+  CMakeTestResultSchema,
+  CMakePresetsResultSchema,
+  CMakeInstallResultSchema,
+  CMakeCleanResultSchema,
+]);
+
+export type CMakeResult = z.infer<typeof CMakeResultSchema>;

--- a/packages/server-cmake/src/tools/cmake.ts
+++ b/packages/server-cmake/src/tools/cmake.ts
@@ -1,0 +1,229 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  compactDualOutput,
+  assertNoFlagInjection,
+  assertAllowedByPolicy,
+  INPUT_LIMITS,
+  compactInput,
+} from "@paretools/shared";
+import { z } from "zod";
+import { cmakeCmd, ctestCmd } from "../lib/cmake-runner.js";
+import {
+  parseCMakeConfigureOutput,
+  parseCMakeBuildOutput,
+  parseCTestOutput,
+  parseCMakePresetsOutput,
+  parseCMakeInstallOutput,
+  parseCMakeCleanOutput,
+} from "../lib/parsers.js";
+import {
+  formatConfigure,
+  compactConfigureMap,
+  formatConfigureCompact,
+  formatBuild,
+  compactBuildMap,
+  formatBuildCompact,
+  formatTest,
+  compactTestMap,
+  formatTestCompact,
+  formatPresets,
+  compactPresetsMap,
+  formatPresetsCompact,
+  formatInstall,
+  compactInstallMap,
+  formatInstallCompact,
+  formatClean,
+  compactCleanMap,
+  formatCleanCompact,
+} from "../lib/formatters.js";
+import { CMakeResultSchema } from "../schemas/index.js";
+
+/** Registers the `cmake` tool on the given MCP server. */
+export function registerCMakeTool(server: McpServer) {
+  server.registerTool(
+    "cmake",
+    {
+      title: "CMake",
+      description:
+        "CMake build system operations: configure, build, test, list-presets, install, clean.",
+      inputSchema: {
+        action: z
+          .enum(["configure", "build", "test", "list-presets", "install", "clean"])
+          .describe("CMake action"),
+        sourceDir: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Source directory containing CMakeLists.txt"),
+        buildDir: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .default("build")
+          .describe("Build directory"),
+        cacheVars: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe("CMake cache variables (-D KEY=VALUE)"),
+        target: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(20)
+          .optional()
+          .describe("Build targets"),
+        config: z
+          .enum(["Debug", "Release", "RelWithDebInfo", "MinSizeRel"])
+          .optional()
+          .describe("Build configuration"),
+        testOutputOnFailure: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("Show output for failed tests"),
+        compact: compactInput,
+      },
+      outputSchema: CMakeResultSchema,
+    },
+    async ({
+      action,
+      sourceDir,
+      buildDir,
+      cacheVars,
+      target,
+      config,
+      testOutputOnFailure,
+      compact,
+    }) => {
+      // Validate inputs
+      if (sourceDir) assertNoFlagInjection(sourceDir, "sourceDir");
+      if (buildDir) assertNoFlagInjection(buildDir, "buildDir");
+      if (target) {
+        for (const t of target) assertNoFlagInjection(t, "target");
+      }
+
+      // Validate cache variable keys
+      if (cacheVars) {
+        const keyRegex = /^[A-Za-z_][A-Za-z0-9_]*$/;
+        for (const key of Object.keys(cacheVars)) {
+          if (!keyRegex.test(key)) {
+            throw new Error(`Invalid cache variable key: "${key}"`);
+          }
+        }
+      }
+
+      // install requires policy gate
+      if (action === "install") {
+        assertAllowedByPolicy("cmake", "cmake");
+      }
+
+      const bDir = buildDir || "build";
+      const cwd = sourceDir || process.cwd();
+
+      switch (action) {
+        case "configure": {
+          const args = ["-S", sourceDir || ".", "-B", bDir];
+          if (config) args.push(`-DCMAKE_BUILD_TYPE=${config}`);
+          if (cacheVars) {
+            for (const [key, value] of Object.entries(cacheVars)) {
+              args.push(`-D${key}=${value}`);
+            }
+          }
+          const result = await cmakeCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseCMakeConfigureOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            bDir,
+          );
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatConfigure,
+            compactConfigureMap,
+            formatConfigureCompact,
+            compact === false,
+          );
+        }
+        case "build": {
+          const args = ["--build", bDir];
+          if (target) {
+            for (const t of target) {
+              args.push("--target", t);
+            }
+          }
+          if (config) args.push("--config", config);
+          const result = await cmakeCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseCMakeBuildOutput(result.stdout, result.stderr, result.exitCode);
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatBuild,
+            compactBuildMap,
+            formatBuildCompact,
+            compact === false,
+          );
+        }
+        case "test": {
+          const args = ["--test-dir", bDir];
+          if (testOutputOnFailure) args.push("--output-on-failure");
+          if (config) args.push("-C", config);
+          const result = await ctestCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseCTestOutput(result.stdout, result.stderr, result.exitCode);
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatTest,
+            compactTestMap,
+            formatTestCompact,
+            compact === false,
+          );
+        }
+        case "list-presets": {
+          const args = ["--list-presets=all"];
+          const result = await cmakeCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseCMakePresetsOutput(result.stdout, result.stderr, result.exitCode);
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatPresets,
+            compactPresetsMap,
+            formatPresetsCompact,
+            compact === false,
+          );
+        }
+        case "install": {
+          const args = ["--install", bDir];
+          if (config) args.push("--config", config);
+          const result = await cmakeCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseCMakeInstallOutput(result.stdout, result.stderr, result.exitCode);
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatInstall,
+            compactInstallMap,
+            formatInstallCompact,
+            compact === false,
+          );
+        }
+        case "clean": {
+          const args = ["--build", bDir, "--target", "clean"];
+          const result = await cmakeCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseCMakeCleanOutput(result.stdout, result.stderr, result.exitCode);
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatClean,
+            compactCleanMap,
+            formatCleanCompact,
+            compact === false,
+          );
+        }
+      }
+    },
+  );
+}

--- a/packages/server-cmake/src/tools/index.ts
+++ b/packages/server-cmake/src/tools/index.ts
@@ -1,0 +1,9 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
+import { registerCMakeTool } from "./cmake.js";
+
+/** Registers all CMake tools on the given MCP server, filtered by policy. */
+export function registerAllTools(server: McpServer) {
+  const s = (name: string) => shouldRegisterTool("cmake", name);
+  if (s("cmake")) registerCMakeTool(server);
+}

--- a/packages/server-cmake/tsconfig.json
+++ b/packages/server-cmake/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@paretools/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src"]
+}

--- a/packages/server-cmake/vitest.config.ts
+++ b/packages/server-cmake/vitest.config.ts
@@ -1,0 +1,3 @@
+import { createVitestConfig } from "../shared/vitest.shared.js";
+
+export default createVitestConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,31 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/server-cmake:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.26.0(zod@4.3.6)
+      '@paretools/shared':
+        specifier: workspace:*
+        version: link:../shared
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@paretools/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/server-db:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary
- Adds new `@paretools/cmake` server package with a single `cmake` tool using action enum dispatch
- Supports 6 actions: `configure`, `build`, `test`, `list-presets`, `install`, `clean`
- Includes full/compact dual output, Zod schemas with discriminated union, and security validation (flag injection, cache var key validation, policy gate for install)

## Actions
| Action | CLI Command | Description |
|--------|-------------|-------------|
| `configure` | `cmake -S . -B build` | Generate build files |
| `build` | `cmake --build build` | Compile project |
| `test` | `ctest --test-dir build` | Run CTest tests |
| `list-presets` | `cmake --list-presets=all` | Enumerate CMake presets |
| `install` | `cmake --install build` | Install (policy-gated) |
| `clean` | `cmake --build build --target clean` | Clean build artifacts |

## Parsers
- GCC/Clang warning/error format (`file:line:col: warning/error: message`)
- MSVC warning/error format (`file(line): warning/error C1234: message`)
- CTest result parsing with summary extraction
- CMake configure warning/error extraction with file/line locations
- Preset listing with section-based parsing

## Test plan
- [x] 106 tests passing (parsers, formatters, security)
- [x] Build succeeds (`tsc`)
- [x] Lint passes (`eslint`)
- [x] Format check passes (`prettier`)
- [x] Changeset included

Closes #315