### PR TITLE
fix(shared): add npm/npx/pnpm/yarn to Windows fallback paths (#839)

### DIFF
--- a/.changeset/fix-win32-fallback-paths-npm.md
+++ b/.changeset/fix-win32-fallback-paths-npm.md
@@ -1,0 +1,5 @@
+---
+"@paretools/shared": patch
+---
+
+Add npm/npx/pnpm/yarn to `_WIN32_FALLBACK_PATHS` so `pare-npm` and other Node-package-manager calls succeed on Windows + Git Bash when the spawned MCP server doesn't inherit the user's PATH (the same root condition as #820). The cross-spawn cmd.exe wrapper in `_buildSpawnConfig` already handled `.cmd` correctly — only the fallback registry was missing entries. Fixes #839.

--- a/packages/shared/__tests__/runner.test.ts
+++ b/packages/shared/__tests__/runner.test.ts
@@ -634,15 +634,33 @@ describe("_probeFallbackPaths", () => {
     expect(_probeFallbackPaths("some-nonexistent-tool")).toBeUndefined();
   });
 
-  it("has fallback entries for git, gh, node, docker", () => {
+  it("has fallback entries for git, gh, node, docker, and node package managers", () => {
     expect(_WIN32_FALLBACK_PATHS).toHaveProperty("git");
     expect(_WIN32_FALLBACK_PATHS).toHaveProperty("gh");
     expect(_WIN32_FALLBACK_PATHS).toHaveProperty("node");
     expect(_WIN32_FALLBACK_PATHS).toHaveProperty("docker");
-    // All entries should be .exe paths
+    expect(_WIN32_FALLBACK_PATHS).toHaveProperty("npm");
+    expect(_WIN32_FALLBACK_PATHS).toHaveProperty("npx");
+    expect(_WIN32_FALLBACK_PATHS).toHaveProperty("pnpm");
+    expect(_WIN32_FALLBACK_PATHS).toHaveProperty("yarn");
+    // Entries must end in .exe/.com (Branch 2 direct spawn) or .cmd/.bat
+    // (Branch 3 cmd.exe wrapper). Extensionless paths would break Branch 3.
     for (const paths of Object.values(_WIN32_FALLBACK_PATHS)) {
       for (const p of paths) {
-        if (p) expect(p).toMatch(/\.exe$/i);
+        if (p) expect(p).toMatch(/\.(exe|com|cmd|bat)$/i);
+      }
+    }
+  });
+
+  it("registers .cmd wrappers for npm/npx/pnpm/yarn (#839)", () => {
+    // Node package managers ship as .cmd on Windows. _buildSpawnConfig
+    // Branch 3 routes them through cmd.exe correctly.
+    for (const cmd of ["npm", "npx", "pnpm", "yarn"]) {
+      const paths = _WIN32_FALLBACK_PATHS[cmd];
+      expect(paths).toBeDefined();
+      expect(paths!.length).toBeGreaterThan(0);
+      for (const p of paths!) {
+        if (p) expect(p).toMatch(/\.cmd$/i);
       }
     }
   });

--- a/packages/shared/src/runner.ts
+++ b/packages/shared/src/runner.ts
@@ -107,7 +107,11 @@ export function _pickBestMatch(lines: string[], platform: string): string {
 /**
  * Well-known installation directories for common dev tools on Windows.
  * Used as a fallback when `where` fails (e.g., MSYS2/Git Bash PATH not
- * inherited by the MCP server process). Only `.exe` entries are probed.
+ * inherited by the MCP server process).
+ *
+ * Entries may be `.exe`/`.com` (spawned directly via Branch 2 of
+ * `_buildSpawnConfig`) or `.cmd`/`.bat` wrappers (routed through cmd.exe via
+ * Branch 3). Both work, and the resolver picks the first that exists on disk.
  *
  * @internal — Exported for unit testing only.
  */
@@ -134,11 +138,35 @@ export const _WIN32_FALLBACK_PATHS: Record<string, string[]> = {
       "docker.exe",
     ),
   ],
+  // Node package managers ship as .cmd wrappers on Windows. The default Node
+  // installer puts them in C:\Program Files\nodejs; npm-installed globals land
+  // in %APPDATA%\npm; pnpm's standalone installer lands in %LOCALAPPDATA%\pnpm.
+  npm: [
+    join(process.env.PROGRAMFILES ?? "C:\\Program Files", "nodejs", "npm.cmd"),
+    join(process.env["PROGRAMFILES(X86)"] ?? "C:\\Program Files (x86)", "nodejs", "npm.cmd"),
+    join(process.env.APPDATA ?? "", "npm", "npm.cmd"),
+  ],
+  npx: [
+    join(process.env.PROGRAMFILES ?? "C:\\Program Files", "nodejs", "npx.cmd"),
+    join(process.env["PROGRAMFILES(X86)"] ?? "C:\\Program Files (x86)", "nodejs", "npx.cmd"),
+    join(process.env.APPDATA ?? "", "npm", "npx.cmd"),
+  ],
+  pnpm: [
+    join(process.env.LOCALAPPDATA ?? "", "pnpm", "pnpm.cmd"),
+    join(process.env.APPDATA ?? "", "npm", "pnpm.cmd"),
+    join(process.env.PROGRAMFILES ?? "C:\\Program Files", "nodejs", "pnpm.cmd"),
+  ],
+  yarn: [
+    join(process.env.APPDATA ?? "", "npm", "yarn.cmd"),
+    join(process.env.PROGRAMFILES ?? "C:\\Program Files", "Yarn", "bin", "yarn.cmd"),
+    join(process.env.PROGRAMFILES ?? "C:\\Program Files", "nodejs", "yarn.cmd"),
+  ],
 };
 
 /**
  * Probes well-known Windows installation paths for a command when `where` fails.
- * Returns the first existing `.exe` path, or `undefined` if none found.
+ * Returns the first existing path (may be .exe/.com or .cmd/.bat — both are
+ * handled correctly downstream by `_buildSpawnConfig`), or `undefined` if none found.
  *
  * @internal — Exported for unit testing only.
  */


### PR DESCRIPTION
## Summary

Closes #839. `pare-npm__*` (and any other Pare tool that calls `npm`/`npx`/`pnpm`/`yarn`) was failing on Windows + Git Bash with `Command not found: "npm"` even with npm installed and resolvable from the calling shell.

## Root cause

`packages/shared/src/runner.ts` already has the cross-spawn cmd.exe pattern (`_buildSpawnConfig` Branch 3) that correctly invokes `.cmd`/`.bat` wrappers without `shell: true`. The chain that broke is upstream of that:

1. `resolveCommand("npm")` calls `where npm`. When the spawned MCP server didn't inherit the user's PATH (the same root condition as #820), `where` returned nothing.
2. Fallback was `_probeFallbackPaths("npm")` — but `_WIN32_FALLBACK_PATHS` only registered `git`, `gh`, `node`, `docker`. **No entry for `npm`/`npx`/`pnpm`/`yarn`.**
3. So `resolveCommand` returned the bare `"npm"` string. cmd.exe then inherited the same broken PATH from the Pare server process and failed to find `npm.cmd` → "is not recognized" stderr → translated to `Command not found`.

## Fix

Add `.cmd` wrappers for npm/npx/pnpm/yarn at their canonical Windows install locations:

- `%PROGRAMFILES%\nodejs` (default Node installer)
- `%PROGRAMFILES(X86)%\nodejs`
- `%APPDATA%\npm` (npm install -g)
- `%LOCALAPPDATA%\pnpm` (pnpm standalone installer)
- `%PROGRAMFILES%\Yarn\bin` (Yarn standalone installer)

Updated the fallback-path assertion test to allow `.cmd`/`.bat` alongside `.exe`/`.com` (Branch 2 of `_buildSpawnConfig` matches `.exe|.com` for direct spawn; everything else falls through to Branch 3 which uses cmd.exe — both code paths already exist and are tested).

## Why no spawn-side changes

`_buildSpawnConfig` Branch 3 already handles `.cmd` correctly via the cross-spawn pattern (`cmd.exe /d /s /c` with `windowsVerbatimArguments: true`). When the resolver returns a `.cmd` path, it falls through Branch 2's `.exe|.com` regex and lands in Branch 3 — verified by the existing `"detects .cmd and uses cmd.exe with shell:false"` test.

## Test plan

- [x] `tsc --noEmit` clean on `@paretools/shared`
- [x] `vitest --filter runner.test` — 96/96 passing (+1 new test asserting `.cmd` wrappers for npm/npx/pnpm/yarn, +5 new properties on existing assertion)
- [x] `eslint` clean on touched files
- [x] `prettier --check` clean on touched files
- [ ] CI matrix (ubuntu/windows/macos × node 20/22) — Windows is the relevant signal here

## Note on the related #820 PATH issue

This fix removes the `npm` failure mode entirely on machines where the Node installer used the canonical paths — but the deeper issue from #820 (the spawned MCP server inheriting a stripped PATH on Windows + Git Bash sub-agent contexts) remains. Worth investigating separately whether Claude Code's MCP launcher strips PATH on those sub-agent contexts. Diagnostic info added in #820's fix should help triage.