### PR TITLE
feat(shared): add dev-mode validation for compactDualOutput

### DIFF
--- a/.changeset/compact-validation.md
+++ b/.changeset/compact-validation.md
@@ -1,0 +1,5 @@
+---
+"@paretools/shared": patch
+---
+
+Add dev-mode runtime validation for compactDualOutput and strippedCompactDualOutput. When an optional `outputSchema` (Zod) is passed and `NODE_ENV !== 'production'` (or `PARE_DEBUG` is set), the structured output is validated against the schema before returning. Mismatches throw a descriptive error with field paths, catching compact-map / schema bugs during development and testing rather than in production.

--- a/packages/shared/__tests__/compact.test.ts
+++ b/packages/shared/__tests__/compact.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { estimateTokens, compactDualOutput } from "../src/output.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+import { estimateTokens, compactDualOutput, strippedCompactDualOutput } from "../src/output.js";
 
 describe("estimateTokens", () => {
   it("returns 1 for a 4-char string", () => {
@@ -78,5 +79,198 @@ describe("compactDualOutput", () => {
       false,
     );
     expect(result.structuredContent).toEqual({ items: [{ id: 1 }], total: 1 });
+  });
+});
+
+describe("compactDualOutput dev-mode validation", () => {
+  let origNodeEnv: string | undefined;
+  let origPareDebug: string | undefined;
+
+  beforeEach(() => {
+    origNodeEnv = process.env.NODE_ENV;
+    origPareDebug = process.env.PARE_DEBUG;
+    // Ensure dev mode is active for most tests
+    delete process.env.NODE_ENV;
+    delete process.env.PARE_DEBUG;
+  });
+
+  afterEach(() => {
+    if (origNodeEnv !== undefined) process.env.NODE_ENV = origNodeEnv;
+    else delete process.env.NODE_ENV;
+    if (origPareDebug !== undefined) process.env.PARE_DEBUG = origPareDebug;
+    else delete process.env.PARE_DEBUG;
+  });
+
+  const schema = z.object({
+    items: z.array(z.object({ id: z.number(), name: z.string() })),
+    total: z.number(),
+  });
+
+  const fullData = { items: [{ id: 1, name: "a", extra: "verbose" }], total: 1 };
+  const formatFull = (d: typeof fullData) => `Full: ${d.total} items`;
+
+  it("passes when compact output matches schema", () => {
+    const validCompactMap = (d: typeof fullData) => ({
+      items: d.items.map((i) => ({ id: i.id, name: i.name })),
+      total: d.total,
+    });
+    const formatCompact = (d: ReturnType<typeof validCompactMap>) => `Compact: ${d.total}`;
+
+    // Force compact path (short rawStdout)
+    expect(() =>
+      compactDualOutput(fullData, "x", formatFull, validCompactMap, formatCompact, false, schema),
+    ).not.toThrow();
+  });
+
+  it("throws when compact output omits a required field", () => {
+    // compactMap omits the required 'name' field
+    const badCompactMap = (d: typeof fullData) => ({
+      items: d.items.map((i) => ({ id: i.id })),
+      total: d.total,
+    });
+    const formatCompact = (d: ReturnType<typeof badCompactMap>) => `Compact: ${d.total}`;
+
+    expect(() =>
+      compactDualOutput(fullData, "x", formatFull, badCompactMap, formatCompact, false, schema),
+    ).toThrow(/compactDualOutput \(compact\): structured output does not match outputSchema/);
+  });
+
+  it("throws with descriptive field path in error message", () => {
+    const badCompactMap = (d: typeof fullData) => ({
+      items: d.items.map((i) => ({ id: i.id })),
+      total: d.total,
+    });
+    const formatCompact = (d: ReturnType<typeof badCompactMap>) => `Compact: ${d.total}`;
+
+    expect(() =>
+      compactDualOutput(fullData, "x", formatFull, badCompactMap, formatCompact, false, schema),
+    ).toThrow(/items\.0\.name/);
+  });
+
+  it("validates full data path when forceFullSchema is true", () => {
+    // Schema requires 'name' to be a string, but full data has it — should pass
+    const noopCompact = () => ({});
+    const noopFormat = () => "";
+
+    expect(() =>
+      compactDualOutput(fullData, "x", formatFull, noopCompact, noopFormat, true, schema),
+    ).not.toThrow();
+  });
+
+  it("validates full data path when structured tokens < raw tokens", () => {
+    const badSchema = z.object({
+      items: z.array(z.object({ id: z.number(), name: z.string() })),
+      total: z.number(),
+      required_field: z.string(), // not in fullData
+    });
+
+    const noopCompact = () => ({});
+    const noopFormat = () => "";
+    const longRaw = "x".repeat(10000);
+
+    expect(() =>
+      compactDualOutput(fullData, longRaw, formatFull, noopCompact, noopFormat, false, badSchema),
+    ).toThrow(/compactDualOutput \(full\)/);
+  });
+
+  it("skips validation in production mode (NODE_ENV=production)", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.PARE_DEBUG;
+
+    const badCompactMap = (d: typeof fullData) => ({
+      items: d.items.map((i) => ({ id: i.id })),
+      total: d.total,
+    });
+    const formatCompact = (d: ReturnType<typeof badCompactMap>) => `Compact: ${d.total}`;
+
+    // Should NOT throw even with a bad compact map
+    expect(() =>
+      compactDualOutput(fullData, "x", formatFull, badCompactMap, formatCompact, false, schema),
+    ).not.toThrow();
+  });
+
+  it("validates in production when PARE_DEBUG is set", () => {
+    process.env.NODE_ENV = "production";
+    process.env.PARE_DEBUG = "1";
+
+    const badCompactMap = (d: typeof fullData) => ({
+      items: d.items.map((i) => ({ id: i.id })),
+      total: d.total,
+    });
+    const formatCompact = (d: ReturnType<typeof badCompactMap>) => `Compact: ${d.total}`;
+
+    expect(() =>
+      compactDualOutput(fullData, "x", formatFull, badCompactMap, formatCompact, false, schema),
+    ).toThrow(/compactDualOutput/);
+  });
+
+  it("skips validation when no outputSchema is provided", () => {
+    const badCompactMap = (d: typeof fullData) => ({
+      items: d.items.map((i) => ({ id: i.id })),
+      total: d.total,
+    });
+    const formatCompact = (d: ReturnType<typeof badCompactMap>) => `Compact: ${d.total}`;
+
+    // No schema → no validation → no error
+    expect(() =>
+      compactDualOutput(fullData, "x", formatFull, badCompactMap, formatCompact, false),
+    ).not.toThrow();
+  });
+});
+
+describe("strippedCompactDualOutput dev-mode validation", () => {
+  let origNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    origNodeEnv = process.env.NODE_ENV;
+    delete process.env.NODE_ENV;
+    delete process.env.PARE_DEBUG;
+  });
+
+  afterEach(() => {
+    if (origNodeEnv !== undefined) process.env.NODE_ENV = origNodeEnv;
+    else delete process.env.NODE_ENV;
+  });
+
+  const schema = z.object({ id: z.number(), label: z.string() });
+
+  const internalData = { id: 1, label: "test", _internal: "hidden" };
+  const formatFull = () => "full text";
+  const schemaMap = (d: typeof internalData) => ({ id: d.id, label: d.label });
+
+  it("throws when compact output mismatches schema", () => {
+    const badCompact = () => ({ id: 1 }); // missing 'label'
+    const formatCompact = () => "compact";
+
+    expect(() =>
+      strippedCompactDualOutput(
+        internalData,
+        "x",
+        formatFull,
+        schemaMap,
+        badCompact,
+        formatCompact,
+        false,
+        schema,
+      ),
+    ).toThrow(/compactDualOutput \(compact\)/);
+  });
+
+  it("passes when outputs match schema", () => {
+    const validCompact = (d: typeof internalData) => ({ id: d.id, label: d.label });
+    const formatCompact = () => "compact";
+
+    expect(() =>
+      strippedCompactDualOutput(
+        internalData,
+        "x",
+        formatFull,
+        schemaMap,
+        validCompact,
+        formatCompact,
+        false,
+        schema,
+      ),
+    ).not.toThrow();
   });
 });

--- a/packages/shared/src/output.ts
+++ b/packages/shared/src/output.ts
@@ -1,4 +1,34 @@
+import type { ZodType } from "zod";
 import type { ToolOutput } from "./types.js";
+
+/**
+ * Returns true when dev-mode validation should run.
+ * Active when NODE_ENV is NOT 'production' or PARE_DEBUG is set.
+ */
+function isDevMode(): boolean {
+  return process.env.NODE_ENV !== "production" || !!process.env.PARE_DEBUG;
+}
+
+/**
+ * Validates `data` against a Zod `outputSchema` in dev mode.
+ * Throws a descriptive error when the data does not match the schema,
+ * helping developers catch compact-map / schema mismatches early.
+ *
+ * No-ops in production (NODE_ENV=production without PARE_DEBUG).
+ */
+function devValidate<T>(data: T, outputSchema: ZodType | undefined, label: string): void {
+  if (!outputSchema || !isDevMode()) return;
+  const result = outputSchema.safeParse(data);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  - ${i.path.join(".")}: ${i.message}`)
+      .join("\n");
+    throw new Error(
+      `compactDualOutput (${label}): structured output does not match outputSchema.\n` +
+        `Validation errors:\n${issues}`,
+    );
+  }
+}
 
 /**
  * Creates the dual-output response that every pare tool returns.
@@ -37,6 +67,9 @@ export function estimateTokens(text: string): number {
  * @param compactMap - Projects full data into a compact shape.
  * @param compactFormat - Formatter for compact data.
  * @param forceFullSchema - When true, skip auto-detection and return full data.
+ * @param outputSchema - Optional Zod schema. In dev mode (NODE_ENV !== 'production' or PARE_DEBUG set),
+ *   the structured output is validated against this schema before returning. Mismatches throw a
+ *   descriptive error, catching compact-map bugs during development/testing rather than in production.
  */
 export function compactDualOutput<T, C>(
   data: T,
@@ -45,9 +78,12 @@ export function compactDualOutput<T, C>(
   compactMap: (d: T) => C,
   compactFormat: (d: C) => string,
   forceFullSchema: boolean,
+  outputSchema?: ZodType,
 ): ToolOutput<T | C> {
   if (forceFullSchema) {
-    return dualOutput(data, humanFormat) as ToolOutput<T | C>;
+    const out = dualOutput(data, humanFormat) as ToolOutput<T | C>;
+    devValidate(out.structuredContent, outputSchema, "full");
+    return out;
   }
 
   const structuredTokens = estimateTokens(JSON.stringify(data));
@@ -55,10 +91,14 @@ export function compactDualOutput<T, C>(
 
   if (structuredTokens >= rawTokens) {
     const compact = compactMap(data);
-    return dualOutput(compact, compactFormat) as ToolOutput<T | C>;
+    const out = dualOutput(compact, compactFormat) as ToolOutput<T | C>;
+    devValidate(out.structuredContent, outputSchema, "compact");
+    return out;
   }
 
-  return dualOutput(data, humanFormat) as ToolOutput<T | C>;
+  const out = dualOutput(data, humanFormat) as ToolOutput<T | C>;
+  devValidate(out.structuredContent, outputSchema, "full");
+  return out;
 }
 
 /**
@@ -96,6 +136,7 @@ export function strippedDualOutput<T, S>(
  * @param compactMap - Projects full data into a compact shape (for compact mode).
  * @param compactFormat - Formatter for compact data.
  * @param forceFullSchema - When true, skip auto-detection and return full data.
+ * @param outputSchema - Optional Zod schema for dev-mode validation (see compactDualOutput).
  */
 export function strippedCompactDualOutput<T, S, C>(
   data: T,
@@ -105,9 +146,12 @@ export function strippedCompactDualOutput<T, S, C>(
   compactMap: (d: T) => C,
   compactFormat: (d: C) => string,
   forceFullSchema: boolean,
+  outputSchema?: ZodType,
 ): ToolOutput<S | C> {
   if (forceFullSchema) {
-    return strippedDualOutput(data, humanFormat, schemaMap) as ToolOutput<S | C>;
+    const out = strippedDualOutput(data, humanFormat, schemaMap) as ToolOutput<S | C>;
+    devValidate(out.structuredContent, outputSchema, "full");
+    return out;
   }
 
   const structuredTokens = estimateTokens(JSON.stringify(data));
@@ -115,8 +159,12 @@ export function strippedCompactDualOutput<T, S, C>(
 
   if (structuredTokens >= rawTokens) {
     const compact = compactMap(data);
-    return dualOutput(compact, compactFormat) as ToolOutput<S | C>;
+    const out = dualOutput(compact, compactFormat) as ToolOutput<S | C>;
+    devValidate(out.structuredContent, outputSchema, "compact");
+    return out;
   }
 
-  return strippedDualOutput(data, humanFormat, schemaMap) as ToolOutput<S | C>;
+  const out = strippedDualOutput(data, humanFormat, schemaMap) as ToolOutput<S | C>;
+  devValidate(out.structuredContent, outputSchema, "full");
+  return out;
 }


### PR DESCRIPTION
## Summary

Closes #659

- Adds dev-mode runtime validation to `compactDualOutput` and `strippedCompactDualOutput` via an optional `outputSchema` (Zod) parameter
- When `NODE_ENV !== 'production'` or `PARE_DEBUG` is set, validates structured output against the schema before returning
- On mismatch, throws a descriptive error with field paths (e.g. `items.0.name: Required`), catching compact-map / schema bugs during `pnpm test` rather than in production
- Skips validation entirely in production mode (zero overhead) unless `PARE_DEBUG` is explicitly set
- No breaking changes — the `outputSchema` parameter is optional, existing call sites are unaffected

## Test plan

- [x] Valid compact map passes without error in dev mode
- [x] Compact map that omits a required field throws descriptive error in dev mode
- [x] Error message includes field paths for easy debugging
- [x] Full data path is also validated (forceFullSchema and non-compact branches)
- [x] Production mode (`NODE_ENV=production`) skips validation entirely
- [x] `PARE_DEBUG=1` overrides production mode and enables validation
- [x] No schema provided — no validation, no error (backward compatible)
- [x] `strippedCompactDualOutput` validated in both compact and full paths
- [x] All 398 shared package tests pass
- [x] TypeScript compiles cleanly