### PR TITLE
fix(ci): replace pnpm audit with trivy scanner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,15 +158,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - name: Audit pnpm-lock.yaml with Trivy
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm audit --audit-level=high
+          scan-type: fs
+          scan-ref: pnpm-lock.yaml
+          severity: HIGH,CRITICAL
+          exit-code: "1"
 
   ci-gate:
     # Always run, even if upstream jobs are skipped

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,15 +70,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - name: Audit pnpm-lock.yaml with Trivy
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm audit --audit-level=high
+          scan-type: fs
+          scan-ref: pnpm-lock.yaml
+          severity: HIGH,CRITICAL
+          exit-code: "1"
 
   summary:
     if: always()


### PR DESCRIPTION
## Summary

Nightly has been failing since 2026-04-15 because npm retired the legacy audit endpoints (`/-/npm/v1/security/audits{,/quick}`). Both now return HTTP 410, so `pnpm audit` hard-fails before it can check anything.

The fix to use npm's new bulk advisory endpoint (`/-/npm/v1/security/advisories/bulk`) only landed in **pnpm 11.0.0-rc.1** and was not backported to the 10.x series. Bumping within 10.x (e.g. to 10.33.0) does not help.

Rather than wait for pnpm 11 stable (and the lockfile regeneration that implies — see #814 for the blast radius of that migration), this swaps the audit step for [`aquasecurity/trivy-action`](https://github.com/aquasecurity/trivy-action), which scans `pnpm-lock.yaml` against its own vulnerability DB.

- Same gating semantics: fails on `HIGH` / `CRITICAL`, matching the prior `--audit-level=high`.
- No pnpm install needed — trivy reads the lockfile directly, so the job is smaller and faster.
- Applied to both `ci.yml` and `nightly.yml`.

Action pinned to SHA `57a97c7` (v0.35.0) to match the project's SHA-pinning convention.

## Test plan

- [ ] CI `audit` job passes on this PR
- [ ] Nightly `audit` job passes on next scheduled run (or manual dispatch)
- [ ] Verify trivy correctly flags a known-high advisory by testing against a deliberately pinned-vulnerable dep locally (optional sanity check)