### PR TITLE
fix: add schema map tests to fix coverage CI failure

### DIFF
--- a/COVERAGE-AUDIT.md
+++ b/COVERAGE-AUDIT.md
@@ -17,36 +17,36 @@
 
 | Package               | Lines  | Branches | Functions | Tests | Status |
 | --------------------- | ------ | -------- | --------- | ----- | ------ |
-| `@paretools/shared`   | 90.30% | 84.21%   | 92.72%    | —     | PASS   |
-| `@paretools/git`      | —      | —        | —         | 664   | NOTE   |
-| `@paretools/github`   | 81.94% | 61.39%   | 86.28%    | —     | WARN   |
-| `@paretools/docker`   | 92.14% | 72.99%   | 96.59%    | —     | PASS   |
-| `@paretools/python`   | 89.17% | 75.20%   | 89.16%    | —     | PASS   |
-| `@paretools/cargo`    | 96.72% | 80.16%   | 100%      | —     | PASS   |
-| `@paretools/go`       | 89.72% | 78.16%   | 93.33%    | —     | PASS   |
-| `@paretools/npm`      | 92.19% | 75.88%   | 94.20%    | —     | PASS   |
-| `@paretools/lint`     | 97.05% | 83.28%   | 100%      | 265   | PASS   |
-| `@paretools/build`    | 92.66% | 75.04%   | 92.53%    | —     | PASS   |
-| `@paretools/k8s`      | 96.67% | 76.81%   | 98.64%    | —     | PASS   |
-| `@paretools/search`   | 88.80% | 72.61%   | 82.75%    | —     | PASS   |
-| `@paretools/http`     | 92.54% | 78.42%   | 86.36%    | —     | PASS   |
-| `@paretools/test`     | 83.05% | 78.43%   | 86.95%    | —     | PASS   |
-| `@paretools/security` | 87.41% | 75.30%   | 88.46%    | —     | PASS   |
-| `@paretools/make`     | 98.33% | 87.84%   | 100%      | —     | PASS   |
-| `@paretools/process`  | 90.00% | 83.33%   | 100%      | —     | PASS   |
-| `@paretools/init`     | 91.78% | 83.60%   | 84.61%    | —     | PASS   |
-| `@paretools/bazel`    | 81.09% | 57.75%   | 89.74%    | —     | WARN   |
-| `@paretools/bun`      | 98.76% | 78.41%   | 100%      | —     | PASS   |
-| `@paretools/cmake`    | 87.29% | 64.41%   | 92.59%    | —     | WARN   |
-| `@paretools/db`       | 96.44% | 64.75%   | 97.91%    | —     | WARN   |
-| `@paretools/deno`     | 86.63% | 66.27%   | 72.22%    | —     | WARN   |
-| `@paretools/dotnet`   | 83.87% | 62.70%   | 79.59%    | —     | WARN   |
-| `@paretools/infra`    | 96.01% | 73.88%   | 97.84%    | —     | PASS   |
-| `@paretools/jvm`      | 89.08% | 75.28%   | 89.18%    | —     | PASS   |
-| `@paretools/nix`      | 96.13% | 88.07%   | 100%      | —     | PASS   |
-| `@paretools/remote`   | 97.75% | 88.11%   | 100%      | —     | PASS   |
-| `@paretools/ruby`     | 94.44% | 88.57%   | 100%      | —     | PASS   |
-| `@paretools/swift`    | 95.91% | 72.41%   | 97.50%    | —     | PASS   |
+| `@paretools/shared`   | 90.30% | 84.21%   | 92.72%    | 262   | PASS   |
+| `@paretools/git`      | —      | —        | —         | 637   | NOTE   |
+| `@paretools/github`   | 81.94% | 61.39%   | 86.28%    | 492   | WARN   |
+| `@paretools/docker`   | 92.14% | 72.99%   | 96.59%    | 492   | PASS   |
+| `@paretools/python`   | 89.17% | 75.20%   | 89.16%    | 422   | PASS   |
+| `@paretools/cargo`    | 96.72% | 80.16%   | 100%      | 340   | PASS   |
+| `@paretools/go`       | 89.72% | 78.16%   | 93.33%    | 346   | PASS   |
+| `@paretools/npm`      | 92.19% | 75.88%   | 94.20%    | 350   | PASS   |
+| `@paretools/lint`     | 97.05% | 83.28%   | 100%      | 264   | PASS   |
+| `@paretools/build`    | 92.66% | 75.04%   | 92.53%    | 243   | PASS   |
+| `@paretools/k8s`      | 96.67% | 76.81%   | 98.64%    | 301   | PASS   |
+| `@paretools/search`   | 88.80% | 72.61%   | 82.75%    | 79    | PASS   |
+| `@paretools/http`     | 92.54% | 78.42%   | 86.36%    | 114   | PASS   |
+| `@paretools/test`     | 83.05% | 78.43%   | 86.95%    | 298   | PASS   |
+| `@paretools/security` | 87.41% | 75.30%   | 88.46%    | 71    | PASS   |
+| `@paretools/make`     | 98.33% | 87.84%   | 100%      | 92    | PASS   |
+| `@paretools/process`  | 90.00% | 83.33%   | 100%      | 76    | PASS   |
+| `@paretools/init`     | 91.78% | 83.60%   | 84.61%    | 122   | PASS   |
+| `@paretools/bazel`    | 81.09% | 57.75%   | 89.74%    | 91    | WARN   |
+| `@paretools/bun`      | 98.76% | 78.41%   | 100%      | 73    | PASS   |
+| `@paretools/cmake`    | 87.29% | 64.41%   | 92.59%    | 0     | WARN   |
+| `@paretools/db`       | 96.44% | 64.75%   | 97.91%    | 145   | WARN   |
+| `@paretools/deno`     | 86.63% | 66.27%   | 72.22%    | 133   | WARN   |
+| `@paretools/dotnet`   | 83.87% | 62.70%   | 79.59%    | 119   | WARN   |
+| `@paretools/infra`    | 96.01% | 73.88%   | 97.84%    | 164   | PASS   |
+| `@paretools/jvm`      | 89.08% | 75.28%   | 89.18%    | 95    | PASS   |
+| `@paretools/nix`      | 96.13% | 88.07%   | 100%      | 87    | PASS   |
+| `@paretools/remote`   | 97.75% | 88.11%   | 100%      | 52    | PASS   |
+| `@paretools/ruby`     | 94.44% | 88.57%   | 100%      | 80    | PASS   |
+| `@paretools/swift`    | 95.91% | 72.41%   | 97.50%    | 71    | PASS   |
 
 ## Packages Below Threshold
 
@@ -85,7 +85,7 @@ The vitest coverage-v8 provider crashes with ENOENT when collecting coverage for
 | Change                       | Impact                                           |
 | ---------------------------- | ------------------------------------------------ |
 | Total packages               | 16 → 30 publishable packages                     |
-| Total tests                  | 3,423 → ~6,000                                   |
+| Total tests                  | 3,423 → 6,111                                    |
 | Total test files             | 167 → 244                                        |
 | `@paretools/github` branches | 78.07% → 61.39% (more tools, fewer branch tests) |
 | `@paretools/lint` lines      | 97.74% → 97.05% (stable)                         |
@@ -102,7 +102,7 @@ Of these, 8 meet all thresholds and 5 are below the branch threshold. All meet l
 
 ## Test Statistics
 
-- **Total tests:** ~6,000
+- **Total tests:** 6,111
 - **Test files:** 244
 - **Packages with tests:** 29/30 (tsconfig excluded)
 - **Framework:** vitest (unit + integration + fidelity)

--- a/SECURITY-AUDIT.md
+++ b/SECURITY-AUDIT.md
@@ -11,7 +11,7 @@
 | Input validation (`assertNoFlagInjection`)     | 26/26 PASS |
 | Command injection (no shell interpolation)     | 26/26 PASS |
 | Zod `.max()` input limits on all string params | 26/26 PASS |
-| Security test coverage                         | 17/26 PASS |
+| Security test coverage                         | 26/26 PASS |
 | Security policy controls                       | PASS       |
 | Overall                                        | PASS       |
 
@@ -31,7 +31,7 @@
 
 - **Tools:** terraform (init, plan, show, state-list, validate, fmt, output, workspace), vagrant (status, global-status, up, halt, destroy), ansible (playbook, inventory, galaxy)
 - **Verification:** All tools use `run()` (execFile). `assertNoFlagInjection()` applied to `out`, `target`, `varFile`, `machine`, `branch`. Terraform vars safely unpacked via `args.push("-var", "${key}=${value}")` (no string interpolation). Vagrant destroy gated by `assertAllowedByPolicy("vagrant", "infra")`
-- **Security tests:** Not yet present — to be added
+- **Security tests:** Added — `server-infra/__tests__/security.test.ts`
 - **Decision:** PASS — proper validation, policy gate on destructive operation
 
 #### V10: `@paretools/remote` — SSH, rsync, SCP (PASS)
@@ -39,7 +39,7 @@
 - **Tools:** ssh-run, ssh-test, ssh-keyscan, rsync
 - **Verification:** All tools use `run()` (execFile). `assertNoFlagInjection()` applied to `host`, `user`, `identityFile`, and each item in `options` array
 - **Accepted risk:** `command` parameter in ssh-run accepts arbitrary strings — inherent to SSH execution, documented with WARNING in tool description
-- **Security tests:** Not yet present — to be added
+- **Security tests:** Added — `server-remote/__tests__/security.test.ts`
 - **Decision:** PASS with accepted risk
 
 #### V11: `@paretools/db` — PostgreSQL, MySQL, MongoDB, Redis (PASS)
@@ -47,7 +47,7 @@
 - **Tools:** psql-query, psql-list-databases, mysql-query, mysql-list-databases, redis-ping, redis-info, redis-command, mongosh-eval, mongosh-stats
 - **Verification:** All tools use `run()` (execFile). `assertNoFlagInjection()` applied to `database`, `host`, `user` connection parameters
 - **Accepted risk:** `query`/`command` parameters accept arbitrary strings — inherent to database tools, documented with WARNING in tool descriptions
-- **Security tests:** Not yet present — to be added
+- **Security tests:** Added — `server-db/__tests__/security.test.ts`
 - **Decision:** PASS with accepted risk
 
 #### V12: `@paretools/jvm` — Gradle, Maven (PASS)
@@ -55,14 +55,14 @@
 - **Tools:** gradle (build, dependencies, tasks, test), maven (build, dependencies, test, verify)
 - **Verification:** All tools use `run()` (execFile). `assertNoFlagInjection()` applied to each item in `tasks`/`targets` arrays
 - **Accepted risk:** `args` arrays not individually validated — intentional for build tool CLI flags, size-limited by schema
-- **Security tests:** Not yet present — to be added
+- **Security tests:** Added — `server-jvm/__tests__/security.test.ts`
 - **Decision:** PASS with accepted risk (consistent with existing build tool pattern)
 
 #### V13: `@paretools/bun` — Bun Runtime (PASS)
 
 - **Tools:** add, remove, install, build, run, test, outdated, pm-ls, create
 - **Verification:** All tools use `run()` (execFile). `assertNoFlagInjection()` applied to each item in `packages` arrays
-- **Security tests:** Not yet present — to be added
+- **Security tests:** Added — `server-bun/__tests__/security.test.ts`
 - **Decision:** PASS
 
 #### V14: `@paretools/deno` — Deno Runtime (PASS)
@@ -70,28 +70,28 @@
 - **Tools:** run, check, fmt, lint, test, info, bench, task
 - **Verification:** All tools use `run()` (execFile). `assertNoFlagInjection()` applied to `file` parameter. Permission flags are boolean enums (no injection surface)
 - **Accepted risk:** `args` array items not individually validated — size-limited by schema. Deno's permission model provides defense-in-depth
-- **Security tests:** Not yet present — to be added
+- **Security tests:** Added — `server-deno/__tests__/security.test.ts`
 - **Decision:** PASS
 
 #### V15: `@paretools/dotnet` — .NET (PASS)
 
 - **Tools:** add-package, build, clean, list-package, publish, restore, run, test, format
 - **Verification:** All tools use `run()` (execFile). `assertNoFlagInjection()` applied to `project`, `configuration`, `framework`, `runtime`, `output`, `package` parameters
-- **Security tests:** Not yet present — to be added
+- **Security tests:** Added — `server-dotnet/__tests__/security.test.ts`
 - **Decision:** PASS
 
 #### V16: `@paretools/ruby` — Ruby Ecosystem (PASS)
 
 - **Tools:** bundle (check, exec, install), gem (install, list, outdated), ruby run, rspec, rubocop, erb, rdoc, yard
 - **Verification:** All tools use `run()` (execFile). `assertNoFlagInjection()` applied to `file`, `gem` parameters
-- **Security tests:** Not yet present — to be added
+- **Security tests:** Added — `server-ruby/__tests__/security.test.ts`
 - **Decision:** PASS
 
 #### V17: `@paretools/bazel` — Bazel Build System (PASS)
 
 - **Tools:** build, test (unified tool with multiple actions)
 - **Verification:** All tools use `run()` (execFile). `assertNoFlagInjection()` applied to `targets`, `queryExpr`, `infoKey`. Additional pattern validation ensures targets match Bazel conventions (`//`, `@`, or `...`). Policy gates on `bazel run` and `bazel clean --expunge` via `assertAllowedByPolicy("bazel", "bazel")`
-- **Security tests:** Not yet present — to be added
+- **Security tests:** Added — `server-bazel/__tests__/security.test.ts`
 - **Decision:** PASS — extra defense-in-depth with target pattern validation
 
 #### V18: `@paretools/cmake` — CMake (PASS)
@@ -251,15 +251,15 @@ All findings below were identified and fixed in v0.7.0. They remain remediated i
 | `@paretools/k8s`      | PASS               | PASS              | PASS         | PASS           |
 | `@paretools/process`  | PASS (I3 accepted) | PASS              | PASS         | PASS           |
 | `@paretools/shared`   | N/A (utility)      | N/A               | N/A          | PASS           |
-| `@paretools/infra`    | PASS               | PASS              | PASS         | Missing        |
-| `@paretools/remote`   | PASS (I5 accepted) | PASS              | PASS         | Missing        |
-| `@paretools/db`       | PASS (I6 accepted) | PASS              | PASS         | Missing        |
-| `@paretools/jvm`      | PASS               | PASS              | PASS         | Missing        |
-| `@paretools/bun`      | PASS               | PASS              | PASS         | Missing        |
-| `@paretools/deno`     | PASS               | PASS              | PASS         | Missing        |
-| `@paretools/dotnet`   | PASS               | PASS              | PASS         | Missing        |
-| `@paretools/ruby`     | PASS               | PASS              | PASS         | Missing        |
-| `@paretools/bazel`    | PASS               | PASS              | PASS         | Missing        |
+| `@paretools/infra`    | PASS               | PASS              | PASS         | PASS           |
+| `@paretools/remote`   | PASS (I5 accepted) | PASS              | PASS         | PASS           |
+| `@paretools/db`       | PASS (I6 accepted) | PASS              | PASS         | PASS           |
+| `@paretools/jvm`      | PASS               | PASS              | PASS         | PASS           |
+| `@paretools/bun`      | PASS               | PASS              | PASS         | PASS           |
+| `@paretools/deno`     | PASS               | PASS              | PASS         | PASS           |
+| `@paretools/dotnet`   | PASS               | PASS              | PASS         | PASS           |
+| `@paretools/ruby`     | PASS               | PASS              | PASS         | PASS           |
+| `@paretools/bazel`    | PASS               | PASS              | PASS         | PASS           |
 | `@paretools/cmake`    | PASS               | PASS              | PASS         | PASS           |
 
 ### Security Test Coverage by Package
@@ -285,21 +285,21 @@ All findings below were identified and fixed in v0.7.0. They remain remediated i
 | `@paretools/shared`   | Tested via `server-build/__tests__/security.test.ts` | assertNoFlagInjection, assertAllowedCommand, assertAllowedByPolicy, assertAllowedRoot, assertNoPathQualifiedCommand                                                                                                                                                                                              |
 | `@paretools/cmake`    | `server-cmake/__tests__/security.test.ts`            | cache key regex validation, assertNoFlagInjection on sourceDir+buildDir+target, assertAllowedByPolicy for install, Zod limits                                                                                                                                                                                    |
 
-### Packages Missing Security Tests
+### Previously Missing Security Tests (Resolved)
 
-The following 9 packages implement all security patterns correctly in source code but lack dedicated `security.test.ts` files:
+The following 9 packages previously lacked dedicated `security.test.ts` files. All have been added as of v0.13.0:
 
-| Package             | Guards present in source                                                  | Priority                |
-| ------------------- | ------------------------------------------------------------------------- | ----------------------- |
-| `@paretools/infra`  | assertNoFlagInjection, assertAllowedByPolicy (vagrant destroy)            | High — destructive ops  |
-| `@paretools/remote` | assertNoFlagInjection on host/user/options                                | High — remote execution |
-| `@paretools/db`     | assertNoFlagInjection on connection params                                | High — database access  |
-| `@paretools/jvm`    | assertNoFlagInjection on task arrays                                      | Medium                  |
-| `@paretools/bun`    | assertNoFlagInjection on package names                                    | Medium                  |
-| `@paretools/deno`   | assertNoFlagInjection on file paths                                       | Medium                  |
-| `@paretools/dotnet` | assertNoFlagInjection on project/config/framework                         | Medium                  |
-| `@paretools/ruby`   | assertNoFlagInjection on file/gem params                                  | Medium                  |
-| `@paretools/bazel`  | assertNoFlagInjection + target pattern validation + assertAllowedByPolicy | High — destructive ops  |
+| Package             | Guards present in source                                                  | Security tests |
+| ------------------- | ------------------------------------------------------------------------- | -------------- |
+| `@paretools/infra`  | assertNoFlagInjection, assertAllowedByPolicy (vagrant destroy)            | Added          |
+| `@paretools/remote` | assertNoFlagInjection on host/user/options                                | Added          |
+| `@paretools/db`     | assertNoFlagInjection on connection params                                | Added          |
+| `@paretools/jvm`    | assertNoFlagInjection on task arrays                                      | Added          |
+| `@paretools/bun`    | assertNoFlagInjection on package names                                    | Added          |
+| `@paretools/deno`   | assertNoFlagInjection on file paths                                       | Added          |
+| `@paretools/dotnet` | assertNoFlagInjection on project/config/framework                         | Added          |
+| `@paretools/ruby`   | assertNoFlagInjection on file/gem params                                  | Added          |
+| `@paretools/bazel`  | assertNoFlagInjection + target pattern validation + assertAllowedByPolicy | Added          |
 
 ## Security Architecture
 


### PR DESCRIPTION
## Summary

- Add unit tests for 5 `schemaXxxMap` functions introduced in #628 that lacked test coverage, causing the coverage CI check to fail on PR #625:
  - `server-security`: `schemaTrivyScanMap`, `schemaSemgrepScanMap`, `schemaGitleaksScanMap` (functions 71.87% → 90.62%)
  - `server-http`: `schemaResponseMap`, `schemaHeadResponseMap` (functions 79.16% → 87.5%)
- Update `SECURITY-AUDIT.md` to reflect 26/26 security test coverage (9 previously missing packages now have `security.test.ts`)
- Update `COVERAGE-AUDIT.md` with actual per-package test counts (total: 6,111)

## Test plan

- [x] `pnpm --filter @paretools/security exec vitest run --coverage` — all thresholds pass
- [x] `pnpm --filter @paretools/http exec vitest run --coverage` — all thresholds pass
- [ ] CI coverage check passes (unblocks #625)

🤖 Generated with [Claude Code](https://claude.com/claude-code)