### PR TITLE
fix(ci): use GitHub App token in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,15 @@ jobs:
       id-token: write
 
     steps:
+      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
 
@@ -38,7 +46,7 @@ jobs:
           title: "chore: version packages"
           commit: "chore: version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- Replace `secrets.GITHUB_TOKEN` with a short-lived GitHub App installation token in `release.yml`
- Pass the App token to both `actions/checkout` (so commits are authored by the App) and `changesets/action` (so the Version Packages PR is created by the App)
- This allows Version Packages PRs to automatically trigger CI, eliminating the manual close/reopen workaround

## Why
GitHub's anti-recursion rule suppresses workflow triggers for events created by the built-in `GITHUB_TOKEN`. Using a separate GitHub App identity avoids this suppression.

## Setup required
Before merging, the following must be configured on the repository:
1. Create a GitHub App (e.g. `pare-ci-bot`) with `Contents: Read & Write` and `Pull Requests: Read & Write` permissions
2. Install the App on the Pare repository
3. Add `RELEASE_APP_ID` as a **repository variable** (Settings > Variables)
4. Add `RELEASE_APP_PRIVATE_KEY` as a **repository secret** (Settings > Secrets)

## Test plan
- [ ] Verify GitHub App is created and installed
- [ ] Verify `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` are configured
- [ ] Merge a changeset to main and confirm the Version Packages PR triggers CI automatically

Closes #572