### PR TITLE
feat(infra): add Ansible tools (playbook, inventory, galaxy)

### DIFF
--- a/packages/server-infra/__tests__/ansible-formatters.test.ts
+++ b/packages/server-infra/__tests__/ansible-formatters.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatAnsiblePlaybook,
+  compactAnsiblePlaybookMap,
+  formatAnsiblePlaybookCompact,
+  formatAnsibleInventory,
+  compactAnsibleInventoryMap,
+  formatAnsibleInventoryCompact,
+  formatAnsibleGalaxy,
+  compactAnsibleGalaxyMap,
+  formatAnsibleGalaxyCompact,
+} from "../src/lib/ansible-formatters.js";
+import type {
+  AnsiblePlaybookResult,
+  AnsibleInventoryResult,
+  AnsibleGalaxyResult,
+} from "../src/schemas/ansible.js";
+
+// ── ansible-playbook formatters ───────────────────────────────────
+
+describe("formatAnsiblePlaybook", () => {
+  it("formats successful playbook run", () => {
+    const data: AnsiblePlaybookResult = {
+      success: true,
+      exitCode: 0,
+      plays: [{ name: "webservers" }],
+      recap: [
+        {
+          host: "web1",
+          ok: 2,
+          changed: 1,
+          unreachable: 0,
+          failed: 0,
+          skipped: 0,
+          rescued: 0,
+          ignored: 0,
+        },
+      ],
+      duration: "12 seconds",
+    };
+    const result = formatAnsiblePlaybook(data);
+    expect(result).toContain("ansible-playbook: success");
+    expect(result).toContain("PLAY: webservers");
+    expect(result).toContain("web1: ok=2 changed=1");
+    expect(result).toContain("duration: 12 seconds");
+  });
+
+  it("formats failed playbook run", () => {
+    const data: AnsiblePlaybookResult = {
+      success: false,
+      exitCode: 2,
+      error: "ERROR! the playbook: missing.yml could not be found",
+    };
+    const result = formatAnsiblePlaybook(data);
+    expect(result).toContain("ansible-playbook: failed");
+    expect(result).toContain("ERROR!");
+  });
+
+  it("formats syntax check success", () => {
+    const data: AnsiblePlaybookResult = {
+      success: true,
+      exitCode: 0,
+      syntaxOk: true,
+    };
+    const result = formatAnsiblePlaybook(data);
+    expect(result).toContain("--syntax-check: OK");
+  });
+
+  it("formats syntax check failure", () => {
+    const data: AnsiblePlaybookResult = {
+      success: false,
+      exitCode: 4,
+      syntaxOk: false,
+      error: "Syntax Error",
+    };
+    const result = formatAnsiblePlaybook(data);
+    expect(result).toContain("--syntax-check: FAILED");
+    expect(result).toContain("Syntax Error");
+  });
+
+  it("formats --list-tasks output", () => {
+    const data: AnsiblePlaybookResult = {
+      success: true,
+      exitCode: 0,
+      taskList: ["Install nginx", "Configure nginx", "Start nginx"],
+    };
+    const result = formatAnsiblePlaybook(data);
+    expect(result).toContain("--list-tasks:");
+    expect(result).toContain("Install nginx");
+    expect(result).toContain("Configure nginx");
+  });
+
+  it("formats --list-tags output", () => {
+    const data: AnsiblePlaybookResult = {
+      success: true,
+      exitCode: 0,
+      tagList: ["web", "config", "deploy"],
+    };
+    const result = formatAnsiblePlaybook(data);
+    expect(result).toContain("--list-tags:");
+    expect(result).toContain("web");
+    expect(result).toContain("config");
+  });
+});
+
+describe("compact ansible-playbook", () => {
+  it("maps and formats compact playbook result", () => {
+    const data: AnsiblePlaybookResult = {
+      success: true,
+      exitCode: 0,
+      plays: [{ name: "webservers" }],
+      recap: [
+        {
+          host: "web1",
+          ok: 2,
+          changed: 1,
+          unreachable: 0,
+          failed: 0,
+          skipped: 0,
+          rescued: 0,
+          ignored: 0,
+        },
+        {
+          host: "web2",
+          ok: 2,
+          changed: 1,
+          unreachable: 0,
+          failed: 0,
+          skipped: 0,
+          rescued: 0,
+          ignored: 0,
+        },
+      ],
+    };
+
+    const compact = compactAnsiblePlaybookMap(data);
+    expect(compact.success).toBe(true);
+    expect(compact.hostCount).toBe(2);
+    expect(compact.totalChanged).toBe(2);
+    expect(compact.totalFailed).toBe(0);
+
+    const text = formatAnsiblePlaybookCompact(compact);
+    expect(text).toBe("ansible-playbook: 2 host(s), 2 changed, 0 failed");
+  });
+
+  it("formats compact failed run", () => {
+    const compact = { success: false, exitCode: 1, hostCount: 0, totalChanged: 0, totalFailed: 0 };
+    expect(formatAnsiblePlaybookCompact(compact)).toBe("ansible-playbook: failed");
+  });
+
+  it("handles no recap data", () => {
+    const data: AnsiblePlaybookResult = {
+      success: true,
+      exitCode: 0,
+      syntaxOk: true,
+    };
+
+    const compact = compactAnsiblePlaybookMap(data);
+    expect(compact.hostCount).toBe(0);
+    expect(compact.totalChanged).toBe(0);
+  });
+});
+
+// ── ansible-inventory formatters ──────────────────────────────────
+
+describe("formatAnsibleInventory", () => {
+  it("formats inventory list", () => {
+    const data: AnsibleInventoryResult = {
+      success: true,
+      exitCode: 0,
+      groups: [
+        { name: "webservers", hosts: ["host1", "host2"] },
+        { name: "dbservers", hosts: ["db1"], children: ["replica-servers"] },
+      ],
+    };
+    const result = formatAnsibleInventory(data);
+    expect(result).toContain("ansible-inventory: success");
+    expect(result).toContain("webservers (2 hosts)");
+    expect(result).toContain("host1");
+    expect(result).toContain("host2");
+    expect(result).toContain("children: replica-servers");
+  });
+
+  it("formats graph output", () => {
+    const data: AnsibleInventoryResult = {
+      success: true,
+      exitCode: 0,
+      graph: "@all:\n  |--@webservers:\n  |  |--host1",
+    };
+    const result = formatAnsibleInventory(data);
+    expect(result).toContain("ansible-inventory --graph:");
+    expect(result).toContain("@all:");
+  });
+
+  it("formats host detail", () => {
+    const data: AnsibleInventoryResult = {
+      success: true,
+      exitCode: 0,
+      hostDetail: {
+        name: "web1",
+        vars: { ansible_host: "192.168.1.1", http_port: 80 },
+      },
+    };
+    const result = formatAnsibleInventory(data);
+    expect(result).toContain("ansible-inventory --host web1:");
+    expect(result).toContain('ansible_host: "192.168.1.1"');
+    expect(result).toContain("http_port: 80");
+  });
+
+  it("formats error", () => {
+    const data: AnsibleInventoryResult = {
+      success: false,
+      exitCode: 1,
+      error: "Unable to parse inventory",
+    };
+    const result = formatAnsibleInventory(data);
+    expect(result).toContain("ansible-inventory: failed");
+    expect(result).toContain("Unable to parse");
+  });
+});
+
+describe("compact ansible-inventory", () => {
+  it("maps and formats compact inventory", () => {
+    const data: AnsibleInventoryResult = {
+      success: true,
+      exitCode: 0,
+      groups: [
+        { name: "webservers", hosts: ["host1", "host2"] },
+        { name: "dbservers", hosts: ["db1"] },
+      ],
+    };
+
+    const compact = compactAnsibleInventoryMap(data);
+    expect(compact.success).toBe(true);
+    expect(compact.groupCount).toBe(2);
+
+    const text = formatAnsibleInventoryCompact(compact);
+    expect(text).toBe("ansible-inventory: 2 group(s)");
+  });
+
+  it("formats compact failed inventory", () => {
+    const compact = { success: false, exitCode: 1, groupCount: 0 };
+    expect(formatAnsibleInventoryCompact(compact)).toBe("ansible-inventory: failed");
+  });
+});
+
+// ── ansible-galaxy formatters ─────────────────────────────────────
+
+describe("formatAnsibleGalaxy", () => {
+  it("formats collection install", () => {
+    const data: AnsibleGalaxyResult = {
+      success: true,
+      exitCode: 0,
+      action: "collection-install",
+      installed: [{ name: "community.general", version: "5.0.0" }],
+    };
+    const result = formatAnsibleGalaxy(data);
+    expect(result).toContain("ansible-galaxy collection-install: success");
+    expect(result).toContain("installed: community.general (5.0.0)");
+  });
+
+  it("formats collection list", () => {
+    const data: AnsibleGalaxyResult = {
+      success: true,
+      exitCode: 0,
+      action: "collection-list",
+      items: [
+        { name: "community.general", version: "6.6.0" },
+        { name: "amazon.aws", version: "5.4.0" },
+      ],
+    };
+    const result = formatAnsibleGalaxy(data);
+    expect(result).toContain("ansible-galaxy collection-list: success");
+    expect(result).toContain("community.general 6.6.0");
+    expect(result).toContain("amazon.aws 5.4.0");
+  });
+
+  it("formats failed galaxy action", () => {
+    const data: AnsibleGalaxyResult = {
+      success: false,
+      exitCode: 1,
+      action: "role-install",
+      error: "ERROR! Failed to resolve role",
+    };
+    const result = formatAnsibleGalaxy(data);
+    expect(result).toContain("ansible-galaxy role-install: failed");
+    expect(result).toContain("ERROR!");
+  });
+
+  it("formats install without version", () => {
+    const data: AnsibleGalaxyResult = {
+      success: true,
+      exitCode: 0,
+      action: "role-install",
+      installed: [{ name: "geerlingguy.nginx" }],
+    };
+    const result = formatAnsibleGalaxy(data);
+    expect(result).toContain("installed: geerlingguy.nginx");
+    expect(result).not.toContain("(undefined)");
+  });
+});
+
+describe("compact ansible-galaxy", () => {
+  it("maps and formats compact galaxy install", () => {
+    const data: AnsibleGalaxyResult = {
+      success: true,
+      exitCode: 0,
+      action: "collection-install",
+      installed: [
+        { name: "community.general", version: "5.0.0" },
+        { name: "amazon.aws", version: "5.4.0" },
+      ],
+    };
+
+    const compact = compactAnsibleGalaxyMap(data);
+    expect(compact.success).toBe(true);
+    expect(compact.action).toBe("collection-install");
+    expect(compact.itemCount).toBe(2);
+
+    const text = formatAnsibleGalaxyCompact(compact);
+    expect(text).toBe("ansible-galaxy collection-install: 2 item(s)");
+  });
+
+  it("maps and formats compact galaxy list", () => {
+    const data: AnsibleGalaxyResult = {
+      success: true,
+      exitCode: 0,
+      action: "role-list",
+      items: [{ name: "geerlingguy.nginx", version: "3.1.0" }],
+    };
+
+    const compact = compactAnsibleGalaxyMap(data);
+    expect(compact.itemCount).toBe(1);
+  });
+
+  it("formats compact failed galaxy", () => {
+    const compact = { success: false, exitCode: 1, action: "collection-install", itemCount: 0 };
+    expect(formatAnsibleGalaxyCompact(compact)).toBe("ansible-galaxy collection-install: failed");
+  });
+});

--- a/packages/server-infra/__tests__/ansible-parsers.test.ts
+++ b/packages/server-infra/__tests__/ansible-parsers.test.ts
@@ -1,0 +1,458 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseAnsiblePlaybookOutput,
+  parseAnsibleInventoryListOutput,
+  parseAnsibleInventoryGraphOutput,
+  parseAnsibleInventoryHostOutput,
+  parseAnsibleGalaxyInstallOutput,
+  parseAnsibleGalaxyListOutput,
+} from "../src/lib/ansible-parsers.js";
+
+// ── ansible-playbook parsing ──────────────────────────────────────
+
+describe("parseAnsiblePlaybookOutput", () => {
+  it("parses successful playbook run with recap", () => {
+    const stdout = `
+PLAY [webservers] *************************************************************
+
+TASK [Gathering Facts] ********************************************************
+ok: [web1]
+ok: [web2]
+
+TASK [Install nginx] **********************************************************
+changed: [web1]
+changed: [web2]
+
+PLAY RECAP *********************************************************************
+web1                       : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+web2                       : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+
+Playbook run took 0 days, 0 hours, 0 minutes, 12 seconds
+`;
+
+    const result = parseAnsiblePlaybookOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.plays).toEqual([{ name: "webservers" }]);
+    expect(result.recap).toHaveLength(2);
+    expect(result.recap![0]).toEqual({
+      host: "web1",
+      ok: 2,
+      changed: 1,
+      unreachable: 0,
+      failed: 0,
+      skipped: 0,
+      rescued: 0,
+      ignored: 0,
+    });
+    expect(result.recap![1]).toEqual({
+      host: "web2",
+      ok: 2,
+      changed: 1,
+      unreachable: 0,
+      failed: 0,
+      skipped: 0,
+      rescued: 0,
+      ignored: 0,
+    });
+    expect(result.duration).toBe("0 days, 0 hours, 0 minutes, 12 seconds");
+  });
+
+  it("parses failed playbook run", () => {
+    const stdout = `
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] ********************************************************
+unreachable: [host1]
+
+PLAY RECAP *********************************************************************
+host1                      : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0
+`;
+
+    const result = parseAnsiblePlaybookOutput(stdout, "", 4);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(4);
+    expect(result.recap).toHaveLength(1);
+    expect(result.recap![0].unreachable).toBe(1);
+  });
+
+  it("parses multiple plays", () => {
+    const stdout = `
+PLAY [webservers] *************************************************************
+
+TASK [Install nginx] **********************************************************
+ok: [web1]
+
+PLAY [dbservers] **************************************************************
+
+TASK [Install postgres] *******************************************************
+changed: [db1]
+
+PLAY RECAP *********************************************************************
+web1                       : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+db1                        : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+`;
+
+    const result = parseAnsiblePlaybookOutput(stdout, "", 0);
+
+    expect(result.plays).toHaveLength(2);
+    expect(result.plays![0].name).toBe("webservers");
+    expect(result.plays![1].name).toBe("dbservers");
+  });
+
+  it("handles empty output on error", () => {
+    const result = parseAnsiblePlaybookOutput(
+      "",
+      "ERROR! the playbook: missing.yml could not be found",
+      1,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toContain("ERROR!");
+  });
+
+  it("parses syntax check success", () => {
+    const stdout = `
+playbook: site.yml
+`;
+    const result = parseAnsiblePlaybookOutput(stdout, "", 0, { syntaxCheck: true });
+
+    expect(result.success).toBe(true);
+    expect(result.syntaxOk).toBe(true);
+  });
+
+  it("parses syntax check failure", () => {
+    const stderr = `ERROR! Syntax Error while loading YAML.`;
+    const result = parseAnsiblePlaybookOutput("", stderr, 4, { syntaxCheck: true });
+
+    expect(result.success).toBe(false);
+    expect(result.syntaxOk).toBe(false);
+    expect(result.error).toContain("Syntax Error");
+  });
+
+  it("parses --list-tasks output", () => {
+    const stdout = `
+playbook: site.yml
+
+  play #1 (webservers): webservers	TAGS: []
+    tasks:
+      Install nginx	TAGS: [web]
+      Configure nginx	TAGS: [web, config]
+      Start nginx	TAGS: [web]
+`;
+
+    const result = parseAnsiblePlaybookOutput(stdout, "", 0, { listTasks: true });
+
+    expect(result.success).toBe(true);
+    expect(result.taskList).toBeDefined();
+    expect(result.taskList!.length).toBeGreaterThan(0);
+    expect(result.taskList!.some((t) => t.includes("Install nginx"))).toBe(true);
+  });
+
+  it("parses --list-tags output", () => {
+    const stdout = `
+playbook: site.yml
+
+  play #1 (webservers): webservers	TAGS: []
+      TASK TAGS: [config, web]
+`;
+
+    const result = parseAnsiblePlaybookOutput(stdout, "", 0, { listTags: true });
+
+    expect(result.success).toBe(true);
+    expect(result.tagList).toBeDefined();
+    expect(result.tagList).toContain("config");
+    expect(result.tagList).toContain("web");
+  });
+
+  it("handles recap with all zeros", () => {
+    const stdout = `
+PLAY RECAP *********************************************************************
+localhost                  : ok=0    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+`;
+
+    const result = parseAnsiblePlaybookOutput(stdout, "", 0);
+
+    expect(result.recap).toHaveLength(1);
+    expect(result.recap![0].host).toBe("localhost");
+    expect(result.recap![0].ok).toBe(0);
+  });
+
+  it("handles no duration in output", () => {
+    const stdout = `
+PLAY RECAP *********************************************************************
+host1                      : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+`;
+
+    const result = parseAnsiblePlaybookOutput(stdout, "", 0);
+
+    expect(result.duration).toBeUndefined();
+  });
+});
+
+// ── ansible-inventory parsing ─────────────────────────────────────
+
+describe("parseAnsibleInventoryListOutput", () => {
+  it("parses JSON inventory list", () => {
+    const stdout = JSON.stringify({
+      _meta: {
+        hostvars: {
+          host1: { ansible_host: "192.168.1.1" },
+          host2: { ansible_host: "192.168.1.2" },
+        },
+      },
+      all: {
+        children: ["ungrouped", "webservers"],
+      },
+      webservers: {
+        hosts: ["host1", "host2"],
+      },
+      ungrouped: {
+        hosts: [],
+      },
+    });
+
+    const result = parseAnsibleInventoryListOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.groups).toBeDefined();
+    expect(result.groups!.length).toBe(3);
+
+    const webservers = result.groups!.find((g) => g.name === "webservers");
+    expect(webservers).toBeDefined();
+    expect(webservers!.hosts).toEqual(["host1", "host2"]);
+
+    const all = result.groups!.find((g) => g.name === "all");
+    expect(all).toBeDefined();
+    expect(all!.children).toEqual(["ungrouped", "webservers"]);
+  });
+
+  it("handles empty inventory", () => {
+    const stdout = JSON.stringify({
+      _meta: { hostvars: {} },
+      all: { children: ["ungrouped"] },
+      ungrouped: { hosts: [] },
+    });
+
+    const result = parseAnsibleInventoryListOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.groups).toBeDefined();
+  });
+
+  it("handles error output", () => {
+    const result = parseAnsibleInventoryListOutput("", "ERROR! Unable to parse inventory", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ERROR!");
+  });
+
+  it("handles invalid JSON", () => {
+    const result = parseAnsibleInventoryListOutput("not json", "", 0);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to parse inventory JSON");
+  });
+
+  it("parses groups with vars", () => {
+    const stdout = JSON.stringify({
+      _meta: { hostvars: {} },
+      webservers: {
+        hosts: ["web1"],
+        vars: { http_port: 80 },
+      },
+    });
+
+    const result = parseAnsibleInventoryListOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    const webservers = result.groups!.find((g) => g.name === "webservers");
+    expect(webservers!.vars).toEqual({ http_port: 80 });
+  });
+});
+
+describe("parseAnsibleInventoryGraphOutput", () => {
+  it("parses graph output", () => {
+    const stdout = `@all:
+  |--@ungrouped:
+  |--@webservers:
+  |  |--host1
+  |  |--host2
+  |--@dbservers:
+  |  |--db1`;
+
+    const result = parseAnsibleInventoryGraphOutput(stdout, "", 0);
+
+    expect(result.success).toBe(true);
+    expect(result.graph).toContain("@all:");
+    expect(result.graph).toContain("host1");
+  });
+
+  it("handles error", () => {
+    const result = parseAnsibleInventoryGraphOutput("", "ERROR!", 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("ERROR!");
+  });
+});
+
+describe("parseAnsibleInventoryHostOutput", () => {
+  it("parses host vars", () => {
+    const stdout = JSON.stringify({
+      ansible_host: "192.168.1.1",
+      ansible_user: "admin",
+      http_port: 8080,
+    });
+
+    const result = parseAnsibleInventoryHostOutput(stdout, "", 0, "web1");
+
+    expect(result.success).toBe(true);
+    expect(result.hostDetail).toBeDefined();
+    expect(result.hostDetail!.name).toBe("web1");
+    expect(result.hostDetail!.vars).toEqual({
+      ansible_host: "192.168.1.1",
+      ansible_user: "admin",
+      http_port: 8080,
+    });
+  });
+
+  it("handles host with no vars", () => {
+    const stdout = "{}";
+
+    const result = parseAnsibleInventoryHostOutput(stdout, "", 0, "host1");
+
+    expect(result.success).toBe(true);
+    expect(result.hostDetail!.name).toBe("host1");
+    expect(result.hostDetail!.vars).toBeUndefined();
+  });
+
+  it("handles error", () => {
+    const result = parseAnsibleInventoryHostOutput("", "ERROR! host not found", 1, "missing");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("host not found");
+  });
+
+  it("handles invalid JSON", () => {
+    const result = parseAnsibleInventoryHostOutput("not json", "", 0, "host1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to parse host vars JSON");
+  });
+});
+
+// ── ansible-galaxy parsing ────────────────────────────────────────
+
+describe("parseAnsibleGalaxyInstallOutput", () => {
+  it("parses collection install output", () => {
+    const stdout = `Starting galaxy collection install process
+Process install dependency map
+Starting collection install process
+Installing 'community.general:5.0.0' to '/home/user/.ansible/collections/ansible_collections/community/general'
+community.general (5.0.0) was installed successfully
+`;
+
+    const result = parseAnsibleGalaxyInstallOutput(stdout, "", 0, "collection-install");
+
+    expect(result.success).toBe(true);
+    expect(result.action).toBe("collection-install");
+    expect(result.installed).toBeDefined();
+    expect(result.installed!.length).toBeGreaterThan(0);
+    expect(result.installed![0].name).toBe("community.general");
+    expect(result.installed![0].version).toBe("5.0.0");
+  });
+
+  it("parses role install output", () => {
+    const stdout = `- downloading role 'nginx', owned by geerlingguy
+- downloading role from https://github.com/geerlingguy/ansible-role-nginx/archive/3.1.0.tar.gz
+- extracting geerlingguy.nginx to /home/user/.ansible/roles/geerlingguy.nginx
+- geerlingguy.nginx (3.1.0) was installed successfully
+`;
+
+    const result = parseAnsibleGalaxyInstallOutput(stdout, "", 0, "role-install");
+
+    expect(result.success).toBe(true);
+    expect(result.action).toBe("role-install");
+    expect(result.installed).toBeDefined();
+    expect(result.installed!.some((i) => i.name === "geerlingguy.nginx")).toBe(true);
+  });
+
+  it("handles install error", () => {
+    const stderr = `ERROR! Failed to resolve collection community.missing`;
+
+    const result = parseAnsibleGalaxyInstallOutput("", stderr, 1, "collection-install");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to resolve");
+  });
+
+  it("handles empty successful install (already installed)", () => {
+    const stdout = `Nothing to do. All requested collections are already installed.`;
+
+    const result = parseAnsibleGalaxyInstallOutput(stdout, "", 0, "collection-install");
+
+    expect(result.success).toBe(true);
+    expect(result.installed).toBeUndefined();
+  });
+});
+
+describe("parseAnsibleGalaxyListOutput", () => {
+  it("parses collection list output", () => {
+    const stdout = `
+# /home/user/.ansible/collections/ansible_collections
+Collection               Version
+------------------------ -------
+amazon.aws               5.4.0
+community.general        6.6.0
+ansible.posix            1.5.2
+`;
+
+    const result = parseAnsibleGalaxyListOutput(stdout, "", 0, "collection-list");
+
+    expect(result.success).toBe(true);
+    expect(result.action).toBe("collection-list");
+    expect(result.items).toBeDefined();
+    expect(result.items!.length).toBe(3);
+    expect(result.items![0]).toEqual({ name: "amazon.aws", version: "5.4.0" });
+    expect(result.items![1]).toEqual({ name: "community.general", version: "6.6.0" });
+    expect(result.items![2]).toEqual({ name: "ansible.posix", version: "1.5.2" });
+  });
+
+  it("parses role list output", () => {
+    const stdout = `
+# roles found in /home/user/.ansible/roles
+- geerlingguy.docker, 6.0.0
+- geerlingguy.nginx, 3.1.0
+`;
+
+    const result = parseAnsibleGalaxyListOutput(stdout, "", 0, "role-list");
+
+    expect(result.success).toBe(true);
+    expect(result.action).toBe("role-list");
+    expect(result.items).toBeDefined();
+    expect(result.items!.length).toBe(2);
+    expect(result.items![0]).toEqual({ name: "geerlingguy.docker", version: "6.0.0" });
+    expect(result.items![1]).toEqual({ name: "geerlingguy.nginx", version: "3.1.0" });
+  });
+
+  it("handles empty list", () => {
+    const stdout = `
+# /home/user/.ansible/collections/ansible_collections
+`;
+
+    const result = parseAnsibleGalaxyListOutput(stdout, "", 0, "collection-list");
+
+    expect(result.success).toBe(true);
+    expect(result.items).toBeUndefined();
+  });
+
+  it("handles error", () => {
+    const result = parseAnsibleGalaxyListOutput("", "ERROR!", 1, "collection-list");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ERROR!");
+  });
+});

--- a/packages/server-infra/__tests__/ansible-security.test.ts
+++ b/packages/server-infra/__tests__/ansible-security.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+
+/** Malicious inputs that must be rejected. */
+const MALICIOUS_INPUTS = [
+  "--eval=rm -rf /",
+  "-e",
+  "--flag",
+  " --flag",
+  "\t-f",
+  "--extra-vars=malicious",
+  "-C",
+  "--syntax-check",
+];
+
+/** Safe inputs that must be accepted. */
+const SAFE_PLAYBOOK_NAMES = [
+  "playbook.yml",
+  "site.yml",
+  "roles/webserver/tasks/main.yml",
+  "deploy.yaml",
+  "my-playbook.yml",
+  "playbooks/setup_db.yml",
+];
+
+const SAFE_INVENTORY_NAMES = [
+  "inventory.ini",
+  "hosts",
+  "staging",
+  "production/hosts.yml",
+  "inventories/dev.ini",
+];
+
+const SAFE_COLLECTION_NAMES = [
+  "community.general",
+  "amazon.aws",
+  "ansible.posix",
+  "my_namespace.my_collection",
+  "geerlingguy.nginx",
+];
+
+describe("security: ansible-playbook — flag injection", () => {
+  it("rejects flag-like playbook names", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "playbook")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe playbook names", () => {
+    for (const safe of SAFE_PLAYBOOK_NAMES) {
+      expect(() => assertNoFlagInjection(safe, "playbook")).not.toThrow();
+    }
+  });
+});
+
+describe("security: ansible-inventory — flag injection", () => {
+  it("rejects flag-like inventory names", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "inventory")).toThrow(
+        /must not start with "-"/,
+      );
+    }
+  });
+
+  it("accepts safe inventory names", () => {
+    for (const safe of SAFE_INVENTORY_NAMES) {
+      expect(() => assertNoFlagInjection(safe, "inventory")).not.toThrow();
+    }
+  });
+});
+
+describe("security: ansible-galaxy — flag injection", () => {
+  it("rejects flag-like collection/role names", () => {
+    for (const malicious of MALICIOUS_INPUTS) {
+      expect(() => assertNoFlagInjection(malicious, "name")).toThrow(/must not start with "-"/);
+    }
+  });
+
+  it("accepts safe collection/role names", () => {
+    for (const safe of SAFE_COLLECTION_NAMES) {
+      expect(() => assertNoFlagInjection(safe, "name")).not.toThrow();
+    }
+  });
+});
+
+describe("Zod .max() constraints — Ansible playbook path", () => {
+  const schema = z.string().max(INPUT_LIMITS.PATH_MAX);
+
+  it("accepts a path within the limit", () => {
+    expect(schema.safeParse("playbook.yml").success).toBe(true);
+  });
+
+  it("rejects a path exceeding PATH_MAX", () => {
+    const oversized = "p".repeat(INPUT_LIMITS.PATH_MAX + 1);
+    expect(schema.safeParse(oversized).success).toBe(false);
+  });
+});
+
+describe("Zod .max() constraints — Ansible host/limit string", () => {
+  const schema = z.string().max(INPUT_LIMITS.SHORT_STRING_MAX);
+
+  it("accepts a host name within the limit", () => {
+    expect(schema.safeParse("webservers").success).toBe(true);
+  });
+
+  it("rejects a host name exceeding SHORT_STRING_MAX", () => {
+    const oversized = "h".repeat(INPUT_LIMITS.SHORT_STRING_MAX + 1);
+    expect(schema.safeParse(oversized).success).toBe(false);
+  });
+});
+
+describe("Zod .max() constraints — Ansible extra-vars string", () => {
+  const schema = z.string().max(INPUT_LIMITS.STRING_MAX);
+
+  it("accepts a normal extra-vars string", () => {
+    expect(schema.safeParse('{"key": "value"}').success).toBe(true);
+  });
+
+  it("rejects an extra-vars string exceeding STRING_MAX", () => {
+    const oversized = "x".repeat(INPUT_LIMITS.STRING_MAX + 1);
+    expect(schema.safeParse(oversized).success).toBe(false);
+  });
+});

--- a/packages/server-infra/src/index.ts
+++ b/packages/server-infra/src/index.ts
@@ -7,6 +7,6 @@ await createServer({
   name: "@paretools/infra",
   version: "0.1.0",
   instructions:
-    "Structured infrastructure-as-code operations (Terraform init, plan, validate, fmt, output, state, workspace, show; Vagrant status, up, halt, destroy, global-status). Returns typed JSON.",
+    "Structured infrastructure-as-code operations (Terraform init, plan, validate, fmt, output, state, workspace, show; Vagrant status, up, halt, destroy, global-status; Ansible playbook, inventory, galaxy). Returns typed JSON.",
   registerTools: registerAllTools,
 });

--- a/packages/server-infra/src/lib/ansible-formatters.ts
+++ b/packages/server-infra/src/lib/ansible-formatters.ts
@@ -1,0 +1,213 @@
+import type {
+  AnsiblePlaybookResult,
+  AnsibleInventoryResult,
+  AnsibleGalaxyResult,
+} from "../schemas/ansible.js";
+
+// ── ansible-playbook: full formatter ──────────────────────────────
+
+export function formatAnsiblePlaybook(data: AnsiblePlaybookResult): string {
+  const lines: string[] = [];
+
+  if (data.syntaxOk !== undefined) {
+    lines.push(
+      data.syntaxOk
+        ? "ansible-playbook --syntax-check: OK"
+        : "ansible-playbook --syntax-check: FAILED",
+    );
+    if (data.error) lines.push(`error: ${data.error}`);
+    return lines.join("\n");
+  }
+
+  if (data.taskList) {
+    lines.push("ansible-playbook --list-tasks:");
+    for (const task of data.taskList) {
+      lines.push(`  ${task}`);
+    }
+    return lines.join("\n");
+  }
+
+  if (data.tagList) {
+    lines.push("ansible-playbook --list-tags:");
+    for (const tag of data.tagList) {
+      lines.push(`  ${tag}`);
+    }
+    return lines.join("\n");
+  }
+
+  lines.push(data.success ? "ansible-playbook: success" : "ansible-playbook: failed");
+
+  if (data.plays) {
+    for (const play of data.plays) {
+      lines.push(`  PLAY: ${play.name}`);
+    }
+  }
+
+  if (data.recap) {
+    lines.push("  PLAY RECAP:");
+    for (const r of data.recap) {
+      lines.push(
+        `    ${r.host}: ok=${r.ok} changed=${r.changed} unreachable=${r.unreachable} failed=${r.failed} skipped=${r.skipped} rescued=${r.rescued} ignored=${r.ignored}`,
+      );
+    }
+  }
+
+  if (data.duration) lines.push(`  duration: ${data.duration}`);
+  if (data.error) lines.push(`error: ${data.error}`);
+
+  return lines.join("\n");
+}
+
+// ── ansible-playbook: compact ─────────────────────────────────────
+
+export interface AnsiblePlaybookCompact {
+  [key: string]: unknown;
+  success: boolean;
+  exitCode: number;
+  hostCount: number;
+  totalChanged: number;
+  totalFailed: number;
+}
+
+export function compactAnsiblePlaybookMap(data: AnsiblePlaybookResult): AnsiblePlaybookCompact {
+  let hostCount = 0;
+  let totalChanged = 0;
+  let totalFailed = 0;
+
+  if (data.recap) {
+    hostCount = data.recap.length;
+    for (const r of data.recap) {
+      totalChanged += r.changed;
+      totalFailed += r.failed;
+    }
+  }
+
+  return {
+    success: data.success,
+    exitCode: data.exitCode,
+    hostCount,
+    totalChanged,
+    totalFailed,
+  };
+}
+
+export function formatAnsiblePlaybookCompact(data: AnsiblePlaybookCompact): string {
+  if (!data.success) return "ansible-playbook: failed";
+  return `ansible-playbook: ${data.hostCount} host(s), ${data.totalChanged} changed, ${data.totalFailed} failed`;
+}
+
+// ── ansible-inventory: full formatter ─────────────────────────────
+
+export function formatAnsibleInventory(data: AnsibleInventoryResult): string {
+  const lines: string[] = [];
+
+  if (data.graph) {
+    lines.push("ansible-inventory --graph:");
+    lines.push(data.graph);
+    return lines.join("\n");
+  }
+
+  if (data.hostDetail) {
+    lines.push(`ansible-inventory --host ${data.hostDetail.name}:`);
+    if (data.hostDetail.vars) {
+      for (const [key, value] of Object.entries(data.hostDetail.vars)) {
+        lines.push(`  ${key}: ${JSON.stringify(value)}`);
+      }
+    }
+    return lines.join("\n");
+  }
+
+  lines.push(data.success ? "ansible-inventory: success" : "ansible-inventory: failed");
+
+  if (data.groups) {
+    for (const group of data.groups) {
+      const hostStr = group.hosts.length > 0 ? ` (${group.hosts.length} hosts)` : "";
+      lines.push(`  ${group.name}${hostStr}`);
+      for (const h of group.hosts) {
+        lines.push(`    ${h}`);
+      }
+      if (group.children) {
+        lines.push(`    children: ${group.children.join(", ")}`);
+      }
+    }
+  }
+
+  if (data.error) lines.push(`error: ${data.error}`);
+
+  return lines.join("\n");
+}
+
+// ── ansible-inventory: compact ────────────────────────────────────
+
+export interface AnsibleInventoryCompact {
+  [key: string]: unknown;
+  success: boolean;
+  exitCode: number;
+  groupCount: number;
+}
+
+export function compactAnsibleInventoryMap(data: AnsibleInventoryResult): AnsibleInventoryCompact {
+  return {
+    success: data.success,
+    exitCode: data.exitCode,
+    groupCount: data.groups?.length ?? 0,
+  };
+}
+
+export function formatAnsibleInventoryCompact(data: AnsibleInventoryCompact): string {
+  if (!data.success) return "ansible-inventory: failed";
+  return `ansible-inventory: ${data.groupCount} group(s)`;
+}
+
+// ── ansible-galaxy: full formatter ────────────────────────────────
+
+export function formatAnsibleGalaxy(data: AnsibleGalaxyResult): string {
+  const lines: string[] = [];
+
+  lines.push(
+    data.success
+      ? `ansible-galaxy ${data.action}: success`
+      : `ansible-galaxy ${data.action}: failed`,
+  );
+
+  if (data.installed) {
+    for (const item of data.installed) {
+      lines.push(`  installed: ${item.name}${item.version ? ` (${item.version})` : ""}`);
+    }
+  }
+
+  if (data.items) {
+    for (const item of data.items) {
+      lines.push(`  ${item.name}${item.version ? ` ${item.version}` : ""}`);
+    }
+  }
+
+  if (data.duration) lines.push(`  duration: ${data.duration}`);
+  if (data.error) lines.push(`error: ${data.error}`);
+
+  return lines.join("\n");
+}
+
+// ── ansible-galaxy: compact ───────────────────────────────────────
+
+export interface AnsibleGalaxyCompact {
+  [key: string]: unknown;
+  success: boolean;
+  exitCode: number;
+  action: string;
+  itemCount: number;
+}
+
+export function compactAnsibleGalaxyMap(data: AnsibleGalaxyResult): AnsibleGalaxyCompact {
+  return {
+    success: data.success,
+    exitCode: data.exitCode,
+    action: data.action,
+    itemCount: (data.installed?.length ?? 0) + (data.items?.length ?? 0),
+  };
+}
+
+export function formatAnsibleGalaxyCompact(data: AnsibleGalaxyCompact): string {
+  if (!data.success) return `ansible-galaxy ${data.action}: failed`;
+  return `ansible-galaxy ${data.action}: ${data.itemCount} item(s)`;
+}

--- a/packages/server-infra/src/lib/ansible-parsers.ts
+++ b/packages/server-infra/src/lib/ansible-parsers.ts
@@ -1,0 +1,403 @@
+import type {
+  AnsiblePlaybookResult,
+  AnsibleHostRecap,
+  AnsiblePlay,
+  AnsibleInventoryResult,
+  AnsibleInventoryGroup,
+  AnsibleInventoryHost,
+  AnsibleGalaxyResult,
+  AnsibleGalaxyItem,
+} from "../schemas/ansible.js";
+
+// ── ansible-playbook ──────────────────────────────────────────────
+
+/**
+ * Parse the PLAY RECAP section of ansible-playbook output.
+ *
+ * Example line:
+ *   host1 : ok=2 changed=1 unreachable=0 failed=0 skipped=1 rescued=0 ignored=0
+ */
+function parseRecap(text: string): AnsibleHostRecap[] {
+  const recaps: AnsibleHostRecap[] = [];
+  const recapMatch = text.indexOf("PLAY RECAP");
+  if (recapMatch === -1) return recaps;
+
+  const recapSection = text.slice(recapMatch);
+  const lines = recapSection.split("\n").slice(1); // skip the "PLAY RECAP ***" line
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // Match: hostname : ok=N changed=N unreachable=N failed=N skipped=N rescued=N ignored=N
+    const m = trimmed.match(
+      /^(\S+)\s*:\s*ok=(\d+)\s+changed=(\d+)\s+unreachable=(\d+)\s+failed=(\d+)\s+skipped=(\d+)\s+rescued=(\d+)\s+ignored=(\d+)/,
+    );
+    if (m) {
+      recaps.push({
+        host: m[1],
+        ok: parseInt(m[2], 10),
+        changed: parseInt(m[3], 10),
+        unreachable: parseInt(m[4], 10),
+        failed: parseInt(m[5], 10),
+        skipped: parseInt(m[6], 10),
+        rescued: parseInt(m[7], 10),
+        ignored: parseInt(m[8], 10),
+      });
+    }
+  }
+
+  return recaps;
+}
+
+/** Parse PLAY headers from ansible-playbook output. */
+function parsePlays(text: string): AnsiblePlay[] {
+  const plays: AnsiblePlay[] = [];
+  // Match: PLAY [play name] ***
+  const playRegex = /^PLAY \[([^\]]*)\]/gm;
+  let match;
+  while ((match = playRegex.exec(text)) !== null) {
+    plays.push({ name: match[1] });
+  }
+  return plays;
+}
+
+/** Parse duration from ansible-playbook output footer. */
+function parseDuration(text: string): string | undefined {
+  // Ansible outputs a "Playbook run took X days, H hours, M minutes, S seconds" line
+  // or just the time in the recap area
+  const m = text.match(/Playbook run took (.+)/);
+  return m ? m[1].trim() : undefined;
+}
+
+/** Parse --list-tasks output. */
+function parseTaskList(text: string): string[] {
+  const tasks: string[] = [];
+  const lines = text.split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    // Task lines are indented and follow the play header
+    // Format: "taskname\tTAGS: [tag1, tag2]" or just "taskname"
+    if (trimmed && !trimmed.startsWith("play #") && !trimmed.startsWith("PLAY") && trimmed !== "") {
+      // Remove TAGS suffix if present
+      const taskMatch = trimmed.match(/^(.+?)(?:\s+TAGS:\s*\[.*\])?$/);
+      if (taskMatch && taskMatch[1]) {
+        const taskName = taskMatch[1].trim();
+        if (taskName && !taskName.startsWith("pattern:") && !taskName.startsWith("tasks:")) {
+          tasks.push(taskName);
+        }
+      }
+    }
+  }
+  return tasks;
+}
+
+/** Parse --list-tags output. */
+function parseTagList(text: string): string[] {
+  const tags = new Set<string>();
+  // Look for "TASK TAGS: [tag1, tag2, ...]" lines
+  const tagRegex = /TASK TAGS:\s*\[([^\]]*)\]/g;
+  let match;
+  while ((match = tagRegex.exec(text)) !== null) {
+    const tagStr = match[1];
+    for (const tag of tagStr.split(",")) {
+      const trimmed = tag.trim();
+      if (trimmed) tags.add(trimmed);
+    }
+  }
+  return Array.from(tags);
+}
+
+export function parseAnsiblePlaybookOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  options?: { syntaxCheck?: boolean; listTasks?: boolean; listTags?: boolean },
+): AnsiblePlaybookResult {
+  const combined = stdout + "\n" + stderr;
+  const success = exitCode === 0;
+
+  // Syntax check mode
+  if (options?.syntaxCheck) {
+    return {
+      success,
+      exitCode,
+      syntaxOk: success,
+      error: !success ? combined.trim() || undefined : undefined,
+    };
+  }
+
+  // List tasks mode
+  if (options?.listTasks) {
+    const taskList = parseTaskList(combined);
+    return {
+      success,
+      exitCode,
+      taskList: taskList.length > 0 ? taskList : undefined,
+      error: !success ? combined.trim() || undefined : undefined,
+    };
+  }
+
+  // List tags mode
+  if (options?.listTags) {
+    const tagList = parseTagList(combined);
+    return {
+      success,
+      exitCode,
+      tagList: tagList.length > 0 ? tagList : undefined,
+      error: !success ? combined.trim() || undefined : undefined,
+    };
+  }
+
+  // Normal playbook run or check (dry-run)
+  const recap = parseRecap(combined);
+  const plays = parsePlays(combined);
+  const duration = parseDuration(combined);
+
+  return {
+    success,
+    exitCode,
+    plays: plays.length > 0 ? plays : undefined,
+    recap: recap.length > 0 ? recap : undefined,
+    duration,
+    error: !success && recap.length === 0 ? combined.trim() || undefined : undefined,
+  };
+}
+
+// ── ansible-inventory ─────────────────────────────────────────────
+
+/** Parse JSON output from `ansible-inventory --list`. */
+export function parseAnsibleInventoryListOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): AnsibleInventoryResult {
+  const success = exitCode === 0;
+
+  if (!success) {
+    return {
+      success,
+      exitCode,
+      error: (stderr || stdout).trim() || undefined,
+    };
+  }
+
+  try {
+    const data = JSON.parse(stdout) as Record<string, unknown>;
+    const groups: AnsibleInventoryGroup[] = [];
+
+    // Ansible --list output has group names as keys, each with hosts/children/vars
+    // Plus a special "_meta" key with hostvars
+    for (const [groupName, groupData] of Object.entries(data)) {
+      if (groupName === "_meta") continue;
+
+      if (typeof groupData === "object" && groupData !== null) {
+        const gd = groupData as Record<string, unknown>;
+        const hosts = Array.isArray(gd.hosts) ? (gd.hosts as string[]) : [];
+        const children = Array.isArray(gd.children) ? (gd.children as string[]) : undefined;
+        const vars =
+          typeof gd.vars === "object" && gd.vars !== null
+            ? (gd.vars as Record<string, unknown>)
+            : undefined;
+
+        groups.push({
+          name: groupName,
+          hosts,
+          children: children && children.length > 0 ? children : undefined,
+          vars: vars && Object.keys(vars).length > 0 ? vars : undefined,
+        });
+      }
+    }
+
+    return {
+      success,
+      exitCode,
+      groups: groups.length > 0 ? groups : undefined,
+    };
+  } catch {
+    return {
+      success: false,
+      exitCode,
+      error: `Failed to parse inventory JSON: ${stdout.slice(0, 200)}`,
+    };
+  }
+}
+
+/** Parse `--graph` output from ansible-inventory. */
+export function parseAnsibleInventoryGraphOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): AnsibleInventoryResult {
+  const success = exitCode === 0;
+
+  if (!success) {
+    return {
+      success,
+      exitCode,
+      error: (stderr || stdout).trim() || undefined,
+    };
+  }
+
+  return {
+    success,
+    exitCode,
+    graph: stdout.trim() || undefined,
+  };
+}
+
+/** Parse `--host` output from ansible-inventory. */
+export function parseAnsibleInventoryHostOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  hostName: string,
+): AnsibleInventoryResult {
+  const success = exitCode === 0;
+
+  if (!success) {
+    return {
+      success,
+      exitCode,
+      error: (stderr || stdout).trim() || undefined,
+    };
+  }
+
+  try {
+    const vars = JSON.parse(stdout) as Record<string, unknown>;
+    const hostDetail: AnsibleInventoryHost = {
+      name: hostName,
+      vars: Object.keys(vars).length > 0 ? vars : undefined,
+    };
+
+    return {
+      success,
+      exitCode,
+      hostDetail,
+    };
+  } catch {
+    return {
+      success: false,
+      exitCode,
+      error: `Failed to parse host vars JSON: ${stdout.slice(0, 200)}`,
+    };
+  }
+}
+
+// ── ansible-galaxy ────────────────────────────────────────────────
+
+/** Parse `ansible-galaxy collection install` or `role install` output. */
+export function parseAnsibleGalaxyInstallOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  action: "collection-install" | "role-install",
+): AnsibleGalaxyResult {
+  const combined = stdout + "\n" + stderr;
+  const success = exitCode === 0;
+  const installed: AnsibleGalaxyItem[] = [];
+
+  if (action === "collection-install") {
+    // Lines like: "namespace.collection (1.2.3) was installed successfully"
+    // or: "Installing 'namespace.collection:1.2.3' to ..."
+    const installRegex = /Installing '([^':]+)(?::([^']+))?'/g;
+    let match;
+    while ((match = installRegex.exec(combined)) !== null) {
+      installed.push({
+        name: match[1],
+        version: match[2] || undefined,
+      });
+    }
+
+    // Also check for "was installed successfully" pattern
+    const successRegex = /(\S+)\s+\(([^)]+)\)\s+was installed successfully/g;
+    while ((match = successRegex.exec(combined)) !== null) {
+      // Avoid duplicates
+      if (!installed.some((i) => i.name === match![1])) {
+        installed.push({
+          name: match[1],
+          version: match[2] || undefined,
+        });
+      }
+    }
+  } else {
+    // role install: "- extracting rolename to /path..."
+    // or "- rolename (version) was installed successfully"
+    const roleRegex = /-\s+(\S+)\s+\(([^)]+)\)\s+was installed successfully/g;
+    let match;
+    while ((match = roleRegex.exec(combined)) !== null) {
+      installed.push({
+        name: match[1],
+        version: match[2] || undefined,
+      });
+    }
+
+    // Also: "- extracting rolename to ..."
+    const extractRegex = /-\s+extracting\s+(\S+)\s+to/g;
+    while ((match = extractRegex.exec(combined)) !== null) {
+      if (!installed.some((i) => i.name === match![1])) {
+        installed.push({ name: match[1] });
+      }
+    }
+  }
+
+  return {
+    success,
+    exitCode,
+    action,
+    installed: installed.length > 0 ? installed : undefined,
+    error: !success ? combined.trim() || undefined : undefined,
+  };
+}
+
+/** Parse `ansible-galaxy collection list` or `role list` output. */
+export function parseAnsibleGalaxyListOutput(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+  action: "collection-list" | "role-list",
+): AnsibleGalaxyResult {
+  const combined = stdout + "\n" + stderr;
+  const success = exitCode === 0;
+  const items: AnsibleGalaxyItem[] = [];
+
+  if (action === "collection-list") {
+    // Lines like: "namespace.collection 1.2.3"
+    // Skip header lines starting with # or Collection
+    const lines = stdout.split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("Collection")) continue;
+      if (trimmed.startsWith("---")) continue;
+
+      const parts = trimmed.split(/\s+/);
+      if (parts.length >= 2 && parts[0].includes(".")) {
+        items.push({
+          name: parts[0],
+          version: parts[1],
+        });
+      }
+    }
+  } else {
+    // role list: "- rolename, version"
+    const lines = stdout.split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      const m = trimmed.match(/^-\s+(\S+),\s*(.+)/);
+      if (m) {
+        items.push({
+          name: m[1],
+          version: m[2].trim(),
+        });
+      }
+    }
+  }
+
+  return {
+    success,
+    exitCode,
+    action,
+    items: items.length > 0 ? items : undefined,
+    error: !success ? combined.trim() || undefined : undefined,
+  };
+}

--- a/packages/server-infra/src/lib/ansible-runner.ts
+++ b/packages/server-infra/src/lib/ansible-runner.ts
@@ -1,0 +1,16 @@
+import { run, type RunResult } from "@paretools/shared";
+
+/** Runs an `ansible-playbook` command with the given arguments. */
+export async function ansiblePlaybookCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("ansible-playbook", args, { cwd, timeout: 600_000 });
+}
+
+/** Runs an `ansible-inventory` command with the given arguments. */
+export async function ansibleInventoryCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("ansible-inventory", args, { cwd, timeout: 300_000 });
+}
+
+/** Runs an `ansible-galaxy` command with the given arguments. */
+export async function ansibleGalaxyCmd(args: string[], cwd?: string): Promise<RunResult> {
+  return run("ansible-galaxy", args, { cwd, timeout: 600_000 });
+}

--- a/packages/server-infra/src/schemas/ansible.ts
+++ b/packages/server-infra/src/schemas/ansible.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+
+// ── ansible-playbook ──────────────────────────────────────────────
+
+export const AnsibleHostRecapSchema = z.object({
+  host: z.string(),
+  ok: z.number(),
+  changed: z.number(),
+  unreachable: z.number(),
+  failed: z.number(),
+  skipped: z.number(),
+  rescued: z.number(),
+  ignored: z.number(),
+});
+
+export type AnsibleHostRecap = z.infer<typeof AnsibleHostRecapSchema>;
+
+export const AnsiblePlaySchema = z.object({
+  name: z.string(),
+  hosts: z.array(z.string()).optional(),
+  taskCount: z.number().optional(),
+});
+
+export type AnsiblePlay = z.infer<typeof AnsiblePlaySchema>;
+
+export const AnsiblePlaybookResultSchema = z.object({
+  success: z.boolean(),
+  exitCode: z.number(),
+  plays: z.array(AnsiblePlaySchema).optional(),
+  recap: z.array(AnsibleHostRecapSchema).optional(),
+  duration: z.string().optional(),
+  taskList: z.array(z.string()).optional(),
+  tagList: z.array(z.string()).optional(),
+  syntaxOk: z.boolean().optional(),
+  error: z.string().optional(),
+});
+
+export type AnsiblePlaybookResult = z.infer<typeof AnsiblePlaybookResultSchema>;
+
+// ── ansible-inventory ─────────────────────────────────────────────
+
+export const AnsibleInventoryHostSchema = z.object({
+  name: z.string(),
+  vars: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type AnsibleInventoryHost = z.infer<typeof AnsibleInventoryHostSchema>;
+
+export const AnsibleInventoryGroupSchema = z.object({
+  name: z.string(),
+  hosts: z.array(z.string()),
+  children: z.array(z.string()).optional(),
+  vars: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type AnsibleInventoryGroup = z.infer<typeof AnsibleInventoryGroupSchema>;
+
+export const AnsibleInventoryResultSchema = z.object({
+  success: z.boolean(),
+  exitCode: z.number(),
+  groups: z.array(AnsibleInventoryGroupSchema).optional(),
+  graph: z.string().optional(),
+  hostDetail: AnsibleInventoryHostSchema.optional(),
+  error: z.string().optional(),
+});
+
+export type AnsibleInventoryResult = z.infer<typeof AnsibleInventoryResultSchema>;
+
+// ── ansible-galaxy ────────────────────────────────────────────────
+
+export const AnsibleGalaxyItemSchema = z.object({
+  name: z.string(),
+  version: z.string().optional(),
+});
+
+export type AnsibleGalaxyItem = z.infer<typeof AnsibleGalaxyItemSchema>;
+
+export const AnsibleGalaxyResultSchema = z.object({
+  success: z.boolean(),
+  exitCode: z.number(),
+  action: z.enum(["collection-install", "role-install", "collection-list", "role-list"]),
+  installed: z.array(AnsibleGalaxyItemSchema).optional(),
+  items: z.array(AnsibleGalaxyItemSchema).optional(),
+  duration: z.string().optional(),
+  error: z.string().optional(),
+});
+
+export type AnsibleGalaxyResult = z.infer<typeof AnsibleGalaxyResultSchema>;

--- a/packages/server-infra/src/tools/ansible-galaxy.ts
+++ b/packages/server-infra/src/tools/ansible-galaxy.ts
@@ -1,0 +1,149 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  compactDualOutput,
+  assertNoFlagInjection,
+  INPUT_LIMITS,
+  compactInput,
+  projectPathInput,
+} from "@paretools/shared";
+import { z } from "zod";
+import { ansibleGalaxyCmd } from "../lib/ansible-runner.js";
+import {
+  parseAnsibleGalaxyInstallOutput,
+  parseAnsibleGalaxyListOutput,
+} from "../lib/ansible-parsers.js";
+import {
+  formatAnsibleGalaxy,
+  compactAnsibleGalaxyMap,
+  formatAnsibleGalaxyCompact,
+} from "../lib/ansible-formatters.js";
+import { AnsibleGalaxyResultSchema } from "../schemas/ansible.js";
+
+/** Registers the `ansible-galaxy` tool on the given MCP server. */
+export function registerAnsibleGalaxyTool(server: McpServer) {
+  server.registerTool(
+    "ansible-galaxy",
+    {
+      title: "Ansible Galaxy",
+      description:
+        "Installs or lists Ansible collections and roles from Galaxy or a requirements file.",
+      inputSchema: {
+        action: z
+          .enum(["collection-install", "role-install", "collection-list", "role-list"])
+          .describe("Galaxy action to perform"),
+        name: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Collection or role name to install (e.g. community.general)"),
+        requirements: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Path to requirements file (-r)"),
+        force: z
+          .boolean()
+          .optional()
+          .describe("Force overwriting an existing collection or role (--force)"),
+        path: projectPathInput,
+        compact: compactInput,
+      },
+      outputSchema: AnsibleGalaxyResultSchema,
+    },
+    async ({ action, name, requirements, force, path, compact }) => {
+      const cwd = path || process.cwd();
+      if (name) assertNoFlagInjection(name, "name");
+      if (requirements) assertNoFlagInjection(requirements, "requirements");
+
+      const args: string[] = [];
+
+      switch (action) {
+        case "collection-install": {
+          args.push("collection", "install");
+          if (name) args.push(name);
+          if (requirements) args.push("-r", requirements);
+          if (force) args.push("--force");
+          const result = await ansibleGalaxyCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseAnsibleGalaxyInstallOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            "collection-install",
+          );
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatAnsibleGalaxy,
+            compactAnsibleGalaxyMap,
+            formatAnsibleGalaxyCompact,
+            compact === false,
+          );
+        }
+
+        case "role-install": {
+          args.push("role", "install");
+          if (name) args.push(name);
+          if (requirements) args.push("-r", requirements);
+          if (force) args.push("--force");
+          const result = await ansibleGalaxyCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseAnsibleGalaxyInstallOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            "role-install",
+          );
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatAnsibleGalaxy,
+            compactAnsibleGalaxyMap,
+            formatAnsibleGalaxyCompact,
+            compact === false,
+          );
+        }
+
+        case "collection-list": {
+          args.push("collection", "list");
+          const result = await ansibleGalaxyCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseAnsibleGalaxyListOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            "collection-list",
+          );
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatAnsibleGalaxy,
+            compactAnsibleGalaxyMap,
+            formatAnsibleGalaxyCompact,
+            compact === false,
+          );
+        }
+
+        case "role-list": {
+          args.push("role", "list");
+          const result = await ansibleGalaxyCmd(args, cwd);
+          const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+          const data = parseAnsibleGalaxyListOutput(
+            result.stdout,
+            result.stderr,
+            result.exitCode,
+            "role-list",
+          );
+          return compactDualOutput(
+            data,
+            rawOutput,
+            formatAnsibleGalaxy,
+            compactAnsibleGalaxyMap,
+            formatAnsibleGalaxyCompact,
+            compact === false,
+          );
+        }
+      }
+    },
+  );
+}

--- a/packages/server-infra/src/tools/ansible-inventory.ts
+++ b/packages/server-infra/src/tools/ansible-inventory.ts
@@ -1,0 +1,107 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  compactDualOutput,
+  assertNoFlagInjection,
+  INPUT_LIMITS,
+  compactInput,
+  projectPathInput,
+} from "@paretools/shared";
+import { z } from "zod";
+import { ansibleInventoryCmd } from "../lib/ansible-runner.js";
+import {
+  parseAnsibleInventoryListOutput,
+  parseAnsibleInventoryGraphOutput,
+  parseAnsibleInventoryHostOutput,
+} from "../lib/ansible-parsers.js";
+import {
+  formatAnsibleInventory,
+  compactAnsibleInventoryMap,
+  formatAnsibleInventoryCompact,
+} from "../lib/ansible-formatters.js";
+import { AnsibleInventoryResultSchema } from "../schemas/ansible.js";
+
+/** Registers the `ansible-inventory` tool on the given MCP server. */
+export function registerAnsibleInventoryTool(server: McpServer) {
+  server.registerTool(
+    "ansible-inventory",
+    {
+      title: "Ansible Inventory",
+      description:
+        "Queries Ansible inventory for hosts, groups, and variables. Returns structured JSON for --list or tree text for --graph.",
+      inputSchema: {
+        inventory: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Inventory file or host list (-i)"),
+        graph: z
+          .boolean()
+          .optional()
+          .describe("Show inventory graph (--graph) instead of JSON list"),
+        host: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Show variables for a specific host (--host)"),
+        vars: z.boolean().optional().describe("Show host variables in graph mode (--vars)"),
+        path: projectPathInput,
+        compact: compactInput,
+      },
+      outputSchema: AnsibleInventoryResultSchema,
+    },
+    async ({ inventory, graph, host, vars, path, compact }) => {
+      const cwd = path || process.cwd();
+      if (inventory) assertNoFlagInjection(inventory, "inventory");
+      if (host) assertNoFlagInjection(host, "host");
+
+      const args: string[] = [];
+      if (inventory) args.push("-i", inventory);
+
+      let data;
+      if (host) {
+        // --host mode: returns vars for a single host
+        args.push("--host", host);
+        const result = await ansibleInventoryCmd(args, cwd);
+        const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+        data = parseAnsibleInventoryHostOutput(result.stdout, result.stderr, result.exitCode, host);
+        return compactDualOutput(
+          data,
+          rawOutput,
+          formatAnsibleInventory,
+          compactAnsibleInventoryMap,
+          formatAnsibleInventoryCompact,
+          compact === false,
+        );
+      } else if (graph) {
+        // --graph mode: returns tree-formatted text
+        args.push("--graph");
+        if (vars) args.push("--vars");
+        const result = await ansibleInventoryCmd(args, cwd);
+        const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+        data = parseAnsibleInventoryGraphOutput(result.stdout, result.stderr, result.exitCode);
+        return compactDualOutput(
+          data,
+          rawOutput,
+          formatAnsibleInventory,
+          compactAnsibleInventoryMap,
+          formatAnsibleInventoryCompact,
+          compact === false,
+        );
+      } else {
+        // --list mode (default): Ansible outputs JSON natively
+        args.push("--list");
+        const result = await ansibleInventoryCmd(args, cwd);
+        const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+        data = parseAnsibleInventoryListOutput(result.stdout, result.stderr, result.exitCode);
+        return compactDualOutput(
+          data,
+          rawOutput,
+          formatAnsibleInventory,
+          compactAnsibleInventoryMap,
+          formatAnsibleInventoryCompact,
+          compact === false,
+        );
+      }
+    },
+  );
+}

--- a/packages/server-infra/src/tools/ansible-playbook.ts
+++ b/packages/server-infra/src/tools/ansible-playbook.ts
@@ -1,0 +1,136 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  compactDualOutput,
+  assertNoFlagInjection,
+  INPUT_LIMITS,
+  compactInput,
+  projectPathInput,
+} from "@paretools/shared";
+import { z } from "zod";
+import { ansiblePlaybookCmd } from "../lib/ansible-runner.js";
+import { parseAnsiblePlaybookOutput } from "../lib/ansible-parsers.js";
+import {
+  formatAnsiblePlaybook,
+  compactAnsiblePlaybookMap,
+  formatAnsiblePlaybookCompact,
+} from "../lib/ansible-formatters.js";
+import { AnsiblePlaybookResultSchema } from "../schemas/ansible.js";
+
+/** Registers the `ansible-playbook` tool on the given MCP server. */
+export function registerAnsiblePlaybookTool(server: McpServer) {
+  server.registerTool(
+    "ansible-playbook",
+    {
+      title: "Ansible Playbook",
+      description:
+        "Runs an Ansible playbook and returns structured play recap with per-host results.",
+      inputSchema: {
+        playbook: z.string().max(INPUT_LIMITS.PATH_MAX).describe("Path to playbook file"),
+        inventory: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Inventory file or host list (-i)"),
+        limit: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Limit to specific hosts or groups (--limit)"),
+        tags: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Only run plays and tasks tagged with these values (--tags)"),
+        skipTags: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Skip plays and tasks tagged with these values (--skip-tags)"),
+        extraVars: z
+          .string()
+          .max(INPUT_LIMITS.STRING_MAX)
+          .optional()
+          .describe("Extra variables as key=value or JSON string (-e)"),
+        check: z.boolean().optional().describe("Run in check mode / dry-run (-C)"),
+        syntaxCheck: z
+          .boolean()
+          .optional()
+          .describe("Perform a syntax check on the playbook (--syntax-check)"),
+        listTasks: z
+          .boolean()
+          .optional()
+          .describe("List all tasks that would be executed (--list-tasks)"),
+        listTags: z.boolean().optional().describe("List all available tags (--list-tags)"),
+        forks: z
+          .number()
+          .int()
+          .min(1)
+          .max(1000)
+          .optional()
+          .describe("Number of parallel processes (-f)"),
+        verbose: z
+          .number()
+          .int()
+          .min(0)
+          .max(4)
+          .optional()
+          .describe("Verbosity level 0-4 (-v through -vvvv)"),
+        path: projectPathInput,
+        compact: compactInput,
+      },
+      outputSchema: AnsiblePlaybookResultSchema,
+    },
+    async ({
+      playbook,
+      inventory,
+      limit,
+      tags,
+      skipTags,
+      extraVars,
+      check,
+      syntaxCheck,
+      listTasks,
+      listTags,
+      forks,
+      verbose,
+      path,
+      compact,
+    }) => {
+      const cwd = path || process.cwd();
+      assertNoFlagInjection(playbook, "playbook");
+      if (inventory) assertNoFlagInjection(inventory, "inventory");
+      if (limit) assertNoFlagInjection(limit, "limit");
+
+      const args: string[] = [playbook];
+
+      if (inventory) args.push("-i", inventory);
+      if (limit) args.push("--limit", limit);
+      if (tags) args.push("--tags", tags);
+      if (skipTags) args.push("--skip-tags", skipTags);
+      if (extraVars) args.push("-e", extraVars);
+      if (check) args.push("-C");
+      if (syntaxCheck) args.push("--syntax-check");
+      if (listTasks) args.push("--list-tasks");
+      if (listTags) args.push("--list-tags");
+      if (forks) args.push("-f", String(forks));
+      if (verbose && verbose > 0) args.push(`-${"v".repeat(verbose)}`);
+
+      const result = await ansiblePlaybookCmd(args, cwd);
+      const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+      const data = parseAnsiblePlaybookOutput(result.stdout, result.stderr, result.exitCode, {
+        syntaxCheck,
+        listTasks,
+        listTags,
+      });
+
+      return compactDualOutput(
+        data,
+        rawOutput,
+        formatAnsiblePlaybook,
+        compactAnsiblePlaybookMap,
+        formatAnsiblePlaybookCompact,
+        compact === false,
+      );
+    },
+  );
+}

--- a/packages/server-infra/src/tools/index.ts
+++ b/packages/server-infra/src/tools/index.ts
@@ -9,6 +9,9 @@ import { registerStateListTool } from "./state-list.js";
 import { registerWorkspaceTool } from "./workspace.js";
 import { registerShowTool } from "./show.js";
 import { registerVagrantTool } from "./vagrant.js";
+import { registerAnsiblePlaybookTool } from "./ansible-playbook.js";
+import { registerAnsibleInventoryTool } from "./ansible-inventory.js";
+import { registerAnsibleGalaxyTool } from "./ansible-galaxy.js";
 
 /** Registers all Infra tools on the given MCP server, filtered by policy. */
 export function registerAllTools(server: McpServer) {
@@ -22,4 +25,7 @@ export function registerAllTools(server: McpServer) {
   if (s("workspace")) registerWorkspaceTool(server);
   if (s("show")) registerShowTool(server);
   if (s("vagrant")) registerVagrantTool(server);
+  if (s("ansible-playbook")) registerAnsiblePlaybookTool(server);
+  if (s("ansible-inventory")) registerAnsibleInventoryTool(server);
+  if (s("ansible-galaxy")) registerAnsibleGalaxyTool(server);
 }


### PR DESCRIPTION
## Summary
- Adds 3 new Ansible tools to the existing `@paretools/infra` package: `ansible-playbook`, `ansible-inventory`, and `ansible-galaxy`
- `ansible-playbook`: Runs playbooks with structured play recap (per-host ok/changed/unreachable/failed/skipped/rescued/ignored), plus `--syntax-check`, `--list-tasks`, and `--list-tags` modes
- `ansible-inventory`: Queries inventory via `--list` (native JSON parsing), `--graph` (tree text), or `--host` (single host vars)
- `ansible-galaxy`: Installs and lists collections and roles with structured output
- Includes full parser, formatter (full + compact), Zod output schema, and security test coverage (63 new tests)

Closes #304

## Test plan
- [x] `pnpm --filter @paretools/infra build` passes
- [x] `pnpm --filter @paretools/infra test` passes (164 total, 63 new Ansible tests)
- [ ] CI matrix (ubuntu/windows/macos x node 20/22) passes
- [ ] Verify `ansible-playbook` parser handles real Ansible output with multi-play, multi-host recaps
- [ ] Verify `ansible-inventory --list` correctly parses native JSON output from Ansible
- [ ] Verify `ansible-galaxy` install/list parsers handle common Galaxy output formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)