### PR TITLE
feat: refine MCP tool annotations for destructive/read-only hints

### DIFF
--- a/.changeset/destructive-annotations.md
+++ b/.changeset/destructive-annotations.md
@@ -1,0 +1,20 @@
+---
+"@paretools/bazel": minor
+"@paretools/bun": minor
+"@paretools/cargo": minor
+"@paretools/cmake": minor
+"@paretools/deno": minor
+"@paretools/docker": minor
+"@paretools/dotnet": minor
+"@paretools/git": minor
+"@paretools/github": minor
+"@paretools/infra": minor
+"@paretools/jvm": minor
+"@paretools/lint": minor
+"@paretools/nix": minor
+"@paretools/process": minor
+"@paretools/ruby": minor
+"@paretools/swift": minor
+---
+
+feat: refine MCP tool annotations (readOnlyHint, destructiveHint) across all servers

--- a/packages/server-bazel/src/tools/bazel.ts
+++ b/packages/server-bazel/src/tools/bazel.ts
@@ -70,6 +70,7 @@ export function registerBazelTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: BazelOutputSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({
       action,

--- a/packages/server-bun/src/tools/build.ts
+++ b/packages/server-bun/src/tools/build.ts
@@ -53,6 +53,7 @@ export function registerBuildTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: BunBuildResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({
       entrypoints,

--- a/packages/server-bun/src/tools/remove.ts
+++ b/packages/server-bun/src/tools/remove.ts
@@ -29,6 +29,7 @@ export function registerRemoveTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: BunRemoveResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ packages, path, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-bun/src/tools/run.ts
+++ b/packages/server-bun/src/tools/run.ts
@@ -35,6 +35,7 @@ export function registerRunTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: BunRunResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ script, args, path, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-cargo/src/tools/remove.ts
+++ b/packages/server-cargo/src/tools/remove.ts
@@ -19,7 +19,7 @@ export function registerRemoveTool(server: McpServer) {
     {
       title: "Cargo Remove",
       description: "Removes dependencies from a Rust project and returns structured output.",
-      annotations: { destructiveHint: true },
+      annotations: { readOnlyHint: false },
       inputSchema: {
         path: projectPathInput,
         packages: z

--- a/packages/server-cmake/src/tools/cmake.ts
+++ b/packages/server-cmake/src/tools/cmake.ts
@@ -82,6 +82,7 @@ export function registerCMakeTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: CMakeResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({
       action,

--- a/packages/server-deno/src/tools/fmt.ts
+++ b/packages/server-deno/src/tools/fmt.ts
@@ -31,6 +31,7 @@ export function registerFmtTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: DenoFmtResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ files, path, check, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-deno/src/tools/run.ts
+++ b/packages/server-deno/src/tools/run.ts
@@ -46,6 +46,7 @@ export function registerRunTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: DenoRunResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ file, args, path, allowRead, allowWrite, allowNet, allowEnv, allowAll, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-deno/src/tools/task.ts
+++ b/packages/server-deno/src/tools/task.ts
@@ -35,6 +35,7 @@ export function registerTaskTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: DenoTaskResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ name, args, path, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-docker/src/tools/run.ts
+++ b/packages/server-docker/src/tools/run.ts
@@ -23,7 +23,7 @@ export function registerRunTool(server: McpServer) {
       title: "Docker Run",
       description:
         "Runs a Docker container from an image and returns structured container ID and status.",
-      annotations: { destructiveHint: true },
+      annotations: { readOnlyHint: false },
       inputSchema: {
         image: z
           .string()

--- a/packages/server-dotnet/src/tools/build.ts
+++ b/packages/server-dotnet/src/tools/build.ts
@@ -54,6 +54,7 @@ export function registerBuildTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: DotnetBuildResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ path, project, configuration, framework, runtime, noRestore, verbosity, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-dotnet/src/tools/publish.ts
+++ b/packages/server-dotnet/src/tools/publish.ts
@@ -64,6 +64,7 @@ export function registerPublishTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: DotnetPublishResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({
       path,

--- a/packages/server-dotnet/src/tools/run.ts
+++ b/packages/server-dotnet/src/tools/run.ts
@@ -75,6 +75,7 @@ export function registerRunTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: DotnetRunResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({
       path,

--- a/packages/server-git/src/tools/cherry-pick.ts
+++ b/packages/server-git/src/tools/cherry-pick.ts
@@ -20,7 +20,7 @@ export function registerCherryPickTool(server: McpServer) {
       title: "Git Cherry-Pick",
       description:
         "Applies specific commits to the current branch. Returns structured data with applied commits, any conflicts, and new commit hash.",
-      annotations: { destructiveHint: true },
+      annotations: { readOnlyHint: false },
       inputSchema: {
         path: repoPathInput,
         commits: z

--- a/packages/server-git/src/tools/merge.ts
+++ b/packages/server-git/src/tools/merge.ts
@@ -14,7 +14,7 @@ export function registerMergeTool(server: McpServer) {
       title: "Git Merge",
       description:
         "Merges a branch into the current branch. Supports abort, continue, and quit actions. Returns structured data with merge status, fast-forward detection, conflicts, and commit hash.",
-      annotations: { destructiveHint: true },
+      annotations: { readOnlyHint: false },
       inputSchema: {
         path: repoPathInput,
         branch: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Branch to merge"),

--- a/packages/server-git/src/tools/push.ts
+++ b/packages/server-git/src/tools/push.ts
@@ -14,7 +14,7 @@ export function registerPushTool(server: McpServer) {
       title: "Git Push",
       description:
         "Pushes commits to a remote repository. Returns structured data with success status, remote, branch, summary, and whether the remote branch was newly created.",
-      annotations: { openWorldHint: true, destructiveHint: true },
+      annotations: { readOnlyHint: false, openWorldHint: true },
       inputSchema: {
         path: repoPathInput,
         remote: z

--- a/packages/server-github/src/tools/issue-close.ts
+++ b/packages/server-github/src/tools/issue-close.ts
@@ -24,7 +24,7 @@ export function registerIssueCloseTool(server: McpServer) {
       title: "Issue Close",
       description:
         "Closes an issue with an optional comment and reason. Returns structured data with issue number, state, URL, reason, and comment URL.",
-      annotations: { openWorldHint: true },
+      annotations: { openWorldHint: true, destructiveHint: true },
       inputSchema: {
         number: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Issue number or URL"),
         comment: z.string().max(INPUT_LIMITS.STRING_MAX).optional().describe("Closing comment"),

--- a/packages/server-infra/src/tools/fmt.ts
+++ b/packages/server-infra/src/tools/fmt.ts
@@ -25,6 +25,7 @@ export function registerFmtTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: TerraformFmtResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ path, diff, recursive, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-infra/src/tools/vagrant.ts
+++ b/packages/server-infra/src/tools/vagrant.ts
@@ -51,6 +51,7 @@ export function registerVagrantTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: VagrantResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ action, machine, workDir, compact }) => {
       const cwd = workDir || process.cwd();

--- a/packages/server-infra/src/tools/workspace.ts
+++ b/packages/server-infra/src/tools/workspace.ts
@@ -33,6 +33,7 @@ export function registerWorkspaceTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: TerraformWorkspaceResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ path, action, name, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-jvm/src/tools/gradle-build.ts
+++ b/packages/server-jvm/src/tools/gradle-build.ts
@@ -40,6 +40,7 @@ export function registerGradleBuildTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: GradleBuildResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ path, tasks, args, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-jvm/src/tools/maven-build.ts
+++ b/packages/server-jvm/src/tools/maven-build.ts
@@ -40,6 +40,7 @@ export function registerMavenBuildTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: MavenBuildResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ path, goals, args, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-nix/src/tools/build.ts
+++ b/packages/server-nix/src/tools/build.ts
@@ -36,6 +36,7 @@ export function registerBuildTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: NixBuildResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ installable, outLink, noLink, path, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-nix/src/tools/develop.ts
+++ b/packages/server-nix/src/tools/develop.ts
@@ -36,6 +36,7 @@ export function registerDevelopTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: NixDevelopResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ installable, command, path, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-nix/src/tools/run.ts
+++ b/packages/server-nix/src/tools/run.ts
@@ -37,6 +37,7 @@ export function registerRunTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: NixRunResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ installable, args, path, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-nix/src/tools/shell.ts
+++ b/packages/server-nix/src/tools/shell.ts
@@ -36,6 +36,7 @@ export function registerShellTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: NixShellResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ packages, command, path, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-process/src/tools/reload.ts
+++ b/packages/server-process/src/tools/reload.ts
@@ -26,7 +26,7 @@ export function registerReloadTool(server: McpServer) {
         "**Security warning**: The `buildCommand` parameter executes arbitrary commands. " +
         "Configure `PARE_PROCESS_ALLOWED_COMMANDS` to restrict which executables are permitted. " +
         "When not configured, any command is allowed.",
-      annotations: { readOnlyHint: false, destructiveHint: true },
+      annotations: { readOnlyHint: false },
       inputSchema: {
         buildCommand: z
           .string()

--- a/packages/server-process/src/tools/run.ts
+++ b/packages/server-process/src/tools/run.ts
@@ -56,7 +56,7 @@ export function registerRunTool(server: McpServer) {
         "Only use shell=true when you trust the input and need shell features. " +
         "Note: shell=true bypasses the ALLOWED_COMMANDS check on arguments, so the entire " +
         "shell expression is executed if the base command is allowed.",
-      annotations: { readOnlyHint: false, destructiveHint: true },
+      annotations: { readOnlyHint: false },
       inputSchema: {
         command: z
           .string()

--- a/packages/server-ruby/src/tools/bundle-exec.ts
+++ b/packages/server-ruby/src/tools/bundle-exec.ts
@@ -39,6 +39,7 @@ export function registerBundleExecTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: BundleExecResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ command, args, path, compact }) => {
       assertNoFlagInjection(command, "command");

--- a/packages/server-ruby/src/tools/run.ts
+++ b/packages/server-ruby/src/tools/run.ts
@@ -32,6 +32,7 @@ export function registerRunTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: RubyRunResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ file, args, path, compact }) => {
       assertNoFlagInjection(file, "file");

--- a/packages/server-swift/src/tools/build.ts
+++ b/packages/server-swift/src/tools/build.ts
@@ -39,6 +39,7 @@ export function registerBuildTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: SwiftBuildResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ configuration, target, product, verbose, path, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-swift/src/tools/package-init.ts
+++ b/packages/server-swift/src/tools/package-init.ts
@@ -34,6 +34,7 @@ export function registerPackageInitTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: SwiftPackageInitResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ type, name, path, compact }) => {
       const cwd = path || process.cwd();

--- a/packages/server-swift/src/tools/run.ts
+++ b/packages/server-swift/src/tools/run.ts
@@ -35,6 +35,7 @@ export function registerRunTool(server: McpServer) {
         compact: compactInput,
       },
       outputSchema: SwiftRunResultSchema,
+      annotations: { readOnlyHint: false },
     },
     async ({ executable, args, path, compact }) => {
       const cwd = path || process.cwd();


### PR DESCRIPTION
## Summary

Closes #699.

- **Reclassifies** 8 tools that were incorrectly marked as `destructiveHint: true` to write operations (`readOnlyHint: false`): git cherry-pick, merge, push; docker run; cargo remove; process run, reload
- **Adds `destructiveHint: true`** to `issue-close` which was missing it
- **Adds missing `annotations`** to 25 tools across bazel, bun, cmake, deno, dotnet, infra, jvm, nix, ruby, and swift servers that had no annotation at all
- All 241 tool files now have correct MCP tool annotations

### Destructive tools (final list)
git clean, rebase, reset, restore; docker compose-down, exec; dotnet clean; github issue-close, pr-merge; k8s apply; swift package-clean

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (all test suites)
- [x] `pnpm lint` passes (pre-existing warning only)
- [x] `prettier --check` passes on all changed files
- [x] Verified all 241 tool files have annotations
- [x] Verified destructiveHint is only on truly destructive operations