### PR TITLE
fix(shared): add fallback PATH probing for Windows MSYS2 environments

### DIFF
--- a/.changeset/fix-msys2-path-fallback.md
+++ b/.changeset/fix-msys2-path-fallback.md
@@ -1,0 +1,5 @@
+---
+"@paretools/shared": patch
+---
+
+Add fallback PATH probing for Windows MSYS2/Git Bash environments where the MCP server process does not inherit the shell PATH, causing commands like git and gh to fail with "Command not found"

--- a/packages/shared/__tests__/runner.test.ts
+++ b/packages/shared/__tests__/runner.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, afterAll } from "vitest";
 import { writeFileSync, unlinkSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { run, escapeCmdArg, _buildSpawnConfig, _pickBestMatch } from "../src/runner.js";
+import {
+  run,
+  escapeCmdArg,
+  _buildSpawnConfig,
+  _pickBestMatch,
+  _probeFallbackPaths,
+  _WIN32_FALLBACK_PATHS,
+} from "../src/runner.js";
 
 // Helper script that prints its args as JSON — avoids issues with inline
 // `-e` code being mangled by cmd.exe parentheses parsing on Windows.
@@ -611,6 +618,52 @@ describe("_pickBestMatch", () => {
   it("handles case-insensitive extension matching", () => {
     const lines = ["C:\\tools\\tool", "C:\\tools\\tool.EXE"];
     expect(_pickBestMatch(lines, "win32")).toBe("C:\\tools\\tool.EXE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _probeFallbackPaths — Windows fallback path probing (#797)
+// ---------------------------------------------------------------------------
+
+describe("_probeFallbackPaths", () => {
+  it("returns undefined for unknown commands", () => {
+    expect(_probeFallbackPaths("some-nonexistent-tool")).toBeUndefined();
+  });
+
+  it("has fallback entries for git, gh, node, docker", () => {
+    expect(_WIN32_FALLBACK_PATHS).toHaveProperty("git");
+    expect(_WIN32_FALLBACK_PATHS).toHaveProperty("gh");
+    expect(_WIN32_FALLBACK_PATHS).toHaveProperty("node");
+    expect(_WIN32_FALLBACK_PATHS).toHaveProperty("docker");
+    // All entries should be .exe paths
+    for (const paths of Object.values(_WIN32_FALLBACK_PATHS)) {
+      for (const p of paths) {
+        if (p) expect(p).toMatch(/\.exe$/i);
+      }
+    }
+  });
+
+  it("returns first existing path when found", () => {
+    // On this machine, at least git or node should be findable
+    if (process.platform === "win32") {
+      const result = _probeFallbackPaths("git");
+      if (result) {
+        expect(result).toMatch(/git\.exe$/i);
+        expect(existsSync(result)).toBe(true);
+      }
+    }
+  });
+
+  it("returns undefined when no candidates exist on disk", () => {
+    // A command with fallback paths that definitely don't exist
+    // We test by checking a tool that's unlikely to be installed in default paths
+    const result = _probeFallbackPaths("docker");
+    // Either finds it or returns undefined — both are valid
+    if (result) {
+      expect(existsSync(result)).toBe(true);
+    } else {
+      expect(result).toBeUndefined();
+    }
   });
 });
 

--- a/packages/shared/src/runner.ts
+++ b/packages/shared/src/runner.ts
@@ -1,5 +1,6 @@
 import { spawn, execFileSync } from "node:child_process";
-import { normalize } from "node:path";
+import { existsSync } from "node:fs";
+import { join, normalize } from "node:path";
 import { stripAnsi } from "./ansi.js";
 import { sanitizeErrorOutput } from "./sanitize.js";
 
@@ -30,6 +31,50 @@ export function _pickBestMatch(lines: string[], platform: string): string {
   return lines[0];
 }
 
+/**
+ * Well-known installation directories for common dev tools on Windows.
+ * Used as a fallback when `where` fails (e.g., MSYS2/Git Bash PATH not
+ * inherited by the MCP server process). Only `.exe` entries are probed.
+ *
+ * @internal — Exported for unit testing only.
+ */
+export const _WIN32_FALLBACK_PATHS: Record<string, string[]> = {
+  git: [
+    join(process.env.PROGRAMFILES ?? "C:\\Program Files", "Git", "cmd", "git.exe"),
+    join(process.env.PROGRAMFILES ?? "C:\\Program Files", "Git", "mingw64", "bin", "git.exe"),
+    join(process.env["PROGRAMFILES(X86)"] ?? "C:\\Program Files (x86)", "Git", "cmd", "git.exe"),
+    join(process.env.LOCALAPPDATA ?? "", "Programs", "Git", "cmd", "git.exe"),
+  ],
+  gh: [
+    join(process.env.PROGRAMFILES ?? "C:\\Program Files", "GitHub CLI", "gh.exe"),
+    join(process.env["PROGRAMFILES(X86)"] ?? "C:\\Program Files (x86)", "GitHub CLI", "gh.exe"),
+    join(process.env.LOCALAPPDATA ?? "", "Programs", "GitHub CLI", "gh.exe"),
+  ],
+  node: [join(process.env.PROGRAMFILES ?? "C:\\Program Files", "nodejs", "node.exe")],
+  docker: [
+    join(
+      process.env.PROGRAMFILES ?? "C:\\Program Files",
+      "Docker",
+      "Docker",
+      "resources",
+      "bin",
+      "docker.exe",
+    ),
+  ],
+};
+
+/**
+ * Probes well-known Windows installation paths for a command when `where` fails.
+ * Returns the first existing `.exe` path, or `undefined` if none found.
+ *
+ * @internal — Exported for unit testing only.
+ */
+export function _probeFallbackPaths(cmd: string): string | undefined {
+  const candidates = _WIN32_FALLBACK_PATHS[cmd];
+  if (!candidates) return undefined;
+  return candidates.find((p) => p && existsSync(p));
+}
+
 function resolveCommand(cmd: string): string {
   // Skip resolution if cmd is already an absolute path
   if (cmd.startsWith("/") || /^[A-Za-z]:[/\\]/.test(cmd)) {
@@ -50,8 +95,15 @@ function resolveCommand(cmd: string): string {
 
     return _pickBestMatch(lines, process.platform) || cmd;
   } catch {
-    // Resolution failed — fall back to the bare command name so existing
-    // behavior (PATH lookup by the shell/OS) is preserved.
+    // Resolution failed — on Windows, probe well-known installation paths
+    // as a fallback. This handles MSYS2/Git Bash environments where the
+    // MCP server process may not inherit the shell's PATH.
+    if (process.platform === "win32") {
+      const fallback = _probeFallbackPaths(cmd);
+      if (fallback) return fallback;
+    }
+    // Fall back to the bare command name so existing behavior
+    // (PATH lookup by the shell/OS) is preserved.
     return cmd;
   }
 }


### PR DESCRIPTION
## Summary
- When the MCP server process doesn't inherit the shell's PATH (common in MSYS2/Git Bash), `where` fails to find commands like `git` and `gh`
- Adds fallback probing of well-known Windows installation directories (`Program Files`, `LocalAppData`) for git, gh, node, and docker
- Only triggers when `where` fails — zero impact on the normal resolution path

Closes #797

## Test plan
- [x] Unit tests for `_probeFallbackPaths` and `_WIN32_FALLBACK_PATHS`
- [x] TypeScript compilation clean
- [x] All 75 runner tests pass