### PR TITLE
feat(git): add --prune option to pull tool

### DIFF
--- a/.changeset/feat-git-pull-prune.md
+++ b/.changeset/feat-git-pull-prune.md
@@ -1,0 +1,5 @@
+---
+"@paretools/git": minor
+---
+
+Add `prune` option to the pull tool for removing stale remote-tracking refs during pull (--prune)

--- a/packages/server-git/src/tools/pull.ts
+++ b/packages/server-git/src/tools/pull.ts
@@ -59,6 +59,10 @@ export function registerPullTool(server: McpServer) {
         depth: z.coerce.number().optional().describe("Shallow fetch depth (--depth)"),
         noVerify: z.boolean().optional().describe("Bypass pre-merge hooks (--no-verify)"),
         squash: z.boolean().optional().describe("Squash pull (--squash)"),
+        prune: z
+          .boolean()
+          .optional()
+          .describe("Remove stale remote-tracking refs before pulling (--prune)"),
       },
       outputSchema: GitPullSchema,
     },
@@ -76,6 +80,7 @@ export function registerPullTool(server: McpServer) {
       depth,
       noVerify,
       squash,
+      prune,
     }) => {
       const cwd = path || process.cwd();
 
@@ -98,6 +103,7 @@ export function registerPullTool(server: McpServer) {
       if (depth !== undefined) args.push(`--depth=${depth}`);
       if (noVerify) args.push("--no-verify");
       if (squash) args.push("--squash");
+      if (prune) args.push("--prune");
       if (strategy) args.push(`--strategy=${strategy}`);
       if (strategyOption) args.push(`-X${strategyOption}`);
       args.push(remote);


### PR DESCRIPTION
## Summary
- Adds `prune` boolean parameter to the `pull` tool, passing `--prune` to remove stale remote-tracking refs during pull
- Note: `remote` tool already supports prune via `action: "prune", name: "origin"` — this just adds the convenience of pruning during pull

Closes #792

## Test plan
- [x] TypeScript compilation clean
- [x] All 11 pull parser tests pass
- [x] Existing integration tests unaffected