### PR TITLE
fix: disable shell mode for helm on Windows to prevent CI timeout

### DIFF
--- a/.changeset/fix-helm-windows-timeout.md
+++ b/.changeset/fix-helm-windows-timeout.md
@@ -1,0 +1,5 @@
+---
+"@paretools/k8s": patch
+---
+
+Fix helm integration test timeout on Windows by disabling shell mode

--- a/packages/server-k8s/src/tools/helm.ts
+++ b/packages/server-k8s/src/tools/helm.ts
@@ -257,7 +257,7 @@ export function registerHelmTool(server: McpServer) {
           }
           if (filter) args.push("--filter", filter);
 
-          const result = await run("helm", args, { timeout: 180_000 });
+          const result = await run("helm", args, { timeout: 180_000, shell: false });
           const data = parseHelmListOutput(
             result.stdout,
             result.stderr,
@@ -285,7 +285,7 @@ export function registerHelmTool(server: McpServer) {
           if (showResources) args.push("--show-resources");
           if (statusRevision !== undefined) args.push("--revision", String(statusRevision));
 
-          const result = await run("helm", args, { timeout: 180_000 });
+          const result = await run("helm", args, { timeout: 180_000, shell: false });
           const data = parseHelmStatusOutput(
             result.stdout,
             result.stderr,
@@ -332,7 +332,7 @@ export function registerHelmTool(server: McpServer) {
           if (noHooks) args.push("--no-hooks");
           if (skipCrds) args.push("--skip-crds");
 
-          const result = await run("helm", args, { timeout: 180_000 });
+          const result = await run("helm", args, { timeout: 180_000, shell: false });
           const data = parseHelmInstallOutput(
             result.stdout,
             result.stderr,
@@ -381,7 +381,7 @@ export function registerHelmTool(server: McpServer) {
           if (noHooks) args.push("--no-hooks");
           if (skipCrds) args.push("--skip-crds");
 
-          const result = await run("helm", args, { timeout: 180_000 });
+          const result = await run("helm", args, { timeout: 180_000, shell: false });
           const data = parseHelmUpgradeOutput(
             result.stdout,
             result.stderr,
@@ -412,7 +412,7 @@ export function registerHelmTool(server: McpServer) {
           if (noHooks) args.push("--no-hooks");
           if (description) args.push("--description", description);
 
-          const result = await run("helm", args, { timeout: 180_000 });
+          const result = await run("helm", args, { timeout: 180_000, shell: false });
           const data = parseHelmUninstallOutput(
             result.stdout,
             result.stderr,
@@ -443,7 +443,7 @@ export function registerHelmTool(server: McpServer) {
           if (waitTimeout) args.push("--timeout", waitTimeout);
           if (noHooks) args.push("--no-hooks");
 
-          const result = await run("helm", args, { timeout: 180_000 });
+          const result = await run("helm", args, { timeout: 180_000, shell: false });
           const data = parseHelmRollbackOutput(
             result.stdout,
             result.stderr,
@@ -471,7 +471,7 @@ export function registerHelmTool(server: McpServer) {
           const args = ["history", release, "-o", "json"];
           if (namespace) args.push("-n", namespace);
 
-          const result = await run("helm", args, { timeout: 180_000 });
+          const result = await run("helm", args, { timeout: 180_000, shell: false });
           const data = parseHelmHistoryOutput(
             result.stdout,
             result.stderr,
@@ -512,7 +512,7 @@ export function registerHelmTool(server: McpServer) {
           if (noHooks) args.push("--no-hooks");
           if (skipCrds) args.push("--skip-crds");
 
-          const result = await run("helm", args, { timeout: 180_000 });
+          const result = await run("helm", args, { timeout: 180_000, shell: false });
           const data = parseHelmTemplateOutput(result.stdout, result.stderr, result.exitCode);
           const rawOutput = (result.stdout + "\n" + result.stderr).trim();
 


### PR DESCRIPTION
## Summary
- Added `shell: false` to all 8 `run("helm", ...)` calls in `packages/server-k8s/src/tools/helm.ts`
- When helm is not installed on Windows, the default `shell: true` behavior causes `cmd.exe` to be spawned, which can hang indefinitely searching for the executable — leading to CI timeout
- With `shell: false`, Node.js `spawn` emits an immediate `ENOENT` error when helm is not found, which the runner already handles gracefully

## Test plan
- [ ] Verify Windows CI no longer times out on helm integration tests when helm is not installed
- [ ] Verify helm tool still works correctly on all platforms when helm IS installed
- [ ] Verify ENOENT error message is properly surfaced when helm is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)