### PR TITLE
fix(init): harden npx execution and config writer safety

### DIFF
--- a/.changeset/init-security-hardening.md
+++ b/.changeset/init-security-hardening.md
@@ -1,0 +1,5 @@
+---
+"@paretools/init": patch
+---
+
+Add package name allowlist for doctor health checks and backup creation for config file modifications

--- a/packages/init/__tests__/doctor/health-check.test.ts
+++ b/packages/init/__tests__/doctor/health-check.test.ts
@@ -1,6 +1,45 @@
 import { describe, it, expect } from "vitest";
 import { formatReport } from "../../src/lib/doctor/report.js";
+import { validateServerPackage, PARETOOLS_PACKAGES } from "../../src/lib/doctor/health-check.js";
 import type { HealthResult } from "../../src/lib/doctor/health-check.js";
+
+describe("validateServerPackage", () => {
+  it("accepts known @paretools packages", () => {
+    const result = validateServerPackage(["-y", "@paretools/git"]);
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts all registered @paretools packages", () => {
+    for (const pkg of PARETOOLS_PACKAGES) {
+      const result = validateServerPackage(["-y", pkg]);
+      expect(result.valid).toBe(true);
+    }
+  });
+
+  it("rejects unknown @paretools packages with warning", () => {
+    const result = validateServerPackage(["-y", "@paretools/malicious-typo"]);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.warning).toContain("@paretools/malicious-typo");
+      expect(result.warning).toContain("typosquatting");
+    }
+  });
+
+  it("allows non-paretools packages without warning", () => {
+    const result = validateServerPackage(["-y", "some-other-server"]);
+    expect(result.valid).toBe(true);
+  });
+
+  it("allows empty args", () => {
+    const result = validateServerPackage([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it("detects @paretools package anywhere in args", () => {
+    const result = validateServerPackage(["--some-flag", "value", "@paretools/fake-pkg"]);
+    expect(result.valid).toBe(false);
+  });
+});
 
 describe("formatReport", () => {
   it("formats passing results", () => {
@@ -35,5 +74,21 @@ describe("formatReport", () => {
 
     const report = formatReport(results);
     expect(report).toContain("1 passed, 1 failed, 2 total");
+  });
+
+  it("includes warning in report when present", () => {
+    const results: HealthResult[] = [
+      {
+        serverId: "pare-fake",
+        status: "pass",
+        toolCount: 5,
+        latencyMs: 500,
+        warning: 'Unknown @paretools package "@paretools/fake"',
+      },
+    ];
+
+    const report = formatReport(results);
+    expect(report).toContain("Warning:");
+    expect(report).toContain("@paretools/fake");
   });
 });

--- a/packages/init/src/index.ts
+++ b/packages/init/src/index.ts
@@ -72,6 +72,9 @@ async function main(): Promise<void> {
     console.log(`\n[dry-run] Would write to: ${result.configPath}\n`);
     console.log(result.output);
   } else {
+    if (result.backupPath) {
+      console.log(`\nBacked up existing config to: ${result.backupPath}`);
+    }
     console.log(`\nWrote ${result.serverCount} Pare servers to: ${result.configPath}`);
     console.log(`\nServers added: ${servers.map((s) => s.id).join(", ")}`);
     console.log(`\nRestart your ${client.name} session to activate the new servers.`);

--- a/packages/init/src/lib/doctor/health-check.ts
+++ b/packages/init/src/lib/doctor/health-check.ts
@@ -7,6 +7,53 @@ export interface HealthResult {
   toolCount?: number;
   latencyMs?: number;
   error?: string;
+  warning?: string;
+}
+
+/**
+ * Known-good @paretools/* package names.
+ * Used to validate npx invocations and guard against typosquatting.
+ */
+export const PARETOOLS_PACKAGES = new Set([
+  "@paretools/git",
+  "@paretools/github",
+  "@paretools/npm",
+  "@paretools/build",
+  "@paretools/lint",
+  "@paretools/test",
+  "@paretools/search",
+  "@paretools/http",
+  "@paretools/make",
+  "@paretools/python",
+  "@paretools/cargo",
+  "@paretools/go",
+  "@paretools/docker",
+  "@paretools/k8s",
+  "@paretools/security",
+  "@paretools/process",
+  "@paretools/init",
+]);
+
+/**
+ * Validate whether a server's args reference a known @paretools/* package.
+ * Returns `{ valid: true }` for known packages, or `{ valid: false, warning }` for unknown ones.
+ */
+export function validateServerPackage(
+  args: string[],
+): { valid: true } | { valid: false; warning: string } {
+  // Look for a @paretools/* package in the args (npx -y @paretools/git)
+  const pkg = args.find((a) => a.startsWith("@paretools/"));
+  if (!pkg) {
+    // Not a paretools package — allow but don't warn (user's own server)
+    return { valid: true };
+  }
+  if (PARETOOLS_PACKAGES.has(pkg)) {
+    return { valid: true };
+  }
+  return {
+    valid: false,
+    warning: `Unknown @paretools package "${pkg}" — possible typosquatting risk. Known packages: ${[...PARETOOLS_PACKAGES].join(", ")}`,
+  };
 }
 
 const SERVER_TIMEOUT = 15_000;

--- a/packages/init/src/lib/doctor/report.ts
+++ b/packages/init/src/lib/doctor/report.ts
@@ -18,6 +18,9 @@ export function formatReport(results: HealthResult[]): string {
     const detail = r.error ? ` — ${r.error}` : "";
 
     lines.push(`  [${icon}] ${r.serverId}${info ? ` (${info})` : ""}${detail}`);
+    if (r.warning) {
+      lines.push(`         Warning: ${r.warning}`);
+    }
   }
 
   lines.push("─".repeat(60));


### PR DESCRIPTION
## Summary

Fixes #612

- **Package name allowlist for doctor health checks**: `validateServerPackage()` validates `@paretools/*` package names in `npx` args against `PARETOOLS_PACKAGES` allowlist before spawning. Unknown `@paretools/*` packages trigger a typosquatting warning in the doctor report. Non-paretools servers (user's own) pass through without warning.
- **`.bak` backup creation for config writers**: `mergeConfig()` creates a `.bak` backup of existing config files before any modification, protecting against data loss from malformed file merges. Backup path is tracked in `MergeResult` and printed in CLI output.
- **Tests**: 12 new tests covering allowlist validation (known/unknown/non-paretools/empty args), report warning display, and backup creation across JSON/TOML/YAML config formats.

## Test plan

- [x] `pnpm --filter @paretools/init test` passes (122 tests, 14 files)
- [x] `tsc --noEmit` passes with no new errors
- [x] `prettier --check` passes on all modified files
- [x] Includes changeset for `@paretools/init` patch bump

Generated with [Claude Code](https://claude.com/claude-code)