### PR TITLE
fix(git): security hardening for rebase exec, bisect run, config set

### DIFF
--- a/.changeset/git-security.md
+++ b/.changeset/git-security.md
@@ -1,0 +1,9 @@
+---
+"@paretools/git": patch
+---
+
+fix(git): add security hardening for rebase exec, bisect run, and config set
+
+- Gate rebase --exec parameter behind assertAllowedByPolicy
+- Gate bisect run command behind assertAllowedByPolicy
+- Block dangerous git config keys that execute commands (core.fsmonitor, core.editor, etc.)

--- a/packages/server-git/src/tools/bisect.ts
+++ b/packages/server-git/src/tools/bisect.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   dualOutput,
   assertNoFlagInjection,
+  assertAllowedByPolicy,
   INPUT_LIMITS,
   repoPathInput,
   coerceJsonArray,
@@ -50,7 +51,7 @@ export function registerBisectTool(server: McpServer) {
           .max(INPUT_LIMITS.MESSAGE_MAX)
           .optional()
           .describe(
-            "Script/command to run for automated bisection (used with run action). Must return exit code 0 for good, 1-124/126-127 for bad, 125 to skip.",
+            "Script/command to run for automated bisection (used with run action). Must return exit code 0 for good, 1-124/126-127 for bad, 125 to skip. Security: the executable is validated against the ALLOWED_COMMANDS policy when configured.",
           ),
         paths: z.preprocess(
           coerceJsonArray,
@@ -113,6 +114,7 @@ export function registerBisectTool(server: McpServer) {
         // Split the command into executable and args for execFile safety
         // git bisect run expects the command as separate args
         const cmdParts = command.split(/\s+/).filter(Boolean);
+        assertAllowedByPolicy(cmdParts[0], "git");
         assertNoFlagInjection(cmdParts[0], "command");
 
         const args = ["bisect", "run", ...cmdParts];

--- a/packages/server-git/src/tools/config.ts
+++ b/packages/server-git/src/tools/config.ts
@@ -1,6 +1,31 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
+
+const DANGEROUS_CONFIG_KEYS = new Set([
+  "core.fsmonitor",
+  "core.pager",
+  "core.editor",
+  "core.sshcommand",
+  "core.hookspath",
+  "core.askpass",
+  "diff.external",
+  "merge.tool",
+  "credential.helper",
+  "filter.lfs.clean",
+  "filter.lfs.smudge",
+  "filter.lfs.process",
+]);
+
+function assertSafeConfigKey(key: string): void {
+  const lower = key.toLowerCase();
+  if (DANGEROUS_CONFIG_KEYS.has(lower)) {
+    throw new Error(
+      `Setting "${key}" is blocked because it can execute arbitrary commands. ` +
+        `Blocked keys: ${[...DANGEROUS_CONFIG_KEYS].sort().join(", ")}`,
+    );
+  }
+}
 import { git } from "../lib/git-runner.js";
 import { parseConfigList } from "../lib/parsers.js";
 import { formatConfig } from "../lib/formatters.js";
@@ -53,6 +78,7 @@ export function registerConfigTool(server: McpServer) {
         }
         assertNoFlagInjection(key, "key");
         assertNoFlagInjection(value, "value");
+        assertSafeConfigKey(key);
 
         const args = ["config"];
         if (scopeFlag) args.push(scopeFlag);

--- a/packages/server-git/src/tools/rebase.ts
+++ b/packages/server-git/src/tools/rebase.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
+import {
+  dualOutput,
+  assertNoFlagInjection,
+  assertAllowedByPolicy,
+  INPUT_LIMITS,
+  repoPathInput,
+} from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseRebase } from "../lib/parsers.js";
 import { formatRebase } from "../lib/formatters.js";
@@ -57,7 +63,9 @@ export function registerRebaseTool(server: McpServer) {
           .string()
           .max(INPUT_LIMITS.STRING_MAX)
           .optional()
-          .describe("Run command after each commit (--exec)"),
+          .describe(
+            "Run command after each commit (--exec). Security: the executable is validated against the ALLOWED_COMMANDS policy when configured.",
+          ),
         empty: z
           .enum(["drop", "keep", "ask"])
           .optional()
@@ -165,7 +173,10 @@ export function registerRebaseTool(server: McpServer) {
       if (params.onto) assertNoFlagInjection(params.onto, "onto");
       if (params.strategy) assertNoFlagInjection(params.strategy, "strategy");
       if (params.strategyOption) assertNoFlagInjection(params.strategyOption, "strategyOption");
-      if (params.exec) assertNoFlagInjection(params.exec, "exec");
+      if (params.exec) {
+        assertAllowedByPolicy(params.exec.split(/\s+/)[0], "git");
+        assertNoFlagInjection(params.exec, "exec");
+      }
 
       // Count commits that will be rebased using git log
       const logResult = await git(["log", "--oneline", `${branch}..HEAD`], cwd);


### PR DESCRIPTION
## Summary

- **rebase --exec** (#724): Gate the `exec` parameter behind `assertAllowedByPolicy` to prevent arbitrary shell command execution via `git rebase --exec`
- **bisect run** (#725): Gate the `command` parameter behind `assertAllowedByPolicy` to prevent arbitrary command execution via `git bisect run`
- **config set** (#726): Add a blocklist of dangerous git config keys (`core.fsmonitor`, `core.editor`, `core.hookspath`, etc.) that can execute arbitrary commands, and reject attempts to set them

All three fixes follow the existing security patterns in the codebase (`assertAllowedByPolicy` from `@paretools/shared`, `assertNoFlagInjection`).

Closes #724
Closes #725
Closes #726

## Test plan

- [x] All 526 existing server-git tests pass (466 passed, 60 skipped)
- [x] Build succeeds
- [ ] CI matrix passes (ubuntu/windows/macos x node 20/22)