### PR TITLE
fix(shared): diagnostic info in "Command not found" errors (refs #820)

### DIFF
--- a/.changeset/fix-runner-diagnostic-error.md
+++ b/.changeset/fix-runner-diagnostic-error.md
@@ -1,0 +1,5 @@
+---
+"@paretools/shared": patch
+---
+
+Improve "Command not found" error: now includes the platform, the first PATH entries the runner saw, and on Windows the well-known fallback paths probed plus whether each exists on disk. Makes #820-style failures (subagent PATH not inherited) self-debugging in the wild.

--- a/packages/shared/__tests__/runner.test.ts
+++ b/packages/shared/__tests__/runner.test.ts
@@ -12,6 +12,7 @@ import {
   _augmentUnixPath,
   _resetAugmentCache,
   _unixExtraPaths,
+  _diagnoseLookup,
 } from "../src/runner.js";
 
 // Helper script that prints its args as JSON — avoids issues with inline
@@ -667,6 +668,71 @@ describe("_probeFallbackPaths", () => {
     } else {
       expect(result).toBeUndefined();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _diagnoseLookup — diagnostic message for "Command not found" errors (#820)
+// ---------------------------------------------------------------------------
+
+describe("_diagnoseLookup", () => {
+  it("includes the platform", () => {
+    const out = _diagnoseLookup("git", "linux", { PATH: "/usr/bin" } as NodeJS.ProcessEnv);
+    expect(out).toContain("platform: linux");
+  });
+
+  it("lists PATH entries the runner saw", () => {
+    const out = _diagnoseLookup("git", "linux", {
+      PATH: "/usr/bin:/usr/local/bin:/opt/homebrew/bin",
+    } as NodeJS.ProcessEnv);
+    expect(out).toContain("PATH (3 entries)");
+    expect(out).toContain("/usr/bin");
+    expect(out).toContain("/usr/local/bin");
+    expect(out).toContain("/opt/homebrew/bin");
+  });
+
+  it("uses ; as PATH separator on Windows", () => {
+    const out = _diagnoseLookup("git", "win32", {
+      PATH: "C:\\Windows;C:\\Program Files\\Git\\cmd",
+    } as NodeJS.ProcessEnv);
+    expect(out).toContain("PATH (2 entries)");
+    expect(out).toContain("C:\\Windows");
+    expect(out).toContain("C:\\Program Files\\Git\\cmd");
+  });
+
+  it("truncates PATH preview when over 8 entries", () => {
+    const dirs = Array.from({ length: 12 }, (_, i) => `/dir${i}`);
+    const out = _diagnoseLookup("git", "linux", {
+      PATH: dirs.join(":"),
+    } as NodeJS.ProcessEnv);
+    expect(out).toContain("PATH (12 entries)");
+    expect(out).toContain("/dir0");
+    expect(out).toContain("/dir7");
+    expect(out).toContain("(4 more)");
+    expect(out).not.toContain("/dir8");
+  });
+
+  it("reports empty PATH cleanly", () => {
+    const out = _diagnoseLookup("git", "linux", { PATH: "" } as NodeJS.ProcessEnv);
+    expect(out).toContain("PATH: (empty)");
+  });
+
+  it("on Windows, lists fallback paths and existence for known commands", () => {
+    const out = _diagnoseLookup("git", "win32", { PATH: "C:\\Windows" } as NodeJS.ProcessEnv);
+    expect(out).toContain("fallback paths probed");
+    expect(out).toMatch(/git\.exe \((exists|missing)\)/);
+  });
+
+  it("on Windows, notes when no fallback registered for a command", () => {
+    const out = _diagnoseLookup("some-unknown-tool", "win32", {
+      PATH: "C:\\Windows",
+    } as NodeJS.ProcessEnv);
+    expect(out).toContain('fallback paths: (none registered for "some-unknown-tool")');
+  });
+
+  it("on Unix, omits the fallback-paths section", () => {
+    const out = _diagnoseLookup("git", "linux", { PATH: "/usr/bin" } as NodeJS.ProcessEnv);
+    expect(out).not.toContain("fallback paths");
   });
 });
 

--- a/packages/shared/src/runner.ts
+++ b/packages/shared/src/runner.ts
@@ -181,6 +181,53 @@ function resolveCommand(cmd: string): string {
   }
 }
 
+/**
+ * Builds a multi-line diagnostic suffix appended to "Command not found" errors
+ * so failures are self-debugging in the wild — see #820 (subagent PATH not
+ * inherited) where the original message gave no hint why lookup failed.
+ *
+ * Includes: platform, the first few PATH entries the runner saw, and on
+ * Windows the fallback paths that were probed plus whether each exists on disk.
+ *
+ * @internal — Exported for unit testing only.
+ */
+export function _diagnoseLookup(
+  cmd: string,
+  platform: string = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const lines: string[] = [];
+  lines.push(`  platform: ${platform}`);
+
+  const sep = platform === "win32" ? ";" : ":";
+  const pathEntries = (env.PATH ?? "").split(sep).filter(Boolean);
+  if (pathEntries.length === 0) {
+    lines.push(`  PATH: (empty)`);
+  } else {
+    const preview = pathEntries.slice(0, 8);
+    lines.push(`  PATH (${pathEntries.length} entries):`);
+    for (const entry of preview) lines.push(`    - ${entry}`);
+    if (pathEntries.length > preview.length) {
+      lines.push(`    ... (${pathEntries.length - preview.length} more)`);
+    }
+  }
+
+  if (platform === "win32") {
+    const fallbacks = _WIN32_FALLBACK_PATHS[cmd];
+    if (fallbacks && fallbacks.length > 0) {
+      lines.push(`  fallback paths probed:`);
+      for (const p of fallbacks) {
+        if (!p) continue;
+        lines.push(`    - ${p} (${existsSync(p) ? "exists" : "missing"})`);
+      }
+    } else {
+      lines.push(`  fallback paths: (none registered for "${cmd}")`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
 /** Options for the command runner, including working directory, timeout, and environment overrides. */
 export interface RunOptions {
   cwd?: string;
@@ -504,7 +551,7 @@ export function run(cmd: string, args: string[], opts?: RunOptions): Promise<Run
       if (err.code === "ENOENT") {
         reject(
           new Error(
-            `Command not found: "${cmd}". Ensure it is installed and available in your PATH.`,
+            `Command not found: "${cmd}". Ensure it is installed and available in your PATH.\n${_diagnoseLookup(cmd)}`,
           ),
         );
         return;
@@ -562,7 +609,7 @@ export function run(cmd: string, args: string[], opts?: RunOptions): Promise<Run
       if (code !== 0 && stderr.includes("is not recognized")) {
         reject(
           new Error(
-            `Command not found: "${cmd}". Ensure it is installed and available in your PATH.`,
+            `Command not found: "${cmd}". Ensure it is installed and available in your PATH.\n${_diagnoseLookup(cmd)}`,
           ),
         );
         return;


### PR DESCRIPTION
## Summary

- "Command not found" errors now include the platform, the first PATH entries the runner saw, and (on Windows) the registered fallback paths plus whether each exists on disk.
- Refs #820 — the original message gave no hint why lookup failed, which made the subagent / Git Bash repro hard to diagnose without local access.

## Why this and not a deeper fix

Per the investigation in #820, asks 1 (per-call lookup) and 2 (Windows fallback paths) were already shipped in #798 and look correct on paper for the reporter's `which git → /mingw64/bin/git`. Without diagnostic info from a fresh failure (Pare version, `where git`, which fallback path was tried) we'd be guessing at additional fallback entries. Better to make the next failure report self-explanatory.

## What the new error looks like

```
Command not found: "git". Ensure it is installed and available in your PATH.
  platform: win32
  PATH (3 entries):
    - C:\Windows\System32
    - C:\Windows
    - C:\Users\dave\AppData\Local\Microsoft\WindowsApps
  fallback paths probed:
    - C:\Program Files\Git\cmd\git.exe (missing)
    - C:\Program Files\Git\mingw64\bin\git.exe (missing)
    - C:\Program Files (x86)\Git\cmd\git.exe (missing)
    - C:\Users\dave\AppData\Local\Programs\Git\cmd\git.exe (missing)
```

When the next #820-style failure hits we'll see immediately whether (a) the PATH is genuinely stripped, (b) Git is installed somewhere not in `_WIN32_FALLBACK_PATHS`, or (c) the `where`/`which` resolver itself is misbehaving.

## Changes

- `packages/shared/src/runner.ts`: new `_diagnoseLookup()` helper; both `Command not found` throw sites append its output.
- `packages/shared/__tests__/runner.test.ts`: 8 unit tests for the new helper.
- `.changeset/fix-runner-diagnostic-error.md`: patch bump for `@paretools/shared`.

## Test plan

- [x] `pnpm --filter @paretools/shared build` — clean
- [x] `pnpm --filter @paretools/shared test` — 95/95 passed
- [x] ESLint clean
- [ ] CI green