### PR TITLE
chore: align bazel and cmake package versions to 0.10.2

### DIFF
--- a/packages/server-bazel/package.json
+++ b/packages/server-bazel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paretools/bazel",
-  "version": "0.1.0",
+  "version": "0.10.2",
   "mcpName": "io.github.Dave-London/pare-bazel",
   "description": "MCP server for Bazel build system operations with structured, token-efficient output",
   "license": "MIT",

--- a/packages/server-bazel/server.json
+++ b/packages/server-bazel/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.Dave-London/pare-bazel",
   "description": "Pare Bazel — Structured Bazel build system operations as typed JSON.",
   "repository": { "url": "https://github.com/Dave-London/Pare", "source": "github" },
-  "version": "0.1.0",
+  "version": "0.10.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/bazel",
-      "version": "0.1.0",
+      "version": "0.10.2",
       "transport": { "type": "stdio" }
     }
   ]

--- a/packages/server-bazel/src/index.ts
+++ b/packages/server-bazel/src/index.ts
@@ -5,7 +5,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { registerAllTools } from "./tools/index.js";
 
 const server = new McpServer(
-  { name: "@paretools/bazel", version: "0.1.0" },
+  { name: "@paretools/bazel", version: "0.10.2" },
   {
     instructions:
       "Structured Bazel build system operations (build, test, query, info, run, clean, fetch). Returns typed JSON.",

--- a/packages/server-cmake/package.json
+++ b/packages/server-cmake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paretools/cmake",
-  "version": "0.1.0",
+  "version": "0.10.2",
   "mcpName": "io.github.Dave-London/pare-cmake",
   "description": "MCP server for CMake build system operations with structured, token-efficient output",
   "license": "MIT",

--- a/packages/server-cmake/server.json
+++ b/packages/server-cmake/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.Dave-London/pare-cmake",
   "description": "Pare CMake — Structured CMake/CTest build system operations as typed JSON.",
   "repository": { "url": "https://github.com/Dave-London/Pare", "source": "github" },
-  "version": "0.1.0",
+  "version": "0.10.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/cmake",
-      "version": "0.1.0",
+      "version": "0.10.2",
       "transport": { "type": "stdio" }
     }
   ]

--- a/packages/server-cmake/src/index.ts
+++ b/packages/server-cmake/src/index.ts
@@ -5,7 +5,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { registerAllTools } from "./tools/index.js";
 
 const server = new McpServer(
-  { name: "@paretools/cmake", version: "0.1.0" },
+  { name: "@paretools/cmake", version: "0.10.2" },
   {
     instructions:
       "Structured CMake build system operations (configure, build, test, list-presets, install, clean). Returns typed JSON.",


### PR DESCRIPTION
## Summary
- Align `@paretools/bazel` and `@paretools/cmake` versions from `0.1.0` to `0.10.2`
- Updates `package.json`, `server.json`, and `src/index.ts` in both packages

## Why
These new packages were created at `0.1.0` instead of the monorepo-aligned `0.10.2`. When changesets processes the minor bump, they end up at `0.2.0` instead of `0.11.0` like every other package. This fix ensures the next Version Packages PR bumps them to `0.11.0`.

## Test plan
- [ ] Merge this PR
- [ ] Verify the Version Packages PR (#574) updates to show both packages at `0.11.0`