### PR TITLE
fix: bump hono pnpm overrides for CVE-2026-29045 and CVE-2026-29087

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   "pnpm": {
     "overrides": {
       "minimatch": ">=10.2.3",
-      "hono": ">=4.11.10",
+      "hono": ">=4.12.4",
+      "@hono/node-server": ">=1.19.10",
       "qs": ">=6.14.2",
       "rollup": ">=4.59.0",
       "serialize-javascript": ">=7.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,10 @@ settings:
 
 overrides:
   minimatch: '>=10.2.3'
-  rollup: '>=4.59.0'
-  hono: '>=4.11.10'
+  hono: '>=4.12.4'
+  '@hono/node-server': '>=1.19.10'
   qs: '>=6.14.2'
+  rollup: '>=4.59.0'
   serialize-javascript: '>=7.0.3'
 
 importers:
@@ -1112,11 +1113,11 @@ packages:
   '@gerrit0/mini-shiki@3.22.0':
     resolution: {integrity: sha512-jMpciqEVUBKE1QwU64S4saNMzpsSza6diNCk4MWAeCxO2+LFi2FIFmL2S0VDLzEJCxuvCbU783xi8Hp/gkM5CQ==}
 
-  '@hono/node-server@1.19.9':
-    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.11.10'
+      hono: '>=4.12.4'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2225,8 +2226,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.2:
-    resolution: {integrity: sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==}
+  hono@4.12.5:
+    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -3467,9 +3468,9 @@ snapshots:
       '@shikijs/types': 3.22.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@1.19.9(hono@4.12.2)':
+  '@hono/node-server@1.19.11(hono@4.12.5)':
     dependencies:
-      hono: 4.12.2
+      hono: 4.12.5
 
   '@humanfs/core@0.19.1': {}
 
@@ -3645,7 +3646,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.2)
+      '@hono/node-server': 1.19.11(hono@4.12.5)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -3655,7 +3656,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.12.2
+      hono: 4.12.5
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4600,7 +4601,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.2: {}
+  hono@4.12.5: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## Summary

Fixes the nightly audit failure that has been failing since 2026-03-01.

Two new high-severity CVEs in transitive Hono dependencies:

- **CVE-2026-29045** (`hono` < 4.12.4): Arbitrary file access via `serveStatic` vulnerability
- **CVE-2026-29087** (`@hono/node-server` < 1.19.10): Authorization bypass for protected static paths via encoded slashes

**Changes:**
- Bumped existing `hono` pnpm override from `>=4.11.10` → `>=4.12.4`
- Added new `@hono/node-server` pnpm override at `>=1.19.10`

## Test plan
- [x] `pnpm audit --audit-level=high` returns zero vulnerabilities locally
- [x] Lockfile updated