### PR TITLE
fix(search): accept file paths instead of crashing with ENOTDIR (#827)

### DIFF
--- a/.changeset/fix-search-accept-file-path.md
+++ b/.changeset/fix-search-accept-file-path.md
@@ -1,0 +1,5 @@
+---
+"@paretools/search": patch
+---
+
+Fix `search` and `count` crashing with `spawn ENOTDIR` when `path` points to a file. Both tools now resolve the supplied path: directories are used as the spawn `cwd` (existing behaviour), file paths are split into a parent-dir `cwd` plus a positional target argument so ripgrep searches just that file. The `find` tool now rejects file paths early with a typed `path must be a directory` error instead of leaking `ENOTDIR`. Missing paths now return a clear `path does not exist` error. Closes #827.

--- a/packages/server-search/__tests__/integration.test.ts
+++ b/packages/server-search/__tests__/integration.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { resolve } from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
@@ -26,6 +28,133 @@ describe("@paretools/search integration", () => {
   afterAll(async () => {
     await transport.close();
   }, 30_000);
+
+  describe("search with file path (issue #827)", () => {
+    let tmpRoot: string;
+    let filePath: string;
+
+    beforeAll(() => {
+      tmpRoot = mkdtempSync(join(tmpdir(), "pare-search-file-path-"));
+      filePath = join(tmpRoot, "data.txt");
+      writeFileSync(filePath, "alpha\nbeta hono@1.0.0\ngamma hono@2.0.0\n");
+    });
+
+    afterAll(() => {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it("accepts a file path without crashing with spawn ENOTDIR", async () => {
+      const result = await client.callTool(
+        {
+          name: "search",
+          arguments: { pattern: "hono@", path: filePath, maxResults: 10 },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        const text = content[0]?.text ?? "";
+        // Tolerate environments where rg isn't installed, but never the
+        // ENOTDIR symptom that this fix targets.
+        expect(text).not.toMatch(/ENOTDIR/);
+        expect(text).toMatch(/rg|ripgrep|command|not found|ENOENT/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(sc.totalMatches).toBe(2);
+      }
+    });
+
+    it("returns a clear error when the path does not exist", async () => {
+      const missing = join(tmpRoot, "no-such-file.txt");
+      const result = await client.callTool(
+        {
+          name: "search",
+          arguments: { pattern: "x", path: missing },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBe(true);
+      const content = result.content as Array<{ type: string; text: string }>;
+      const text = content[0]?.text ?? "";
+      expect(text).toMatch(/path does not exist/);
+      expect(text).not.toMatch(/ENOTDIR/);
+    });
+  });
+
+  describe("count with file path (issue #827)", () => {
+    let tmpRoot: string;
+    let filePath: string;
+
+    beforeAll(() => {
+      tmpRoot = mkdtempSync(join(tmpdir(), "pare-count-file-path-"));
+      filePath = join(tmpRoot, "data.txt");
+      writeFileSync(filePath, "x\nx\ny\nx\n");
+    });
+
+    afterAll(() => {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it("accepts a file path without crashing with spawn ENOTDIR", async () => {
+      const result = await client.callTool(
+        {
+          name: "count",
+          arguments: { pattern: "x", path: filePath },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        const text = content[0]?.text ?? "";
+        expect(text).not.toMatch(/ENOTDIR/);
+        expect(text).toMatch(/rg|ripgrep|command|not found|ENOENT/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        const totalMatches = sc.totalMatches as number | undefined;
+        expect(totalMatches).toBe(3);
+      }
+    });
+  });
+
+  describe("find with file path (issue #827)", () => {
+    let tmpRoot: string;
+    let filePath: string;
+
+    beforeAll(() => {
+      tmpRoot = mkdtempSync(join(tmpdir(), "pare-find-file-path-"));
+      filePath = join(tmpRoot, "data.txt");
+      writeFileSync(filePath, "irrelevant\n");
+    });
+
+    afterAll(() => {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it("rejects a file path with a typed error rather than spawn ENOTDIR", async () => {
+      const result = await client.callTool(
+        {
+          name: "find",
+          arguments: { pattern: "x", path: filePath },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBe(true);
+      const content = result.content as Array<{ type: string; text: string }>;
+      const text = content[0]?.text ?? "";
+      expect(text).toMatch(/path must be a directory/);
+      expect(text).not.toMatch(/ENOTDIR/);
+    });
+  });
 
   describe("find", () => {
     it("returns structured output with default compact mode", async () => {

--- a/packages/server-search/__tests__/resolve-search-path.test.ts
+++ b/packages/server-search/__tests__/resolve-search-path.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveSearchPath } from "../src/lib/search-runner.js";
+
+describe("resolveSearchPath", () => {
+  let root: string;
+  let nestedDir: string;
+  let filePath: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "pare-search-resolve-"));
+    nestedDir = join(root, "nested");
+    mkdirSync(nestedDir);
+    filePath = join(root, "data.txt");
+    writeFileSync(filePath, "hello\nworld\n");
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns process.cwd() and '.' when path is undefined", () => {
+    const resolved = resolveSearchPath(undefined);
+    expect(resolved.cwd).toBe(process.cwd());
+    expect(resolved.target).toBe(".");
+    expect(resolved.isFile).toBe(false);
+  });
+
+  it("treats a directory path as cwd with target '.'", () => {
+    const resolved = resolveSearchPath(nestedDir);
+    expect(resolved.cwd).toBe(nestedDir);
+    expect(resolved.target).toBe(".");
+    expect(resolved.isFile).toBe(false);
+  });
+
+  it("treats a file path by using its parent dir as cwd and the file as target", () => {
+    const resolved = resolveSearchPath(filePath);
+    expect(resolved.cwd).toBe(root);
+    expect(resolved.target).toBe(filePath);
+    expect(resolved.isFile).toBe(true);
+  });
+
+  it("throws a clear error when the path does not exist", () => {
+    const missing = join(root, "does-not-exist.txt");
+    expect(() => resolveSearchPath(missing)).toThrow(/path does not exist/);
+    // Crucially, it must NOT leak the raw `spawn ENOTDIR` error type.
+    expect(() => resolveSearchPath(missing)).not.toThrow(/ENOTDIR/);
+  });
+
+  it("resolves relative paths against process.cwd()", () => {
+    // "." is always a valid directory relative to cwd
+    const resolved = resolveSearchPath(".");
+    expect(resolved.isFile).toBe(false);
+    expect(resolved.target).toBe(".");
+  });
+});

--- a/packages/server-search/src/lib/search-runner.ts
+++ b/packages/server-search/src/lib/search-runner.ts
@@ -1,4 +1,6 @@
 import { run, type RunResult } from "@paretools/shared";
+import { statSync } from "node:fs";
+import { dirname, isAbsolute, resolve as resolvePath } from "node:path";
 
 /** Platform-specific install hints for commands used by the search package. */
 const INSTALL_HINTS: Record<string, string> = {
@@ -60,6 +62,60 @@ export async function rgCmd(args: string[], cwd?: string): Promise<RunResult> {
 
 export async function fdCmd(args: string[], cwd?: string): Promise<RunResult> {
   return runWithInstallHint("fd", args, { cwd, timeout: 180_000 });
+}
+
+/**
+ * Result of resolving a user-supplied `path` parameter into a `cwd` for the
+ * underlying CLI plus a positional target path to pass to it.
+ *
+ * - For directory inputs, `cwd` is the directory itself and `target` is "."
+ *   (preserves current behaviour).
+ * - For file inputs, `cwd` is the file's parent directory and `target` is the
+ *   absolute file path so the CLI searches just that file rather than crashing
+ *   with `spawn ENOTDIR` when the file path is used as a process cwd.
+ */
+export interface ResolvedSearchPath {
+  cwd: string;
+  target: string;
+  isFile: boolean;
+}
+
+/**
+ * Resolves a user-supplied search path into a safe (cwd, target) pair.
+ *
+ * Throws a typed Error with a clear message when the path does not exist or
+ * is neither a regular file nor a directory.
+ */
+export function resolveSearchPath(inputPath: string | undefined): ResolvedSearchPath {
+  if (!inputPath) {
+    return { cwd: process.cwd(), target: ".", isFile: false };
+  }
+
+  const absolute = isAbsolute(inputPath) ? inputPath : resolvePath(process.cwd(), inputPath);
+
+  let stat;
+  try {
+    stat = statSync(absolute);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      throw new Error(`path does not exist: ${inputPath}`);
+    }
+    if (code === "EACCES") {
+      throw new Error(`path is not accessible: ${inputPath}`);
+    }
+    throw err;
+  }
+
+  if (stat.isDirectory()) {
+    return { cwd: absolute, target: ".", isFile: false };
+  }
+
+  if (stat.isFile()) {
+    return { cwd: dirname(absolute), target: absolute, isFile: true };
+  }
+
+  throw new Error(`path is not a regular file or directory: ${inputPath}`);
 }
 
 export async function yqCmd(

--- a/packages/server-search/src/tools/count.ts
+++ b/packages/server-search/src/tools/count.ts
@@ -7,7 +7,7 @@ import {
   compactInput,
   pathInput,
 } from "@paretools/shared";
-import { rgCmd } from "../lib/search-runner.js";
+import { rgCmd, resolveSearchPath } from "../lib/search-runner.js";
 import { parseRgCountOutput } from "../lib/parsers.js";
 import { formatCount, compactCountMap, formatCountCompact } from "../lib/formatters.js";
 import { CountResultSchema } from "../schemas/index.js";
@@ -115,8 +115,14 @@ export function registerCountTool(server: McpServer) {
       if (type) assertNoFlagInjection(type, "type");
       if (!fixedStrings) validateRegexPattern(pattern);
 
-      const cwd = path || process.cwd();
+      const { cwd, target, isFile } = resolveSearchPath(path);
       const args = countMatches ? ["--count-matches"] : ["--count"];
+
+      // When the target is a single file, rg omits the `file:` prefix and
+      // prints just the count; force it on so the parser stays consistent.
+      if (isFile) {
+        args.push("--with-filename");
+      }
 
       if (!caseSensitive) {
         args.push("--ignore-case");
@@ -160,9 +166,12 @@ export function registerCountTool(server: McpServer) {
 
       args.push(pattern);
 
-      // Always pass "." as the search path so rg searches the directory
-      // instead of reading from stdin (which hangs when stdin is piped)
-      args.push(".");
+      // Always pass an explicit target so rg searches the path instead of
+      // reading from stdin (which hangs when stdin is piped). When the user
+      // supplied a file path, `target` is the file's absolute path and `cwd`
+      // is its parent directory; when they supplied a directory (or nothing),
+      // `target` is "." and `cwd` is that directory.
+      args.push(target);
       const result = await rgCmd(args, cwd);
 
       // rg exits with code 1 when no matches are found — that's not an error

--- a/packages/server-search/src/tools/find.ts
+++ b/packages/server-search/src/tools/find.ts
@@ -7,7 +7,7 @@ import {
   compactInput,
   pathInput,
 } from "@paretools/shared";
-import { fdCmd } from "../lib/search-runner.js";
+import { fdCmd, resolveSearchPath } from "../lib/search-runner.js";
 import { parseFdOutput } from "../lib/parsers.js";
 import { formatFind, compactFindMap, formatFindCompact } from "../lib/formatters.js";
 import { FindResultSchema } from "../schemas/index.js";
@@ -117,7 +117,17 @@ export function registerFindTool(server: McpServer) {
       if (size) assertNoFlagInjection(size, "size");
       if (changedWithin) assertNoFlagInjection(changedWithin, "changedWithin");
 
-      const cwd = path || process.cwd();
+      // fd walks a directory tree; a file path is not meaningful as a search
+      // root. Resolve the path to surface clear errors for missing paths and
+      // reject file inputs with a typed error (matches the schema description).
+      const resolved = resolveSearchPath(path);
+      if (resolved.isFile) {
+        throw new Error(
+          `path must be a directory for find (got a file): ${path ?? ""}. ` +
+            `Use search or count to operate on a single file.`,
+        );
+      }
+      const cwd = resolved.cwd;
       const args = ["--color", "never"];
 
       if (type) {

--- a/packages/server-search/src/tools/search.ts
+++ b/packages/server-search/src/tools/search.ts
@@ -7,7 +7,7 @@ import {
   compactInput,
   pathInput,
 } from "@paretools/shared";
-import { rgCmd } from "../lib/search-runner.js";
+import { rgCmd, resolveSearchPath } from "../lib/search-runner.js";
 import { parseRgJsonOutput } from "../lib/parsers.js";
 import { formatSearch, compactSearchMap, formatSearchCompact } from "../lib/formatters.js";
 import { SearchResultSchema } from "../schemas/index.js";
@@ -114,7 +114,7 @@ export function registerSearchTool(server: McpServer) {
       if (type) assertNoFlagInjection(type, "type");
       if (!fixedStrings) validateRegexPattern(pattern);
 
-      const cwd = path || process.cwd();
+      const { cwd, target } = resolveSearchPath(path);
       const args = ["--json"];
 
       if (!caseSensitive) {
@@ -171,9 +171,12 @@ export function registerSearchTool(server: McpServer) {
 
       args.push(pattern);
 
-      // Always pass "." as the search path so rg searches the directory
-      // instead of reading from stdin (which hangs when stdin is piped)
-      args.push(".");
+      // Always pass an explicit target so rg searches the path instead of
+      // reading from stdin (which hangs when stdin is piped). When the user
+      // supplied a file path, `target` is the file's absolute path and `cwd`
+      // is its parent directory; when they supplied a directory (or nothing),
+      // `target` is "." and `cwd` is that directory.
+      args.push(target);
       const result = await rgCmd(args, cwd);
 
       // rg exits with code 1 when no matches are found — that's not an error

--- a/tests/smoke/mocked/small-servers-1.smoke.test.ts
+++ b/tests/smoke/mocked/small-servers-1.smoke.test.ts
@@ -54,6 +54,13 @@ vi.mock("../../../packages/server-search/src/lib/search-runner.js", () => ({
   rgCmd: vi.fn(),
   fdCmd: vi.fn(),
   jqCmd: vi.fn(),
+  // Default to the directory case — preserves pre-#827 behavior. Tests that
+  // need to exercise the file-input path can override per-test.
+  resolveSearchPath: vi.fn((p: string | undefined) => ({
+    cwd: p ?? process.cwd(),
+    target: ".",
+    isFile: false,
+  })),
 }));
 
 // ── Mock curl runner ────────────────────────────────────────────────────────

--- a/tests/smoke/suite/small-servers.recorded.test.ts
+++ b/tests/smoke/suite/small-servers.recorded.test.ts
@@ -30,6 +30,13 @@ vi.mock("../../../packages/server-search/src/lib/search-runner.js", () => ({
   rgCmd: vi.fn(),
   fdCmd: vi.fn(),
   jqCmd: vi.fn(),
+  // Default to the directory case — preserves pre-#827 behavior. Tests that
+  // need to exercise the file-input path can override per-test.
+  resolveSearchPath: vi.fn((p: string | undefined) => ({
+    cwd: p ?? process.cwd(),
+    target: ".",
+    isFile: false,
+  })),
 }));
 
 // ── Mock curl runner ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fixes `pare-search__search` and `pare-search__count` crashing with `spawn ENOTDIR` when `path` points to a file. The schema description already promises file or directory; now both work.
- `pare-search__find` (fd) genuinely walks directories, so it now surfaces a typed `path must be a directory for find` error instead of leaking the raw Node `ENOTDIR`.
- Missing paths now produce a clear `path does not exist: <path>` error.

Closes #827.

## Root cause

`packages/server-search/src/tools/search.ts` (and `count.ts`, `find.ts`) used the user-supplied `path` as the spawn `cwd` unconditionally:

```ts
const cwd = path || process.cwd();
```

`child_process.spawn` throws `ENOTDIR` synchronously when `cwd` is set to a non-directory path, so the error leaked out as `{ "error": "spawn ENOTDIR" }`.

## Fix

New helper `resolveSearchPath(path)` in `lib/search-runner.ts` returns `{ cwd, target, isFile }`:

- `undefined` → `cwd = process.cwd()`, `target = "."`
- directory → `cwd = <dir>`, `target = "."` (existing behaviour)
- file → `cwd = dirname(file)`, `target = <absolute-file-path>`, `isFile = true`
- missing → throws `path does not exist: <path>`

`search.ts` and `count.ts` route through it and append `target` instead of a hard-coded `"."`. `count.ts` also adds `--with-filename` when `isFile`, because rg drops the `file:` prefix when given a single file and the parser expects `file:count`.

`find.ts` resolves the path the same way but throws when the input is a file (fd is not meaningful for a single file root).

## Before / after

```jsonc
// Before
search({ path: "/repo/pnpm-lock.yaml", pattern: "^  hono@" })
// → { "error": "spawn ENOTDIR" }

// After
search({ path: "/repo/pnpm-lock.yaml", pattern: "^  hono@" })
// → { matches: [...], totalMatches: 2 }
```

## Test plan

- [x] `pnpm --filter @paretools/search build` — clean
- [x] `pnpm --filter @paretools/search test` — 88/88 passing (added 5 unit tests for `resolveSearchPath`, plus 4 integration tests covering search/count file-path success and find/missing-path typed errors)
- [x] `pnpm lint` on touched files — clean
- [x] `prettier --check` on touched files — clean
- [ ] CI matrix (ubuntu/windows/macos x node 20/22)
