### PR TITLE
feat(git): support raw file blob extraction in show tool

### DIFF
--- a/.changeset/show-file-blobs.md
+++ b/.changeset/show-file-blobs.md
@@ -1,0 +1,5 @@
+---
+"@paretools/git": minor
+---
+
+feat(git): support extracting raw file blobs via show tool

--- a/packages/server-git/__tests__/formatters.test.ts
+++ b/packages/server-git/__tests__/formatters.test.ts
@@ -5,6 +5,7 @@ import {
   formatDiff,
   formatBranch,
   formatShow,
+  formatShowBlob,
   formatTag,
   formatStashList,
   formatStash,
@@ -215,6 +216,40 @@ describe("formatShow", () => {
 
     expect(output).toContain("aaa11122 chore: empty commit");
     expect(output).toContain("0 files changed, +0 -0");
+  });
+});
+
+describe("formatShowBlob", () => {
+  it("formats blob extraction with file header and content", () => {
+    const show: GitShow = {
+      objectType: "blob",
+      objectName: "HEAD:src/index.ts",
+      objectSize: 42,
+      file: "src/index.ts",
+      fileContent: 'export const hello = "world";',
+      message: "blob HEAD:src/index.ts",
+    };
+    const output = formatShowBlob(show);
+
+    expect(output).toContain("src/index.ts");
+    expect(output).toContain("HEAD:src/index.ts");
+    expect(output).toContain("42 bytes");
+    expect(output).toContain('export const hello = "world";');
+  });
+
+  it("handles missing size gracefully", () => {
+    const show: GitShow = {
+      objectType: "blob",
+      objectName: "abc123:README.md",
+      file: "README.md",
+      fileContent: "# Hello",
+      message: "blob abc123:README.md",
+    };
+    const output = formatShowBlob(show);
+
+    expect(output).toContain("README.md");
+    expect(output).not.toContain("bytes");
+    expect(output).toContain("# Hello");
   });
 });
 

--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -268,6 +268,26 @@ describe("@paretools/git integration", () => {
       expect(Array.isArray(diff.files)).toBe(true);
       expect(Array.isArray(diff.files)).toBe(true);
     });
+
+    it("extracts raw file blob at HEAD when file param is provided", async () => {
+      const result = await client.callTool(
+        {
+          name: "show",
+          arguments: { ref: "HEAD", file: "package.json", compact: false },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      expect(sc.objectType).toBe("blob");
+      expect(sc.file).toBe("package.json");
+      expect(sc.fileContent).toEqual(expect.any(String));
+      expect((sc.fileContent as string).length).toBeGreaterThan(0);
+      expect(sc.objectSize).toEqual(expect.any(Number));
+      expect(sc.objectName).toBe("HEAD:package.json");
+    });
   });
 });
 

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -79,6 +79,13 @@ export function formatBranch(b: GitBranchFull): string {
     .join("\n");
 }
 
+/** Formats a blob extraction result into a human-readable view with file header. */
+export function formatShowBlob(s: GitShow): string {
+  const size = s.objectSize !== undefined ? ` (${s.objectSize} bytes)` : "";
+  const header = `── ${s.file ?? s.objectName ?? "blob"} @ ${s.objectName ?? "unknown"}${size} ──`;
+  return `${header}\n${s.fileContent ?? ""}`;
+}
+
 /** Formats structured git show data into a human-readable commit detail view with diff summary. */
 export function formatShow(s: GitShow): string {
   if (s.objectType && s.objectType !== "commit") {

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -88,7 +88,8 @@ export type GitBranchFull = {
 
 export type GitBranch = z.infer<typeof GitBranchSchema>;
 
-/** Zod schema for structured git show output with commit metadata and diff statistics. */
+/** Zod schema for structured git show output with commit metadata and diff statistics.
+ *  When `file` is provided (blob extraction via `ref:file`), only blob-specific fields are returned. */
 export const GitShowSchema = z.object({
   hash: z.string().optional(),
   hashShort: z.string().optional(),
@@ -98,6 +99,10 @@ export const GitShowSchema = z.object({
   objectName: z.string().optional(),
   objectSize: z.number().optional(),
   message: z.string(),
+  /** File path extracted from the ref (only present for blob extraction). */
+  file: z.string().optional(),
+  /** Raw file content at the given ref (only present for blob extraction). */
+  fileContent: z.string().optional(),
   diff: z
     .object({
       files: z.array(GitDiffFileSchema),

--- a/packages/server-git/src/tools/show.ts
+++ b/packages/server-git/src/tools/show.ts
@@ -4,7 +4,12 @@ import { compactDualOutput, INPUT_LIMITS, compactInput, repoPathInput } from "@p
 import { assertNoFlagInjection } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseShow } from "../lib/parsers.js";
-import { formatShow, compactShowMap, formatShowCompact } from "../lib/formatters.js";
+import {
+  formatShow,
+  compactShowMap,
+  formatShowCompact,
+  formatShowBlob,
+} from "../lib/formatters.js";
 import type { GitShow } from "../schemas/index.js";
 import { GitShowSchema } from "../schemas/index.js";
 
@@ -20,7 +25,8 @@ export function registerShowTool(server: McpServer) {
     "show",
     {
       title: "Git Show",
-      description: "Shows commit details and diff statistics for a given ref.",
+      description:
+        "Shows commit details and diff statistics for a given ref. When `file` is provided, extracts raw file content at that ref (e.g., `git show HEAD:src/index.ts`).",
       annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
@@ -30,6 +36,13 @@ export function registerShowTool(server: McpServer) {
           .optional()
           .default("HEAD")
           .describe("Commit hash, branch, or tag (default: HEAD)"),
+        file: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "File path to extract from the ref (e.g., 'src/index.ts'). Returns raw file content at that ref.",
+          ),
         dateFormat: z
           .string()
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
@@ -55,6 +68,7 @@ export function registerShowTool(server: McpServer) {
     async ({
       path,
       ref,
+      file,
       dateFormat,
       diffFilter,
       patch,
@@ -67,8 +81,39 @@ export function registerShowTool(server: McpServer) {
       const cwd = path || process.cwd();
       const commitRef = ref || "HEAD";
       assertNoFlagInjection(commitRef, "ref");
+      if (file) assertNoFlagInjection(file, "file");
       if (dateFormat) assertNoFlagInjection(dateFormat, "dateFormat");
       if (diffFilter) assertNoFlagInjection(diffFilter, "diffFilter");
+
+      // ── Blob extraction: git show <ref>:<file> ──────────────────────
+      if (file) {
+        const blobRef = `${commitRef}:${file}`;
+        const result = await git(["show", blobRef], cwd);
+        if (result.exitCode !== 0) {
+          throw new Error(`git show failed for ${blobRef}: ${result.stderr}`);
+        }
+        const content = result.stdout;
+        const sizeResult = await git(["cat-file", "-s", blobRef], cwd);
+        const objectSize =
+          sizeResult.exitCode === 0 ? parseInt(sizeResult.stdout.trim(), 10) : undefined;
+
+        const show: GitShow = {
+          objectType: "blob",
+          objectName: blobRef,
+          ...(Number.isFinite(objectSize) ? { objectSize } : {}),
+          file,
+          fileContent: content,
+          message: `blob ${blobRef}`,
+        };
+        return compactDualOutput(
+          show,
+          content,
+          formatShowBlob,
+          compactShowMap,
+          formatShowCompact,
+          compact === false,
+        );
+      }
 
       const typeResult = await git(["cat-file", "-t", commitRef], cwd);
       const objectType: GitShow["objectType"] =


### PR DESCRIPTION
## Summary
- Adds a new optional `file` parameter to the `show` tool that enables extracting raw file content at a specific ref via `git show <ref>:<file>` syntax
- Returns structured blob output with `objectType: "blob"`, `file`, `fileContent`, and `objectSize` fields
- Includes `assertNoFlagInjection()` on the `file` parameter for security

Closes #750

## Test plan
- [x] Unit test for `formatShowBlob` formatter (header with size, handles missing size)
- [x] Integration test: extract `package.json` at HEAD via `file` param, verify structured blob fields
- [x] All 666 existing tests pass (19 test files)
- [x] Build succeeds