### PR TITLE
fix(ci): pin pnpm to 10.29.2 in all workflow steps

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -26,6 +26,8 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v4
+        with:
+          version: 10.29.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
           fetch-depth: 2
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v4
+        with:
+          version: 10.29.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -54,6 +56,8 @@ jobs:
           fetch-depth: 2
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v4
+        with:
+          version: 10.29.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -86,6 +90,8 @@ jobs:
           fetch-depth: 2
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v4
+        with:
+          version: 10.29.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -105,6 +111,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v4
+        with:
+          version: 10.29.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -128,6 +136,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v4
+        with:
+          version: 10.29.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -143,6 +153,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v4
+        with:
+          version: 10.29.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,8 @@ jobs:
           fetch-depth: 2
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v4
+        with:
+          version: 10.29.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -39,6 +41,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v4
+        with:
+          version: 10.29.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -55,6 +59,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v4
+        with:
+          version: 10.29.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v4
+        with:
+          version: 10.29.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v4
+        with:
+          version: 10.29.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
## Summary

Fixes 7 consecutive nightly failures (Apr 30 → May 6, issues #848, #849, #850, #851, #853, #858, #859) and unblocks PR #847's failing CI.

## Root cause

`pnpm/action-setup@v4` was invoked without a `version:` parameter across all workflows, so it installed pnpm **latest**. pnpm 11 requires Node ≥ 22.13 and imports `node:sqlite` (a Node-22 builtin). On Node-20 jobs (`windows-latest, 20` and `macos-latest, 20`), the subsequent `actions/setup-node` step calls `pnpm store path --silent` to set up its cache, which crashes with:

```
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
```

The failure surfaces on the `setup-node` step, masking the real cause.

`package.json` already has `"packageManager": "pnpm@10.29.2"`, but the action wasn't reading it.

## Change

Add `with: version: 10.29.2` to all 12 `pnpm/action-setup` invocations across:
- `.github/workflows/ci.yml` (6 jobs)
- `.github/workflows/nightly.yml` (3 jobs)
- `.github/workflows/release.yml` (1 job)
- `.github/workflows/sbom.yml` (1 job)
- `.github/workflows/canary.yml` (1 job)

## Followup (out of scope)

- PR #847 has a separate `pnpm test` failure on `macos-latest, 22` and a `coverage` job failure that aren't explained by this — likely flaky or a real macOS-22 bug. Re-run after this merges to triage.
- After merge, the 7 stale auto-filed nightly issues can be batch-closed.
- Node 20 is EOL April 2026. Eventually we should drop Node 20 from the matrix and bump `engines.node` to `>=22`, but that's a published-package breaking change and a separate decision.

## Test plan

- [ ] CI on this PR passes (proves the fix works on push/PR events)
- [ ] Tonight's nightly succeeds on all 6 OS×Node cells
- [ ] Re-run PR #847 CI after merge — verify windows-20 / macos-20 jobs pass
