### PR TITLE
fix(security): bump hono override to >=4.12.14 (GHSA-458j-xx4x-4375)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "pnpm": {
     "overrides": {
       "minimatch": ">=10.2.3",
-      "hono": ">=4.12.12",
+      "hono": ">=4.12.14",
       "@hono/node-server": ">=1.19.13",
       "qs": ">=6.14.2",
       "rollup": ">=4.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   minimatch: '>=10.2.3'
-  hono: '>=4.12.12'
+  hono: '>=4.12.14'
   '@hono/node-server': '>=1.19.13'
   qs: '>=6.14.2'
   rollup: '>=4.59.0'
@@ -1289,7 +1289,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.12'
+      hono: '>=4.12.14'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2376,8 +2376,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -3780,9 +3780,9 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  '@hono/node-server@1.19.13(hono@4.12.15)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.15
 
   '@humanfs/core@0.19.1': {}
 
@@ -3958,7 +3958,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
+      '@hono/node-server': 1.19.13(hono@4.12.15)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -3968,7 +3968,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.12
+      hono: 4.12.15
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4936,7 +4936,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.12: {}
+  hono@4.12.15: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## Summary

- Existing `pnpm.overrides` for `hono` was `>=4.12.12`, which still resolved to a vulnerable version (4.12.12).
- [GHSA-458j-xx4x-4375](https://github.com/advisories/GHSA-458j-xx4x-4375) — XSS in `hono/jsx` SSR via attribute-name injection — is fixed in `4.12.14`.
- Bumps the override to `>=4.12.14`; the lockfile re-resolves to `4.12.15`.

`hono` is pulled in transitively by `@modelcontextprotocol/sdk` → `@hono/node-server`. Pare doesn't depend on it directly.

## Why no changeset

CI / security-only override. No `@paretools/*` published-package behavior change. Per CLAUDE.md changeset rules.

## Closes

Code-scanning alert #8.

## Test plan

- [x] `pnpm install` succeeds; lockfile delta is hono-only (9 lines added, 9 removed)
- [ ] CI passes (build, test, lint, audit)