### PR TITLE
feat(bazel): add @paretools/bazel server package

### DIFF
--- a/.changeset/bazel-tool.md
+++ b/.changeset/bazel-tool.md
@@ -1,0 +1,5 @@
+---
+"@paretools/bazel": minor
+---
+
+Add bazel tool with build, test, query, info, run, clean, and fetch actions

--- a/packages/server-bazel/__tests__/formatters.test.ts
+++ b/packages/server-bazel/__tests__/formatters.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatBazelBuild,
+  formatBazelTest,
+  formatBazelQuery,
+  formatBazelInfo,
+  formatBazelRun,
+  formatBazelClean,
+  formatBazelFetch,
+  compactBazelBuildMap,
+  formatBazelBuildCompact,
+  compactBazelTestMap,
+  formatBazelTestCompact,
+  compactBazelQueryMap,
+  formatBazelQueryCompact,
+  compactBazelInfoMap,
+  formatBazelInfoCompact,
+  compactBazelRunMap,
+  formatBazelRunCompact,
+  compactBazelCleanMap,
+  formatBazelCleanCompact,
+  compactBazelFetchMap,
+  formatBazelFetchCompact,
+} from "../src/lib/formatters.js";
+import type {
+  BazelBuildResult,
+  BazelTestResult,
+  BazelQueryResult,
+  BazelInfoResult,
+  BazelRunResult,
+  BazelCleanResult,
+  BazelFetchResult,
+} from "../src/schemas/index.js";
+
+// ── Build formatters ─────────────────────────────────────────────────
+
+describe("formatBazelBuild", () => {
+  it("formats successful build", () => {
+    const data: BazelBuildResult = {
+      action: "build",
+      success: true,
+      targets: [],
+      summary: { totalTargets: 2, successTargets: 2, failedTargets: 0 },
+      durationMs: 5123,
+      exitCode: 0,
+    };
+    const out = formatBazelBuild(data);
+    expect(out).toContain("success");
+    expect(out).toContain("5123ms");
+    expect(out).toContain("2 targets");
+  });
+
+  it("formats failed build with errors", () => {
+    const data: BazelBuildResult = {
+      action: "build",
+      success: false,
+      targets: [{ label: "//src:app", status: "failed" }],
+      summary: { totalTargets: 1, successTargets: 0, failedTargets: 1 },
+      errors: [{ file: "/BUILD", line: 5, message: "compile error" }],
+      durationMs: 3000,
+      exitCode: 1,
+    };
+    const out = formatBazelBuild(data);
+    expect(out).toContain("failed");
+    expect(out).toContain("/BUILD:5");
+    expect(out).toContain("compile error");
+  });
+});
+
+describe("compactBazelBuild", () => {
+  it("maps and formats compact build", () => {
+    const data: BazelBuildResult = {
+      action: "build",
+      success: true,
+      targets: [],
+      summary: { totalTargets: 3, successTargets: 3, failedTargets: 0 },
+      exitCode: 0,
+    };
+    const compact = compactBazelBuildMap(data);
+    expect(compact.totalTargets).toBe(3);
+    expect(compact.failedTargets).toBe(0);
+    const text = formatBazelBuildCompact(compact);
+    expect(text).toContain("success");
+    expect(text).toContain("3 targets");
+  });
+});
+
+// ── Test formatters ──────────────────────────────────────────────────
+
+describe("formatBazelTest", () => {
+  it("formats passing tests", () => {
+    const data: BazelTestResult = {
+      action: "test",
+      success: true,
+      tests: [{ label: "//test:unit", status: "passed", durationMs: 300 }],
+      summary: { totalTests: 1, passed: 1, failed: 0, timeout: 0, flaky: 0, skipped: 0 },
+      durationMs: 500,
+      exitCode: 0,
+    };
+    const out = formatBazelTest(data);
+    expect(out).toContain("ok");
+    expect(out).toContain("1 passed");
+    expect(out).toContain("//test:unit");
+  });
+
+  it("formats mixed results", () => {
+    const data: BazelTestResult = {
+      action: "test",
+      success: false,
+      tests: [
+        { label: "//test:unit", status: "passed", durationMs: 300 },
+        { label: "//test:fail", status: "failed", durationMs: 1200 },
+      ],
+      summary: { totalTests: 2, passed: 1, failed: 1, timeout: 0, flaky: 0, skipped: 0 },
+      exitCode: 3,
+    };
+    const out = formatBazelTest(data);
+    expect(out).toContain("FAILED");
+    expect(out).toContain("1 failed");
+  });
+});
+
+describe("compactBazelTest", () => {
+  it("maps and formats compact test", () => {
+    const data: BazelTestResult = {
+      action: "test",
+      success: false,
+      tests: [
+        { label: "//test:unit", status: "passed", durationMs: 300 },
+        { label: "//test:fail", status: "failed", durationMs: 1200 },
+      ],
+      summary: { totalTests: 2, passed: 1, failed: 1, timeout: 0, flaky: 0, skipped: 0 },
+      exitCode: 3,
+    };
+    const compact = compactBazelTestMap(data);
+    expect(compact.failedTests).toHaveLength(1);
+    expect(compact.failedTests![0].label).toBe("//test:fail");
+    const text = formatBazelTestCompact(compact);
+    expect(text).toContain("FAILED");
+    expect(text).toContain("1 failed");
+  });
+});
+
+// ── Query formatters ─────────────────────────────────────────────────
+
+describe("formatBazelQuery", () => {
+  it("formats query results", () => {
+    const data: BazelQueryResult = {
+      action: "query",
+      success: true,
+      results: ["//src:app", "//src:lib"],
+      count: 2,
+      exitCode: 0,
+    };
+    const out = formatBazelQuery(data);
+    expect(out).toContain("2 results");
+    expect(out).toContain("//src:app");
+  });
+
+  it("formats empty query", () => {
+    const data: BazelQueryResult = {
+      action: "query",
+      success: true,
+      results: [],
+      count: 0,
+      exitCode: 0,
+    };
+    expect(formatBazelQuery(data)).toBe("bazel query: no results.");
+  });
+});
+
+describe("compactBazelQuery", () => {
+  it("maps and formats compact query", () => {
+    const data: BazelQueryResult = {
+      action: "query",
+      success: true,
+      results: ["//a", "//b"],
+      count: 2,
+      exitCode: 0,
+    };
+    const compact = compactBazelQueryMap(data);
+    expect(compact.count).toBe(2);
+    const text = formatBazelQueryCompact(compact);
+    expect(text).toContain("2 results");
+  });
+});
+
+// ── Info formatters ──────────────────────────────────────────────────
+
+describe("formatBazelInfo", () => {
+  it("formats info output", () => {
+    const data: BazelInfoResult = {
+      action: "info",
+      success: true,
+      info: { workspace: "/home/user/project", "bazel-bin": "/path/to/bazel-bin" },
+      exitCode: 0,
+    };
+    const out = formatBazelInfo(data);
+    expect(out).toContain("workspace: /home/user/project");
+    expect(out).toContain("bazel-bin: /path/to/bazel-bin");
+  });
+
+  it("formats empty info", () => {
+    const data: BazelInfoResult = {
+      action: "info",
+      success: true,
+      info: {},
+      exitCode: 0,
+    };
+    expect(formatBazelInfo(data)).toBe("bazel info: no data.");
+  });
+});
+
+describe("compactBazelInfo", () => {
+  it("formats single key compact info", () => {
+    const data: BazelInfoResult = {
+      action: "info",
+      success: true,
+      info: { workspace: "/home/user/project" },
+      exitCode: 0,
+    };
+    const compact = compactBazelInfoMap(data);
+    const text = formatBazelInfoCompact(compact);
+    expect(text).toContain("workspace=/home/user/project");
+  });
+
+  it("formats multi-key compact info", () => {
+    const data: BazelInfoResult = {
+      action: "info",
+      success: true,
+      info: { workspace: "/a", "bazel-bin": "/b" },
+      exitCode: 0,
+    };
+    const compact = compactBazelInfoMap(data);
+    const text = formatBazelInfoCompact(compact);
+    expect(text).toContain("2 keys");
+  });
+});
+
+// ── Run formatters ───────────────────────────────────────────────────
+
+describe("formatBazelRun", () => {
+  it("formats successful run", () => {
+    const data: BazelRunResult = {
+      action: "run",
+      success: true,
+      target: "//src:app",
+      stdout: "Hello",
+      exitCode: 0,
+    };
+    const out = formatBazelRun(data);
+    expect(out).toContain("success");
+    expect(out).toContain("//src:app");
+    expect(out).toContain("Hello");
+  });
+});
+
+describe("compactBazelRun", () => {
+  it("maps and formats compact run", () => {
+    const data: BazelRunResult = {
+      action: "run",
+      success: true,
+      target: "//src:app",
+      stdout: "Hello",
+      exitCode: 0,
+    };
+    const compact = compactBazelRunMap(data);
+    expect(compact.target).toBe("//src:app");
+    const text = formatBazelRunCompact(compact);
+    expect(text).toContain("success");
+  });
+});
+
+// ── Clean formatters ─────────────────────────────────────────────────
+
+describe("formatBazelClean", () => {
+  it("formats clean success", () => {
+    const data: BazelCleanResult = {
+      action: "clean",
+      success: true,
+      expunged: false,
+      exitCode: 0,
+    };
+    expect(formatBazelClean(data)).toBe("bazel clean: success");
+  });
+
+  it("formats clean with expunge", () => {
+    const data: BazelCleanResult = {
+      action: "clean",
+      success: true,
+      expunged: true,
+      exitCode: 0,
+    };
+    expect(formatBazelClean(data)).toBe("bazel clean: success (expunged)");
+  });
+});
+
+describe("compactBazelClean", () => {
+  it("maps and formats compact clean", () => {
+    const data: BazelCleanResult = {
+      action: "clean",
+      success: true,
+      expunged: true,
+      exitCode: 0,
+    };
+    const compact = compactBazelCleanMap(data);
+    expect(compact.expunged).toBe(true);
+    const text = formatBazelCleanCompact(compact);
+    expect(text).toContain("success");
+    expect(text).toContain("expunged");
+  });
+});
+
+// ── Fetch formatters ─────────────────────────────────────────────────
+
+describe("formatBazelFetch", () => {
+  it("formats fetch success", () => {
+    const data: BazelFetchResult = { action: "fetch", success: true, exitCode: 0 };
+    expect(formatBazelFetch(data)).toBe("bazel fetch: success");
+  });
+
+  it("formats fetch failure", () => {
+    const data: BazelFetchResult = { action: "fetch", success: false, exitCode: 1 };
+    expect(formatBazelFetch(data)).toContain("failed");
+  });
+});
+
+describe("compactBazelFetch", () => {
+  it("maps and formats compact fetch", () => {
+    const data: BazelFetchResult = { action: "fetch", success: true, exitCode: 0 };
+    const compact = compactBazelFetchMap(data);
+    expect(compact.exitCode).toBe(0);
+    const text = formatBazelFetchCompact(compact);
+    expect(text).toBe("bazel fetch: success");
+  });
+});

--- a/packages/server-bazel/__tests__/parsers.test.ts
+++ b/packages/server-bazel/__tests__/parsers.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseBazelBuildOutput,
+  parseBazelTestOutput,
+  parseBazelQueryOutput,
+  parseBazelInfoOutput,
+  parseBazelRunOutput,
+  parseBazelCleanOutput,
+  parseBazelFetchOutput,
+} from "../src/lib/parsers.js";
+
+// ── Build ────────────────────────────────────────────────────────────
+
+describe("parseBazelBuildOutput", () => {
+  it("parses build success", () => {
+    const stderr = [
+      "INFO: Analyzed 2 targets (15 packages loaded, 234 targets configured).",
+      "INFO: Found 2 targets...",
+      "INFO: Elapsed time: 5.123s, Critical Path: 2.450s",
+      "INFO: 10 processes: 4 internal, 6 linux-sandbox.",
+      "INFO: Build completed successfully, 10 total actions",
+    ].join("\n");
+    const result = parseBazelBuildOutput("", stderr, 0);
+
+    expect(result.action).toBe("build");
+    expect(result.success).toBe(true);
+    expect(result.summary.totalTargets).toBe(2);
+    expect(result.summary.successTargets).toBe(2);
+    expect(result.summary.failedTargets).toBe(0);
+    expect(result.durationMs).toBe(5123);
+    expect(result.exitCode).toBe(0);
+    expect(result.errors).toBeUndefined();
+  });
+
+  it("parses build failure with errors", () => {
+    const stderr = [
+      "ERROR: /home/user/project/src/BUILD:5:10: Compiling src/main.cc failed: (Exit 1): gcc failed",
+      "src/main.cc:10:5: error: use of undeclared identifier 'foo'",
+      "ERROR: /home/user/project/src/BUILD:5:10: Target //src:app failed to build",
+      "INFO: Elapsed time: 3.456s, Critical Path: 1.230s",
+      "ERROR: Build did NOT complete successfully",
+    ].join("\n");
+    const result = parseBazelBuildOutput("", stderr, 1);
+
+    expect(result.action).toBe("build");
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.durationMs).toBe(3456);
+    expect(result.errors).toBeDefined();
+    expect(result.errors!.length).toBeGreaterThan(0);
+    // Should find the file-based error
+    const fileError = result.errors!.find((e) => e.file);
+    expect(fileError).toBeDefined();
+    expect(fileError!.file).toBe("/home/user/project/src/BUILD");
+    expect(fileError!.line).toBe(5);
+  });
+
+  it("handles empty output with nonzero exit code", () => {
+    const result = parseBazelBuildOutput("", "", 1);
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.summary.totalTargets).toBe(0);
+  });
+});
+
+// ── Test ─────────────────────────────────────────────────────────────
+
+describe("parseBazelTestOutput", () => {
+  it("parses mixed test results (pass/fail/timeout)", () => {
+    const stderr = [
+      "INFO: Analyzed 3 test targets (0 packages loaded, 0 targets configured).",
+      "INFO: Found 3 test targets...",
+      "//test:unit_test                                                 PASSED in 0.3s",
+      "  Stats over 1 runs: 1 test passed",
+      "//test:integration_test                                          FAILED in 1.2s",
+      "  /home/user/.cache/bazel/_bazel/test/integration_test/test.log",
+      "//test:slow_test                                                 TIMEOUT in 60.0s",
+      "  /home/user/.cache/bazel/_bazel/test/slow_test/test.log",
+      "",
+      "Executed 3 out of 3 tests: 1 test passes.",
+      "INFO: Elapsed time: 62.456s, Critical Path: 60.123s",
+      "INFO: Build completed, 1 test FAILED, 3 total actions",
+    ].join("\n");
+    const result = parseBazelTestOutput("", stderr, 3);
+
+    expect(result.action).toBe("test");
+    expect(result.success).toBe(false);
+    expect(result.tests).toHaveLength(3);
+    expect(result.tests[0]).toEqual({
+      label: "//test:unit_test",
+      status: "passed",
+      durationMs: 300,
+    });
+    expect(result.tests[1]).toEqual({
+      label: "//test:integration_test",
+      status: "failed",
+      durationMs: 1200,
+    });
+    expect(result.tests[2]).toEqual({
+      label: "//test:slow_test",
+      status: "timeout",
+      durationMs: 60000,
+    });
+    expect(result.summary.totalTests).toBe(3);
+    expect(result.summary.passed).toBe(1);
+    expect(result.summary.failed).toBe(1);
+    expect(result.summary.timeout).toBe(1);
+    expect(result.durationMs).toBe(62456);
+  });
+
+  it("parses all passing tests", () => {
+    const stderr = [
+      "INFO: Analyzed 2 test targets (0 packages loaded, 0 targets configured).",
+      "//test:unit_test                                                 PASSED in 0.5s",
+      "//test:other_test                                                PASSED in 1.0s",
+      "Executed 2 out of 2 tests: 2 test passes.",
+      "INFO: Elapsed time: 2.500s, Critical Path: 1.200s",
+    ].join("\n");
+    const result = parseBazelTestOutput("", stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.tests).toHaveLength(2);
+    expect(result.summary.passed).toBe(2);
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.timeout).toBe(0);
+  });
+
+  it("handles empty test output", () => {
+    const result = parseBazelTestOutput("", "", 0);
+    expect(result.success).toBe(true);
+    expect(result.tests).toHaveLength(0);
+    expect(result.summary.totalTests).toBe(0);
+  });
+});
+
+// ── Query ────────────────────────────────────────────────────────────
+
+describe("parseBazelQueryOutput", () => {
+  it("parses query output (label format)", () => {
+    const stdout = ["//src:app", "//src:lib", "//src:utils", "//test:unit_test"].join("\n");
+    const result = parseBazelQueryOutput(stdout, "", 0);
+
+    expect(result.action).toBe("query");
+    expect(result.success).toBe(true);
+    expect(result.results).toEqual(["//src:app", "//src:lib", "//src:utils", "//test:unit_test"]);
+    expect(result.count).toBe(4);
+  });
+
+  it("parses empty query", () => {
+    const result = parseBazelQueryOutput("", "", 0);
+    expect(result.success).toBe(true);
+    expect(result.results).toEqual([]);
+    expect(result.count).toBe(0);
+  });
+
+  it("handles query error", () => {
+    const result = parseBazelQueryOutput("", "ERROR: bad query", 1);
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+// ── Info ─────────────────────────────────────────────────────────────
+
+describe("parseBazelInfoOutput", () => {
+  it("parses info output (all keys)", () => {
+    const stdout = [
+      "bazel-bin: /home/user/.cache/bazel/_bazel/user/abc123/execroot/project/bazel-bin",
+      "bazel-genfiles: /home/user/.cache/bazel/_bazel/user/abc123/execroot/project/bazel-genfiles",
+      "bazel-testlogs: /home/user/.cache/bazel/_bazel/user/abc123/execroot/project/bazel-testlogs",
+      "execution_root: /home/user/.cache/bazel/_bazel/user/abc123/execroot/project",
+      "output_base: /home/user/.cache/bazel/_bazel/user/abc123",
+      "output_path: /home/user/.cache/bazel/_bazel/user/abc123/execroot/project/bazel-out",
+      "workspace: /home/user/project",
+    ].join("\n");
+    const result = parseBazelInfoOutput(stdout, "", 0);
+
+    expect(result.action).toBe("info");
+    expect(result.success).toBe(true);
+    expect(Object.keys(result.info)).toHaveLength(7);
+    expect(result.info["workspace"]).toBe("/home/user/project");
+    expect(result.info["bazel-bin"]).toBe(
+      "/home/user/.cache/bazel/_bazel/user/abc123/execroot/project/bazel-bin",
+    );
+  });
+
+  it("parses info output (single key)", () => {
+    const stdout = "/home/user/.cache/bazel/_bazel/user/abc123/execroot/project/bazel-bin\n";
+    const result = parseBazelInfoOutput(stdout, "", 0, "bazel-bin");
+
+    expect(result.success).toBe(true);
+    expect(result.info["bazel-bin"]).toBe(
+      "/home/user/.cache/bazel/_bazel/user/abc123/execroot/project/bazel-bin",
+    );
+  });
+
+  it("handles info error", () => {
+    const result = parseBazelInfoOutput("", "ERROR: unknown key", 1);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── Run ──────────────────────────────────────────────────────────────
+
+describe("parseBazelRunOutput", () => {
+  it("parses successful run", () => {
+    const result = parseBazelRunOutput("Hello, World!", "", 0, "//src:app");
+    expect(result.action).toBe("run");
+    expect(result.success).toBe(true);
+    expect(result.target).toBe("//src:app");
+    expect(result.stdout).toBe("Hello, World!");
+    expect(result.stderr).toBeUndefined();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("parses failed run", () => {
+    const result = parseBazelRunOutput("", "Error: segfault", 139, "//src:app");
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(139);
+    expect(result.stderr).toBe("Error: segfault");
+  });
+});
+
+// ── Clean ────────────────────────────────────────────────────────────
+
+describe("parseBazelCleanOutput", () => {
+  it("parses clean success", () => {
+    const result = parseBazelCleanOutput("", "INFO: Starting clean.", 0, false);
+    expect(result.action).toBe("clean");
+    expect(result.success).toBe(true);
+    expect(result.expunged).toBe(false);
+  });
+
+  it("parses clean with expunge", () => {
+    const result = parseBazelCleanOutput("", "INFO: Starting clean (--expunge).", 0, true);
+    expect(result.success).toBe(true);
+    expect(result.expunged).toBe(true);
+  });
+
+  it("handles clean failure", () => {
+    const result = parseBazelCleanOutput("", "ERROR: clean failed", 1, false);
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+// ── Fetch ────────────────────────────────────────────────────────────
+
+describe("parseBazelFetchOutput", () => {
+  it("parses fetch success", () => {
+    const result = parseBazelFetchOutput("", "", 0);
+    expect(result.action).toBe("fetch");
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("handles fetch failure", () => {
+    const result = parseBazelFetchOutput("", "ERROR: fetch failed", 1);
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/packages/server-bazel/__tests__/security.test.ts
+++ b/packages/server-bazel/__tests__/security.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+
+// ── Target pattern validation ────────────────────────────────────────
+
+describe("Bazel target pattern validation", () => {
+  function validateTarget(t: string): void {
+    assertNoFlagInjection(t, "targets");
+    if (!t.startsWith("//") && !t.startsWith("@") && t !== "...") {
+      throw new Error(`Invalid Bazel target pattern: "${t}". Must start with //, @, or be "..."`);
+    }
+  }
+
+  it("accepts valid target patterns", () => {
+    expect(() => validateTarget("//src:app")).not.toThrow();
+    expect(() => validateTarget("//...")).not.toThrow();
+    expect(() => validateTarget("//src/...")).not.toThrow();
+    expect(() => validateTarget("@repo//src:lib")).not.toThrow();
+    expect(() => validateTarget("...")).not.toThrow();
+  });
+
+  it("rejects invalid target patterns", () => {
+    expect(() => validateTarget("rm -rf /")).toThrow();
+    expect(() => validateTarget("src:app")).toThrow(/Invalid Bazel target pattern/);
+    expect(() => validateTarget("just-a-string")).toThrow(/Invalid Bazel target pattern/);
+  });
+
+  it("rejects flag injection in targets", () => {
+    expect(() => validateTarget("--config=evil")).toThrow();
+    expect(() => validateTarget("-exec")).toThrow();
+  });
+});
+
+// ── assertNoFlagInjection on inputs ──────────────────────────────────
+
+describe("assertNoFlagInjection on bazel inputs", () => {
+  it("rejects flags in queryExpr", () => {
+    expect(() => assertNoFlagInjection("--output=evil", "queryExpr")).toThrow();
+  });
+
+  it("allows valid query expressions", () => {
+    expect(() => assertNoFlagInjection("deps(//src:app)", "queryExpr")).not.toThrow();
+    expect(() => assertNoFlagInjection("kind('cc_library', //src/...)", "queryExpr")).not.toThrow();
+  });
+
+  it("rejects flags in infoKey", () => {
+    expect(() => assertNoFlagInjection("--exec", "infoKey")).toThrow();
+  });
+
+  it("allows valid info keys", () => {
+    expect(() => assertNoFlagInjection("bazel-bin", "infoKey")).not.toThrow();
+    expect(() => assertNoFlagInjection("workspace", "infoKey")).not.toThrow();
+    expect(() => assertNoFlagInjection("execution_root", "infoKey")).not.toThrow();
+  });
+});
+
+// ── Zod schema limits ────────────────────────────────────────────────
+
+describe("Zod schema limits", () => {
+  it("rejects targets array exceeding max", () => {
+    const schema = z.array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX)).max(50);
+    const oversized = Array.from({ length: 51 }, (_, i) => `//src:target_${i}`);
+    const result = schema.safeParse(oversized);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects excessively long target string", () => {
+    const schema = z.string().max(INPUT_LIMITS.SHORT_STRING_MAX);
+    const longStr = "a".repeat(INPUT_LIMITS.SHORT_STRING_MAX + 1);
+    const result = schema.safeParse(longStr);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects excessively long queryExpr", () => {
+    const schema = z.string().max(INPUT_LIMITS.STRING_MAX);
+    const longStr = "a".repeat(INPUT_LIMITS.STRING_MAX + 1);
+    const result = schema.safeParse(longStr);
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/server-bazel/package.json
+++ b/packages/server-bazel/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@paretools/bazel",
+  "version": "0.1.0",
+  "mcpName": "io.github.Dave-London/pare-bazel",
+  "description": "MCP server for Bazel build system operations with structured, token-efficient output",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "structured-output",
+    "ai",
+    "bazel",
+    "bazelisk",
+    "build-system"
+  ],
+  "homepage": "https://github.com/Dave-London/Pare/tree/main/packages/server-bazel",
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "bin": {
+    "pare-bazel": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dave-London/Pare.git",
+    "directory": "packages/server-bazel"
+  },
+  "bugs": {
+    "url": "https://github.com/Dave-London/Pare/issues"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@paretools/shared": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@paretools/tsconfig": "workspace:*",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/server-bazel/server.json
+++ b/packages/server-bazel/server.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Dave-London/pare-bazel",
+  "description": "Pare Bazel — Structured Bazel build system operations as typed JSON.",
+  "repository": { "url": "https://github.com/Dave-London/Pare", "source": "github" },
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@paretools/bazel",
+      "version": "0.1.0",
+      "transport": { "type": "stdio" }
+    }
+  ]
+}

--- a/packages/server-bazel/src/index.ts
+++ b/packages/server-bazel/src/index.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerAllTools } from "./tools/index.js";
+
+const server = new McpServer(
+  { name: "@paretools/bazel", version: "0.1.0" },
+  {
+    instructions:
+      "Structured Bazel build system operations (build, test, query, info, run, clean, fetch). Returns typed JSON.",
+  },
+);
+
+registerAllTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/server-bazel/src/lib/bazel-runner.ts
+++ b/packages/server-bazel/src/lib/bazel-runner.ts
@@ -1,0 +1,5 @@
+import { run, type RunResult } from "@paretools/shared";
+
+export async function bazelCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("bazel", args, { cwd, timeout: 300_000 });
+}

--- a/packages/server-bazel/src/lib/formatters.ts
+++ b/packages/server-bazel/src/lib/formatters.ts
@@ -1,0 +1,340 @@
+import type {
+  BazelBuildResult,
+  BazelTestResult,
+  BazelQueryResult,
+  BazelInfoResult,
+  BazelRunResult,
+  BazelCleanResult,
+  BazelFetchResult,
+  BazelResult,
+} from "../schemas/index.js";
+
+// ── Build ────────────────────────────────────────────────────────────
+
+export function formatBazelBuild(data: BazelBuildResult): string {
+  const status = data.success ? "success" : "failed";
+  const duration = data.durationMs ? ` (${data.durationMs}ms)` : "";
+  const lines = [
+    `bazel build: ${status}${duration} — ${data.summary.totalTargets} targets (${data.summary.successTargets} ok, ${data.summary.failedTargets} failed)`,
+  ];
+  for (const e of data.errors ?? []) {
+    const loc = e.file ? `${e.file}${e.line ? `:${e.line}` : ""}` : (e.target ?? "");
+    lines.push(`  ${loc ? `${loc}: ` : ""}${e.message}`);
+  }
+  return lines.join("\n");
+}
+
+export interface BazelBuildCompact {
+  [key: string]: unknown;
+  action: "build";
+  success: boolean;
+  totalTargets: number;
+  successTargets: number;
+  failedTargets: number;
+  errors?: BazelBuildResult["errors"];
+  exitCode: number;
+}
+
+export function compactBazelBuildMap(data: BazelBuildResult): BazelBuildCompact {
+  const compact: BazelBuildCompact = {
+    action: "build",
+    success: data.success,
+    totalTargets: data.summary.totalTargets,
+    successTargets: data.summary.successTargets,
+    failedTargets: data.summary.failedTargets,
+    exitCode: data.exitCode,
+  };
+  if (data.errors?.length) compact.errors = data.errors;
+  return compact;
+}
+
+export function formatBazelBuildCompact(data: BazelBuildCompact): string {
+  const status = data.success ? "success" : "failed";
+  return `bazel build: ${status} (${data.totalTargets} targets, ${data.failedTargets} failed)`;
+}
+
+// ── Test ─────────────────────────────────────────────────────────────
+
+export function formatBazelTest(data: BazelTestResult): string {
+  const status = data.success ? "ok" : "FAILED";
+  const duration = data.durationMs ? ` (${data.durationMs}ms)` : "";
+  const lines = [
+    `bazel test: ${status}${duration} — ${data.summary.passed} passed, ${data.summary.failed} failed, ${data.summary.timeout} timeout, ${data.summary.flaky} flaky`,
+  ];
+  for (const t of data.tests) {
+    const dur = t.durationMs ? ` (${t.durationMs}ms)` : "";
+    lines.push(`  ${t.status.padEnd(9)} ${t.label}${dur}`);
+    if (t.failureMessage) {
+      for (const line of t.failureMessage.split("\n")) {
+        lines.push(`           ${line}`);
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+export interface BazelTestCompact {
+  [key: string]: unknown;
+  action: "test";
+  success: boolean;
+  totalTests: number;
+  passed: number;
+  failed: number;
+  timeout: number;
+  flaky: number;
+  failedTests?: Array<{ label: string; durationMs?: number }>;
+  exitCode: number;
+}
+
+export function compactBazelTestMap(data: BazelTestResult): BazelTestCompact {
+  const failedTests = data.tests
+    .filter((t) => t.status === "failed" || t.status === "timeout")
+    .map((t) => ({ label: t.label, durationMs: t.durationMs }));
+  const compact: BazelTestCompact = {
+    action: "test",
+    success: data.success,
+    totalTests: data.summary.totalTests,
+    passed: data.summary.passed,
+    failed: data.summary.failed,
+    timeout: data.summary.timeout,
+    flaky: data.summary.flaky,
+    exitCode: data.exitCode,
+  };
+  if (failedTests.length > 0) compact.failedTests = failedTests;
+  return compact;
+}
+
+export function formatBazelTestCompact(data: BazelTestCompact): string {
+  const status = data.success ? "ok" : "FAILED";
+  return `bazel test: ${status}. ${data.passed} passed; ${data.failed} failed; ${data.timeout} timeout`;
+}
+
+// ── Query ────────────────────────────────────────────────────────────
+
+export function formatBazelQuery(data: BazelQueryResult): string {
+  if (data.count === 0) return "bazel query: no results.";
+  const lines = [`bazel query: ${data.count} results`];
+  for (const r of data.results) {
+    lines.push(`  ${r}`);
+  }
+  return lines.join("\n");
+}
+
+export interface BazelQueryCompact {
+  [key: string]: unknown;
+  action: "query";
+  success: boolean;
+  count: number;
+  results: string[];
+  exitCode: number;
+}
+
+export function compactBazelQueryMap(data: BazelQueryResult): BazelQueryCompact {
+  return {
+    action: "query",
+    success: data.success,
+    count: data.count,
+    results: data.results,
+    exitCode: data.exitCode,
+  };
+}
+
+export function formatBazelQueryCompact(data: BazelQueryCompact): string {
+  if (data.count === 0) return "bazel query: no results.";
+  return `bazel query: ${data.count} results`;
+}
+
+// ── Info ─────────────────────────────────────────────────────────────
+
+export function formatBazelInfo(data: BazelInfoResult): string {
+  const entries = Object.entries(data.info);
+  if (entries.length === 0) return "bazel info: no data.";
+  const lines = [`bazel info:`];
+  for (const [key, value] of entries) {
+    lines.push(`  ${key}: ${value}`);
+  }
+  return lines.join("\n");
+}
+
+export interface BazelInfoCompact {
+  [key: string]: unknown;
+  action: "info";
+  success: boolean;
+  info: Record<string, string>;
+  exitCode: number;
+}
+
+export function compactBazelInfoMap(data: BazelInfoResult): BazelInfoCompact {
+  return {
+    action: "info",
+    success: data.success,
+    info: data.info,
+    exitCode: data.exitCode,
+  };
+}
+
+export function formatBazelInfoCompact(data: BazelInfoCompact): string {
+  const count = Object.keys(data.info).length;
+  if (count === 0) return "bazel info: no data.";
+  if (count === 1) {
+    const [key, value] = Object.entries(data.info)[0];
+    return `bazel info: ${key}=${value}`;
+  }
+  return `bazel info: ${count} keys`;
+}
+
+// ── Run ──────────────────────────────────────────────────────────────
+
+export function formatBazelRun(data: BazelRunResult): string {
+  const status = data.success ? "success" : "failed";
+  const lines = [`bazel run ${data.target}: ${status} (exit code ${data.exitCode})`];
+  if (data.stdout) lines.push(`stdout:\n${data.stdout}`);
+  if (data.stderr) lines.push(`stderr:\n${data.stderr}`);
+  return lines.join("\n");
+}
+
+export interface BazelRunCompact {
+  [key: string]: unknown;
+  action: "run";
+  success: boolean;
+  target: string;
+  exitCode: number;
+}
+
+export function compactBazelRunMap(data: BazelRunResult): BazelRunCompact {
+  return {
+    action: "run",
+    success: data.success,
+    target: data.target,
+    exitCode: data.exitCode,
+  };
+}
+
+export function formatBazelRunCompact(data: BazelRunCompact): string {
+  const status = data.success ? "success" : "failed";
+  return `bazel run ${data.target}: ${status} (exit code ${data.exitCode})`;
+}
+
+// ── Clean ────────────────────────────────────────────────────────────
+
+export function formatBazelClean(data: BazelCleanResult): string {
+  const status = data.success ? "success" : "failed";
+  const expunged = data.expunged ? " (expunged)" : "";
+  return `bazel clean: ${status}${expunged}`;
+}
+
+export interface BazelCleanCompact {
+  [key: string]: unknown;
+  action: "clean";
+  success: boolean;
+  expunged: boolean;
+  exitCode: number;
+}
+
+export function compactBazelCleanMap(data: BazelCleanResult): BazelCleanCompact {
+  return {
+    action: "clean",
+    success: data.success,
+    expunged: data.expunged,
+    exitCode: data.exitCode,
+  };
+}
+
+export function formatBazelCleanCompact(data: BazelCleanCompact): string {
+  const status = data.success ? "success" : "failed";
+  const expunged = data.expunged ? " (expunged)" : "";
+  return `bazel clean: ${status}${expunged}`;
+}
+
+// ── Fetch ────────────────────────────────────────────────────────────
+
+export function formatBazelFetch(data: BazelFetchResult): string {
+  return data.success ? "bazel fetch: success" : `bazel fetch: failed (exit code ${data.exitCode})`;
+}
+
+export interface BazelFetchCompact {
+  [key: string]: unknown;
+  action: "fetch";
+  success: boolean;
+  exitCode: number;
+}
+
+export function compactBazelFetchMap(data: BazelFetchResult): BazelFetchCompact {
+  return {
+    action: "fetch",
+    success: data.success,
+    exitCode: data.exitCode,
+  };
+}
+
+export function formatBazelFetchCompact(data: BazelFetchCompact): string {
+  return data.success ? "bazel fetch: success" : `bazel fetch: failed (exit code ${data.exitCode})`;
+}
+
+// ── Dispatch formatters ──────────────────────────────────────────────
+
+type CompactResult =
+  | BazelBuildCompact
+  | BazelTestCompact
+  | BazelQueryCompact
+  | BazelInfoCompact
+  | BazelRunCompact
+  | BazelCleanCompact
+  | BazelFetchCompact;
+
+export function formatBazelResult(data: BazelResult): string {
+  switch (data.action) {
+    case "build":
+      return formatBazelBuild(data);
+    case "test":
+      return formatBazelTest(data);
+    case "query":
+      return formatBazelQuery(data);
+    case "info":
+      return formatBazelInfo(data);
+    case "run":
+      return formatBazelRun(data);
+    case "clean":
+      return formatBazelClean(data);
+    case "fetch":
+      return formatBazelFetch(data);
+  }
+}
+
+export function compactBazelResultMap(data: BazelResult): CompactResult {
+  switch (data.action) {
+    case "build":
+      return compactBazelBuildMap(data);
+    case "test":
+      return compactBazelTestMap(data);
+    case "query":
+      return compactBazelQueryMap(data);
+    case "info":
+      return compactBazelInfoMap(data);
+    case "run":
+      return compactBazelRunMap(data);
+    case "clean":
+      return compactBazelCleanMap(data);
+    case "fetch":
+      return compactBazelFetchMap(data);
+  }
+}
+
+export function formatBazelResultCompact(data: CompactResult): string {
+  switch (data.action) {
+    case "build":
+      return formatBazelBuildCompact(data as BazelBuildCompact);
+    case "test":
+      return formatBazelTestCompact(data as BazelTestCompact);
+    case "query":
+      return formatBazelQueryCompact(data as BazelQueryCompact);
+    case "info":
+      return formatBazelInfoCompact(data as BazelInfoCompact);
+    case "run":
+      return formatBazelRunCompact(data as BazelRunCompact);
+    case "clean":
+      return formatBazelCleanCompact(data as BazelCleanCompact);
+    case "fetch":
+      return formatBazelFetchCompact(data as BazelFetchCompact);
+  }
+}

--- a/packages/server-bazel/src/lib/parsers.ts
+++ b/packages/server-bazel/src/lib/parsers.ts
@@ -1,0 +1,269 @@
+import type {
+  BazelBuildResult,
+  BazelTestResult,
+  BazelQueryResult,
+  BazelInfoResult,
+  BazelRunResult,
+  BazelCleanResult,
+  BazelFetchResult,
+} from "../schemas/index.js";
+
+// ── Build ────────────────────────────────────────────────────────────
+
+export function parseBazelBuildOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): BazelBuildResult {
+  const combined = stderr + "\n" + stdout;
+  const success = exitCode === 0;
+
+  // Parse target count from "INFO: Analyzed N targets"
+  const analyzedMatch = combined.match(/INFO: Analyzed (\d+) targets?/);
+  const totalTargets = analyzedMatch ? parseInt(analyzedMatch[1], 10) : 0;
+
+  // Parse errors with file/line info: ERROR: /path/BUILD:line:col: ...
+  const errors: BazelBuildResult["errors"] = [];
+  const errorLines = combined.split("\n").filter((l) => l.startsWith("ERROR:"));
+  for (const line of errorLines) {
+    const fileMatch = line.match(/^ERROR: ([^:]+):(\d+):(\d+): (.+)/);
+    if (fileMatch) {
+      errors.push({
+        file: fileMatch[1],
+        line: parseInt(fileMatch[2], 10),
+        message: fileMatch[4],
+      });
+    } else {
+      const msgMatch = line.match(/^ERROR: (.+)/);
+      if (msgMatch) {
+        // Try to extract a target label from error messages like "Target //src:app failed to build"
+        const targetMatch = msgMatch[1].match(/Target (\/\/\S+) failed/);
+        errors.push({
+          target: targetMatch ? targetMatch[1] : undefined,
+          message: msgMatch[1],
+        });
+      }
+    }
+  }
+
+  // Parse duration from "Elapsed time: X.XXXs"
+  const durationMatch = combined.match(/Elapsed time: ([\d.]+)s/);
+  const durationMs = durationMatch ? Math.round(parseFloat(durationMatch[1]) * 1000) : undefined;
+
+  // Count failed targets from errors
+  const failedTargets = errors.filter((e) => e.target).length;
+  const successTargets = success ? totalTargets : totalTargets - Math.max(failedTargets, 0);
+
+  // Build target list
+  const targets: BazelBuildResult["targets"] = [];
+  // Extract target labels that failed
+  const failedLabels = new Set(errors.filter((e) => e.target).map((e) => e.target!));
+
+  // If we know total targets, generate success entries for the non-failed ones
+  if (totalTargets > 0) {
+    for (const label of failedLabels) {
+      targets.push({ label, status: "failed" });
+    }
+    // We don't have individual success target labels from the output,
+    // but we can still report the summary accurately
+  }
+
+  return {
+    action: "build",
+    success,
+    targets,
+    summary: {
+      totalTargets,
+      successTargets: Math.max(0, successTargets),
+      failedTargets: failedLabels.size,
+    },
+    errors: errors.length > 0 ? errors : undefined,
+    durationMs,
+    exitCode,
+  };
+}
+
+// ── Test ─────────────────────────────────────────────────────────────
+
+export function parseBazelTestOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): BazelTestResult {
+  const combined = stderr + "\n" + stdout;
+  const success = exitCode === 0;
+
+  // Parse individual test results
+  // Pattern: //label  STATUS in X.Xs
+  const testPattern = /^(\/\/\S+)\s+(PASSED|FAILED|FLAKY|TIMEOUT|NO STATUS)\s+in\s+([\d.]+)s/gm;
+  const tests: BazelTestResult["tests"] = [];
+  let match;
+
+  while ((match = testPattern.exec(combined)) !== null) {
+    const statusMap: Record<string, BazelTestResult["tests"][number]["status"]> = {
+      PASSED: "passed",
+      FAILED: "failed",
+      FLAKY: "flaky",
+      TIMEOUT: "timeout",
+      "NO STATUS": "no_status",
+    };
+    tests.push({
+      label: match[1],
+      status: statusMap[match[2]] || "no_status",
+      durationMs: Math.round(parseFloat(match[3]) * 1000),
+    });
+  }
+
+  // Parse summary counts
+  let passed = 0;
+  let failed = 0;
+  let timeout = 0;
+  let flaky = 0;
+  let skipped = 0;
+
+  for (const t of tests) {
+    switch (t.status) {
+      case "passed":
+        passed++;
+        break;
+      case "failed":
+        failed++;
+        break;
+      case "timeout":
+        timeout++;
+        break;
+      case "flaky":
+        flaky++;
+        break;
+      case "skipped":
+        skipped++;
+        break;
+    }
+  }
+
+  // Parse duration from "Elapsed time: X.XXXs"
+  const durationMatch = combined.match(/Elapsed time: ([\d.]+)s/);
+  const durationMs = durationMatch ? Math.round(parseFloat(durationMatch[1]) * 1000) : undefined;
+
+  return {
+    action: "test",
+    success,
+    tests,
+    summary: {
+      totalTests: tests.length,
+      passed,
+      failed,
+      timeout,
+      flaky,
+      skipped,
+    },
+    durationMs,
+    exitCode,
+  };
+}
+
+// ── Query ────────────────────────────────────────────────────────────
+
+export function parseBazelQueryOutput(
+  stdout: string,
+  _stderr: string,
+  exitCode: number,
+): BazelQueryResult {
+  const success = exitCode === 0;
+  const results = stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  return {
+    action: "query",
+    success,
+    results,
+    count: results.length,
+    exitCode,
+  };
+}
+
+// ── Info ─────────────────────────────────────────────────────────────
+
+export function parseBazelInfoOutput(
+  stdout: string,
+  _stderr: string,
+  exitCode: number,
+  infoKey?: string,
+): BazelInfoResult {
+  const success = exitCode === 0;
+  const info: Record<string, string> = {};
+
+  if (infoKey) {
+    // Single key mode: stdout is just the value
+    info[infoKey] = stdout.trim();
+  } else {
+    // Multi-key mode: parse "key: value" lines
+    for (const line of stdout.split("\n")) {
+      const colonIdx = line.indexOf(": ");
+      if (colonIdx > 0) {
+        const key = line.substring(0, colonIdx).trim();
+        const value = line.substring(colonIdx + 2).trim();
+        if (key) info[key] = value;
+      }
+    }
+  }
+
+  return {
+    action: "info",
+    success,
+    info,
+    exitCode,
+  };
+}
+
+// ── Run ──────────────────────────────────────────────────────────────
+
+export function parseBazelRunOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  target: string,
+): BazelRunResult {
+  const success = exitCode === 0;
+
+  return {
+    action: "run",
+    success,
+    target,
+    stdout: stdout.trim(),
+    stderr: stderr.trim() || undefined,
+    exitCode,
+  };
+}
+
+// ── Clean ────────────────────────────────────────────────────────────
+
+export function parseBazelCleanOutput(
+  _stdout: string,
+  _stderr: string,
+  exitCode: number,
+  expunged: boolean,
+): BazelCleanResult {
+  return {
+    action: "clean",
+    success: exitCode === 0,
+    expunged,
+    exitCode,
+  };
+}
+
+// ── Fetch ────────────────────────────────────────────────────────────
+
+export function parseBazelFetchOutput(
+  _stdout: string,
+  _stderr: string,
+  exitCode: number,
+): BazelFetchResult {
+  return {
+    action: "fetch",
+    success: exitCode === 0,
+    exitCode,
+  };
+}

--- a/packages/server-bazel/src/schemas/index.ts
+++ b/packages/server-bazel/src/schemas/index.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+
+// ── Build ────────────────────────────────────────────────────────────
+
+export const BazelBuildTargetSchema = z.object({
+  label: z.string(),
+  status: z.enum(["success", "failed", "skipped"]),
+});
+
+export const BazelBuildResultSchema = z.object({
+  action: z.literal("build"),
+  success: z.boolean(),
+  targets: z.array(BazelBuildTargetSchema),
+  summary: z.object({
+    totalTargets: z.number(),
+    successTargets: z.number(),
+    failedTargets: z.number(),
+  }),
+  errors: z
+    .array(
+      z.object({
+        target: z.string().optional(),
+        message: z.string(),
+        file: z.string().optional(),
+        line: z.number().optional(),
+      }),
+    )
+    .optional(),
+  durationMs: z.number().optional(),
+  exitCode: z.number(),
+});
+
+export type BazelBuildResult = z.infer<typeof BazelBuildResultSchema>;
+
+// ── Test ─────────────────────────────────────────────────────────────
+
+export const BazelTestCaseSchema = z.object({
+  label: z.string(),
+  status: z.enum(["passed", "failed", "timeout", "flaky", "skipped", "no_status"]),
+  durationMs: z.number().optional(),
+  failureMessage: z.string().optional(),
+});
+
+export const BazelTestResultSchema = z.object({
+  action: z.literal("test"),
+  success: z.boolean(),
+  tests: z.array(BazelTestCaseSchema),
+  summary: z.object({
+    totalTests: z.number(),
+    passed: z.number(),
+    failed: z.number(),
+    timeout: z.number(),
+    flaky: z.number(),
+    skipped: z.number(),
+  }),
+  durationMs: z.number().optional(),
+  exitCode: z.number(),
+});
+
+export type BazelTestResult = z.infer<typeof BazelTestResultSchema>;
+
+// ── Query ────────────────────────────────────────────────────────────
+
+export const BazelQueryResultSchema = z.object({
+  action: z.literal("query"),
+  success: z.boolean(),
+  results: z.array(z.string()),
+  count: z.number(),
+  exitCode: z.number(),
+});
+
+export type BazelQueryResult = z.infer<typeof BazelQueryResultSchema>;
+
+// ── Info ─────────────────────────────────────────────────────────────
+
+export const BazelInfoResultSchema = z.object({
+  action: z.literal("info"),
+  success: z.boolean(),
+  info: z.record(z.string(), z.string()),
+  exitCode: z.number(),
+});
+
+export type BazelInfoResult = z.infer<typeof BazelInfoResultSchema>;
+
+// ── Run ──────────────────────────────────────────────────────────────
+
+export const BazelRunResultSchema = z.object({
+  action: z.literal("run"),
+  success: z.boolean(),
+  target: z.string(),
+  stdout: z.string(),
+  stderr: z.string().optional(),
+  exitCode: z.number(),
+});
+
+export type BazelRunResult = z.infer<typeof BazelRunResultSchema>;
+
+// ── Clean ────────────────────────────────────────────────────────────
+
+export const BazelCleanResultSchema = z.object({
+  action: z.literal("clean"),
+  success: z.boolean(),
+  expunged: z.boolean(),
+  exitCode: z.number(),
+});
+
+export type BazelCleanResult = z.infer<typeof BazelCleanResultSchema>;
+
+// ── Fetch ────────────────────────────────────────────────────────────
+
+export const BazelFetchResultSchema = z.object({
+  action: z.literal("fetch"),
+  success: z.boolean(),
+  exitCode: z.number(),
+});
+
+export type BazelFetchResult = z.infer<typeof BazelFetchResultSchema>;
+
+// ── Union ────────────────────────────────────────────────────────────
+
+export const BazelResultSchema = z.discriminatedUnion("action", [
+  BazelBuildResultSchema,
+  BazelTestResultSchema,
+  BazelQueryResultSchema,
+  BazelInfoResultSchema,
+  BazelRunResultSchema,
+  BazelCleanResultSchema,
+  BazelFetchResultSchema,
+]);
+
+export type BazelResult = z.infer<typeof BazelResultSchema>;

--- a/packages/server-bazel/src/tools/bazel.ts
+++ b/packages/server-bazel/src/tools/bazel.ts
@@ -1,0 +1,241 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  compactDualOutput,
+  assertNoFlagInjection,
+  assertAllowedByPolicy,
+  INPUT_LIMITS,
+  compactInput,
+  projectPathInput,
+} from "@paretools/shared";
+import { bazelCmd } from "../lib/bazel-runner.js";
+import {
+  parseBazelBuildOutput,
+  parseBazelTestOutput,
+  parseBazelQueryOutput,
+  parseBazelInfoOutput,
+  parseBazelRunOutput,
+  parseBazelCleanOutput,
+  parseBazelFetchOutput,
+} from "../lib/parsers.js";
+import {
+  formatBazelResult,
+  compactBazelResultMap,
+  formatBazelResultCompact,
+} from "../lib/formatters.js";
+
+// MCP listTools requires an object-shaped outputSchema; discriminated unions are not supported.
+const BazelOutputSchema = z.object({ action: z.string() }).passthrough();
+
+/** Registers the `bazel` tool on the given MCP server. */
+export function registerBazelTool(server: McpServer) {
+  server.registerTool(
+    "bazel",
+    {
+      title: "Bazel",
+      description: "Bazel build system operations: build, test, query, info, run, clean, fetch.",
+      inputSchema: {
+        action: z
+          .enum(["build", "test", "query", "info", "run", "clean", "fetch"])
+          .describe("Bazel action"),
+        targets: z
+          .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+          .max(50)
+          .optional()
+          .describe("Target patterns (e.g. //src:app, //...)"),
+        workDir: projectPathInput,
+        queryExpr: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Query expression for query action"),
+        queryOutput: z
+          .enum(["label", "label_kind", "minrank", "maxrank", "package", "location", "build"])
+          .optional()
+          .default("label")
+          .describe("Query output format"),
+        keepGoing: z.boolean().optional().describe("Continue after errors (-k)"),
+        testOutput: z
+          .enum(["summary", "errors", "all", "streamed"])
+          .optional()
+          .default("errors")
+          .describe("Test output mode"),
+        verboseFailures: z.boolean().optional().default(true).describe("Verbose failure messages"),
+        infoKey: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Specific info key"),
+        expunge: z.boolean().optional().describe("Full clean with --expunge"),
+        compact: compactInput,
+      },
+      outputSchema: BazelOutputSchema,
+    },
+    async ({
+      action,
+      targets,
+      workDir,
+      queryExpr,
+      queryOutput,
+      keepGoing,
+      testOutput,
+      verboseFailures,
+      infoKey,
+      expunge,
+      compact,
+    }) => {
+      const cwd = workDir || process.cwd();
+
+      // Validate targets
+      if (targets) {
+        for (const t of targets) {
+          assertNoFlagInjection(t, "targets");
+          // Validate target pattern: must start with //, @, or be ...
+          if (!t.startsWith("//") && !t.startsWith("@") && t !== "...") {
+            throw new Error(
+              `Invalid Bazel target pattern: "${t}". Must start with //, @, or be "..."`,
+            );
+          }
+        }
+      }
+      if (queryExpr) assertNoFlagInjection(queryExpr, "queryExpr");
+      if (infoKey) assertNoFlagInjection(infoKey, "infoKey");
+
+      // Policy gates
+      if (action === "run") assertAllowedByPolicy("bazel", "bazel");
+      if (action === "clean" && expunge) assertAllowedByPolicy("bazel", "bazel");
+
+      // Common flags
+      const baseFlags = ["--nocolor", "--curses=no"];
+
+      switch (action) {
+        case "build": {
+          if (!targets?.length) throw new Error("targets required for build");
+          const args = ["build", ...baseFlags];
+          if (keepGoing) args.push("-k");
+          if (verboseFailures) args.push("--verbose_failures");
+          args.push(...targets);
+          const result = await bazelCmd(args, cwd);
+          const data = parseBazelBuildOutput(result.stdout, result.stderr, result.exitCode);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatBazelResult,
+            compactBazelResultMap,
+            formatBazelResultCompact,
+            compact === false,
+          );
+        }
+        case "test": {
+          if (!targets?.length) throw new Error("targets required for test");
+          const args = ["test", ...baseFlags];
+          if (keepGoing) args.push("-k");
+          if (verboseFailures) args.push("--verbose_failures");
+          if (testOutput) args.push(`--test_output=${testOutput}`);
+          args.push(...targets);
+          const result = await bazelCmd(args, cwd);
+          const data = parseBazelTestOutput(result.stdout, result.stderr, result.exitCode);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatBazelResult,
+            compactBazelResultMap,
+            formatBazelResultCompact,
+            compact === false,
+          );
+        }
+        case "query": {
+          if (!queryExpr) throw new Error("queryExpr required for query");
+          const args = ["query", ...baseFlags];
+          if (queryOutput) args.push(`--output=${queryOutput}`);
+          if (keepGoing) args.push("-k");
+          args.push(queryExpr);
+          const result = await bazelCmd(args, cwd);
+          const data = parseBazelQueryOutput(result.stdout, result.stderr, result.exitCode);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatBazelResult,
+            compactBazelResultMap,
+            formatBazelResultCompact,
+            compact === false,
+          );
+        }
+        case "info": {
+          const args = ["info", ...baseFlags];
+          if (infoKey) args.push(infoKey);
+          const result = await bazelCmd(args, cwd);
+          const data = parseBazelInfoOutput(result.stdout, result.stderr, result.exitCode, infoKey);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatBazelResult,
+            compactBazelResultMap,
+            formatBazelResultCompact,
+            compact === false,
+          );
+        }
+        case "run": {
+          if (!targets?.length || targets.length !== 1)
+            throw new Error("exactly one target required for run");
+          const args = ["run", ...baseFlags, ...targets];
+          const result = await bazelCmd(args, cwd);
+          const data = parseBazelRunOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            targets[0],
+          );
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatBazelResult,
+            compactBazelResultMap,
+            formatBazelResultCompact,
+            compact === false,
+          );
+        }
+        case "clean": {
+          const args = ["clean", ...baseFlags];
+          if (expunge) args.push("--expunge");
+          const result = await bazelCmd(args, cwd);
+          const data = parseBazelCleanOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            !!expunge,
+          );
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatBazelResult,
+            compactBazelResultMap,
+            formatBazelResultCompact,
+            compact === false,
+          );
+        }
+        case "fetch": {
+          if (!targets?.length) throw new Error("targets required for fetch");
+          const args = ["fetch", ...baseFlags, ...targets];
+          const result = await bazelCmd(args, cwd);
+          const data = parseBazelFetchOutput(result.stdout, result.stderr, result.exitCode);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatBazelResult,
+            compactBazelResultMap,
+            formatBazelResultCompact,
+            compact === false,
+          );
+        }
+      }
+    },
+  );
+}

--- a/packages/server-bazel/src/tools/index.ts
+++ b/packages/server-bazel/src/tools/index.ts
@@ -1,0 +1,8 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shouldRegisterTool } from "@paretools/shared";
+import { registerBazelTool } from "./bazel.js";
+
+export function registerAllTools(server: McpServer) {
+  const s = (name: string) => shouldRegisterTool("bazel", name);
+  if (s("bazel")) registerBazelTool(server);
+}

--- a/packages/server-bazel/tsconfig.json
+++ b/packages/server-bazel/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@paretools/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src"]
+}

--- a/packages/server-bazel/vitest.config.ts
+++ b/packages/server-bazel/vitest.config.ts
@@ -1,0 +1,3 @@
+import { createVitestConfig } from "../shared/vitest.shared.js";
+
+export default createVitestConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,31 @@ importers:
         specifier: ^9.0.0
         version: 9.39.2
 
+  packages/server-bazel:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.26.0(zod@4.3.6)
+      '@paretools/shared':
+        specifier: workspace:*
+        version: link:../shared
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@paretools/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/server-build:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary
- Adds new `@paretools/bazel` MCP server package with a single `bazel` tool using action enum dispatch
- Supports 7 actions: `build`, `test`, `query`, `info`, `run`, `clean`, `fetch`
- Includes full/compact dual-output formatters, Zod output schemas, and security guards (flag injection, target validation, policy gates)

## Actions
| Action | Description |
|--------|-------------|
| `build` | Compile targets, parse errors with file/line info |
| `test` | Run tests, parse pass/fail/timeout/flaky results |
| `query` | Dependency graph queries with configurable output format |
| `info` | Workspace info (all keys or single key) |
| `run` | Execute binary target (policy-gated) |
| `clean` | Clear build output (expunge is policy-gated) |
| `fetch` | Download external dependencies |

## Test plan
- [x] 50 unit tests passing (parsers, formatters, security)
- [x] Build passes (`tsc`)
- [x] Lint passes (`eslint`)
- [x] Format passes (`prettier`)
- [x] Changeset included

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)