### PR TITLE
feat: add MCP tool annotations across all servers

### DIFF
--- a/.changeset/tool-annotations.md
+++ b/.changeset/tool-annotations.md
@@ -1,0 +1,32 @@
+---
+"@paretools/git": minor
+"@paretools/github": minor
+"@paretools/npm": minor
+"@paretools/build": minor
+"@paretools/lint": minor
+"@paretools/test": minor
+"@paretools/search": minor
+"@paretools/http": minor
+"@paretools/docker": minor
+"@paretools/python": minor
+"@paretools/cargo": minor
+"@paretools/go": minor
+"@paretools/k8s": minor
+"@paretools/security": minor
+"@paretools/make": minor
+"@paretools/process": minor
+"@paretools/swift": minor
+"@paretools/ruby": minor
+"@paretools/remote": minor
+"@paretools/nix": minor
+"@paretools/jvm": minor
+"@paretools/infra": minor
+"@paretools/dotnet": minor
+"@paretools/deno": minor
+"@paretools/db": minor
+"@paretools/cmake": minor
+"@paretools/bun": minor
+"@paretools/bazel": minor
+---
+
+Add MCP tool annotations (readOnlyHint, destructiveHint, openWorldHint) across all server packages to help AI agents understand tool behavior and safety characteristics

--- a/packages/server-build/src/tools/tsc.ts
+++ b/packages/server-build/src/tools/tsc.ts
@@ -21,6 +21,7 @@ export function registerTscTool(server: McpServer) {
       description:
         "Runs the TypeScript compiler and returns structured diagnostics (file, line, column, code, message). " +
         "Note: In compact mode, diagnostics are trimmed to file, line, and code — column and message fields are omitted to save tokens.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         noEmit: z

--- a/packages/server-bun/src/tools/add.ts
+++ b/packages/server-bun/src/tools/add.ts
@@ -19,6 +19,7 @@ export function registerAddTool(server: McpServer) {
     {
       title: "Bun Add",
       description: "Runs `bun add` to add one or more packages and returns structured output.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         packages: z
           .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))

--- a/packages/server-bun/src/tools/install.ts
+++ b/packages/server-bun/src/tools/install.ts
@@ -14,6 +14,7 @@ export function registerInstallTool(server: McpServer) {
       title: "Bun Install",
       description:
         "Runs `bun install` to install project dependencies and returns structured output with package count.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         frozen: z
           .boolean()

--- a/packages/server-bun/src/tools/outdated.ts
+++ b/packages/server-bun/src/tools/outdated.ts
@@ -13,6 +13,7 @@ export function registerOutdatedTool(server: McpServer) {
       title: "Bun Outdated",
       description:
         "Runs `bun outdated` to check for outdated packages and returns structured version info.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         compact: compactInput,

--- a/packages/server-bun/src/tools/pm-ls.ts
+++ b/packages/server-bun/src/tools/pm-ls.ts
@@ -14,6 +14,7 @@ export function registerPmLsTool(server: McpServer) {
       title: "Bun PM List",
       description:
         "Runs `bun pm ls` to list installed packages and returns structured package info.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         all: z.boolean().optional().describe("Show all transitive dependencies (--all)"),
         path: projectPathInput,

--- a/packages/server-bun/src/tools/test.ts
+++ b/packages/server-bun/src/tools/test.ts
@@ -20,6 +20,7 @@ export function registerTestTool(server: McpServer) {
       title: "Bun Test",
       description:
         "Runs `bun test` and returns structured pass/fail results with per-test details.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         files: z
           .array(z.string().max(INPUT_LIMITS.PATH_MAX))

--- a/packages/server-cargo/src/tools/add.ts
+++ b/packages/server-cargo/src/tools/add.ts
@@ -20,6 +20,7 @@ export function registerAddTool(server: McpServer) {
       title: "Cargo Add",
       description:
         "Adds dependencies to a Rust project and returns structured output. WARNING: may execute untrusted code.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         packages: z

--- a/packages/server-cargo/src/tools/audit.ts
+++ b/packages/server-cargo/src/tools/audit.ts
@@ -19,6 +19,7 @@ export function registerAuditTool(server: McpServer) {
     {
       title: "Cargo Audit",
       description: "Runs cargo audit and returns structured vulnerability data.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         fix: z

--- a/packages/server-cargo/src/tools/check.ts
+++ b/packages/server-cargo/src/tools/check.ts
@@ -20,6 +20,7 @@ export function registerCheckTool(server: McpServer) {
       title: "Cargo Check",
       description:
         "Runs cargo check (type check without full build) and returns structured diagnostics. Faster than build for error checking.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         package: z

--- a/packages/server-cargo/src/tools/clippy.ts
+++ b/packages/server-cargo/src/tools/clippy.ts
@@ -19,6 +19,7 @@ export function registerClippyTool(server: McpServer) {
     {
       title: "Cargo Clippy",
       description: "Runs cargo clippy and returns structured lint diagnostics.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         noDeps: z

--- a/packages/server-cargo/src/tools/test.ts
+++ b/packages/server-cargo/src/tools/test.ts
@@ -20,6 +20,7 @@ export function registerTestTool(server: McpServer) {
       title: "Cargo Test",
       description:
         "Runs cargo test and returns structured test results (name, status, pass/fail counts).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         filter: z

--- a/packages/server-cargo/src/tools/tree.ts
+++ b/packages/server-cargo/src/tools/tree.ts
@@ -19,6 +19,7 @@ export function registerTreeTool(server: McpServer) {
     {
       title: "Cargo Tree",
       description: "Displays the dependency tree for a Rust project.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         depth: z.number().optional().describe("Maximum depth of the dependency tree to display"),

--- a/packages/server-cargo/src/tools/update.ts
+++ b/packages/server-cargo/src/tools/update.ts
@@ -19,6 +19,7 @@ export function registerUpdateTool(server: McpServer) {
     {
       title: "Cargo Update",
       description: "Updates dependencies in the lock file. Optionally updates a single package.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         package: z

--- a/packages/server-db/src/tools/mongosh-eval.ts
+++ b/packages/server-db/src/tools/mongosh-eval.ts
@@ -24,6 +24,7 @@ export function registerMongoshEvalTool(server: McpServer) {
       description:
         "Evaluates a MongoDB expression via mongosh and returns the output. " +
         "WARNING: The expression is executed as-is — do not pass untrusted input.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         expression: z
           .string()

--- a/packages/server-db/src/tools/mongosh-stats.ts
+++ b/packages/server-db/src/tools/mongosh-stats.ts
@@ -23,6 +23,7 @@ export function registerMongoshStatsTool(server: McpServer) {
       title: "MongoDB Stats",
       description:
         "Gets MongoDB database statistics (collections, objects, data size, storage, indexes) via mongosh.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         uri: z
           .string()

--- a/packages/server-db/src/tools/mysql-list-databases.ts
+++ b/packages/server-db/src/tools/mysql-list-databases.ts
@@ -22,6 +22,7 @@ export function registerMysqlListDatabasesTool(server: McpServer) {
     {
       title: "MySQL List Databases",
       description: "Lists all MySQL databases with structured output.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         host: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Database host"),
         port: z.number().optional().describe("Database port (default: 3306)"),

--- a/packages/server-db/src/tools/mysql-query.ts
+++ b/packages/server-db/src/tools/mysql-query.ts
@@ -24,6 +24,7 @@ export function registerMysqlQueryTool(server: McpServer) {
       description:
         "Executes a MySQL query and returns structured tabular output. " +
         "WARNING: The query is executed as-is against the target database — do not pass untrusted input.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         query: z.string().max(INPUT_LIMITS.STRING_MAX).describe("SQL query to execute"),
         database: z

--- a/packages/server-db/src/tools/psql-list-databases.ts
+++ b/packages/server-db/src/tools/psql-list-databases.ts
@@ -22,6 +22,7 @@ export function registerPsqlListDatabasesTool(server: McpServer) {
     {
       title: "PostgreSQL List Databases",
       description: "Lists all PostgreSQL databases via psql with owner, encoding, and size info.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         host: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Database host"),
         port: z.number().optional().describe("Database port (default: 5432)"),

--- a/packages/server-db/src/tools/psql-query.ts
+++ b/packages/server-db/src/tools/psql-query.ts
@@ -20,6 +20,7 @@ export function registerPsqlQueryTool(server: McpServer) {
       description:
         "Executes a PostgreSQL query via psql and returns structured tabular output. " +
         "WARNING: The query is executed as-is against the target database — do not pass untrusted input.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         query: z.string().max(INPUT_LIMITS.STRING_MAX).describe("SQL query to execute"),
         database: z

--- a/packages/server-db/src/tools/redis-command.ts
+++ b/packages/server-db/src/tools/redis-command.ts
@@ -24,6 +24,7 @@ export function registerRedisCommandTool(server: McpServer) {
       description:
         "Executes a Redis command via redis-cli and returns the response. " +
         "WARNING: The command is executed as-is — do not pass untrusted input.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         command: z
           .string()

--- a/packages/server-db/src/tools/redis-info.ts
+++ b/packages/server-db/src/tools/redis-info.ts
@@ -19,6 +19,7 @@ export function registerRedisInfoTool(server: McpServer) {
       title: "Redis Info",
       description:
         "Gets Redis server info with structured sections (server, clients, memory, etc.).",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         section: z
           .string()

--- a/packages/server-db/src/tools/redis-ping.ts
+++ b/packages/server-db/src/tools/redis-ping.ts
@@ -18,6 +18,7 @@ export function registerRedisPingTool(server: McpServer) {
     {
       title: "Redis Ping",
       description: "Tests Redis connectivity by sending a PING command.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         host: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Redis host"),
         port: z.number().optional().describe("Redis port (default: 6379)"),

--- a/packages/server-deno/src/tools/check.ts
+++ b/packages/server-deno/src/tools/check.ts
@@ -20,6 +20,7 @@ export function registerCheckTool(server: McpServer) {
       title: "Deno Check",
       description:
         "Runs `deno check` for type-checking without execution. Returns structured type errors.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         files: filePatternsInput("Files to type-check (at least one required)", []),
         path: projectPathInput,

--- a/packages/server-deno/src/tools/info.ts
+++ b/packages/server-deno/src/tools/info.ts
@@ -20,6 +20,7 @@ export function registerInfoTool(server: McpServer) {
       title: "Deno Info",
       description:
         "Runs `deno info` to show dependency information for a module. Returns structured dependency data.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         module: z
           .string()

--- a/packages/server-deno/src/tools/lint.ts
+++ b/packages/server-deno/src/tools/lint.ts
@@ -21,6 +21,7 @@ export function registerLintTool(server: McpServer) {
       title: "Deno Lint",
       description:
         "Runs `deno lint` and returns structured diagnostics with file, line, column, code, and message.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         files: filePatternsInput("Files or directories to lint (default: current directory)"),
         path: projectPathInput,

--- a/packages/server-deno/src/tools/test.ts
+++ b/packages/server-deno/src/tools/test.ts
@@ -21,6 +21,7 @@ export function registerTestTool(server: McpServer) {
       title: "Deno Test",
       description:
         "Runs `deno test` and returns structured pass/fail output with per-test results.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         files: filePatternsInput("Test files or directories to run (default: auto-discovered)"),
         filter: z

--- a/packages/server-docker/src/tools/build.ts
+++ b/packages/server-docker/src/tools/build.ts
@@ -20,6 +20,7 @@ export function registerBuildTool(server: McpServer) {
       title: "Docker Build",
       description:
         "Builds a Docker image and returns structured build results including image ID, duration, and errors.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: z.string().max(INPUT_LIMITS.PATH_MAX).optional().describe("Build context path"),
         /** #98: Support multiple tags — accepts string or string[] for multiple -t flags. */

--- a/packages/server-docker/src/tools/compose-build.ts
+++ b/packages/server-docker/src/tools/compose-build.ts
@@ -23,6 +23,7 @@ export function registerComposeBuildTool(server: McpServer) {
       title: "Docker Compose Build",
       description:
         "Builds Docker Compose service images and returns structured per-service build status.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: z
           .string()

--- a/packages/server-docker/src/tools/compose-down.ts
+++ b/packages/server-docker/src/tools/compose-down.ts
@@ -22,6 +22,7 @@ export function registerComposeDownTool(server: McpServer) {
     {
       title: "Docker Compose Down",
       description: "Stops Docker Compose services and returns structured status.",
+      annotations: { destructiveHint: true },
       inputSchema: {
         path: z
           .string()

--- a/packages/server-docker/src/tools/compose-logs.ts
+++ b/packages/server-docker/src/tools/compose-logs.ts
@@ -22,6 +22,7 @@ export function registerComposeLogsTool(server: McpServer) {
     {
       title: "Docker Compose Logs",
       description: "Retrieves Docker Compose service logs as structured entries.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: z
           .string()

--- a/packages/server-docker/src/tools/compose-ps.ts
+++ b/packages/server-docker/src/tools/compose-ps.ts
@@ -18,6 +18,7 @@ export function registerComposePsTool(server: McpServer) {
     {
       title: "Docker Compose PS",
       description: "Lists Docker Compose services with structured state and status information.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: z
           .string()

--- a/packages/server-docker/src/tools/compose-up.ts
+++ b/packages/server-docker/src/tools/compose-up.ts
@@ -18,6 +18,7 @@ export function registerComposeUpTool(server: McpServer) {
     {
       title: "Docker Compose Up",
       description: "Starts Docker Compose services and returns structured status.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: z
           .string()

--- a/packages/server-docker/src/tools/images.ts
+++ b/packages/server-docker/src/tools/images.ts
@@ -18,6 +18,7 @@ export function registerImagesTool(server: McpServer) {
     {
       title: "Docker Images",
       description: "Lists Docker images with structured repository, tag, size, and creation info.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         all: z
           .boolean()

--- a/packages/server-docker/src/tools/inspect.ts
+++ b/packages/server-docker/src/tools/inspect.ts
@@ -20,6 +20,7 @@ export function registerInspectTool(server: McpServer) {
       title: "Docker Inspect",
       description:
         "Shows detailed container or image information with structured state, image, and platform data.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         target: z
           .union([

--- a/packages/server-docker/src/tools/logs.ts
+++ b/packages/server-docker/src/tools/logs.ts
@@ -18,6 +18,7 @@ export function registerLogsTool(server: McpServer) {
     {
       title: "Docker Logs",
       description: "Retrieves container logs as structured line arrays.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         container: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Container name or ID"),
         tail: z

--- a/packages/server-docker/src/tools/network-ls.ts
+++ b/packages/server-docker/src/tools/network-ls.ts
@@ -19,6 +19,7 @@ export function registerNetworkLsTool(server: McpServer) {
     {
       title: "Docker Network LS",
       description: "Lists Docker networks with structured driver and scope information.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: cwdPathInput,
         filter: z

--- a/packages/server-docker/src/tools/ps.ts
+++ b/packages/server-docker/src/tools/ps.ts
@@ -18,6 +18,7 @@ export function registerPsTool(server: McpServer) {
     {
       title: "Docker PS",
       description: "Lists Docker containers with structured status, ports, and state information.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         all: z
           .boolean()

--- a/packages/server-docker/src/tools/pull.ts
+++ b/packages/server-docker/src/tools/pull.ts
@@ -20,6 +20,7 @@ export function registerPullTool(server: McpServer) {
       title: "Docker Pull",
       description:
         "Pulls a Docker image from a registry and returns structured result with digest info.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         image: z
           .string()

--- a/packages/server-docker/src/tools/run.ts
+++ b/packages/server-docker/src/tools/run.ts
@@ -21,6 +21,7 @@ export function registerRunTool(server: McpServer) {
       title: "Docker Run",
       description:
         "Runs a Docker container from an image and returns structured container ID and status.",
+      annotations: { destructiveHint: true },
       inputSchema: {
         image: z
           .string()

--- a/packages/server-docker/src/tools/stats.ts
+++ b/packages/server-docker/src/tools/stats.ts
@@ -20,6 +20,7 @@ export function registerStatsTool(server: McpServer) {
       title: "Docker Stats",
       description:
         "Returns a snapshot of container resource usage (CPU, memory, network/block I/O, PIDs) as structured data.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         containers: z
           .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))

--- a/packages/server-docker/src/tools/volume-ls.ts
+++ b/packages/server-docker/src/tools/volume-ls.ts
@@ -20,6 +20,7 @@ export function registerVolumeLsTool(server: McpServer) {
       title: "Docker Volume LS",
       description:
         "Lists Docker volumes with structured driver, mountpoint, and scope information.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: cwdPathInput,
         filter: z

--- a/packages/server-dotnet/src/tools/add-package.ts
+++ b/packages/server-dotnet/src/tools/add-package.ts
@@ -24,6 +24,7 @@ export function registerAddPackageTool(server: McpServer) {
       title: ".NET Add Package",
       description:
         "Runs dotnet add package to add a NuGet package and returns structured results. WARNING: may execute untrusted code.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         project: z

--- a/packages/server-dotnet/src/tools/clean.ts
+++ b/packages/server-dotnet/src/tools/clean.ts
@@ -19,6 +19,7 @@ export function registerCleanTool(server: McpServer) {
     {
       title: ".NET Clean",
       description: "Runs dotnet clean to remove build outputs and returns structured results.",
+      annotations: { destructiveHint: true },
       inputSchema: {
         path: projectPathInput,
         project: z

--- a/packages/server-dotnet/src/tools/list-package.ts
+++ b/packages/server-dotnet/src/tools/list-package.ts
@@ -24,6 +24,7 @@ export function registerListPackageTool(server: McpServer) {
       title: ".NET List Packages",
       description:
         "Runs dotnet list package and returns structured NuGet package listings per project and framework.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         project: z

--- a/packages/server-dotnet/src/tools/restore.ts
+++ b/packages/server-dotnet/src/tools/restore.ts
@@ -20,6 +20,7 @@ export function registerRestoreTool(server: McpServer) {
       title: ".NET Restore",
       description:
         "Runs dotnet restore to restore NuGet dependencies and returns structured results.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         project: z

--- a/packages/server-dotnet/src/tools/test.ts
+++ b/packages/server-dotnet/src/tools/test.ts
@@ -20,6 +20,7 @@ export function registerTestTool(server: McpServer) {
       title: ".NET Test",
       description:
         "Runs dotnet test and returns structured test results (name, status, pass/fail counts).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         project: z

--- a/packages/server-git/src/tools/bisect.ts
+++ b/packages/server-git/src/tools/bisect.ts
@@ -14,6 +14,7 @@ export function registerBisectTool(server: McpServer) {
       title: "Git Bisect",
       description:
         "Binary search for the commit that introduced a bug. Returns structured data with action taken, current commit, remaining steps estimate, and result.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         action: z

--- a/packages/server-git/src/tools/blame.ts
+++ b/packages/server-git/src/tools/blame.ts
@@ -20,6 +20,7 @@ export function registerBlameTool(server: McpServer) {
       title: "Git Blame",
       description:
         "Shows commit annotations for a file, grouped by commit. Returns structured blame data with deduplicated commit metadata (hash, author, email, date) and their attributed lines.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         file: z.string().max(INPUT_LIMITS.PATH_MAX).describe("File path to blame"),

--- a/packages/server-git/src/tools/branch.ts
+++ b/packages/server-git/src/tools/branch.ts
@@ -14,6 +14,7 @@ export function registerBranchTool(server: McpServer) {
     {
       title: "Git Branch",
       description: "Lists, creates, renames, or deletes branches. Returns structured branch data.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         create: z

--- a/packages/server-git/src/tools/cherry-pick.ts
+++ b/packages/server-git/src/tools/cherry-pick.ts
@@ -20,6 +20,7 @@ export function registerCherryPickTool(server: McpServer) {
       title: "Git Cherry-Pick",
       description:
         "Applies specific commits to the current branch. Returns structured data with applied commits, any conflicts, and new commit hash.",
+      annotations: { destructiveHint: true },
       inputSchema: {
         path: repoPathInput,
         commits: z

--- a/packages/server-git/src/tools/clean.ts
+++ b/packages/server-git/src/tools/clean.ts
@@ -14,6 +14,7 @@ export function registerCleanTool(server: McpServer) {
       title: "Git Clean",
       description:
         "Removes untracked files from the working tree. DEFAULTS TO DRY-RUN MODE for safety — shows what would be removed without actually deleting. Set force=true AND dryRun=false to actually remove files.",
+      annotations: { destructiveHint: true },
       inputSchema: {
         path: repoPathInput,
         dryRun: z

--- a/packages/server-git/src/tools/config.ts
+++ b/packages/server-git/src/tools/config.ts
@@ -14,6 +14,7 @@ export function registerConfigTool(server: McpServer) {
       title: "Git Config",
       description:
         "Manages git configuration values. Supports get, set, list, and unset actions. Operates at local, global, system, or worktree scope.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         action: z

--- a/packages/server-git/src/tools/diff.ts
+++ b/packages/server-git/src/tools/diff.ts
@@ -15,6 +15,7 @@ export function registerDiffTool(server: McpServer) {
       title: "Git Diff",
       description:
         "Returns file-level diff statistics as structured data. Use full=true for patch content.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         staged: z.boolean().optional().default(false).describe("Show staged changes (--cached)"),

--- a/packages/server-git/src/tools/log-graph.ts
+++ b/packages/server-git/src/tools/log-graph.ts
@@ -15,6 +15,7 @@ export function registerLogGraphTool(server: McpServer) {
       title: "Git Log Graph",
       description:
         "Returns visual branch topology as structured data. Wraps `git log --graph --oneline --decorate`.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         maxCount: z

--- a/packages/server-git/src/tools/log.ts
+++ b/packages/server-git/src/tools/log.ts
@@ -20,6 +20,7 @@ export function registerLogTool(server: McpServer) {
     {
       title: "Git Log",
       description: "Returns commit history as structured data.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         maxCount: z

--- a/packages/server-git/src/tools/merge.ts
+++ b/packages/server-git/src/tools/merge.ts
@@ -14,6 +14,7 @@ export function registerMergeTool(server: McpServer) {
       title: "Git Merge",
       description:
         "Merges a branch into the current branch. Supports abort, continue, and quit actions. Returns structured data with merge status, fast-forward detection, conflicts, and commit hash.",
+      annotations: { destructiveHint: true },
       inputSchema: {
         path: repoPathInput,
         branch: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Branch to merge"),

--- a/packages/server-git/src/tools/pull.ts
+++ b/packages/server-git/src/tools/pull.ts
@@ -14,6 +14,7 @@ export function registerPullTool(server: McpServer) {
       title: "Git Pull",
       description:
         "Pulls changes from a remote repository. Returns structured data with success status, summary, change statistics, conflicts, up-to-date and fast-forward indicators.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: repoPathInput,
         remote: z

--- a/packages/server-git/src/tools/push.ts
+++ b/packages/server-git/src/tools/push.ts
@@ -14,6 +14,7 @@ export function registerPushTool(server: McpServer) {
       title: "Git Push",
       description:
         "Pushes commits to a remote repository. Returns structured data with success status, remote, branch, summary, and whether the remote branch was newly created.",
+      annotations: { openWorldHint: true, destructiveHint: true },
       inputSchema: {
         path: repoPathInput,
         remote: z

--- a/packages/server-git/src/tools/rebase.ts
+++ b/packages/server-git/src/tools/rebase.ts
@@ -14,6 +14,7 @@ export function registerRebaseTool(server: McpServer) {
       title: "Git Rebase",
       description:
         "Rebases the current branch onto a target branch. Supports abort, continue, skip, and quit for conflict resolution. Returns structured data with success status, branch info, conflicts, and rebased commit count.",
+      annotations: { destructiveHint: true },
       inputSchema: {
         path: repoPathInput,
         branch: z

--- a/packages/server-git/src/tools/reflog.ts
+++ b/packages/server-git/src/tools/reflog.ts
@@ -17,6 +17,7 @@ export function registerReflogTool(server: McpServer) {
       title: "Git Reflog",
       description:
         "Returns reference log entries as structured data, useful for recovery operations. Also supports checking if a reflog exists.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         action: z

--- a/packages/server-git/src/tools/remote.ts
+++ b/packages/server-git/src/tools/remote.ts
@@ -26,6 +26,7 @@ export function registerRemoteTool(server: McpServer) {
       title: "Git Remote",
       description:
         "Manages remote repositories. Supports list (default), add, remove, rename, set-url, prune, and show actions. Returns structured remote data.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         action: z

--- a/packages/server-git/src/tools/reset.ts
+++ b/packages/server-git/src/tools/reset.ts
@@ -14,6 +14,7 @@ export function registerResetTool(server: McpServer) {
       title: "Git Reset",
       description:
         "Resets the current HEAD to a specified state. Supports soft, mixed, hard, merge, and keep modes. The 'hard' mode requires confirm=true as a safety guard since it permanently discards changes. Returns structured data with the ref, mode, and list of affected files.",
+      annotations: { destructiveHint: true },
       inputSchema: {
         path: repoPathInput,
         files: z

--- a/packages/server-git/src/tools/show.ts
+++ b/packages/server-git/src/tools/show.ts
@@ -21,6 +21,7 @@ export function registerShowTool(server: McpServer) {
     {
       title: "Git Show",
       description: "Shows commit details and diff statistics for a given ref.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         ref: z

--- a/packages/server-git/src/tools/stash-list.ts
+++ b/packages/server-git/src/tools/stash-list.ts
@@ -15,6 +15,7 @@ export function registerStashListTool(server: McpServer) {
       title: "Git Stash List",
       description:
         "Lists all stash entries with index, message, date, branch, and optional file change summary. Returns structured stash data.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         maxCount: z.number().optional().describe("Limit number of stash entries (-n/--max-count)"),

--- a/packages/server-git/src/tools/status.ts
+++ b/packages/server-git/src/tools/status.ts
@@ -14,6 +14,7 @@ export function registerStatusTool(server: McpServer) {
       title: "Git Status",
       description:
         "Returns the working tree status as structured data (branch, staged, modified, untracked, conflicts).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         pathspec: z

--- a/packages/server-git/src/tools/submodule.ts
+++ b/packages/server-git/src/tools/submodule.ts
@@ -14,6 +14,7 @@ export function registerSubmoduleTool(server: McpServer) {
       title: "Git Submodule",
       description:
         "Manages git submodules. Supports list (default), add, update, sync, and deinit actions. List returns structured submodule data with path, SHA, branch, and status.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: repoPathInput,
         action: z

--- a/packages/server-github/src/tools/api.ts
+++ b/packages/server-github/src/tools/api.ts
@@ -14,6 +14,7 @@ export function registerApiTool(server: McpServer) {
       title: "GitHub API",
       description:
         "Makes arbitrary GitHub API calls via `gh api`. Supports all HTTP methods, request bodies, field parameters, pagination, and jq filtering. Returns structured data with status, parsed JSON body, endpoint, and method.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         endpoint: z
           .string()

--- a/packages/server-github/src/tools/discussion-list.ts
+++ b/packages/server-github/src/tools/discussion-list.ts
@@ -61,6 +61,7 @@ export function registerDiscussionListTool(server: McpServer) {
       title: "Discussion List",
       description:
         "Lists GitHub Discussions for a repository via GraphQL. Returns structured list with discussion number, title, author, category, answered status, and comment count.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         repo: z
           .string()

--- a/packages/server-github/src/tools/gist-create.ts
+++ b/packages/server-github/src/tools/gist-create.ts
@@ -28,6 +28,7 @@ export function registerGistCreateTool(server: McpServer) {
       title: "Gist Create",
       description:
         "Creates a new GitHub gist from one or more files. Returns structured data with gist ID, URL, visibility, file names, description, and file count.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         files: z
           .array(z.string().max(INPUT_LIMITS.PATH_MAX))

--- a/packages/server-github/src/tools/issue-close.ts
+++ b/packages/server-github/src/tools/issue-close.ts
@@ -24,6 +24,7 @@ export function registerIssueCloseTool(server: McpServer) {
       title: "Issue Close",
       description:
         "Closes an issue with an optional comment and reason. Returns structured data with issue number, state, URL, reason, and comment URL.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         number: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Issue number or URL"),
         comment: z.string().max(INPUT_LIMITS.STRING_MAX).optional().describe("Closing comment"),

--- a/packages/server-github/src/tools/issue-comment.ts
+++ b/packages/server-github/src/tools/issue-comment.ts
@@ -24,6 +24,7 @@ export function registerIssueCommentTool(server: McpServer) {
       title: "Issue Comment",
       description:
         "Adds, edits, or deletes a comment on an issue. Returns structured data with the comment URL, operation type, comment ID, issue number, and body echo.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         number: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Issue number or URL"),
         body: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Comment text"),

--- a/packages/server-github/src/tools/issue-create.ts
+++ b/packages/server-github/src/tools/issue-create.ts
@@ -23,6 +23,7 @@ export function registerIssueCreateTool(server: McpServer) {
       title: "Issue Create",
       description:
         "Creates a new issue. Returns structured data with issue number, URL, and labels applied.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         title: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Issue title"),
         body: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Issue body/description"),

--- a/packages/server-github/src/tools/issue-list.ts
+++ b/packages/server-github/src/tools/issue-list.ts
@@ -23,6 +23,7 @@ export function registerIssueListTool(server: McpServer) {
       title: "Issue List",
       description:
         "Lists issues with optional filters. Returns structured list with issue number, state, title, labels, assignees, author, creation date, and milestone.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         state: z
           .enum(["open", "closed", "all"])

--- a/packages/server-github/src/tools/issue-update.ts
+++ b/packages/server-github/src/tools/issue-update.ts
@@ -28,6 +28,7 @@ export function registerIssueUpdateTool(server: McpServer) {
         "For list fields (labels, assignees, projects), use `add*` to append and `remove*` to " +
         "delete specific items without affecting others. " +
         "Returns structured data with issue number and URL.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         // ── Target ──────────────────────────────────────────────────
         /** Issue number (integer) or full GitHub issue URL. */

--- a/packages/server-github/src/tools/issue-view.ts
+++ b/packages/server-github/src/tools/issue-view.ts
@@ -24,6 +24,7 @@ export function registerIssueViewTool(server: McpServer) {
       title: "Issue View",
       description:
         "Views an issue by number or URL. Returns structured data with state, labels, assignees, author, milestone, close reason, and body.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         number: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Issue number or URL"),
         comments: z

--- a/packages/server-github/src/tools/label-create.ts
+++ b/packages/server-github/src/tools/label-create.ts
@@ -24,6 +24,7 @@ export function registerLabelCreateTool(server: McpServer) {
       title: "Label Create",
       description:
         "Creates a new repository label. Returns structured data with label name, description, color, and URL.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         name: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Label name"),
         description: z

--- a/packages/server-github/src/tools/label-list.ts
+++ b/packages/server-github/src/tools/label-list.ts
@@ -21,6 +21,7 @@ export function registerLabelListTool(server: McpServer) {
       title: "Label List",
       description:
         "Lists repository labels. Returns structured data with label name, description, color, and default status.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         limit: z
           .number()

--- a/packages/server-github/src/tools/pr-checks.ts
+++ b/packages/server-github/src/tools/pr-checks.ts
@@ -31,6 +31,7 @@ export function registerPrChecksTool(server: McpServer) {
       title: "PR Checks",
       description:
         "Lists check/status results for a pull request. Returns structured data with check names, states, URLs, and summary counts (passed, failed, pending).",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         number: z
           .string()

--- a/packages/server-github/src/tools/pr-comment.ts
+++ b/packages/server-github/src/tools/pr-comment.ts
@@ -24,6 +24,7 @@ export function registerPrCommentTool(server: McpServer) {
       title: "PR Comment",
       description:
         "Adds, edits, or deletes a comment on a pull request. Returns structured data with the comment URL, operation type, comment ID, and body echo.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         number: z
           .string()

--- a/packages/server-github/src/tools/pr-create.ts
+++ b/packages/server-github/src/tools/pr-create.ts
@@ -25,6 +25,7 @@ export function registerPrCreateTool(server: McpServer) {
     {
       title: "PR Create",
       description: "Creates a new pull request. Returns structured data with PR number and URL.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         title: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Pull request title"),
         body: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Pull request body/description"),

--- a/packages/server-github/src/tools/pr-diff.ts
+++ b/packages/server-github/src/tools/pr-diff.ts
@@ -17,6 +17,7 @@ export function registerPrDiffTool(server: McpServer) {
       title: "PR Diff",
       description:
         "Returns file-level diff statistics for a pull request. Use full=true for patch content.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         number: z
           .string()

--- a/packages/server-github/src/tools/pr-list.ts
+++ b/packages/server-github/src/tools/pr-list.ts
@@ -24,6 +24,7 @@ export function registerPrListTool(server: McpServer) {
       title: "PR List",
       description:
         "Lists pull requests with optional filters. Returns structured list with PR number, state, title, author, branch, labels, draft status, and merge readiness.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         state: z
           .enum(["open", "closed", "merged", "all"])

--- a/packages/server-github/src/tools/pr-merge.ts
+++ b/packages/server-github/src/tools/pr-merge.ts
@@ -31,6 +31,7 @@ export function registerPrMergeTool(server: McpServer) {
       title: "PR Merge",
       description:
         "Merges a pull request by number, URL, or branch. Returns structured data with merge status, method, URL, and branch deletion status.",
+      annotations: { openWorldHint: true, destructiveHint: true },
       inputSchema: {
         number: z
           .string()

--- a/packages/server-github/src/tools/pr-review.ts
+++ b/packages/server-github/src/tools/pr-review.ts
@@ -14,6 +14,7 @@ export function registerPrReviewTool(server: McpServer) {
       title: "PR Review",
       description:
         "Submits a review on a pull request (approve, request-changes, or comment). Returns structured data with the review event, URL, and body echo.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         number: z
           .string()

--- a/packages/server-github/src/tools/pr-update.ts
+++ b/packages/server-github/src/tools/pr-update.ts
@@ -24,6 +24,7 @@ export function registerPrUpdateTool(server: McpServer) {
       title: "PR Update",
       description:
         "Updates pull request metadata (title, body, labels, assignees, reviewers, milestone, base branch, projects). Returns structured data with PR number and URL.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         number: z
           .string()

--- a/packages/server-github/src/tools/pr-view.ts
+++ b/packages/server-github/src/tools/pr-view.ts
@@ -25,6 +25,7 @@ export function registerPrViewTool(server: McpServer) {
       title: "PR View",
       description:
         "Views a pull request by number, URL, or branch. Returns structured data with state, checks, review decision, diff stats, author, labels, draft status, assignees, milestone, and timestamps.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         number: z
           .string()

--- a/packages/server-github/src/tools/release-create.ts
+++ b/packages/server-github/src/tools/release-create.ts
@@ -24,6 +24,7 @@ export function registerReleaseCreateTool(server: McpServer) {
       title: "Release Create",
       description:
         "Creates a new GitHub release with optional asset uploads. Returns structured data with tag, URL, draft, prerelease status, and assets uploaded count.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         tag: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Tag name for the release"),
         title: z

--- a/packages/server-github/src/tools/release-list.ts
+++ b/packages/server-github/src/tools/release-list.ts
@@ -27,6 +27,7 @@ export function registerReleaseListTool(server: McpServer) {
       title: "Release List",
       description:
         "Lists GitHub releases for a repository. Returns structured list with tag, name, draft/prerelease/latest status, publish date, creation date, and URL.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         // S-gap P1: Align default limit to CLI default (30)
         limit: z

--- a/packages/server-github/src/tools/repo-clone.ts
+++ b/packages/server-github/src/tools/repo-clone.ts
@@ -24,6 +24,7 @@ export function registerRepoCloneTool(server: McpServer) {
       title: "Repo Clone",
       description:
         "Clones a GitHub repository. Returns structured data with success status, repo name, target directory, and message.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         repo: z
           .string()

--- a/packages/server-github/src/tools/repo-view.ts
+++ b/packages/server-github/src/tools/repo-view.ts
@@ -30,6 +30,7 @@ export function registerRepoViewTool(server: McpServer) {
       title: "Repo View",
       description:
         "Views repository details. Returns structured data with name, owner, description, stars, forks, languages, topics, license, and dates.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         repo: z
           .string()

--- a/packages/server-github/src/tools/run-list.ts
+++ b/packages/server-github/src/tools/run-list.ts
@@ -24,6 +24,7 @@ export function registerRunListTool(server: McpServer) {
       title: "Run List",
       description:
         "Lists workflow runs with optional filters. Returns structured list with run ID, status, conclusion, and workflow details.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         limit: z
           .number()

--- a/packages/server-github/src/tools/run-rerun.ts
+++ b/packages/server-github/src/tools/run-rerun.ts
@@ -24,6 +24,7 @@ export function registerRunRerunTool(server: McpServer) {
       title: "Run Rerun",
       description:
         "Re-runs a workflow run by ID. Optionally re-runs only failed jobs or a specific job. Returns structured result with run ID, status, and URL.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         runId: z.number().describe("Workflow run ID to re-run"),
         failedOnly: z

--- a/packages/server-github/src/tools/run-view.ts
+++ b/packages/server-github/src/tools/run-view.ts
@@ -31,6 +31,7 @@ export function registerRunViewTool(server: McpServer) {
       title: "Run View",
       description:
         "Views a workflow run by ID. Returns structured data with status, conclusion, jobs (with steps), and workflow details.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         id: z.number().describe("Workflow run ID"),
         logFailed: z

--- a/packages/server-go/src/tools/env.ts
+++ b/packages/server-go/src/tools/env.ts
@@ -21,6 +21,7 @@ export function registerEnvTool(server: McpServer) {
       title: "Go Env",
       description:
         "Returns Go environment variables as structured JSON. Optionally request specific variables.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         vars: z

--- a/packages/server-go/src/tools/get.ts
+++ b/packages/server-go/src/tools/get.ts
@@ -21,6 +21,7 @@ export function registerGetTool(server: McpServer) {
     {
       title: "Go Get",
       description: "Downloads and installs Go packages and their dependencies.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         packages: z
           .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))

--- a/packages/server-go/src/tools/golangci-lint.ts
+++ b/packages/server-go/src/tools/golangci-lint.ts
@@ -25,6 +25,7 @@ export function registerGolangciLintTool(server: McpServer) {
       title: "golangci-lint",
       description:
         "Runs golangci-lint and returns structured lint diagnostics (file, line, linter, severity, message).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         patterns: z

--- a/packages/server-go/src/tools/list.ts
+++ b/packages/server-go/src/tools/list.ts
@@ -20,6 +20,7 @@ export function registerListTool(server: McpServer) {
       title: "Go List",
       description:
         "Lists Go packages or modules and returns structured information. When `modules` is true, lists modules (with path, version, dir); otherwise lists packages (with dir, importPath, name, goFiles, testGoFiles).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         packages: z

--- a/packages/server-go/src/tools/mod-tidy.ts
+++ b/packages/server-go/src/tools/mod-tidy.ts
@@ -32,6 +32,7 @@ export function registerModTidyTool(server: McpServer) {
     {
       title: "Go Mod Tidy",
       description: "Runs go mod tidy to add missing and remove unused module dependencies.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         diff: z

--- a/packages/server-go/src/tools/test.ts
+++ b/packages/server-go/src/tools/test.ts
@@ -20,6 +20,7 @@ export function registerTestTool(server: McpServer) {
       title: "Go Test",
       description:
         "Runs go test and returns structured test results (name, status, package, elapsed).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         packages: z

--- a/packages/server-go/src/tools/vet.ts
+++ b/packages/server-go/src/tools/vet.ts
@@ -20,6 +20,7 @@ export function registerVetTool(server: McpServer) {
       title: "Go Vet",
       description:
         "Runs go vet and returns structured static analysis diagnostics with analyzer names. Uses -json flag for native JSON output with automatic text fallback.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         packages: z

--- a/packages/server-http/src/tools/get.ts
+++ b/packages/server-http/src/tools/get.ts
@@ -29,6 +29,7 @@ export function registerGetTool(server: McpServer) {
       title: "HTTP GET",
       description:
         "Makes an HTTP GET request via curl and returns structured response data. Convenience wrapper for the request tool.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         url: z
           .string()

--- a/packages/server-http/src/tools/head.ts
+++ b/packages/server-http/src/tools/head.ts
@@ -29,6 +29,7 @@ export function registerHeadTool(server: McpServer) {
       title: "HTTP HEAD",
       description:
         "Makes an HTTP HEAD request via curl and returns structured response headers (no body). Use to check resource existence, content type, or cache headers.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         url: z
           .string()

--- a/packages/server-http/src/tools/post.ts
+++ b/packages/server-http/src/tools/post.ts
@@ -29,6 +29,7 @@ export function registerPostTool(server: McpServer) {
       title: "HTTP POST",
       description:
         "Makes an HTTP POST request via curl and returns structured response data. Convenience wrapper for the request tool with required body.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         url: z
           .string()

--- a/packages/server-http/src/tools/request.ts
+++ b/packages/server-http/src/tools/request.ts
@@ -29,6 +29,7 @@ export function registerRequestTool(server: McpServer) {
       title: "HTTP Request",
       description:
         "Makes an HTTP request via curl and returns structured response data (status, headers, body, timing).",
+      annotations: { openWorldHint: true },
       inputSchema: {
         url: z
           .string()

--- a/packages/server-infra/src/tools/ansible-galaxy.ts
+++ b/packages/server-infra/src/tools/ansible-galaxy.ts
@@ -27,6 +27,7 @@ export function registerAnsibleGalaxyTool(server: McpServer) {
       title: "Ansible Galaxy",
       description:
         "Installs or lists Ansible collections and roles from Galaxy or a requirements file.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         action: z
           .enum(["collection-install", "role-install", "collection-list", "role-list"])

--- a/packages/server-infra/src/tools/ansible-inventory.ts
+++ b/packages/server-infra/src/tools/ansible-inventory.ts
@@ -28,6 +28,7 @@ export function registerAnsibleInventoryTool(server: McpServer) {
       title: "Ansible Inventory",
       description:
         "Queries Ansible inventory for hosts, groups, and variables. Returns structured JSON for --list or tree text for --graph.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         inventory: z
           .string()

--- a/packages/server-infra/src/tools/ansible-playbook.ts
+++ b/packages/server-infra/src/tools/ansible-playbook.ts
@@ -24,6 +24,7 @@ export function registerAnsiblePlaybookTool(server: McpServer) {
       title: "Ansible Playbook",
       description:
         "Runs an Ansible playbook and returns structured play recap with per-host results.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         playbook: z.string().max(INPUT_LIMITS.PATH_MAX).describe("Path to playbook file"),
         inventory: z

--- a/packages/server-infra/src/tools/init.ts
+++ b/packages/server-infra/src/tools/init.ts
@@ -14,6 +14,7 @@ export function registerInitTool(server: McpServer) {
       title: "Terraform Init",
       description:
         "Initializes a Terraform working directory. Downloads providers, configures backend, and prepares for plan/apply.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         upgrade: z

--- a/packages/server-infra/src/tools/output.ts
+++ b/packages/server-infra/src/tools/output.ts
@@ -13,6 +13,7 @@ export function registerOutputTool(server: McpServer) {
       title: "Terraform Output",
       description:
         "Shows Terraform output values from the current state. Returns structured name/value/type/sensitive data.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         compact: compactInput,

--- a/packages/server-infra/src/tools/plan.ts
+++ b/packages/server-infra/src/tools/plan.ts
@@ -20,6 +20,7 @@ export function registerPlanTool(server: McpServer) {
       title: "Terraform Plan",
       description:
         "Shows the Terraform execution plan with resource change counts. Read-only — does not modify infrastructure.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         out: z

--- a/packages/server-infra/src/tools/show.ts
+++ b/packages/server-infra/src/tools/show.ts
@@ -20,6 +20,7 @@ export function registerShowTool(server: McpServer) {
       title: "Terraform Show",
       description:
         "Shows the current Terraform state or a saved plan file in structured JSON. Returns resources, outputs, and version info.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         planFile: z

--- a/packages/server-infra/src/tools/state-list.ts
+++ b/packages/server-infra/src/tools/state-list.ts
@@ -13,6 +13,7 @@ export function registerStateListTool(server: McpServer) {
       title: "Terraform State List",
       description:
         "Lists all resources tracked in the Terraform state. Returns resource addresses.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         compact: compactInput,

--- a/packages/server-infra/src/tools/validate.ts
+++ b/packages/server-infra/src/tools/validate.ts
@@ -13,6 +13,7 @@ export function registerValidateTool(server: McpServer) {
       title: "Terraform Validate",
       description:
         "Validates Terraform configuration files for syntax and consistency errors. Returns structured diagnostics.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         compact: compactInput,

--- a/packages/server-jvm/src/tools/gradle-dependencies.ts
+++ b/packages/server-jvm/src/tools/gradle-dependencies.ts
@@ -22,6 +22,7 @@ export function registerGradleDependenciesTool(server: McpServer) {
     {
       title: "Gradle Dependencies",
       description: "Shows the Gradle dependency tree with structured output per configuration.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         configuration: z

--- a/packages/server-jvm/src/tools/gradle-tasks.ts
+++ b/packages/server-jvm/src/tools/gradle-tasks.ts
@@ -17,6 +17,7 @@ export function registerGradleTasksTool(server: McpServer) {
       title: "Gradle Tasks",
       description:
         "Lists available Gradle tasks with descriptions and groups. Uses `gradle tasks --all`.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         all: z

--- a/packages/server-jvm/src/tools/gradle-test.ts
+++ b/packages/server-jvm/src/tools/gradle-test.ts
@@ -23,6 +23,7 @@ export function registerGradleTestTool(server: McpServer) {
       title: "Gradle Test",
       description:
         "Runs `gradle test` and returns structured test results with pass/fail counts and individual test outcomes.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         filter: z

--- a/packages/server-jvm/src/tools/maven-dependencies.ts
+++ b/packages/server-jvm/src/tools/maven-dependencies.ts
@@ -15,6 +15,7 @@ export function registerMavenDependenciesTool(server: McpServer) {
     {
       title: "Maven Dependencies",
       description: "Shows the Maven dependency tree with structured output per artifact.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         compact: compactInput,

--- a/packages/server-jvm/src/tools/maven-test.ts
+++ b/packages/server-jvm/src/tools/maven-test.ts
@@ -19,6 +19,7 @@ export function registerMavenTestTool(server: McpServer) {
       title: "Maven Test",
       description:
         "Runs `mvn test` and returns structured Surefire test results with pass/fail/error counts.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         filter: z

--- a/packages/server-jvm/src/tools/maven-verify.ts
+++ b/packages/server-jvm/src/tools/maven-verify.ts
@@ -17,6 +17,7 @@ export function registerMavenVerifyTool(server: McpServer) {
       title: "Maven Verify",
       description:
         "Runs `mvn verify` to execute all checks (compile, test, integration-test, verify phases) and returns structured results.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         args: z

--- a/packages/server-k8s/src/tools/apply.ts
+++ b/packages/server-k8s/src/tools/apply.ts
@@ -23,6 +23,7 @@ export function registerApplyTool(server: McpServer) {
     {
       title: "Kubectl Apply",
       description: "Applies a Kubernetes manifest file.",
+      annotations: { openWorldHint: true, destructiveHint: true },
       inputSchema: {
         file: z
           .union([

--- a/packages/server-k8s/src/tools/describe.ts
+++ b/packages/server-k8s/src/tools/describe.ts
@@ -24,6 +24,7 @@ export function registerDescribeTool(server: McpServer) {
     {
       title: "Kubectl Describe",
       description: "Describes a Kubernetes resource with detailed information.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         resource: z
           .string()

--- a/packages/server-k8s/src/tools/get.ts
+++ b/packages/server-k8s/src/tools/get.ts
@@ -19,6 +19,7 @@ export function registerGetTool(server: McpServer) {
     {
       title: "Kubectl Get",
       description: "Gets Kubernetes resources and returns structured JSON output.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         resource: z
           .string()

--- a/packages/server-k8s/src/tools/helm.ts
+++ b/packages/server-k8s/src/tools/helm.ts
@@ -70,6 +70,7 @@ export function registerHelmTool(server: McpServer) {
       title: "Helm",
       description:
         "Manages Helm releases (install, upgrade, list, status, history, template). Returns structured JSON output.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         action: z
           .enum([

--- a/packages/server-k8s/src/tools/logs.ts
+++ b/packages/server-k8s/src/tools/logs.ts
@@ -18,6 +18,7 @@ export function registerLogsTool(server: McpServer) {
     {
       title: "Kubectl Logs",
       description: "Gets logs from a Kubernetes pod.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         pod: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Pod name"),
         namespace: z

--- a/packages/server-lint/src/tools/biome-check.ts
+++ b/packages/server-lint/src/tools/biome-check.ts
@@ -21,6 +21,7 @@ export function registerBiomeCheckTool(server: McpServer) {
       title: "Biome Check",
       description:
         "Runs Biome check (lint + format) and returns structured diagnostics (file, line, rule, severity, message).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         patterns: z

--- a/packages/server-lint/src/tools/format-check.ts
+++ b/packages/server-lint/src/tools/format-check.ts
@@ -25,6 +25,7 @@ export function registerFormatCheckTool(server: McpServer) {
       title: "Prettier Check",
       description:
         "Checks if files are formatted and returns a structured list of files needing formatting.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         patterns: z

--- a/packages/server-lint/src/tools/hadolint.ts
+++ b/packages/server-lint/src/tools/hadolint.ts
@@ -21,6 +21,7 @@ export function registerHadolintTool(server: McpServer) {
       title: "Hadolint",
       description:
         "Runs Hadolint (Dockerfile linter) and returns structured diagnostics (file, line, rule, severity, message).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         patterns: z

--- a/packages/server-lint/src/tools/lint.ts
+++ b/packages/server-lint/src/tools/lint.ts
@@ -22,6 +22,7 @@ export function registerLintTool(server: McpServer) {
       title: "ESLint Check",
       description:
         "Runs ESLint and returns structured diagnostics (file, line, column, rule, severity, message).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         patterns: z

--- a/packages/server-lint/src/tools/oxlint.ts
+++ b/packages/server-lint/src/tools/oxlint.ts
@@ -21,6 +21,7 @@ export function registerOxlintTool(server: McpServer) {
       title: "Oxlint Check",
       description:
         "Runs Oxlint and returns structured diagnostics (file, line, column, rule, severity, message).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         patterns: z

--- a/packages/server-lint/src/tools/shellcheck.ts
+++ b/packages/server-lint/src/tools/shellcheck.ts
@@ -26,6 +26,7 @@ export function registerShellcheckTool(server: McpServer) {
       title: "ShellCheck",
       description:
         "Runs ShellCheck (shell script linter) and returns structured diagnostics (file, line, column, rule, severity, message).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         patterns: z

--- a/packages/server-lint/src/tools/stylelint.ts
+++ b/packages/server-lint/src/tools/stylelint.ts
@@ -22,6 +22,7 @@ export function registerStylelintTool(server: McpServer) {
       title: "Stylelint Check",
       description:
         "Runs Stylelint and returns structured diagnostics (file, line, column, rule, severity, message).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         patterns: z

--- a/packages/server-make/src/tools/list.ts
+++ b/packages/server-make/src/tools/list.ts
@@ -61,6 +61,7 @@ export function registerListTool(server: McpServer) {
       title: "Make/Just List Targets",
       description:
         "Lists available make or just targets with optional descriptions. Auto-detects make vs just.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         tool: z

--- a/packages/server-nix/src/tools/flake-check.ts
+++ b/packages/server-nix/src/tools/flake-check.ts
@@ -24,6 +24,7 @@ export function registerFlakeCheckTool(server: McpServer) {
       title: "Nix Flake Check",
       description:
         "Checks a Nix flake for errors and returns structured check results, warnings, and errors.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         flakeRef: z
           .string()

--- a/packages/server-nix/src/tools/flake-show.ts
+++ b/packages/server-nix/src/tools/flake-show.ts
@@ -20,6 +20,7 @@ export function registerFlakeShowTool(server: McpServer) {
       title: "Nix Flake Show",
       description:
         "Shows the outputs of a Nix flake as a structured tree. Uses --json for machine-parseable output by default.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         flakeRef: z
           .string()

--- a/packages/server-nix/src/tools/flake-update.ts
+++ b/packages/server-nix/src/tools/flake-update.ts
@@ -24,6 +24,7 @@ export function registerFlakeUpdateTool(server: McpServer) {
       title: "Nix Flake Update",
       description:
         "Updates flake lock file inputs and returns structured information about what was updated.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         inputs: z
           .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))

--- a/packages/server-npm/src/tools/audit.ts
+++ b/packages/server-npm/src/tools/audit.ts
@@ -22,6 +22,7 @@ export function registerAuditTool(server: McpServer) {
       description:
         "Runs npm/pnpm/yarn audit and returns structured vulnerability data. " +
         "Auto-detects package manager via lock files (pnpm-lock.yaml → pnpm, yarn.lock → yarn, otherwise npm).",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         level: z

--- a/packages/server-npm/src/tools/info.ts
+++ b/packages/server-npm/src/tools/info.ts
@@ -23,6 +23,7 @@ export function registerInfoTool(server: McpServer) {
       description:
         "Shows detailed package metadata from the npm registry. " +
         "Works with npm, pnpm, and yarn (all query the same registry).",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         package: z
           .string()

--- a/packages/server-npm/src/tools/install.ts
+++ b/packages/server-npm/src/tools/install.ts
@@ -26,6 +26,7 @@ export function registerInstallTool(server: McpServer) {
         "Auto-detects package manager via lock files (pnpm-lock.yaml → pnpm, yarn.lock → yarn, otherwise npm). " +
         "Lifecycle scripts (preinstall/postinstall) are skipped by default for safety. " +
         "Set ignoreScripts to false if packages need postinstall scripts to work (e.g., esbuild, sharp).",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         args: z

--- a/packages/server-npm/src/tools/list.ts
+++ b/packages/server-npm/src/tools/list.ts
@@ -25,6 +25,7 @@ export function registerListTool(server: McpServer) {
       description:
         "Lists installed packages as structured dependency data. " +
         "Auto-detects package manager via lock files (pnpm-lock.yaml → pnpm, yarn.lock → yarn, otherwise npm).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         depth: z

--- a/packages/server-npm/src/tools/outdated.ts
+++ b/packages/server-npm/src/tools/outdated.ts
@@ -22,6 +22,7 @@ export function registerOutdatedTool(server: McpServer) {
       description:
         "Checks for outdated packages and returns structured update information. " +
         "Auto-detects package manager via lock files (pnpm-lock.yaml → pnpm, yarn.lock → yarn, otherwise npm).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         packages: z

--- a/packages/server-npm/src/tools/search.ts
+++ b/packages/server-npm/src/tools/search.ts
@@ -21,6 +21,7 @@ export function registerSearchTool(server: McpServer) {
       description:
         "Searches the npm registry for packages matching a query. " +
         "Note: pnpm and yarn do not have a search command, so this always uses npm.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         query: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Search query string"),
         path: projectPathInput,

--- a/packages/server-python/src/tools/conda.ts
+++ b/packages/server-python/src/tools/conda.ts
@@ -28,6 +28,7 @@ export function registerCondaTool(server: McpServer) {
       title: "Conda",
       description:
         "Runs conda commands (list, info, env-list, create, remove, update) and returns structured JSON output.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         action: z
           .enum(["list", "info", "env-list", "create", "remove", "update"])

--- a/packages/server-python/src/tools/mypy.ts
+++ b/packages/server-python/src/tools/mypy.ts
@@ -21,6 +21,7 @@ export function registerMypyTool(server: McpServer) {
       title: "mypy Type Check",
       description:
         "Runs mypy and returns structured type-check diagnostics (file, line, severity, message, code).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         targets: z

--- a/packages/server-python/src/tools/pip-audit.ts
+++ b/packages/server-python/src/tools/pip-audit.ts
@@ -19,6 +19,7 @@ export function registerPipAuditTool(server: McpServer) {
     {
       title: "pip Audit",
       description: "Runs pip-audit and returns a structured vulnerability report.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         requirements: z

--- a/packages/server-python/src/tools/pip-install.ts
+++ b/packages/server-python/src/tools/pip-install.ts
@@ -24,6 +24,7 @@ export function registerPipInstallTool(server: McpServer) {
       title: "pip Install",
       description:
         "Runs pip install and returns a structured summary of installed packages. WARNING: may execute untrusted code.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         packages: z
           .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))

--- a/packages/server-python/src/tools/pip-list.ts
+++ b/packages/server-python/src/tools/pip-list.ts
@@ -19,6 +19,7 @@ export function registerPipListTool(server: McpServer) {
     {
       title: "pip List",
       description: "Runs pip list and returns a structured list of installed packages.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: cwdPathInput,
         local: z

--- a/packages/server-python/src/tools/pip-show.ts
+++ b/packages/server-python/src/tools/pip-show.ts
@@ -21,6 +21,7 @@ export function registerPipShowTool(server: McpServer) {
       description:
         "Runs pip show and returns structured package metadata (name, version, summary, dependencies). " +
         "Supports multiple packages in a single call.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         package: z
           .string()

--- a/packages/server-python/src/tools/poetry.ts
+++ b/packages/server-python/src/tools/poetry.ts
@@ -21,6 +21,7 @@ export function registerPoetryTool(server: McpServer) {
       description:
         "Runs Poetry commands and returns structured output. " +
         "Supports install, add, remove, show, build, update, lock, check, and export actions.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         action: z
           .enum(["install", "add", "remove", "show", "build", "update", "lock", "check", "export"])

--- a/packages/server-python/src/tools/pytest.ts
+++ b/packages/server-python/src/tools/pytest.ts
@@ -26,6 +26,7 @@ export function registerPytestTool(server: McpServer) {
       title: "pytest",
       description:
         "Runs pytest and returns structured test results (passed, failed, errors, skipped, failures).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         targets: z

--- a/packages/server-python/src/tools/ruff.ts
+++ b/packages/server-python/src/tools/ruff.ts
@@ -22,6 +22,7 @@ export function registerRuffTool(server: McpServer) {
       title: "ruff Lint",
       description:
         "Runs ruff check and returns structured lint diagnostics (file, line, code, message).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         targets: z

--- a/packages/server-python/src/tools/uv-install.ts
+++ b/packages/server-python/src/tools/uv-install.ts
@@ -20,6 +20,7 @@ export function registerUvInstallTool(server: McpServer) {
       title: "uv Install",
       description:
         "Runs uv pip install and returns a structured summary of installed packages. WARNING: may execute untrusted code.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: cwdPathInput,
         packages: z

--- a/packages/server-remote/src/tools/rsync.ts
+++ b/packages/server-remote/src/tools/rsync.ts
@@ -20,6 +20,7 @@ export function registerRsyncTool(server: McpServer) {
       title: "Rsync File Sync",
       description:
         "Syncs files between local and remote locations using rsync. WARNING: Defaults to dry-run mode for safety — set dryRun=false to actually transfer files. Returns structured transfer statistics.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         source: z
           .string()

--- a/packages/server-remote/src/tools/ssh-keyscan.ts
+++ b/packages/server-remote/src/tools/ssh-keyscan.ts
@@ -23,6 +23,7 @@ export function registerSshKeyscanTool(server: McpServer) {
       title: "SSH Keyscan",
       description:
         "Retrieves public host keys from a remote SSH server using `ssh-keyscan`. Useful for populating known_hosts or verifying host key fingerprints.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         host: z
           .string()

--- a/packages/server-remote/src/tools/ssh-run.ts
+++ b/packages/server-remote/src/tools/ssh-run.ts
@@ -19,6 +19,7 @@ export function registerSshRunTool(server: McpServer) {
       title: "SSH Run Command",
       description:
         "Executes a command on a remote host via SSH. WARNING: This runs commands on a remote machine. Ensure the host and command are correct before executing. Returns structured output with stdout, stderr, exit code, and duration.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         host: z
           .string()

--- a/packages/server-remote/src/tools/ssh-test.ts
+++ b/packages/server-remote/src/tools/ssh-test.ts
@@ -19,6 +19,7 @@ export function registerSshTestTool(server: McpServer) {
       title: "SSH Test Connection",
       description:
         "Tests SSH connectivity to a remote host using `ssh -T`. Returns whether the host is reachable and any banner message.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         host: z
           .string()

--- a/packages/server-ruby/src/tools/bundle-check.ts
+++ b/packages/server-ruby/src/tools/bundle-check.ts
@@ -17,6 +17,7 @@ export function registerBundleCheckTool(server: McpServer) {
       title: "Bundle Check",
       description:
         "Verifies that the Gemfile's dependencies are satisfied without installing them.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         compact: compactInput,

--- a/packages/server-ruby/src/tools/bundle-install.ts
+++ b/packages/server-ruby/src/tools/bundle-install.ts
@@ -17,6 +17,7 @@ export function registerBundleInstallTool(server: McpServer) {
       title: "Bundle Install",
       description:
         "Installs Gemfile dependencies using `bundle install` and returns structured output with success status and duration.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         compact: compactInput,

--- a/packages/server-ruby/src/tools/check.ts
+++ b/packages/server-ruby/src/tools/check.ts
@@ -20,6 +20,7 @@ export function registerCheckTool(server: McpServer) {
       title: "Ruby Syntax Check",
       description:
         "Checks a Ruby file for syntax errors using `ruby -c` and returns structured validation results.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         file: z
           .string()

--- a/packages/server-ruby/src/tools/gem-install.ts
+++ b/packages/server-ruby/src/tools/gem-install.ts
@@ -24,6 +24,7 @@ export function registerGemInstallTool(server: McpServer) {
       title: "Gem Install",
       description:
         "Installs a Ruby gem using `gem install` and returns structured output with success status and duration.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         gem: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Name of the gem to install"),
         version: z

--- a/packages/server-ruby/src/tools/gem-list.ts
+++ b/packages/server-ruby/src/tools/gem-list.ts
@@ -20,6 +20,7 @@ export function registerGemListTool(server: McpServer) {
       title: "Gem List",
       description:
         "Lists installed Ruby gems with version information. Returns structured JSON with gem names and versions.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         filter: z
           .string()

--- a/packages/server-ruby/src/tools/gem-outdated.ts
+++ b/packages/server-ruby/src/tools/gem-outdated.ts
@@ -16,6 +16,7 @@ export function registerGemOutdatedTool(server: McpServer) {
     {
       title: "Gem Outdated",
       description: "Lists outdated Ruby gems showing current and latest available versions.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         compact: compactInput,

--- a/packages/server-search/src/tools/count.ts
+++ b/packages/server-search/src/tools/count.ts
@@ -21,6 +21,7 @@ export function registerCountTool(server: McpServer) {
       title: "Match Count",
       description:
         "Counts pattern matches per file using ripgrep. Returns per-file match counts and totals.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         pattern: z
           .string()

--- a/packages/server-search/src/tools/find.ts
+++ b/packages/server-search/src/tools/find.ts
@@ -20,6 +20,7 @@ export function registerFindTool(server: McpServer) {
       title: "Find Files",
       description:
         "Finds files and directories using fd with structured output. Returns file paths, names, and extensions.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         pattern: z
           .string()

--- a/packages/server-search/src/tools/jq.ts
+++ b/packages/server-search/src/tools/jq.ts
@@ -20,6 +20,7 @@ export function registerJqTool(server: McpServer) {
       title: "JSON Processor",
       description:
         "Processes and transforms JSON using jq expressions. Accepts JSON from a file path or inline string. Returns the transformed result.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         expression: z
           .string()

--- a/packages/server-search/src/tools/search.ts
+++ b/packages/server-search/src/tools/search.ts
@@ -21,6 +21,7 @@ export function registerSearchTool(server: McpServer) {
       title: "Code Search",
       description:
         "Searches file contents using ripgrep with structured JSON output. Returns match locations with file, line, column, matched text, and line content.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         pattern: z
           .string()

--- a/packages/server-search/src/tools/yq.ts
+++ b/packages/server-search/src/tools/yq.ts
@@ -20,6 +20,7 @@ export function registerYqTool(server: McpServer) {
       title: "YAML/JSON/XML/TOML Processor",
       description:
         "Processes and transforms YAML, JSON, XML, TOML, and properties files using yq expressions. Accepts input from a file path or inline string. Returns the transformed result.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         expression: z
           .string()

--- a/packages/server-security/src/tools/gitleaks.ts
+++ b/packages/server-security/src/tools/gitleaks.ts
@@ -28,6 +28,7 @@ export function registerGitleaksTool(server: McpServer) {
       title: "Gitleaks Secret Detection",
       description:
         "Runs Gitleaks to detect hardcoded secrets in git repositories. Returns structured finding data with redacted secrets.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
         redact: z

--- a/packages/server-security/src/tools/semgrep.ts
+++ b/packages/server-security/src/tools/semgrep.ts
@@ -27,6 +27,7 @@ export function registerSemgrepTool(server: McpServer) {
       title: "Semgrep Static Analysis",
       description:
         "Runs Semgrep static analysis with structured rules and findings. Returns structured finding data with severity summary.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         patterns: z
           .preprocess(

--- a/packages/server-security/src/tools/trivy.ts
+++ b/packages/server-security/src/tools/trivy.ts
@@ -26,6 +26,7 @@ export function registerTrivyTool(server: McpServer) {
       title: "Trivy Security Scanner",
       description:
         "Runs Trivy vulnerability/misconfiguration scanner on container images, filesystems, or IaC configs. Returns structured vulnerability data with severity summary.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         target: z
           .string()

--- a/packages/server-swift/src/tools/package-clean.ts
+++ b/packages/server-swift/src/tools/package-clean.ts
@@ -16,6 +16,7 @@ export function registerPackageCleanTool(server: McpServer) {
     {
       title: "Swift Package Clean",
       description: "Cleans Swift package build artifacts and returns structured result.",
+      annotations: { destructiveHint: true },
       inputSchema: {
         path: projectPathInput,
         compact: compactInput,

--- a/packages/server-swift/src/tools/package-resolve.ts
+++ b/packages/server-swift/src/tools/package-resolve.ts
@@ -16,6 +16,7 @@ export function registerPackageResolveTool(server: McpServer) {
     {
       title: "Swift Package Resolve",
       description: "Resolves Swift package dependencies and returns structured resolution results.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         path: projectPathInput,
         compact: compactInput,

--- a/packages/server-swift/src/tools/package-show-dependencies.ts
+++ b/packages/server-swift/src/tools/package-show-dependencies.ts
@@ -18,6 +18,7 @@ export function registerPackageShowDependenciesTool(server: McpServer) {
       title: "Swift Package Show Dependencies",
       description:
         "Shows the dependency tree of a Swift package and returns structured dependency data.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         format: z
           .enum(["text", "json", "dot"])

--- a/packages/server-swift/src/tools/package-update.ts
+++ b/packages/server-swift/src/tools/package-update.ts
@@ -23,6 +23,7 @@ export function registerPackageUpdateTool(server: McpServer) {
     {
       title: "Swift Package Update",
       description: "Updates Swift package dependencies and returns structured update results.",
+      annotations: { openWorldHint: true },
       inputSchema: {
         packages: z
           .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))

--- a/packages/server-swift/src/tools/test.ts
+++ b/packages/server-swift/src/tools/test.ts
@@ -20,6 +20,7 @@ export function registerTestTool(server: McpServer) {
       title: "Swift Test",
       description:
         "Runs swift test and returns structured test results (name, status, pass/fail counts).",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         filter: z
           .string()

--- a/packages/server-test/src/tools/coverage.ts
+++ b/packages/server-test/src/tools/coverage.ts
@@ -208,6 +208,7 @@ export function registerCoverageTool(server: McpServer) {
     {
       title: "Test Coverage",
       description: "Runs tests with coverage and returns structured coverage summary per file.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         framework: z

--- a/packages/server-test/src/tools/playwright.ts
+++ b/packages/server-test/src/tools/playwright.ts
@@ -117,6 +117,7 @@ export function registerPlaywrightTool(server: McpServer) {
       title: "Playwright Tests",
       description:
         "Runs Playwright tests with JSON reporter and returns structured results with pass/fail status, duration, and error messages.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         filter: z

--- a/packages/server-test/src/tools/run.ts
+++ b/packages/server-test/src/tools/run.ts
@@ -260,6 +260,7 @@ export function registerRunTool(server: McpServer) {
       title: "Run Tests",
       description:
         "Auto-detects test framework (pytest/jest/vitest/mocha), runs tests, returns structured results with failures.",
+      annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
         framework: z


### PR DESCRIPTION
## Summary

Closes #678

- Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `openWorldHint`) to **177 tools** across all 28 server packages
- Annotations are placed in the `registerTool` metadata object alongside `title`, `description`, `inputSchema`, and `outputSchema`
- Tools with no applicable annotations (e.g., `git add`, `git commit`, `cargo fmt`) are left without annotations, relying on MCP SDK defaults

### Annotation guidelines applied

| Annotation | Applied to |
|---|---|
| `readOnlyHint: true` | Tools that only read/query state (e.g., `git status`, `docker ps`, `npm list`, all search tools) |
| `destructiveHint: true` | Tools that can destroy data or are hard to reverse (e.g., `git reset`, `git clean`, `docker compose-down`, `k8s apply`) |
| `openWorldHint: true` | Tools that interact with external systems/network (e.g., `git push/pull`, all GitHub tools, all HTTP tools, `npm install`) |

Many tools have multiple annotations. For example:
- `git push` — `openWorldHint: true, destructiveHint: true` (force push can destroy remote state)
- `http get` — `readOnlyHint: true, openWorldHint: true` (reads data but over the network)
- `k8s apply` — `openWorldHint: true, destructiveHint: true` (modifies cluster state remotely)

### Packages affected

All 28 `@paretools/*` server packages (minor version bump via changeset).

## Test plan

- [x] TypeScript build passes across all 30 packages (0 errors)
- [x] All tests pass (58/60 turbo tasks cached/passed; git integration tests pass on re-run — known Windows CI flakiness)
- [x] Changeset included for minor version bump

Generated with [Claude Code](https://claude.com/claude-code)