### PR TITLE
fix(git): add `create` shorthand parameter to tag tool

### DIFF
--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -1261,6 +1261,72 @@ describe("@paretools/git write-tool integration", () => {
       }
     });
 
+    it("creates a lightweight tag via create shorthand", async () => {
+      const result = await client.callTool(
+        {
+          name: "tag",
+          arguments: { path: tempDir, create: "v1.1.0-shorthand" },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toBeDefined();
+
+      const textContent = result.content as Array<{ type: string; text: string }>;
+      expect(textContent.length).toBeGreaterThan(0);
+      expect(textContent[0].text).toContain("v1.1.0-shorthand");
+
+      if (result.structuredContent) {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc.success).toBe(true);
+        expect(sc.action).toBe("create");
+        expect(sc.name).toBe("v1.1.0-shorthand");
+        expect(sc.annotated).toBe(false);
+      }
+    });
+
+    it("creates an annotated tag via create shorthand with message", async () => {
+      const result = await client.callTool(
+        {
+          name: "tag",
+          arguments: {
+            path: tempDir,
+            create: "v1.2.0-shorthand",
+            message: "Shorthand annotated release",
+          },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toBeDefined();
+
+      const textContent = result.content as Array<{ type: string; text: string }>;
+      expect(textContent[0].text).toContain("v1.2.0-shorthand");
+
+      if (result.structuredContent) {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc.success).toBe(true);
+        expect(sc.annotated).toBe(true);
+      }
+    });
+
+    it("rejects flag-injection in create shorthand", async () => {
+      const result = await client.callTool(
+        {
+          name: "tag",
+          arguments: { path: tempDir, create: "--force" },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBe(true);
+    });
+
     it("creates an annotated tag with message", async () => {
       const result = await client.callTool(
         {

--- a/packages/server-git/src/tools/tag.ts
+++ b/packages/server-git/src/tools/tag.ts
@@ -34,6 +34,13 @@ export function registerTagTool(server: McpServer) {
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe("Tag name (required for create and delete actions)"),
+        create: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "Shorthand: create a tag with this name. Sets action=create and name automatically.",
+          ),
         message: z
           .string()
           .max(INPUT_LIMITS.MESSAGE_MAX)
@@ -78,8 +85,9 @@ export function registerTagTool(server: McpServer) {
     },
     async ({
       path,
-      action,
-      name,
+      action: rawAction,
+      name: rawName,
+      create: createShorthand,
       message,
       commit,
       pattern,
@@ -94,6 +102,10 @@ export function registerTagTool(server: McpServer) {
       compact,
     }) => {
       const cwd = path || process.cwd();
+
+      // Resolve `create` shorthand: sets action=create and name automatically
+      const action = createShorthand ? "create" : rawAction;
+      const name = createShorthand || rawName;
 
       if (action === "create") {
         if (!name) {


### PR DESCRIPTION
## Summary
- The tag tool required `{ action: "create", name: "v1.0" }` while the branch tool accepts `{ create: "branchname" }` directly — users expected the same pattern
- Adds `create` string parameter as a shorthand that sets `action=create` and `name` automatically
- Full backward compat: `{ action: "create", name: "v1.0" }` still works
- Includes `assertNoFlagInjection` on the `create` value (already covered by the existing `name` validation path)

Closes #776

## Test plan
- [x] tsc clean
- [x] 163 parser/formatter unit tests pass
- [x] New integration tests: lightweight tag via `create`, annotated tag via `create` + `message`, flag-injection rejection