### PR TITLE
chore(changeset): add missing changeset for search file-path fix (#827)

### DIFF
--- a/.changeset/fix-search-accept-file-path.md
+++ b/.changeset/fix-search-accept-file-path.md
@@ -1,0 +1,5 @@
+---
+"@paretools/search": patch
+---
+
+Fix `pare-search__search` and `pare-search__count` crashing with `spawn ENOTDIR` when `path` points to a file. The schema already promised file or directory; now both work. `pare-search__find` (fd) genuinely walks directories, so it now returns a typed `path must be a directory for find` error instead of leaking the raw Node `ENOTDIR`. Missing paths produce a clear `path does not exist: <path>` error. Closes #827.


### PR DESCRIPTION
## Summary

The fix for #827 (search/count accept file paths instead of crashing with `ENOTDIR`) landed on `main` as commits 31af1fbc and 508fd43a, but the corresponding changeset file from PR #832 never made it onto `main` because that PR was closed earlier today as redundant (its commits were already on `main` via a separate path).

Net effect today: `@paretools/search` would be published in the next release **without patch notes for a user-visible bug fix**. The existing changeset PR #831 doesn't include any non-dep `@paretools/search` entry — confirmed by re-reading its body.

## Fix

Add `.changeset/fix-search-accept-file-path.md` describing the search/count/find fix as a `patch` bump on `@paretools/search`. Wording follows PR #832's summary.

## Test plan

- [x] Changeset file format follows the project convention (matches the format of `fix-runner-diagnostic-error.md` and `fix-turbo-task-accounting.md` already on main).
- [x] After this merges, `pare-ci-bot` should regenerate #831 to include a non-dep entry under `@paretools/search@0.18.1`.