### PR TITLE
feat(git): add batch branch deletion support

### DIFF
--- a/.changeset/feat-batch-branch-delete.md
+++ b/.changeset/feat-batch-branch-delete.md
@@ -1,0 +1,5 @@
+---
+"@paretools/git": minor
+---
+
+Add batch branch deletion — pass an array of branch names to `delete` param

--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -498,6 +498,88 @@ describe("@paretools/git write-tool integration", () => {
     });
   });
 
+  describe("branch batch delete", () => {
+    it("deletes a single branch (backward compat)", async () => {
+      gitInTemp(["branch", "single-del-test"]);
+      const result = await client.callTool(
+        {
+          name: "branch",
+          arguments: { path: tempDir, delete: "single-del-test" },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBeUndefined();
+      const sc = result.structuredContent as Record<string, unknown>;
+      const branches = sc.branches as Record<string, unknown>[];
+      expect(branches.find((b) => b.name === "single-del-test")).toBeUndefined();
+    });
+
+    it("deletes an array of branches", async () => {
+      gitInTemp(["branch", "batch-del-1"]);
+      gitInTemp(["branch", "batch-del-2"]);
+      gitInTemp(["branch", "batch-del-3"]);
+      const result = await client.callTool(
+        {
+          name: "branch",
+          arguments: {
+            path: tempDir,
+            delete: ["batch-del-1", "batch-del-2", "batch-del-3"],
+          },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBeUndefined();
+      const sc = result.structuredContent as Record<string, unknown>;
+      const branches = sc.branches as Record<string, unknown>[];
+      expect(branches.find((b) => b.name === "batch-del-1")).toBeUndefined();
+      expect(branches.find((b) => b.name === "batch-del-2")).toBeUndefined();
+      expect(branches.find((b) => b.name === "batch-del-3")).toBeUndefined();
+    });
+
+    it("fails when one branch in an array does not exist", async () => {
+      gitInTemp(["branch", "batch-mixed-1"]);
+      const result = await client.callTool(
+        {
+          name: "branch",
+          arguments: {
+            path: tempDir,
+            delete: ["batch-mixed-1", "nonexistent-branch-xyz"],
+          },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBe(true);
+    });
+
+    it("force-deletes an array of branches with forceDelete as array", async () => {
+      gitInTemp(["branch", "batch-fd-1"]);
+      gitInTemp(["branch", "batch-fd-2"]);
+      const result = await client.callTool(
+        {
+          name: "branch",
+          arguments: {
+            path: tempDir,
+            forceDelete: ["batch-fd-1", "batch-fd-2"],
+          },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBeUndefined();
+      const sc = result.structuredContent as Record<string, unknown>;
+      const branches = sc.branches as Record<string, unknown>[];
+      expect(branches.find((b) => b.name === "batch-fd-1")).toBeUndefined();
+      expect(branches.find((b) => b.name === "batch-fd-2")).toBeUndefined();
+    });
+  });
+
   describe("checkout", () => {
     it("creates a new branch and returns structured checkout data", async () => {
       const result = await client.callTool(

--- a/packages/server-git/src/tools/branch.ts
+++ b/packages/server-git/src/tools/branch.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { compactDualOutput, INPUT_LIMITS, compactInput, repoPathInput } from "@paretools/shared";
+import {
+  compactDualOutput,
+  INPUT_LIMITS,
+  compactInput,
+  repoPathInput,
+  coerceJsonArray,
+} from "@paretools/shared";
 import { assertNoFlagInjection, assertValidSortKey } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseBranch } from "../lib/parsers.js";
@@ -28,10 +34,12 @@ export function registerBranchTool(server: McpServer) {
           .optional()
           .describe("Start point for branch creation (commit, tag, or branch)"),
         delete: z
-          .string()
-          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .union([
+            z.string().max(INPUT_LIMITS.SHORT_STRING_MAX),
+            z.preprocess(coerceJsonArray, z.array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))),
+          ])
           .optional()
-          .describe("Delete branch with this name"),
+          .describe("Delete branch(es) — pass a single name or an array of names"),
         rename: z
           .string()
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
@@ -59,10 +67,14 @@ export function registerBranchTool(server: McpServer) {
           .describe("Filter branches matching a pattern (<pattern>)"),
         all: z.boolean().optional().default(false).describe("Include remote branches"),
         forceDelete: z
-          .union([z.boolean(), z.string().max(INPUT_LIMITS.SHORT_STRING_MAX)])
+          .union([
+            z.boolean(),
+            z.string().max(INPUT_LIMITS.SHORT_STRING_MAX),
+            z.preprocess(coerceJsonArray, z.array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))),
+          ])
           .optional()
           .describe(
-            "Force-delete unmerged branches (-D). Pass true (requires `delete` param) or a branch name string.",
+            "Force-delete unmerged branches (-D). Pass true (requires `delete` param), a branch name string, or an array of branch names.",
           ),
         merged: z.coerce
           .boolean()
@@ -150,18 +162,34 @@ export function registerBranchTool(server: McpServer) {
         }
       }
 
-      // Delete branch
-      // forceDelete can be true (use `delete` param as branch name) or a string (branch name to force-delete)
-      const forceDeleteBranch = typeof forceDelete === "string" ? forceDelete : undefined;
-      const isForceDelete = forceDelete === true || typeof forceDelete === "string";
-      const branchToDelete = deleteBranch ?? forceDeleteBranch;
+      // Delete branch(es)
+      // Normalize deleteBranch and forceDelete into a list of branches to delete
+      const isForceDelete =
+        forceDelete === true || typeof forceDelete === "string" || Array.isArray(forceDelete);
+      const deleteFlag = isForceDelete ? "-D" : "-d";
 
-      if (branchToDelete) {
-        assertNoFlagInjection(branchToDelete, "branch name");
-        const deleteFlag = isForceDelete ? "-D" : "-d";
-        const result = await git(["branch", deleteFlag, branchToDelete], cwd);
+      // Collect branch names to delete from both params
+      let branchesToDelete: string[] = [];
+      if (deleteBranch) {
+        if (Array.isArray(deleteBranch)) {
+          branchesToDelete.push(...deleteBranch);
+        } else {
+          branchesToDelete.push(deleteBranch);
+        }
+      }
+      if (typeof forceDelete === "string") {
+        branchesToDelete.push(forceDelete);
+      } else if (Array.isArray(forceDelete)) {
+        branchesToDelete.push(...(forceDelete as string[]));
+      }
+
+      if (branchesToDelete.length > 0) {
+        for (const name of branchesToDelete) {
+          assertNoFlagInjection(name, "branch name");
+        }
+        const result = await git(["branch", deleteFlag, ...branchesToDelete], cwd);
         if (result.exitCode !== 0) {
-          throw new Error(`Failed to delete branch: ${result.stderr}`);
+          throw new Error(`Failed to delete branch(es): ${result.stderr}`);
         }
       }
 


### PR DESCRIPTION
## Summary
- The `branch` tool's `delete` param now accepts both a single string and an array of branch names, enabling batch deletion in one call (closes #802)
- The `forceDelete` param similarly accepts an array of branch names for batch force-deletion
- Uses `z.preprocess(coerceJsonArray, ...)` for MCP client compatibility with JSON-stringified arrays
- Each branch name is validated with `assertNoFlagInjection` before passing to `git branch -d/-D`

## Test plan
- [x] Single branch deletion still works (backward compat)
- [x] Array of branches deletion works
- [x] Mixed success/failure (one exists, one doesn't) returns error
- [x] Force-delete with array of branch names works
- [x] Existing forceDelete tests still pass (boolean and string variants)

Fixes #802