### PR TITLE
fix(init,shared): fix npx bin resolution and add global error handlers

### DIFF
--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -25,6 +25,7 @@
   },
   "type": "module",
   "bin": {
+    "@paretools/init": "./dist/index.js",
     "pare-init": "./dist/index.js",
     "pare-doctor": "./dist/doctor.js"
   },

--- a/packages/shared/src/server.ts
+++ b/packages/shared/src/server.ts
@@ -56,10 +56,19 @@ function applyStrictInputSchemas(server: McpServer): void {
  * Creates an MCP server with the standard Pare boilerplate:
  * instantiates McpServer, registers tools via callback, connects StdioServerTransport.
  *
+ * Installs global error handlers so that uncaught exceptions and unhandled
+ * rejections are written to stderr before the process exits — making "Connection
+ * closed" failures diagnosable instead of silent.
+ *
  * @returns The connected McpServer instance (for testing or advanced use).
  */
 export async function createServer(options: CreateServerOptions): Promise<McpServer> {
   const { name, version, instructions, registerTools } = options;
+
+  // Install global error handlers so startup/runtime crashes are visible on
+  // stderr instead of silently killing the process (which MCP clients report
+  // as "Connection closed" with no diagnostic info).
+  installGlobalErrorHandlers(name);
 
   const server = new McpServer({ name, version }, { instructions });
   applyStrictInputSchemas(server);
@@ -84,4 +93,31 @@ export async function createServer(options: CreateServerOptions): Promise<McpSer
   await server.connect(transport);
 
   return server;
+}
+
+/**
+ * Installs process-level error handlers that write to stderr before exiting.
+ *
+ * Without these, an uncaught exception or unhandled rejection during server
+ * startup (e.g., a broken import, a Zod schema conversion failure, or a
+ * missing dependency) causes a silent exit. MCP clients then report
+ * "Connection closed" with no useful diagnostic information.
+ *
+ * These handlers are installed once per process and are idempotent.
+ */
+let globalHandlersInstalled = false;
+function installGlobalErrorHandlers(serverName: string): void {
+  if (globalHandlersInstalled) return;
+  globalHandlersInstalled = true;
+
+  process.on("uncaughtException", (err) => {
+    process.stderr.write(`[${serverName}] Fatal uncaught exception: ${err.stack ?? err.message}\n`);
+    process.exit(1);
+  });
+
+  process.on("unhandledRejection", (reason) => {
+    const msg = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason);
+    process.stderr.write(`[${serverName}] Fatal unhandled rejection: ${msg}\n`);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
## Summary

- **@paretools/init**: Add `"@paretools/init"` bin entry so `npx @paretools/init` resolves correctly. Previously only `pare-init` was registered, causing `npm error could not determine executable to run`. Fixes #738.
- **@paretools/shared**: Install global `uncaughtException`/`unhandledRejection` handlers in `createServer()` so MCP "Connection closed" failures log to stderr with a stack trace instead of dying silently. Addresses #739 (could not reproduce, but this ensures future crashes are diagnosable).

## Test plan

- [x] `pnpm --filter @paretools/init run build` passes
- [x] HTTP server responds to MCP `initialize` + `tools/list` locally
- [x] CI (build, test, lint)