### PR TITLE
fix: resolve nightly audit CVEs and code scanning alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,9 @@
       "rollup": ">=4.59.0",
       "serialize-javascript": ">=7.0.3",
       "flatted": ">=3.4.2",
-      "express-rate-limit": ">=8.2.2"
+      "express-rate-limit": ">=8.2.2",
+      "path-to-regexp": ">=8.4.0",
+      "brace-expansion": ">=5.0.5"
     }
   }
 }

--- a/packages/init/src/lib/detect.ts
+++ b/packages/init/src/lib/detect.ts
@@ -98,7 +98,7 @@ function markerExists(dir: string, marker: string, checkExists: (p: string) => b
 
   // For glob patterns like *.csproj, do a simple directory listing check.
   try {
-    const ext = marker.replace("*", "");
+    const ext = marker.replace(/\*/g, "");
     const entries = readdirSync(dir);
     return entries.some((e) => e.endsWith(ext));
   } catch {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,8 @@ overrides:
   serialize-javascript: '>=7.0.3'
   flatted: '>=3.4.2'
   express-rate-limit: '>=8.2.2'
+  path-to-regexp: '>=8.4.0'
+  brace-expansion: '>=5.0.5'
 
 importers:
 
@@ -1947,8 +1949,8 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2757,8 +2759,8 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.0:
+    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -4358,7 +4360,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5073,7 +5075,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   mri@1.2.0: {}
 
@@ -5160,7 +5162,7 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.0: {}
 
   path-type@4.0.0: {}
 
@@ -5291,7 +5293,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary
- Add pnpm overrides for `path-to-regexp >=8.4.0` (GHSA-j3q9-mxjg-w52f, ReDoS) and `brace-expansion >=5.0.5` (GHSA-f886-m6hf-6m8v, infinite loop) — both transitive deps
- Fix incomplete string sanitization in `packages/init/src/lib/detect.ts` — `.replace("*", "")` only replaced the first occurrence; now uses `.replace(/\*/g, "")` (CodeQL alert #22)
- Dismiss 4 false-positive CodeQL alerts (#19, #20, #21, #23) with documented rationale:
  - #19: `runner.ts` — standard `process.env` inheritance with `shell: false`
  - #20/#21: `runner.ts` — Windows cmd.exe branch uses `shell: false` + `windowsVerbatimArguments` + escape functions (cross-spawn pattern)
  - #23: benchmark script — dev-only, hardcoded inputs

Fixes the nightly audit failure from March 28 and clears all 6 code-scanning alerts.

## Test plan
- [x] `pnpm audit --audit-level=high` returns 0 vulnerabilities
- [x] `pnpm test` (init package) — 175/175 passing
- [ ] CI audit job passes
- [ ] Scorecard re-scan clears alert #8 (auto after merge)