### PR TITLE
chore: add glama.json for Glama.ai directory listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["Dave-London"]
+}


### PR DESCRIPTION
Adds `glama.json` to the repo root so [Glama.ai](https://glama.ai/mcp/servers) can auto-discover and list Pare in their MCP server directory.

After merge, claim ownership at Glama by authenticating with GitHub.