### PR TITLE
fix(git): accept 'create' parameter in tag tool (#776)

### DIFF
--- a/packages/server-git/src/tools/tag.ts
+++ b/packages/server-git/src/tools/tag.ts
@@ -29,6 +29,13 @@ export function registerTagTool(server: McpServer) {
           .optional()
           .default("list")
           .describe("Tag action to perform (default: list)"),
+        create: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "Shorthand to create a tag with this name (sets action=create). Consistent with branch tool's create parameter.",
+          ),
         name: z
           .string()
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
@@ -78,8 +85,9 @@ export function registerTagTool(server: McpServer) {
     },
     async ({
       path,
-      action,
-      name,
+      action: rawAction,
+      create: createShorthand,
+      name: rawName,
       message,
       commit,
       pattern,
@@ -94,6 +102,10 @@ export function registerTagTool(server: McpServer) {
       compact,
     }) => {
       const cwd = path || process.cwd();
+
+      // Support `create` shorthand parameter (consistent with branch tool)
+      const action = createShorthand ? "create" : rawAction;
+      const name = createShorthand || rawName;
 
       if (action === "create") {
         if (!name) {


### PR DESCRIPTION
## Summary
Fixes #776.

The `tag` tool now accepts a `create` shorthand parameter (e.g. `{create: 'v0.2.5', message: '...'}`) matching the `branch` tool's API pattern.

## Problem
The `branch` tool accepts `{create: 'my-branch'}` but the `tag` tool requires `{action: 'create', name: 'v0.2.5'}`. Calling `tag` with `{create: 'v0.2.5'}` results in:
```
MCP error -32602: Input validation error: Unrecognized key: "create"
```

## Solution
Added `create` as an optional shorthand parameter that, when provided, sets `action='create'` and uses the value as the tag name. The existing `action` + `name` approach continues to work unchanged.

## Changes
- `packages/server-git/src/tools/tag.ts`: Added `create` input parameter and resolution logic