### PR TITLE
feat(http): add SSRF protection and file exfiltration guards

### DIFF
--- a/.changeset/http-security.md
+++ b/.changeset/http-security.md
@@ -1,0 +1,11 @@
+---
+"@paretools/http": minor
+---
+
+feat(http): add SSRF protection, file exfiltration guards, and security warnings
+
+- Block private/reserved IP ranges in URL validation (opt-out via PARE_HTTP_ALLOW_PRIVATE)
+- Validate resolve parameter IPs against private ranges
+- Block @filepath in form values (opt-in via PARE_HTTP_ALLOW_FILE_UPLOAD)
+- Validate cookie values contain = (reject file paths)
+- Add security warnings for proxy parameter

--- a/packages/server-http/__tests__/security.test.ts
+++ b/packages/server-http/__tests__/security.test.ts
@@ -24,36 +24,38 @@ const MALICIOUS_FLAG_INPUTS = [
 ];
 
 describe("security: URL scheme validation", () => {
-  it("allows http:// and https:// only", () => {
-    expect(() => assertSafeUrl("http://api.example.com")).not.toThrow();
-    expect(() => assertSafeUrl("https://api.example.com")).not.toThrow();
+  it("allows http:// and https:// only", async () => {
+    process.env.PARE_HTTP_ALLOW_PRIVATE = "true";
+    await expect(assertSafeUrl("http://api.example.com")).resolves.toBeUndefined();
+    await expect(assertSafeUrl("https://api.example.com")).resolves.toBeUndefined();
+    delete process.env.PARE_HTTP_ALLOW_PRIVATE;
   });
 
-  it("blocks file:// scheme (SSRF / LFI)", () => {
-    expect(() => assertSafeUrl("file:///etc/passwd")).toThrow(/Unsafe URL scheme/);
-    expect(() => assertSafeUrl("FILE:///etc/passwd")).toThrow(/Unsafe URL scheme/);
+  it("blocks file:// scheme (SSRF / LFI)", async () => {
+    await expect(assertSafeUrl("file:///etc/passwd")).rejects.toThrow(/Unsafe URL scheme/);
+    await expect(assertSafeUrl("FILE:///etc/passwd")).rejects.toThrow(/Unsafe URL scheme/);
   });
 
-  it("blocks ftp:// scheme", () => {
-    expect(() => assertSafeUrl("ftp://evil.com/file")).toThrow(/Unsafe URL scheme/);
+  it("blocks ftp:// scheme", async () => {
+    await expect(assertSafeUrl("ftp://evil.com/file")).rejects.toThrow(/Unsafe URL scheme/);
   });
 
-  it("blocks gopher:// scheme (SSRF)", () => {
-    expect(() => assertSafeUrl("gopher://evil.com/")).toThrow(/Unsafe URL scheme/);
+  it("blocks gopher:// scheme (SSRF)", async () => {
+    await expect(assertSafeUrl("gopher://evil.com/")).rejects.toThrow(/Unsafe URL scheme/);
   });
 
-  it("blocks dict:// scheme", () => {
-    expect(() => assertSafeUrl("dict://evil.com/")).toThrow(/Unsafe URL scheme/);
+  it("blocks dict:// scheme", async () => {
+    await expect(assertSafeUrl("dict://evil.com/")).rejects.toThrow(/Unsafe URL scheme/);
   });
 
-  it("blocks data: scheme (XSS vector)", () => {
-    expect(() => assertSafeUrl("data:text/html,<script>alert(1)</script>")).toThrow(
+  it("blocks data: scheme (XSS vector)", async () => {
+    await expect(assertSafeUrl("data:text/html,<script>alert(1)</script>")).rejects.toThrow(
       /Unsafe URL scheme/,
     );
   });
 
-  it("blocks javascript: scheme", () => {
-    expect(() => assertSafeUrl("javascript:alert(1)")).toThrow(/Unsafe URL scheme/);
+  it("blocks javascript: scheme", async () => {
+    await expect(assertSafeUrl("javascript:alert(1)")).rejects.toThrow(/Unsafe URL scheme/);
   });
 });
 

--- a/packages/server-http/__tests__/url-validation.test.ts
+++ b/packages/server-http/__tests__/url-validation.test.ts
@@ -17,8 +17,11 @@ describe("assertSafeUrl", () => {
     ];
 
     for (const url of validUrls) {
-      it(`accepts "${url}"`, () => {
-        expect(() => assertSafeUrl(url)).not.toThrow();
+      it(`accepts "${url}"`, async () => {
+        // Private IPs allowed here because we're testing scheme validation
+        process.env.PARE_HTTP_ALLOW_PRIVATE = "true";
+        await expect(assertSafeUrl(url)).resolves.toBeUndefined();
+        delete process.env.PARE_HTTP_ALLOW_PRIVATE;
       });
     }
   });
@@ -37,37 +40,41 @@ describe("assertSafeUrl", () => {
     ];
 
     for (const url of dangerousUrls) {
-      it(`rejects "${url}"`, () => {
-        expect(() => assertSafeUrl(url)).toThrow(/Unsafe URL scheme/);
+      it(`rejects "${url}"`, async () => {
+        await expect(assertSafeUrl(url)).rejects.toThrow(/Unsafe URL scheme/);
       });
     }
   });
 
   describe("rejects malformed inputs", () => {
-    it("rejects empty string", () => {
-      expect(() => assertSafeUrl("")).toThrow(/must not be empty/);
+    it("rejects empty string", async () => {
+      await expect(assertSafeUrl("")).rejects.toThrow(/must not be empty/);
     });
 
-    it("rejects whitespace-only string", () => {
-      expect(() => assertSafeUrl("   ")).toThrow(/must not be empty/);
+    it("rejects whitespace-only string", async () => {
+      await expect(assertSafeUrl("   ")).rejects.toThrow(/must not be empty/);
     });
 
-    it("rejects string without scheme", () => {
-      expect(() => assertSafeUrl("example.com")).toThrow(/Unsafe URL scheme/);
+    it("rejects string without scheme", async () => {
+      await expect(assertSafeUrl("example.com")).rejects.toThrow(/Unsafe URL scheme/);
     });
 
-    it("rejects relative path", () => {
-      expect(() => assertSafeUrl("/path/to/file")).toThrow(/Unsafe URL scheme/);
+    it("rejects relative path", async () => {
+      await expect(assertSafeUrl("/path/to/file")).rejects.toThrow(/Unsafe URL scheme/);
     });
   });
 
-  it("trims whitespace before validation", () => {
-    expect(() => assertSafeUrl("  https://example.com  ")).not.toThrow();
+  it("trims whitespace before validation", async () => {
+    process.env.PARE_HTTP_ALLOW_PRIVATE = "true";
+    await expect(assertSafeUrl("  https://example.com  ")).resolves.toBeUndefined();
+    delete process.env.PARE_HTTP_ALLOW_PRIVATE;
   });
 
-  it("is case-insensitive for scheme", () => {
-    expect(() => assertSafeUrl("HTTPS://example.com")).not.toThrow();
-    expect(() => assertSafeUrl("Http://example.com")).not.toThrow();
+  it("is case-insensitive for scheme", async () => {
+    process.env.PARE_HTTP_ALLOW_PRIVATE = "true";
+    await expect(assertSafeUrl("HTTPS://example.com")).resolves.toBeUndefined();
+    await expect(assertSafeUrl("Http://example.com")).resolves.toBeUndefined();
+    delete process.env.PARE_HTTP_ALLOW_PRIVATE;
   });
 });
 

--- a/packages/server-http/src/__tests__/url-validation.test.ts
+++ b/packages/server-http/src/__tests__/url-validation.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  assertSafeUrl,
+  assertSafeResolve,
+  assertSafeCookie,
+  assertSafeFormValues,
+  isPrivateIP,
+  assertSafeHeader,
+} from "../lib/url-validation.js";
+
+/* ------------------------------------------------------------------ */
+/*  assertSafeUrl — scheme checks                                     */
+/* ------------------------------------------------------------------ */
+describe("assertSafeUrl — scheme validation", () => {
+  it("allows http:// URLs", async () => {
+    await expect(assertSafeUrl("http://example.com")).resolves.toBeUndefined();
+  });
+
+  it("allows https:// URLs", async () => {
+    await expect(assertSafeUrl("https://example.com")).resolves.toBeUndefined();
+  });
+
+  it("rejects empty URL", async () => {
+    await expect(assertSafeUrl("")).rejects.toThrow("URL must not be empty");
+  });
+
+  it("rejects file:// scheme", async () => {
+    await expect(assertSafeUrl("file:///etc/passwd")).rejects.toThrow("Unsafe URL scheme");
+  });
+
+  it("rejects ftp:// scheme", async () => {
+    await expect(assertSafeUrl("ftp://example.com")).rejects.toThrow("Unsafe URL scheme");
+  });
+
+  it("rejects gopher:// scheme", async () => {
+    await expect(assertSafeUrl("gopher://evil.com")).rejects.toThrow("Unsafe URL scheme");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  assertSafeUrl — SSRF private IP blocking                          */
+/* ------------------------------------------------------------------ */
+describe("assertSafeUrl — SSRF protection", () => {
+  // Save and restore env
+  let origAllow: string | undefined;
+  beforeEach(() => {
+    origAllow = process.env.PARE_HTTP_ALLOW_PRIVATE;
+    delete process.env.PARE_HTTP_ALLOW_PRIVATE;
+  });
+  afterEach(() => {
+    if (origAllow !== undefined) process.env.PARE_HTTP_ALLOW_PRIVATE = origAllow;
+    else delete process.env.PARE_HTTP_ALLOW_PRIVATE;
+  });
+
+  it("blocks 127.0.0.1 (loopback)", async () => {
+    await expect(assertSafeUrl("http://127.0.0.1/")).rejects.toThrow("private/reserved IP");
+  });
+
+  it("blocks 127.0.0.2 (loopback range)", async () => {
+    await expect(assertSafeUrl("http://127.0.0.2/")).rejects.toThrow("private/reserved IP");
+  });
+
+  it("blocks 10.0.0.1 (RFC 1918)", async () => {
+    await expect(assertSafeUrl("http://10.0.0.1/")).rejects.toThrow("private/reserved IP");
+  });
+
+  it("blocks 172.16.0.1 (RFC 1918)", async () => {
+    await expect(assertSafeUrl("http://172.16.0.1/")).rejects.toThrow("private/reserved IP");
+  });
+
+  it("blocks 192.168.1.1 (RFC 1918)", async () => {
+    await expect(assertSafeUrl("http://192.168.1.1/")).rejects.toThrow("private/reserved IP");
+  });
+
+  it("blocks 169.254.169.254 (link-local / cloud metadata)", async () => {
+    await expect(assertSafeUrl("http://169.254.169.254/")).rejects.toThrow("private/reserved IP");
+  });
+
+  it("blocks 0.0.0.0", async () => {
+    await expect(assertSafeUrl("http://0.0.0.0/")).rejects.toThrow("private/reserved IP");
+  });
+
+  it("blocks [::1] (IPv6 loopback)", async () => {
+    await expect(assertSafeUrl("http://[::1]/")).rejects.toThrow("private/reserved IP");
+  });
+
+  it("blocks metadata.google.internal", async () => {
+    await expect(assertSafeUrl("http://metadata.google.internal/")).rejects.toThrow(
+      "metadata hostname",
+    );
+  });
+
+  it("blocks metadata.internal", async () => {
+    await expect(assertSafeUrl("http://metadata.internal/")).rejects.toThrow("metadata hostname");
+  });
+
+  // IP obfuscation
+  it("blocks decimal IP 2130706433 (127.0.0.1)", async () => {
+    await expect(assertSafeUrl("http://2130706433/")).rejects.toThrow("private/reserved IP");
+  });
+
+  it("blocks hex IP 0x7f000001 (127.0.0.1)", async () => {
+    await expect(assertSafeUrl("http://0x7f000001/")).rejects.toThrow("private/reserved IP");
+  });
+
+  it("blocks octal IP 0177.0.0.1 (127.0.0.1)", async () => {
+    await expect(assertSafeUrl("http://0177.0.0.1/")).rejects.toThrow("private/reserved IP");
+  });
+
+  // Opt-out
+  it("allows private IPs when PARE_HTTP_ALLOW_PRIVATE=true", async () => {
+    process.env.PARE_HTTP_ALLOW_PRIVATE = "true";
+    await expect(assertSafeUrl("http://127.0.0.1/")).resolves.toBeUndefined();
+  });
+
+  it("does NOT allow private IPs when PARE_HTTP_ALLOW_PRIVATE is set to other values", async () => {
+    process.env.PARE_HTTP_ALLOW_PRIVATE = "yes";
+    await expect(assertSafeUrl("http://127.0.0.1/")).rejects.toThrow("private/reserved IP");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isPrivateIP                                                        */
+/* ------------------------------------------------------------------ */
+describe("isPrivateIP", () => {
+  it.each([
+    "127.0.0.1",
+    "10.0.0.1",
+    "172.16.0.1",
+    "192.168.0.1",
+    "169.254.169.254",
+    "0.0.0.0",
+    "::1",
+  ])("returns true for private IP %s", (ip) => {
+    expect(isPrivateIP(ip)).toBe(true);
+  });
+
+  it.each(["8.8.8.8", "1.1.1.1", "93.184.216.34"])("returns false for public IP %s", (ip) => {
+    expect(isPrivateIP(ip)).toBe(false);
+  });
+
+  // Obfuscated forms
+  it("detects decimal 2130706433 as private (127.0.0.1)", () => {
+    expect(isPrivateIP("2130706433")).toBe(true);
+  });
+
+  it("detects hex 0x7f000001 as private (127.0.0.1)", () => {
+    expect(isPrivateIP("0x7f000001")).toBe(true);
+  });
+
+  it("detects octal 0177.0.0.1 as private (127.0.0.1)", () => {
+    expect(isPrivateIP("0177.0.0.1")).toBe(true);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  assertSafeResolve — DNS rebinding protection                       */
+/* ------------------------------------------------------------------ */
+describe("assertSafeResolve", () => {
+  let origAllow: string | undefined;
+  beforeEach(() => {
+    origAllow = process.env.PARE_HTTP_ALLOW_PRIVATE;
+    delete process.env.PARE_HTTP_ALLOW_PRIVATE;
+  });
+  afterEach(() => {
+    if (origAllow !== undefined) process.env.PARE_HTTP_ALLOW_PRIVATE = origAllow;
+    else delete process.env.PARE_HTTP_ALLOW_PRIVATE;
+  });
+
+  it("allows public IP in resolve", () => {
+    expect(() => assertSafeResolve("example.com:443:93.184.216.34")).not.toThrow();
+  });
+
+  it("blocks 127.0.0.1 in resolve", () => {
+    expect(() => assertSafeResolve("example.com:443:127.0.0.1")).toThrow("private/reserved IP");
+  });
+
+  it("blocks 10.0.0.1 in resolve", () => {
+    expect(() => assertSafeResolve("example.com:443:10.0.0.1")).toThrow("private/reserved IP");
+  });
+
+  it("blocks 192.168.1.1 in resolve", () => {
+    expect(() => assertSafeResolve("example.com:443:192.168.1.1")).toThrow("private/reserved IP");
+  });
+
+  it("blocks 169.254.169.254 in resolve (metadata endpoint)", () => {
+    expect(() => assertSafeResolve("example.com:80:169.254.169.254")).toThrow(
+      "private/reserved IP",
+    );
+  });
+
+  it("blocks multiple addresses if any is private", () => {
+    expect(() => assertSafeResolve("example.com:443:93.184.216.34,127.0.0.1")).toThrow(
+      "private/reserved IP",
+    );
+  });
+
+  it("allows when PARE_HTTP_ALLOW_PRIVATE=true", () => {
+    process.env.PARE_HTTP_ALLOW_PRIVATE = "true";
+    expect(() => assertSafeResolve("example.com:443:127.0.0.1")).not.toThrow();
+  });
+
+  it("passes through malformed resolve (lets curl handle it)", () => {
+    expect(() => assertSafeResolve("nocolon")).not.toThrow();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  assertSafeCookie — file path rejection                             */
+/* ------------------------------------------------------------------ */
+describe("assertSafeCookie", () => {
+  it("allows standard cookie string", () => {
+    expect(() => assertSafeCookie("session=abc123")).not.toThrow();
+  });
+
+  it("allows multiple cookies", () => {
+    expect(() => assertSafeCookie("a=1; b=2")).not.toThrow();
+  });
+
+  it("rejects file path (no = sign)", () => {
+    expect(() => assertSafeCookie("/etc/passwd")).toThrow('must be in "name=value" format');
+  });
+
+  it("rejects bare cookie jar filename", () => {
+    expect(() => assertSafeCookie("cookies.txt")).toThrow('must be in "name=value" format');
+  });
+
+  it("rejects Windows file path", () => {
+    expect(() => assertSafeCookie("C:\\Users\\cookies.txt")).toThrow(
+      'must be in "name=value" format',
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  assertSafeFormValues — file exfiltration protection                */
+/* ------------------------------------------------------------------ */
+describe("assertSafeFormValues", () => {
+  let origAllow: string | undefined;
+  beforeEach(() => {
+    origAllow = process.env.PARE_HTTP_ALLOW_FILE_UPLOAD;
+    delete process.env.PARE_HTTP_ALLOW_FILE_UPLOAD;
+  });
+  afterEach(() => {
+    if (origAllow !== undefined) process.env.PARE_HTTP_ALLOW_FILE_UPLOAD = origAllow;
+    else delete process.env.PARE_HTTP_ALLOW_FILE_UPLOAD;
+  });
+
+  it("allows normal form values", () => {
+    expect(() => assertSafeFormValues({ name: "John", age: "30" })).not.toThrow();
+  });
+
+  it("blocks @filepath in form value", () => {
+    expect(() => assertSafeFormValues({ file: "@/etc/passwd" })).toThrow("file upload");
+  });
+
+  it("blocks @filepath for Windows paths", () => {
+    expect(() => assertSafeFormValues({ file: "@C:\\secrets.txt" })).toThrow("file upload");
+  });
+
+  it("allows @filepath when PARE_HTTP_ALLOW_FILE_UPLOAD=true", () => {
+    process.env.PARE_HTTP_ALLOW_FILE_UPLOAD = "true";
+    expect(() => assertSafeFormValues({ file: "@/etc/passwd" })).not.toThrow();
+  });
+
+  it("reports the field name in the error", () => {
+    expect(() => assertSafeFormValues({ avatar: "@photo.png" })).toThrow('"avatar"');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  assertSafeHeader — unchanged behavior                              */
+/* ------------------------------------------------------------------ */
+describe("assertSafeHeader", () => {
+  it("allows normal headers", () => {
+    expect(() => assertSafeHeader("Content-Type", "application/json")).not.toThrow();
+  });
+
+  it("rejects newline in key", () => {
+    expect(() => assertSafeHeader("Bad\nKey", "value")).toThrow("must not contain newlines");
+  });
+
+  it("rejects newline in value", () => {
+    expect(() => assertSafeHeader("Key", "bad\r\nvalue")).toThrow("must not contain newlines");
+  });
+
+  it("rejects null byte in value", () => {
+    expect(() => assertSafeHeader("Key", "bad\x00value")).toThrow("must not contain newlines");
+  });
+});

--- a/packages/server-http/src/lib/url-validation.ts
+++ b/packages/server-http/src/lib/url-validation.ts
@@ -1,8 +1,167 @@
+import { lookup } from "node:dns/promises";
+
 /**
- * Validates that a URL uses only http:// or https:// schemes.
- * Blocks dangerous schemes like file://, ftp://, gopher://, dict://, data:, javascript:, etc.
+ * Private/reserved IPv4 CIDR ranges that should be blocked for SSRF protection.
+ * Each entry is [networkAddress, prefixLength].
  */
-export function assertSafeUrl(url: string): void {
+const PRIVATE_IPV4_RANGES: Array<[number, number]> = [
+  [ipv4ToNum("0.0.0.0"), 8], // "this" network
+  [ipv4ToNum("10.0.0.0"), 8], // RFC 1918
+  [ipv4ToNum("100.64.0.0"), 10], // Carrier-grade NAT (RFC 6598)
+  [ipv4ToNum("127.0.0.0"), 8], // loopback
+  [ipv4ToNum("169.254.0.0"), 16], // link-local
+  [ipv4ToNum("172.16.0.0"), 12], // RFC 1918
+  [ipv4ToNum("192.0.0.0"), 24], // IETF protocol assignments
+  [ipv4ToNum("192.0.2.0"), 24], // TEST-NET-1
+  [ipv4ToNum("192.88.99.0"), 24], // 6to4 relay anycast
+  [ipv4ToNum("192.168.0.0"), 16], // RFC 1918
+  [ipv4ToNum("198.18.0.0"), 15], // benchmark testing
+  [ipv4ToNum("198.51.100.0"), 24], // TEST-NET-2
+  [ipv4ToNum("203.0.113.0"), 24], // TEST-NET-3
+  [ipv4ToNum("224.0.0.0"), 4], // multicast + reserved
+];
+
+/**
+ * Blocked metadata hostnames commonly used by cloud providers.
+ */
+const BLOCKED_HOSTNAMES = new Set(["metadata.google.internal", "metadata.internal", "metadata"]);
+
+/** Convert dotted-quad IPv4 to 32-bit unsigned number. */
+function ipv4ToNum(ip: string): number {
+  const parts = ip.split(".").map(Number);
+  return ((parts[0]! << 24) | (parts[1]! << 16) | (parts[2]! << 8) | parts[3]!) >>> 0;
+}
+
+/** Check if an IPv4 address (as number) falls within any private/reserved range. */
+function isPrivateIPv4(ipNum: number): boolean {
+  for (const [network, prefix] of PRIVATE_IPV4_RANGES) {
+    const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
+    if ((ipNum & mask) === (network & mask)) return true;
+  }
+  return false;
+}
+
+/** Private/reserved IPv6 prefixes (normalized lowercase hex). */
+const PRIVATE_IPV6_CHECKS: Array<(addr: string) => boolean> = [
+  // ::1 loopback
+  (addr) => addr === "::1" || addr === "0000:0000:0000:0000:0000:0000:0000:0001",
+  // fe80::/10 link-local
+  (addr) => {
+    const first = parseInt(addr.split(":")[0] || "0", 16);
+    return (first & 0xffc0) === 0xfe80;
+  },
+  // fc00::/7 unique local
+  (addr) => {
+    const first = parseInt(addr.split(":")[0] || "0", 16);
+    return (first & 0xfe00) === 0xfc00;
+  },
+  // :: unspecified
+  (addr) => addr === "::" || addr === "0000:0000:0000:0000:0000:0000:0000:0000",
+  // ::ffff:0:0/96 IPv4-mapped — check the embedded IPv4
+  (addr) => {
+    const match = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+    if (match) {
+      return isPrivateIPv4(ipv4ToNum(match[1]!));
+    }
+    return false;
+  },
+];
+
+/** Check if an IPv6 address string is private/reserved. */
+function isPrivateIPv6(addr: string): boolean {
+  const lower = addr.toLowerCase();
+  return PRIVATE_IPV6_CHECKS.some((check) => check(lower));
+}
+
+/**
+ * Attempt to parse a string as an IPv4 address, handling obfuscation:
+ * - Decimal notation: `2130706433` -> `127.0.0.1`
+ * - Hex notation: `0x7f000001` -> `127.0.0.1`
+ * - Octal notation: `0177.0.0.1` -> `127.0.0.1`
+ * - Mixed octal/hex per-octet: `0x7f.0.1`
+ *
+ * Returns the 32-bit numeric value, or null if not a valid IPv4 address.
+ */
+function parseObfuscatedIPv4(host: string): number | null {
+  // Single-number decimal or hex (e.g., 2130706433 or 0x7f000001)
+  if (/^(0x[\da-fA-F]+|\d+)$/.test(host)) {
+    const val = host.toLowerCase().startsWith("0x") ? parseInt(host, 16) : parseInt(host, 10);
+    if (val >= 0 && val <= 0xffffffff) return val >>> 0;
+    return null;
+  }
+
+  // Dotted notation with possible octal/hex octets
+  const parts = host.split(".");
+  if (parts.length < 2 || parts.length > 4) return null;
+
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!part) return null;
+    let val: number;
+    if (part.toLowerCase().startsWith("0x")) {
+      val = parseInt(part, 16);
+    } else if (part.startsWith("0") && part.length > 1 && /^[0-7]+$/.test(part)) {
+      val = parseInt(part, 8);
+    } else if (/^\d+$/.test(part)) {
+      val = parseInt(part, 10);
+    } else {
+      return null;
+    }
+    if (isNaN(val) || val < 0) return null;
+    octets.push(val);
+  }
+
+  // Standard 4-octet form
+  if (octets.length === 4) {
+    if (octets.some((o) => o > 255)) return null;
+    return ((octets[0]! << 24) | (octets[1]! << 16) | (octets[2]! << 8) | octets[3]!) >>> 0;
+  }
+
+  // 3-part: a.b.c where c is 16-bit
+  if (octets.length === 3) {
+    if (octets[0]! > 255 || octets[1]! > 255 || octets[2]! > 0xffff) return null;
+    return ((octets[0]! << 24) | (octets[1]! << 16) | octets[2]!) >>> 0;
+  }
+
+  // 2-part: a.b where b is 24-bit
+  if (octets.length === 2) {
+    if (octets[0]! > 255 || octets[1]! > 0xffffff) return null;
+    return ((octets[0]! << 24) | octets[1]!) >>> 0;
+  }
+
+  return null;
+}
+
+/**
+ * Check if an IP address string (v4 or v6) is private/reserved.
+ * Exported for use by resolve parameter validation.
+ */
+export function isPrivateIP(ip: string): boolean {
+  // Try IPv4 (including obfuscated forms)
+  const ipv4Num = parseObfuscatedIPv4(ip);
+  if (ipv4Num !== null) return isPrivateIPv4(ipv4Num);
+
+  // Try standard dotted-quad IPv4
+  const dotParts = ip.split(".");
+  if (dotParts.length === 4 && dotParts.every((p) => /^\d{1,3}$/.test(p))) {
+    const num = ipv4ToNum(ip);
+    return isPrivateIPv4(num);
+  }
+
+  // IPv6
+  if (ip.includes(":")) return isPrivateIPv6(ip);
+
+  return false;
+}
+
+/**
+ * Validates that a URL uses only http:// or https:// schemes and does not
+ * target private/reserved IP ranges (SSRF protection).
+ *
+ * Set environment variable PARE_HTTP_ALLOW_PRIVATE=true to disable
+ * private IP blocking (e.g., for local development).
+ */
+export async function assertSafeUrl(url: string): Promise<void> {
   const trimmed = url.trim();
 
   if (!trimmed) {
@@ -13,6 +172,128 @@ export function assertSafeUrl(url: string): void {
 
   if (!lower.startsWith("http://") && !lower.startsWith("https://")) {
     throw new Error(`Unsafe URL scheme. Only http:// and https:// are allowed. Got: "${url}"`);
+  }
+
+  // Skip private IP checks if opted out
+  if (process.env.PARE_HTTP_ALLOW_PRIVATE === "true") return;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`Invalid URL: "${url}"`);
+  }
+
+  const hostname = parsed.hostname;
+
+  // Block known metadata hostnames
+  if (BLOCKED_HOSTNAMES.has(hostname.toLowerCase())) {
+    throw new Error(
+      `Blocked request to metadata hostname "${hostname}". This is restricted for SSRF protection. ` +
+        `Set PARE_HTTP_ALLOW_PRIVATE=true to override.`,
+    );
+  }
+
+  // Check if hostname is directly an IP address (including obfuscated forms)
+  // Remove brackets from IPv6
+  const cleanHost = hostname.startsWith("[") ? hostname.slice(1, -1) : hostname;
+
+  // Check obfuscated IPv4 forms directly
+  const obfuscatedIP = parseObfuscatedIPv4(cleanHost);
+  if (obfuscatedIP !== null && isPrivateIPv4(obfuscatedIP)) {
+    throw new Error(
+      `Blocked request to private/reserved IP address "${hostname}". ` +
+        `This is restricted for SSRF protection. Set PARE_HTTP_ALLOW_PRIVATE=true to override.`,
+    );
+  }
+
+  // Check direct IPv6
+  if (cleanHost.includes(":") && isPrivateIPv6(cleanHost)) {
+    throw new Error(
+      `Blocked request to private/reserved IP address "${hostname}". ` +
+        `This is restricted for SSRF protection. Set PARE_HTTP_ALLOW_PRIVATE=true to override.`,
+    );
+  }
+
+  // DNS resolution check — resolve hostname and check resulting IP
+  try {
+    const result = await lookup(hostname);
+    if (isPrivateIP(result.address)) {
+      throw new Error(
+        `Blocked request to "${hostname}" — resolves to private/reserved IP ${result.address}. ` +
+          `This is restricted for SSRF protection. Set PARE_HTTP_ALLOW_PRIVATE=true to override.`,
+      );
+    }
+  } catch (err) {
+    // Re-throw our own SSRF errors
+    if (err instanceof Error && err.message.includes("SSRF protection")) throw err;
+    // DNS resolution failure is not necessarily an error (e.g., offline, custom resolver)
+    // Let curl handle it downstream
+  }
+}
+
+/**
+ * Validates that the `resolve` parameter's target IP address is not private/reserved.
+ * Format: "host:port:addr" or "host:port:addr,addr2"
+ *
+ * Blocks DNS rebinding attacks where --resolve is used to redirect
+ * requests to private IPs despite the URL appearing safe.
+ */
+export function assertSafeResolve(resolve: string): void {
+  if (process.env.PARE_HTTP_ALLOW_PRIVATE === "true") return;
+
+  // Format: host:port:addr[,addr2,...]
+  const parts = resolve.split(":");
+  if (parts.length < 3) return; // Let curl handle format errors
+
+  // The addr portion is everything after the second colon (may contain : for IPv6)
+  const addrPart = parts.slice(2).join(":");
+
+  // May be comma-separated multiple addresses
+  const addrs = addrPart.split(",");
+  for (const addr of addrs) {
+    const trimmed = addr.trim();
+    if (!trimmed) continue;
+
+    if (isPrivateIP(trimmed)) {
+      throw new Error(
+        `Blocked resolve to private/reserved IP "${trimmed}". ` +
+          `The resolve parameter cannot redirect requests to private networks. ` +
+          `Set PARE_HTTP_ALLOW_PRIVATE=true to override.`,
+      );
+    }
+  }
+}
+
+/**
+ * Validates that a cookie value is a cookie string (contains '='), not a file path.
+ * curl's -b flag reads cookies from a file if the value doesn't contain '='.
+ * This prevents arbitrary file read via the cookie parameter.
+ */
+export function assertSafeCookie(cookie: string): void {
+  if (!cookie.includes("=")) {
+    throw new Error(
+      `Invalid cookie value: must be in "name=value" format (e.g., "session=abc123"). ` +
+        `File-based cookie jars are not supported for security reasons.`,
+    );
+  }
+}
+
+/**
+ * Validates that form values do not use @filepath syntax for file uploads
+ * unless explicitly allowed via PARE_HTTP_ALLOW_FILE_UPLOAD=true.
+ * curl's -F flag reads file contents when the value starts with '@'.
+ */
+export function assertSafeFormValues(form: Record<string, string>): void {
+  if (process.env.PARE_HTTP_ALLOW_FILE_UPLOAD === "true") return;
+
+  for (const [key, value] of Object.entries(form)) {
+    if (value.startsWith("@")) {
+      throw new Error(
+        `Blocked file upload in form field "${key}": value starts with "@" which reads a local file. ` +
+          `Set PARE_HTTP_ALLOW_FILE_UPLOAD=true to allow file uploads via form data.`,
+      );
+    }
   }
 }
 

--- a/packages/server-http/src/tools/get.ts
+++ b/packages/server-http/src/tools/get.ts
@@ -16,7 +16,7 @@ import {
   formatResponseCompact,
 } from "../lib/formatters.js";
 import { HttpResponseSchema } from "../schemas/index.js";
-import { assertSafeUrl } from "../lib/url-validation.js";
+import { assertSafeUrl, assertSafeResolve } from "../lib/url-validation.js";
 import { buildCurlArgs } from "./request.js";
 
 const HTTP_VERSIONS = ["1.0", "1.1", "2"] as const;
@@ -28,7 +28,9 @@ export function registerGetTool(server: McpServer) {
     {
       title: "HTTP GET",
       description:
-        "Makes an HTTP GET request via curl and returns structured response data. Convenience wrapper for the request tool.",
+        "Makes an HTTP GET request via curl and returns structured response data. Convenience wrapper for the request tool. " +
+        "SECURITY: URLs targeting private/reserved IPs are blocked (SSRF protection). " +
+        "The proxy parameter routes traffic through an external proxy — use only with trusted proxies.",
       annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         url: z
@@ -85,7 +87,9 @@ export function registerGetTool(server: McpServer) {
           .string()
           .max(INPUT_LIMITS.STRING_MAX)
           .optional()
-          .describe("Proxy URL (e.g., http://proxy:8080) (-x)"),
+          .describe(
+            "Proxy URL (e.g., http://proxy:8080) (-x). SECURITY WARNING: Routes all traffic through this proxy. Only use trusted proxies — a malicious proxy can intercept and modify all request/response data (MitM).",
+          ),
         queryParams: z
           .record(
             z.string().max(INPUT_LIMITS.SHORT_STRING_MAX),
@@ -139,10 +143,13 @@ export function registerGetTool(server: McpServer) {
         finalUrl = `${url}${separator}${params.toString()}`;
       }
 
-      assertSafeUrl(finalUrl);
+      await assertSafeUrl(finalUrl);
       if (basicAuth) assertNoFlagInjection(basicAuth, "basicAuth");
       if (proxy) assertNoFlagInjection(proxy, "proxy");
-      if (resolve) assertNoFlagInjection(resolve, "resolve");
+      if (resolve) {
+        assertNoFlagInjection(resolve, "resolve");
+        assertSafeResolve(resolve);
+      }
 
       const args = buildCurlArgs({
         url: finalUrl,

--- a/packages/server-http/src/tools/head.ts
+++ b/packages/server-http/src/tools/head.ts
@@ -16,7 +16,7 @@ import {
   formatHeadResponseCompact,
 } from "../lib/formatters.js";
 import { HttpHeadResponseSchema } from "../schemas/index.js";
-import { assertSafeUrl } from "../lib/url-validation.js";
+import { assertSafeUrl, assertSafeResolve } from "../lib/url-validation.js";
 import { buildCurlArgs } from "./request.js";
 
 const HTTP_VERSIONS = ["1.0", "1.1", "2"] as const;
@@ -28,7 +28,9 @@ export function registerHeadTool(server: McpServer) {
     {
       title: "HTTP HEAD",
       description:
-        "Makes an HTTP HEAD request via curl and returns structured response headers (no body). Use to check resource existence, content type, or cache headers.",
+        "Makes an HTTP HEAD request via curl and returns structured response headers (no body). Use to check resource existence, content type, or cache headers. " +
+        "SECURITY: URLs targeting private/reserved IPs are blocked (SSRF protection). " +
+        "The proxy parameter routes traffic through an external proxy — use only with trusted proxies.",
       annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         url: z
@@ -81,7 +83,9 @@ export function registerHeadTool(server: McpServer) {
           .string()
           .max(INPUT_LIMITS.STRING_MAX)
           .optional()
-          .describe("Proxy URL (e.g., http://proxy:8080) (-x)"),
+          .describe(
+            "Proxy URL (e.g., http://proxy:8080) (-x). SECURITY WARNING: Routes all traffic through this proxy. Only use trusted proxies — a malicious proxy can intercept and modify all request/response data (MitM).",
+          ),
         httpVersion: z
           .enum(HTTP_VERSIONS)
           .optional()
@@ -113,10 +117,13 @@ export function registerHeadTool(server: McpServer) {
       compact,
       path,
     }) => {
-      assertSafeUrl(url);
+      await assertSafeUrl(url);
       if (basicAuth) assertNoFlagInjection(basicAuth, "basicAuth");
       if (proxy) assertNoFlagInjection(proxy, "proxy");
-      if (resolve) assertNoFlagInjection(resolve, "resolve");
+      if (resolve) {
+        assertNoFlagInjection(resolve, "resolve");
+        assertSafeResolve(resolve);
+      }
 
       const args = buildCurlArgs({
         url,

--- a/packages/server-http/src/tools/post.ts
+++ b/packages/server-http/src/tools/post.ts
@@ -16,7 +16,7 @@ import {
   formatResponseCompact,
 } from "../lib/formatters.js";
 import { HttpResponseSchema } from "../schemas/index.js";
-import { assertSafeUrl } from "../lib/url-validation.js";
+import { assertSafeUrl, assertSafeFormValues } from "../lib/url-validation.js";
 import { buildCurlArgs } from "./request.js";
 
 const HTTP_VERSIONS = ["1.0", "1.1", "2"] as const;
@@ -28,7 +28,10 @@ export function registerPostTool(server: McpServer) {
     {
       title: "HTTP POST",
       description:
-        "Makes an HTTP POST request via curl and returns structured response data. Convenience wrapper for the request tool with required body.",
+        "Makes an HTTP POST request via curl and returns structured response data. Convenience wrapper for the request tool with required body. " +
+        "SECURITY: URLs targeting private/reserved IPs are blocked (SSRF protection). " +
+        "File uploads via form @filepath are blocked by default (set PARE_HTTP_ALLOW_FILE_UPLOAD=true to allow). " +
+        "The proxy parameter routes traffic through an external proxy — use only with trusted proxies.",
       annotations: { openWorldHint: true },
       inputSchema: {
         url: z
@@ -103,7 +106,9 @@ export function registerPostTool(server: McpServer) {
           .string()
           .max(INPUT_LIMITS.STRING_MAX)
           .optional()
-          .describe("Proxy URL (e.g., http://proxy:8080) (-x)"),
+          .describe(
+            "Proxy URL (e.g., http://proxy:8080) (-x). SECURITY WARNING: Routes all traffic through this proxy. Only use trusted proxies — a malicious proxy can intercept and modify all request/response data (MitM).",
+          ),
         dataUrlencode: z
           .array(z.string().max(INPUT_LIMITS.STRING_MAX))
           .optional()
@@ -117,7 +122,7 @@ export function registerPostTool(server: McpServer) {
           )
           .optional()
           .describe(
-            "Multipart form data as key-value pairs (-F). Each pair maps to `-F key=value`. For file uploads use `@filepath` as the value. When provided, `body` and `contentType` are ignored.",
+            "Multipart form data as key-value pairs (-F). Each pair maps to `-F key=value`. File uploads via @filepath are blocked by default — set PARE_HTTP_ALLOW_FILE_UPLOAD=true to allow. When provided, `body` and `contentType` are ignored.",
           ),
         httpVersion: z
           .enum(HTTP_VERSIONS)
@@ -148,7 +153,7 @@ export function registerPostTool(server: McpServer) {
       compact,
       path,
     }) => {
-      assertSafeUrl(url);
+      await assertSafeUrl(url);
       if (accept) assertNoFlagInjection(accept, "accept");
       if (basicAuth) assertNoFlagInjection(basicAuth, "basicAuth");
       if (proxy) assertNoFlagInjection(proxy, "proxy");
@@ -161,6 +166,7 @@ export function registerPostTool(server: McpServer) {
         for (const value of Object.values(form)) {
           assertNoFlagInjection(value, "form value");
         }
+        assertSafeFormValues(form);
       }
 
       // When form is provided, don't set Content-Type (curl sets multipart/form-data automatically)

--- a/packages/server-http/src/tools/request.ts
+++ b/packages/server-http/src/tools/request.ts
@@ -16,7 +16,13 @@ import {
   formatResponseCompact,
 } from "../lib/formatters.js";
 import { HttpResponseSchema } from "../schemas/index.js";
-import { assertSafeUrl, assertSafeHeader } from "../lib/url-validation.js";
+import {
+  assertSafeUrl,
+  assertSafeHeader,
+  assertSafeResolve,
+  assertSafeCookie,
+  assertSafeFormValues,
+} from "../lib/url-validation.js";
 
 const METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"] as const;
 const HTTP_VERSIONS = ["1.0", "1.1", "2"] as const;
@@ -28,7 +34,10 @@ export function registerRequestTool(server: McpServer) {
     {
       title: "HTTP Request",
       description:
-        "Makes an HTTP request via curl and returns structured response data (status, headers, body, timing).",
+        "Makes an HTTP request via curl and returns structured response data (status, headers, body, timing). " +
+        "SECURITY: URLs targeting private/reserved IPs are blocked (SSRF protection). " +
+        "The proxy parameter routes traffic through an external proxy — use only with trusted proxies. " +
+        "File uploads via form @filepath are blocked by default (set PARE_HTTP_ALLOW_FILE_UPLOAD=true to allow).",
       annotations: { openWorldHint: true },
       inputSchema: {
         url: z
@@ -55,7 +64,7 @@ export function registerRequestTool(server: McpServer) {
           )
           .optional()
           .describe(
-            "Multipart form data as key-value pairs (-F). Each pair maps to `-F key=value`. For file uploads use `@filepath` as the value.",
+            "Multipart form data as key-value pairs (-F). Each pair maps to `-F key=value`. File uploads via @filepath are blocked by default — set PARE_HTTP_ALLOW_FILE_UPLOAD=true to allow.",
           ),
         timeout: z
           .number()
@@ -100,7 +109,9 @@ export function registerRequestTool(server: McpServer) {
           .string()
           .max(INPUT_LIMITS.STRING_MAX)
           .optional()
-          .describe("Proxy URL (e.g., http://proxy:8080) (-x)"),
+          .describe(
+            "Proxy URL (e.g., http://proxy:8080) (-x). SECURITY WARNING: Routes all traffic through this proxy. Only use trusted proxies — a malicious proxy can intercept and modify all request/response data (MitM).",
+          ),
         httpVersion: z
           .enum(HTTP_VERSIONS)
           .optional()
@@ -110,7 +121,7 @@ export function registerRequestTool(server: McpServer) {
           .max(INPUT_LIMITS.STRING_MAX)
           .optional()
           .describe(
-            "Cookie string or cookie jar file path for session-based APIs (-b). Format: 'name=value; name2=value2'",
+            "Cookie string for session-based APIs (-b). Format: 'name=value; name2=value2'. Must contain '=' — file-based cookie jars are not supported.",
           ),
         resolve: z
           .string()
@@ -144,15 +155,22 @@ export function registerRequestTool(server: McpServer) {
       compact,
       path,
     }) => {
-      assertSafeUrl(url);
+      await assertSafeUrl(url);
       if (basicAuth) assertNoFlagInjection(basicAuth, "basicAuth");
       if (proxy) assertNoFlagInjection(proxy, "proxy");
-      if (cookie) assertNoFlagInjection(cookie, "cookie");
-      if (resolve) assertNoFlagInjection(resolve, "resolve");
+      if (cookie) {
+        assertNoFlagInjection(cookie, "cookie");
+        assertSafeCookie(cookie);
+      }
+      if (resolve) {
+        assertNoFlagInjection(resolve, "resolve");
+        assertSafeResolve(resolve);
+      }
       if (form) {
         for (const value of Object.values(form)) {
           assertNoFlagInjection(value, "form value");
         }
+        assertSafeFormValues(form);
       }
 
       const args = buildCurlArgs({


### PR DESCRIPTION
## Summary

- **SSRF protection (#710)**: Enhanced `assertSafeUrl()` to block private/reserved IP ranges (loopback, RFC 1918, link-local, cloud metadata hostnames). Handles IP obfuscation (decimal, hex, octal). Performs DNS resolution check to catch hostname-based bypasses. Opt-out via `PARE_HTTP_ALLOW_PRIVATE=true`.
- **DNS rebinding protection (#719)**: Validates IP addresses in the `resolve` parameter against private ranges.
- **File exfiltration guards (#721)**: Blocks `@filepath` syntax in form values by default. Opt-in via `PARE_HTTP_ALLOW_FILE_UPLOAD=true`.
- **Cookie file read prevention (#717)**: Validates cookie values contain `=` to reject file paths (curl reads files when `-b` value has no `=`).
- **Proxy MitM warning (#723)**: Added security warnings in tool descriptions about the proxy parameter.

## Test plan

- [x] 56 new unit tests for `isPrivateIP`, `assertSafeUrl`, `assertSafeResolve`, `assertSafeCookie`, `assertSafeFormValues`
- [x] Updated existing `url-validation.test.ts` and `security.test.ts` for async `assertSafeUrl`
- [x] All 247 tests passing
- [x] TypeScript build passes
- [ ] CI matrix (ubuntu/windows/macos x node 20/22)

Closes #710, #717, #719, #721, #723