### PR TITLE
fix(git): return patch content when diff full=true

### DIFF
--- a/packages/server-git/src/tools/diff.ts
+++ b/packages/server-git/src/tools/diff.ts
@@ -179,7 +179,7 @@ export function registerDiffTool(server: McpServer) {
           formatDiff,
           compactDiffMap,
           formatDiffCompact,
-          compact === false,
+          compact === false || full,
         );
       }
 
@@ -254,7 +254,7 @@ export function registerDiffTool(server: McpServer) {
         formatDiff,
         compactDiffMap,
         formatDiffCompact,
-        compact === false,
+        compact === false || full,
       );
     },
   );


### PR DESCRIPTION
## Summary
- **Bug**: When calling `diff` with `full=true`, the structured response could lose patch/chunk content due to auto-compaction in `compactDualOutput`.
- **Fix**: Force full schema mode whenever `full=true`, ensuring patch content is always preserved.
- Affects both the regular `full=true` path and the `atomicFull=true` path.

Fixes #608

## Test plan
- [x] Added test: `#608 diff full=true returns patch chunks in structuredContent`
- [x] Added test: `#608 diff full=true with atomicFull returns patch chunks`
- [x] All 313 existing tests in the git package pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)