### PR TITLE
fix: dynamic serverInfo.version from package.json (#657)

### DIFF
--- a/.changeset/fix-server-version.md
+++ b/.changeset/fix-server-version.md
@@ -1,0 +1,33 @@
+---
+"@paretools/shared": patch
+"@paretools/git": patch
+"@paretools/github": patch
+"@paretools/npm": patch
+"@paretools/docker": patch
+"@paretools/cargo": patch
+"@paretools/go": patch
+"@paretools/python": patch
+"@paretools/lint": patch
+"@paretools/build": patch
+"@paretools/test": patch
+"@paretools/search": patch
+"@paretools/http": patch
+"@paretools/k8s": patch
+"@paretools/security": patch
+"@paretools/make": patch
+"@paretools/process": patch
+"@paretools/bazel": patch
+"@paretools/bun": patch
+"@paretools/cmake": patch
+"@paretools/db": patch
+"@paretools/deno": patch
+"@paretools/dotnet": patch
+"@paretools/infra": patch
+"@paretools/jvm": patch
+"@paretools/nix": patch
+"@paretools/remote": patch
+"@paretools/ruby": patch
+"@paretools/swift": patch
+---
+
+fix: read serverInfo.version from package.json instead of hardcoding

--- a/packages/server-bazel/src/index.ts
+++ b/packages/server-bazel/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/bazel",
-  version: "0.10.2",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured Bazel build system operations (build, test, query, info, run, clean, fetch). Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-build/src/index.ts
+++ b/packages/server-build/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/build",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured build tool operations (tsc, esbuild, vite, webpack, generic build). Returns typed JSON with structured error diagnostics and build results.",
   registerTools: registerAllTools,

--- a/packages/server-bun/src/index.ts
+++ b/packages/server-bun/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/bun",
-  version: "0.1.0",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured Bun runtime operations (run, test, build, install, add, remove, outdated, pm-ls). Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-cargo/src/index.ts
+++ b/packages/server-cargo/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/cargo",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured Rust/Cargo operations (build, test, clippy, run, add, remove, fmt, doc, check). Returns typed JSON with structured compiler errors, test results, lint warnings, and dependency management output.",
   registerTools: registerAllTools,

--- a/packages/server-cmake/src/index.ts
+++ b/packages/server-cmake/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/cmake",
-  version: "0.10.2",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured CMake build system operations (configure, build, test, list-presets, install, clean). Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-db/src/index.ts
+++ b/packages/server-db/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/db",
-  version: "0.1.0",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured database CLI operations (psql, mysql, redis-cli, mongosh). Returns typed JSON with query results, server info, and connectivity status.",
   registerTools: registerAllTools,

--- a/packages/server-deno/src/index.ts
+++ b/packages/server-deno/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/deno",
-  version: "0.1.0",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured Deno runtime operations (run, test, fmt, lint, check, task, info). Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-docker/src/index.ts
+++ b/packages/server-docker/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/docker",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured Docker operations (ps, build, logs, images, run, exec, compose-up, compose-down, compose-build, pull). Returns typed JSON with structured container, image, and build data.",
   registerTools: registerAllTools,

--- a/packages/server-dotnet/src/index.ts
+++ b/packages/server-dotnet/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/dotnet",
-  version: "0.1.0",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured .NET CLI operations (build, test, run, publish, restore, clean, add-package, list-package). Returns typed JSON with significantly fewer tokens than raw CLI output.",
   registerTools: registerAllTools,

--- a/packages/server-git/src/index.ts
+++ b/packages/server-git/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/git",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured git operations (status, log, diff, branch, show, add, commit, push, pull, checkout). Returns typed JSON with significantly fewer tokens than raw CLI output.",
   registerTools: registerAllTools,

--- a/packages/server-github/src/index.ts
+++ b/packages/server-github/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/github",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured GitHub operations (PRs, issues, actions runs) via gh CLI. Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-go/src/index.ts
+++ b/packages/server-go/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/go",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured Go toolchain operations (build, test, vet, run, mod-tidy, fmt, generate). Returns typed JSON with structured compiler errors, test results, vet warnings, run output, and more.",
   registerTools: registerAllTools,

--- a/packages/server-http/src/index.ts
+++ b/packages/server-http/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/http",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured HTTP request operations via curl (request, get, post, head). Returns typed JSON with status, headers, body, timing, and size.",
   registerTools: registerAllTools,

--- a/packages/server-infra/src/index.ts
+++ b/packages/server-infra/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/infra",
-  version: "0.1.0",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured infrastructure-as-code operations (Terraform init, plan, validate, fmt, output, state, workspace, show; Vagrant status, up, halt, destroy, global-status; Ansible playbook, inventory, galaxy). Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-jvm/src/index.ts
+++ b/packages/server-jvm/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/jvm",
-  version: "0.1.0",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured JVM build tool operations (Gradle, Maven). Run builds, tests, list tasks, show dependencies. Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-k8s/src/index.ts
+++ b/packages/server-k8s/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/k8s",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured Kubernetes kubectl and Helm operations (get, describe, logs, apply, helm). Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-lint/src/index.ts
+++ b/packages/server-lint/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/lint",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured linting and formatting operations (ESLint, Prettier, Biome). Returns typed JSON with structured violation details and counts.",
   registerTools: registerAllTools,

--- a/packages/server-make/src/index.ts
+++ b/packages/server-make/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/make",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured Make/Just task runner operations (run, list). Auto-detects make vs just. Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-nix/src/index.ts
+++ b/packages/server-nix/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/nix",
-  version: "0.11.0",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured Nix operations (build, run, develop, shell, flake show/check/update). Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-npm/src/index.ts
+++ b/packages/server-npm/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/npm",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured npm/pnpm operations (install, audit, outdated, list, run, test, init). Returns typed JSON with structured dependency, vulnerability, and script execution data.",
   registerTools: registerAllTools,

--- a/packages/server-process/src/index.ts
+++ b/packages/server-process/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/process",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured process execution (run, reload). Runs commands with timeout, environment, and signal support. Returns typed JSON with exit code, stdout, stderr, duration, and timeout status.",
   registerTools: registerAllTools,

--- a/packages/server-python/src/index.ts
+++ b/packages/server-python/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/python",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured Python tool operations (pip install, mypy, ruff, pip-audit, pytest, uv, black). Returns typed JSON with structured type errors, lint violations, vulnerability data, test results, and formatting status.",
   registerTools: registerAllTools,

--- a/packages/server-remote/src/index.ts
+++ b/packages/server-remote/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/remote",
-  version: "0.1.0",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured remote operations (SSH, rsync). Run commands on remote hosts, test connectivity, scan host keys, and sync files. Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-ruby/src/index.ts
+++ b/packages/server-ruby/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/ruby",
-  version: "0.1.0",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured Ruby & Bundler operations (run, check, gem-list, gem-install, gem-outdated, bundle-install, bundle-exec, bundle-check). Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-search/src/index.ts
+++ b/packages/server-search/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/search",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured code search operations (ripgrep + fd). Returns typed JSON with match locations, file lists, and match counts.",
   registerTools: registerAllTools,

--- a/packages/server-security/src/index.ts
+++ b/packages/server-security/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/security",
-  version: "0.1.0",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured security scanning operations (trivy, semgrep, gitleaks). Returns typed JSON with vulnerability and finding data.",
   registerTools: registerAllTools,

--- a/packages/server-swift/src/index.ts
+++ b/packages/server-swift/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/swift",
-  version: "0.11.0",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured Swift operations (build, test, run, package resolve/update/show-dependencies/clean/init). Returns typed JSON.",
   registerTools: registerAllTools,

--- a/packages/server-test/src/index.ts
+++ b/packages/server-test/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { createServer } from "@paretools/shared";
+import { createServer, readPackageVersion } from "@paretools/shared";
 import { registerAllTools } from "./tools/index.js";
 
 await createServer({
   name: "@paretools/test",
-  version: "0.8.1",
+  version: readPackageVersion(import.meta.url),
   instructions:
     "Structured test runner operations (run, coverage). Auto-detects pytest, jest, vitest, and mocha. Returns typed JSON with structured pass/fail results and failure details.",
   registerTools: registerAllTools,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -59,3 +59,4 @@ export {
 export type { PareErrorCategoryType, PareError } from "./errors.js";
 export { createServer } from "./server.js";
 export type { CreateServerOptions } from "./server.js";
+export { readPackageVersion } from "./version.js";

--- a/packages/shared/src/version.ts
+++ b/packages/shared/src/version.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Reads the `version` field from the nearest `package.json` relative to
+ * the calling module's `import.meta.url`.
+ *
+ * Walks up directory tree from the given module URL until it finds a
+ * `package.json` with a `version` field, or returns `"0.0.0"` as a
+ * fallback.
+ *
+ * @example
+ * ```ts
+ * import { readPackageVersion } from "@paretools/shared";
+ * const version = readPackageVersion(import.meta.url);
+ * ```
+ */
+export function readPackageVersion(importMetaUrl: string): string {
+  let dir = dirname(fileURLToPath(importMetaUrl));
+
+  // Walk up to find the nearest package.json with a version field
+  for (;;) {
+    try {
+      const pkgPath = join(dir, "package.json");
+      const raw = readFileSync(pkgPath, "utf-8");
+      const pkg = JSON.parse(raw) as { version?: string };
+      if (pkg.version) {
+        return pkg.version;
+      }
+    } catch {
+      // No package.json in this directory, keep walking up
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      // Reached filesystem root
+      break;
+    }
+    dir = parent;
+  }
+
+  return "0.0.0";
+}


### PR DESCRIPTION
## Summary

- Adds `readPackageVersion(importMetaUrl)` helper to `@paretools/shared` that walks up from a module's `import.meta.url` to find the nearest `package.json` and reads the `version` field
- Updates all 28 server packages to use `readPackageVersion(import.meta.url)` instead of hardcoded version strings (e.g. `"0.8.1"`)
- The MCP `serverInfo.version` in the initialize handshake now always reflects the actual published npm package version

Closes #657

## Test plan

- [x] `pnpm build` passes (all 30 packages)
- [x] `pnpm --filter @paretools/shared test` passes (363 tests)
- [x] `pnpm --filter @paretools/git test` passes (661 tests)
- [ ] Verify `serverInfo.version` in MCP initialize response matches `package.json` version