### PR TITLE
fix(process): add security hardening to reload and run tools

### DIFF
--- a/.changeset/process-security.md
+++ b/.changeset/process-security.md
@@ -1,0 +1,12 @@
+---
+"@paretools/process": patch
+---
+
+fix(process): add security hardening to reload and run tools
+
+- Add assertAllowedByPolicy check to reload tool buildCommand parameter
+- Add assertAllowedRoot check to reload tool path parameter
+- Replace sh -c shell execution with direct executable + args in reload tool
+- Add destructiveHint annotation to both reload and run tools
+- Add security warnings about arbitrary command execution in tool descriptions
+- Document PARE_PROCESS_ALLOWED_COMMANDS and PARE_PROCESS_ALLOWED_ROOTS configuration

--- a/packages/server-process/src/tools/reload.ts
+++ b/packages/server-process/src/tools/reload.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { strippedDualOutput, run, INPUT_LIMITS, cwdPathInput } from "@paretools/shared";
+import {
+  strippedDualOutput,
+  run,
+  INPUT_LIMITS,
+  cwdPathInput,
+  assertAllowedByPolicy,
+  assertAllowedRoot,
+} from "@paretools/shared";
 import { formatReload, schemaReloadMap } from "../lib/formatters.js";
 import { ReloadResultSchema } from "../schemas/index.js";
 import type { ReloadResultInternal } from "../schemas/index.js";
@@ -15,8 +22,11 @@ export function registerReloadTool(server: McpServer) {
         "Rebuilds the MCP server (or a specified project) and sends a `notifications/tools/list_changed` " +
         "notification so the host re-fetches tool definitions. Useful during local development when code " +
         "changes require a rebuild without restarting the session.\n\n" +
-        "Default build command: `pnpm build`. Override with `buildCommand` for custom setups.",
-      annotations: { readOnlyHint: false },
+        "Default build command: `pnpm build`. Override with `buildCommand` for custom setups.\n\n" +
+        "**Security warning**: The `buildCommand` parameter executes arbitrary commands. " +
+        "Configure `PARE_PROCESS_ALLOWED_COMMANDS` to restrict which executables are permitted. " +
+        "When not configured, any command is allowed.",
+      annotations: { readOnlyHint: false, destructiveHint: true },
       inputSchema: {
         buildCommand: z
           .string()
@@ -41,13 +51,20 @@ export function registerReloadTool(server: McpServer) {
       const cmd = buildCommand ?? "pnpm build";
       const timeoutMs = timeout ?? 120_000;
 
+      // Security: validate the executable against the allowed-commands policy
+      const parts = cmd.split(/\s+/);
+      const executable = parts[0]!;
+      const args = parts.slice(1);
+      assertAllowedByPolicy(executable, "process");
+      assertAllowedRoot(cwd, "process");
+
       const start = Date.now();
       let rebuilt = false;
       let buildOutput: string | undefined;
       let error: string | undefined;
 
       try {
-        const result = await run("sh", ["-c", cmd], {
+        const result = await run(executable, args, {
           cwd,
           timeout: timeoutMs,
           shell: false,

--- a/packages/server-process/src/tools/run.ts
+++ b/packages/server-process/src/tools/run.ts
@@ -45,12 +45,18 @@ export function registerRunTool(server: McpServer) {
       title: "Process Run",
       description:
         "Runs a command and returns structured output (stdout, stderr, exit code, duration, timeout status).\n\n" +
-        "**Security note**: The `shell` parameter enables shell-mode execution. " +
+        "**Security warning**: This tool executes arbitrary commands on the host system. " +
+        "Configure `PARE_PROCESS_ALLOWED_COMMANDS` (comma-separated list of allowed executables) " +
+        "to restrict which commands can be run. Without this configuration, ANY command is permitted.\n\n" +
+        "Configure `PARE_PROCESS_ALLOWED_ROOTS` to restrict working directories.\n\n" +
+        "**Shell mode**: The `shell` parameter enables shell-mode execution. " +
         "When shell=true, the command string is passed through the system shell " +
         "(e.g., /bin/sh or cmd.exe), enabling features like glob expansion, piping, " +
         "and variable substitution — but also exposing the command to shell injection risks. " +
-        "Only use shell=true when you trust the input and need shell features.",
-      annotations: { readOnlyHint: false },
+        "Only use shell=true when you trust the input and need shell features. " +
+        "Note: shell=true bypasses the ALLOWED_COMMANDS check on arguments, so the entire " +
+        "shell expression is executed if the base command is allowed.",
+      annotations: { readOnlyHint: false, destructiveHint: true },
       inputSchema: {
         command: z
           .string()


### PR DESCRIPTION
## Summary

- **reload tool (#708)**: Add `assertAllowedByPolicy` and `assertAllowedRoot` checks before executing the build command. Replace `sh -c` shell execution with direct `run(executable, args)` to prevent shell injection. Add `destructiveHint: true` annotation and security warning in description.
- **run tool (#709)**: Add `destructiveHint: true` annotation. Expand security warnings to prominently document `PARE_PROCESS_ALLOWED_COMMANDS` and `PARE_PROCESS_ALLOWED_ROOTS` configuration. Add warning about `shell=true` bypassing argument-level checks.

Closes #708
Closes #709

## Test plan

- [x] All 85 existing tests pass (6 test files)
- [x] Build succeeds for `@paretools/process`
- [ ] CI matrix (ubuntu/windows/macos x node 20/22)