### PR TITLE
fix(git): accept string in forceDelete param (#662)

### DIFF
--- a/.changeset/fix-branch-force-delete.md
+++ b/.changeset/fix-branch-force-delete.md
@@ -1,0 +1,5 @@
+---
+"@paretools/git": patch
+---
+
+fix(git): accept string branch name in `forceDelete` param, matching `delete` behavior

--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -436,6 +436,48 @@ describe("@paretools/git write-tool integration", () => {
     });
   });
 
+  describe("branch forceDelete", () => {
+    it("force-deletes with forceDelete=true and delete=branchName", async () => {
+      // Create an unmerged branch so only -D works
+      gitInTemp(["branch", "fd-bool-test"]);
+      const result = await client.callTool(
+        {
+          name: "branch",
+          arguments: { path: tempDir, delete: "fd-bool-test", forceDelete: true },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBeUndefined();
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      // The deleted branch should no longer appear in the list
+      const branches = sc.branches as Record<string, unknown>[];
+      expect(branches.find((b) => b.name === "fd-bool-test")).toBeUndefined();
+    });
+
+    it("force-deletes with forceDelete=branchName (string)", async () => {
+      // Create an unmerged branch so only -D works
+      gitInTemp(["branch", "fd-string-test"]);
+      const result = await client.callTool(
+        {
+          name: "branch",
+          arguments: { path: tempDir, forceDelete: "fd-string-test" },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBeUndefined();
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      // The deleted branch should no longer appear in the list
+      const branches = sc.branches as Record<string, unknown>[];
+      expect(branches.find((b) => b.name === "fd-string-test")).toBeUndefined();
+    });
+  });
+
   describe("checkout", () => {
     it("creates a new branch and returns structured checkout data", async () => {
       const result = await client.callTool(

--- a/packages/server-git/src/tools/branch.ts
+++ b/packages/server-git/src/tools/branch.ts
@@ -57,7 +57,12 @@ export function registerBranchTool(server: McpServer) {
           .optional()
           .describe("Filter branches matching a pattern (<pattern>)"),
         all: z.boolean().optional().default(false).describe("Include remote branches"),
-        forceDelete: z.boolean().optional().describe("Force-delete unmerged branches (-D)"),
+        forceDelete: z
+          .union([z.boolean(), z.string().max(INPUT_LIMITS.SHORT_STRING_MAX)])
+          .optional()
+          .describe(
+            "Force-delete unmerged branches (-D). Pass true (requires `delete` param) or a branch name string.",
+          ),
         merged: z.boolean().optional().describe("Filter to branches merged into HEAD (--merged)"),
         noMerged: z
           .boolean()
@@ -139,10 +144,15 @@ export function registerBranchTool(server: McpServer) {
       }
 
       // Delete branch
-      if (deleteBranch) {
-        assertNoFlagInjection(deleteBranch, "branch name");
-        const deleteFlag = forceDelete ? "-D" : "-d";
-        const result = await git(["branch", deleteFlag, deleteBranch], cwd);
+      // forceDelete can be true (use `delete` param as branch name) or a string (branch name to force-delete)
+      const forceDeleteBranch = typeof forceDelete === "string" ? forceDelete : undefined;
+      const isForceDelete = forceDelete === true || typeof forceDelete === "string";
+      const branchToDelete = deleteBranch ?? forceDeleteBranch;
+
+      if (branchToDelete) {
+        assertNoFlagInjection(branchToDelete, "branch name");
+        const deleteFlag = isForceDelete ? "-D" : "-d";
+        const result = await git(["branch", deleteFlag, branchToDelete], cwd);
         if (result.exitCode !== 0) {
           throw new Error(`Failed to delete branch: ${result.stderr}`);
         }


### PR DESCRIPTION
## Summary

Closes #662

The `branch` tool's `forceDelete` param was typed as `boolean`, but agents naturally pass a branch name string (e.g. `forceDelete: "my-branch"`), which caused a Zod validation error.

- Changed `forceDelete` to accept `boolean | string` via `z.union([z.boolean(), z.string()])`
- When a string is passed, it is treated as the branch name to force-delete (using `-D`), without needing a separate `delete` param
- When `true` is passed, existing behavior is preserved (uses `delete` param as the branch name)
- Added two integration tests covering both usage patterns

## Test plan

- [x] `forceDelete: true` with `delete: "branch-name"` still works (boolean path)
- [x] `forceDelete: "branch-name"` works directly (string path)
- [x] All 663 existing tests pass
- [x] ESLint and Prettier pass on changed files
- [x] Build succeeds