### PR TITLE
fix(ci): switch SBOM generator to cdxgen for pnpm support

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -27,7 +27,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Generate CycloneDX SBOM
-        run: npx @cyclonedx/cyclonedx-npm --output-file sbom.json --output-format JSON
+        run: npx @cyclonedx/cdxgen -o sbom.json
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:


### PR DESCRIPTION
## Summary
- Replace `@cyclonedx/cyclonedx-npm` with `@cyclonedx/cdxgen` in the SBOM workflow
- `cyclonedx-npm` uses `npm ls` internally which fails in pnpm monorepos with hundreds of missing devDependency errors (exit code 254)
- `cdxgen` natively supports pnpm lockfiles and produces accurate SBOMs

## Test plan
- [ ] SBOM Generation workflow passes on merge to main
- [ ] `sbom.json` artifact is uploaded successfully