### PR TITLE
fix(git): use git checkout --detach for all detach operations (#669)

### DIFF
--- a/.changeset/fix-669-checkout-detach-tag.md
+++ b/.changeset/fix-669-checkout-detach-tag.md
@@ -1,0 +1,5 @@
+---
+"@paretools/git": patch
+---
+
+Fix checkout: use git checkout --detach instead of git switch --detach to support tag refs on all git versions (#669)

--- a/packages/server-git/src/tools/checkout.ts
+++ b/packages/server-git/src/tools/checkout.ts
@@ -91,14 +91,17 @@ export function registerCheckoutTool(server: McpServer) {
         return dualOutput(checkoutResult, formatCheckout);
       }
 
-      // When startPoint is provided, git switch -c may reject tags ("a branch is expected, got tag").
-      // Use git checkout -b directly in that case for full compatibility.
+      // git switch has two tag-related incompatibilities vs git checkout:
+      //   1. `git switch -c <branch> <tag>` → "a branch is expected, got tag" (#666)
+      //   2. `git switch --detach <tag>` → "reference is not a branch" on older git (#669)
+      // Use git checkout for both cases; it handles all ref types universally.
       const needsCheckoutForStartPoint = Boolean(
         startPoint && (create || forceCreate) && preferSwitch,
       );
+      const needsCheckoutForDetach = Boolean(detach && preferSwitch);
       let cmd: string;
       let createFlag: string | undefined;
-      if (needsCheckoutForStartPoint || !preferSwitch) {
+      if (needsCheckoutForStartPoint || needsCheckoutForDetach || !preferSwitch) {
         cmd = "checkout";
         if (forceCreate) createFlag = "-B";
         else if (create) createFlag = "-b";

--- a/tests/smoke/mocked/git-tools-1.smoke.test.ts
+++ b/tests/smoke/mocked/git-tools-1.smoke.test.ts
@@ -839,6 +839,21 @@ describe("Smoke: git.checkout", () => {
     expect(parsed.detached).toBe(true);
     const args = vi.mocked(git).mock.calls[1][0];
     expect(args).toContain("--detach");
+    // Must use git checkout --detach, not git switch --detach (switch rejects tags on older git)
+    expect(args[0]).toBe("checkout");
+  });
+
+  // S5b: Detach HEAD at tag — must use git checkout, not git switch (#669)
+  it("S5b [P1] detach HEAD at tag uses git checkout", async () => {
+    mockGit("main\n");
+    mockGit("", "HEAD is now at abc1234 v1.2.3");
+    mockGit("HEAD\n");
+    mockGit("");
+    await callAndValidate({ ...DEFAULTS, ref: "v1.2.3", detach: true });
+    const args = vi.mocked(git).mock.calls[1][0];
+    expect(args[0]).toBe("checkout");
+    expect(args).toContain("--detach");
+    expect(args).not.toContain("switch");
   });
 
   // S6: Orphan branch creation


### PR DESCRIPTION
## Summary

`git switch --detach <tag>` fails on older git versions with "reference is not a branch". `git checkout --detach` handles tags, branches, and commits universally across all git versions.

**Change**: when `detach=true`, always use `git checkout --detach` regardless of the `useSwitch` setting. This is the same pattern already applied for `startPoint` in #668.

```typescript
// Before: git switch --detach <ref>  ← fails for tags on older git
// After:  git checkout --detach <ref> ← works for all ref types
const needsCheckoutForDetach = Boolean(detach && preferSwitch);
```

Added smoke test S5b to lock in that `detach` always routes through `git checkout`.

## Test plan
- [ ] S5 (detach at commit) still passes
- [ ] S5b (detach at tag uses `git checkout`) passes
- [ ] CI passes