### PR TITLE
fix(shared): register stub resource handlers to suppress -32603 errors in OpenCode

### DIFF
--- a/.changeset/fix-648-resources-read.md
+++ b/.changeset/fix-648-resources-read.md
@@ -1,0 +1,7 @@
+---
+"@paretools/shared": patch
+---
+
+fix: register stub resource handlers to suppress spurious -32603 errors in OpenCode
+
+Some MCP clients (e.g. OpenCode) fire a `resources/read` request after every tool call that returns `structuredContent`. Because Pare servers register no resource handlers, the SDK responded with `-32601 Method Not Found` (displayed as `-32603` by OpenCode). Now `createServer()` registers empty `resources/list` and `resources/read` handlers so these requests receive a clean `-32602 InvalidParams` ("Resource not found") response instead.

--- a/packages/shared/__tests__/server.test.ts
+++ b/packages/shared/__tests__/server.test.ts
@@ -10,6 +10,7 @@ vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => {
       this.connect = vi.fn().mockResolvedValue(undefined);
       this.sendToolListChanged = vi.fn();
       this.registerTool = vi.fn();
+      this.server = { registerCapabilities: vi.fn(), setRequestHandler: vi.fn() };
     }),
   };
 });
@@ -149,6 +150,7 @@ describe("createServer", () => {
       this._info = info;
       this._opts = opts;
       this.registerTool = vi.fn();
+      this.server = { registerCapabilities: vi.fn(), setRequestHandler: vi.fn() };
       this.connect = vi.fn().mockImplementation(() => {
         callOrder.push("connect");
         return Promise.resolve();

--- a/packages/shared/src/server.ts
+++ b/packages/shared/src/server.ts
@@ -1,5 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  ErrorCode,
+  ListResourcesRequestSchema,
+  McpError,
+  ReadResourceRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 import { createLazyToolManager, type LazyToolManager } from "./lazy-tools.js";
 import { isLazyEnabled } from "./tool-filter.js";
 import { strictifyInputSchema } from "./strict-input.js";
@@ -62,6 +68,17 @@ export async function createServer(options: CreateServerOptions): Promise<McpSer
   const lazyManager = lazy ? createLazyToolManager(server) : undefined;
 
   registerTools(server, lazyManager);
+
+  // Pare servers are tool-only and register no resources. Some MCP clients
+  // (e.g. OpenCode) fire `resources/read` after every structured tool call,
+  // which causes a -32603 InternalError because no resource handler exists.
+  // Register stub handlers so those requests receive a clean -32602 response
+  // ("Resource not found") instead of the confusing generic error.
+  server.server.registerCapabilities({ resources: {} });
+  server.server.setRequestHandler(ListResourcesRequestSchema, () => ({ resources: [] }));
+  server.server.setRequestHandler(ReadResourceRequestSchema, (request) => {
+    throw new McpError(ErrorCode.InvalidParams, `Resource not found: ${request.params.uri}`);
+  });
 
   const transport = new StdioServerTransport();
   await server.connect(transport);


### PR DESCRIPTION
## Summary

Closes #648.

Some MCP clients (notably OpenCode) fire a `resources/read` request after every tool call that returns `structuredContent` (i.e. tools with `outputSchema`). Because Pare servers register no resource handlers, the SDK responded with `-32601 Method Not Found`, which OpenCode displays as a confusing `-32603` error after every git/npm/etc. tool call.

**Root cause**: `McpServer` only registers resource handlers lazily when `registerResource()` is called. Since Pare servers never register resources, no `resources/read` handler exists.

**Fix**: `createServer()` now registers two stub handlers before connecting the transport:
- `resources/list` → `{ resources: [] }` — correctly advertises an empty resource set
- `resources/read` → throws `McpError(InvalidParams, "Resource not found: <uri>")` — returns a proper -32602 response for unknown URIs

This changes the error from a confusing `-32603 Internal Error` / `-32601 Method Not Found` to a semantically correct `-32602 Invalid Params` ("Resource not found"), and clients that respect `resources/list` will stop making `resources/read` calls entirely.

## Test plan
- [x] All 6 `createServer` unit tests pass (mock updated to include `server.server`)
- [x] TypeScript compiles cleanly
- [x] `@paretools/shared` build succeeds