### PR TITLE
test(npm): cover install.ts helpers and unblock coverage gate

### DIFF
--- a/packages/server-npm/__tests__/install-helpers.test.ts
+++ b/packages/server-npm/__tests__/install-helpers.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import {
+  assertSafeRegistryUrl,
+  composeInstallFlags,
+  getLockfileHash,
+} from "../src/tools/install.js";
+
+describe("assertSafeRegistryUrl", () => {
+  const ENV_KEY = "PARE_NPM_ALLOW_HTTP_REGISTRY";
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = original;
+  });
+
+  it("accepts https:// URLs", () => {
+    expect(() => assertSafeRegistryUrl("https://registry.npmjs.org")).not.toThrow();
+  });
+
+  it("accepts uppercase HTTPS:// (case-insensitive)", () => {
+    expect(() => assertSafeRegistryUrl("HTTPS://registry.npmjs.org")).not.toThrow();
+  });
+
+  it("rejects http:// when PARE_NPM_ALLOW_HTTP_REGISTRY is unset", () => {
+    expect(() => assertSafeRegistryUrl("http://internal.example.com")).toThrowError(
+      /Registry URL scheme not allowed/,
+    );
+  });
+
+  it("rejects http:// when PARE_NPM_ALLOW_HTTP_REGISTRY is not exactly 'true'", () => {
+    process.env[ENV_KEY] = "1";
+    expect(() => assertSafeRegistryUrl("http://internal.example.com")).toThrow();
+    process.env[ENV_KEY] = "false";
+    expect(() => assertSafeRegistryUrl("http://internal.example.com")).toThrow();
+  });
+
+  it("accepts http:// when PARE_NPM_ALLOW_HTTP_REGISTRY=true", () => {
+    process.env[ENV_KEY] = "true";
+    expect(() => assertSafeRegistryUrl("http://internal.example.com")).not.toThrow();
+  });
+
+  it("rejects non-http(s) schemes regardless of env", () => {
+    expect(() => assertSafeRegistryUrl("ftp://example.com")).toThrow();
+    expect(() => assertSafeRegistryUrl("file:///etc/passwd")).toThrow();
+    process.env[ENV_KEY] = "true";
+    expect(() => assertSafeRegistryUrl("ftp://example.com")).toThrow();
+  });
+
+  it("error message includes the rejected URL", () => {
+    let caught: Error | undefined;
+    try {
+      assertSafeRegistryUrl("ftp://example.com");
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught?.message).toContain("ftp://example.com");
+  });
+});
+
+describe("getLockfileHash", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "pare-npm-lockhash-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns sha256 of pnpm-lock.yaml when present", async () => {
+    const body = "lockfileVersion: '9.0'\n";
+    writeFileSync(join(tmp, "pnpm-lock.yaml"), body);
+    const expected = createHash("sha256").update(body).digest("hex");
+    expect(await getLockfileHash(tmp, "pnpm")).toBe(expected);
+  });
+
+  it("returns sha256 of yarn.lock when present", async () => {
+    const body = "# yarn lockfile v1\n";
+    writeFileSync(join(tmp, "yarn.lock"), body);
+    const expected = createHash("sha256").update(body).digest("hex");
+    expect(await getLockfileHash(tmp, "yarn")).toBe(expected);
+  });
+
+  it("returns sha256 of package-lock.json when present (npm)", async () => {
+    const body = '{"lockfileVersion": 3}\n';
+    writeFileSync(join(tmp, "package-lock.json"), body);
+    const expected = createHash("sha256").update(body).digest("hex");
+    expect(await getLockfileHash(tmp, "npm")).toBe(expected);
+  });
+
+  it("returns undefined when the lockfile is missing", async () => {
+    expect(await getLockfileHash(tmp, "pnpm")).toBeUndefined();
+    expect(await getLockfileHash(tmp, "yarn")).toBeUndefined();
+    expect(await getLockfileHash(tmp, "npm")).toBeUndefined();
+  });
+
+  it("hash differs when lockfile contents differ", async () => {
+    writeFileSync(join(tmp, "pnpm-lock.yaml"), "v1");
+    const before = await getLockfileHash(tmp, "pnpm");
+    writeFileSync(join(tmp, "pnpm-lock.yaml"), "v2");
+    const after = await getLockfileHash(tmp, "pnpm");
+    expect(before).not.toBe(after);
+  });
+});
+
+describe("composeInstallFlags", () => {
+  it("returns no flags for an empty options object on pnpm", () => {
+    expect(composeInstallFlags("pnpm", {})).toEqual([]);
+  });
+
+  it("appends --json on npm", () => {
+    expect(composeInstallFlags("npm", {})).toEqual(["--json"]);
+  });
+
+  it("returns no flags for empty options on yarn", () => {
+    expect(composeInstallFlags("yarn", {})).toEqual([]);
+  });
+
+  it("ignoreScripts → --ignore-scripts (all PMs)", () => {
+    expect(composeInstallFlags("pnpm", { ignoreScripts: true })).toContain("--ignore-scripts");
+    expect(composeInstallFlags("npm", { ignoreScripts: true })).toContain("--ignore-scripts");
+    expect(composeInstallFlags("yarn", { ignoreScripts: true })).toContain("--ignore-scripts");
+  });
+
+  it("filter → --filter=<value> only on pnpm", () => {
+    expect(composeInstallFlags("pnpm", { filter: "@scope/pkg" })).toContain("--filter=@scope/pkg");
+    expect(composeInstallFlags("npm", { filter: "@scope/pkg" })).not.toContain(
+      "--filter=@scope/pkg",
+    );
+    expect(composeInstallFlags("yarn", { filter: "@scope/pkg" })).not.toContain(
+      "--filter=@scope/pkg",
+    );
+  });
+
+  it("saveDev → --save-dev (all PMs)", () => {
+    expect(composeInstallFlags("pnpm", { saveDev: true })).toContain("--save-dev");
+    expect(composeInstallFlags("npm", { saveDev: true })).toContain("--save-dev");
+    expect(composeInstallFlags("yarn", { saveDev: true })).toContain("--save-dev");
+  });
+
+  it("frozenLockfile → --frozen-lockfile on pnpm/yarn but not npm (npm uses ci subcommand)", () => {
+    expect(composeInstallFlags("pnpm", { frozenLockfile: true })).toContain("--frozen-lockfile");
+    expect(composeInstallFlags("yarn", { frozenLockfile: true })).toContain("--frozen-lockfile");
+    expect(composeInstallFlags("npm", { frozenLockfile: true })).not.toContain("--frozen-lockfile");
+  });
+
+  it("dryRun → --dry-run (all PMs)", () => {
+    expect(composeInstallFlags("pnpm", { dryRun: true })).toContain("--dry-run");
+    expect(composeInstallFlags("npm", { dryRun: true })).toContain("--dry-run");
+    expect(composeInstallFlags("yarn", { dryRun: true })).toContain("--dry-run");
+  });
+
+  it("production → PM-specific flag", () => {
+    expect(composeInstallFlags("npm", { production: true })).toContain("--omit=dev");
+    expect(composeInstallFlags("pnpm", { production: true })).toContain("--prod");
+    expect(composeInstallFlags("yarn", { production: true })).toContain("--production");
+  });
+
+  it("legacyPeerDeps → --legacy-peer-deps only on npm", () => {
+    expect(composeInstallFlags("npm", { legacyPeerDeps: true })).toContain("--legacy-peer-deps");
+    expect(composeInstallFlags("pnpm", { legacyPeerDeps: true })).not.toContain(
+      "--legacy-peer-deps",
+    );
+    expect(composeInstallFlags("yarn", { legacyPeerDeps: true })).not.toContain(
+      "--legacy-peer-deps",
+    );
+  });
+
+  it("force → --force, noAudit → --no-audit, exact → --save-exact, global → --global", () => {
+    const flags = composeInstallFlags("pnpm", {
+      force: true,
+      noAudit: true,
+      exact: true,
+      global: true,
+    });
+    expect(flags).toEqual(
+      expect.arrayContaining(["--force", "--no-audit", "--save-exact", "--global"]),
+    );
+  });
+
+  it("registry → --registry=<value>", () => {
+    expect(composeInstallFlags("pnpm", { registry: "https://npm.pkg.github.com" })).toContain(
+      "--registry=https://npm.pkg.github.com",
+    );
+  });
+
+  it("composes multiple options in stable order", () => {
+    expect(
+      composeInstallFlags("pnpm", {
+        ignoreScripts: true,
+        filter: "@scope/pkg",
+        saveDev: true,
+        frozenLockfile: true,
+        dryRun: true,
+      }),
+    ).toEqual([
+      "--ignore-scripts",
+      "--filter=@scope/pkg",
+      "--save-dev",
+      "--frozen-lockfile",
+      "--dry-run",
+    ]);
+  });
+
+  it("npm with frozenLockfile produces no --frozen-lockfile (caller uses ci subcommand instead)", () => {
+    expect(composeInstallFlags("npm", { frozenLockfile: true })).toEqual(["--json"]);
+  });
+});

--- a/packages/server-npm/src/tools/install.ts
+++ b/packages/server-npm/src/tools/install.ts
@@ -131,26 +131,20 @@ export function registerInstallTool(server: McpServer) {
       const cwd = path || process.cwd();
       const pm = await detectPackageManager(cwd, packageManager);
 
-      const flags: string[] = [];
-      if (ignoreScripts) flags.push("--ignore-scripts");
-      if (pm === "pnpm" && filter) flags.push(`--filter=${filter}`);
-      if (saveDev) flags.push("--save-dev");
-      if (frozenLockfile) {
-        if (pm !== "npm") flags.push("--frozen-lockfile");
-      }
-      if (dryRun) flags.push("--dry-run");
-      if (production) {
-        if (pm === "npm") flags.push("--omit=dev");
-        else if (pm === "pnpm") flags.push("--prod");
-        else flags.push("--production");
-      }
-      if (legacyPeerDeps && pm === "npm") flags.push("--legacy-peer-deps");
-      if (force) flags.push("--force");
-      if (noAudit) flags.push("--no-audit");
-      if (exact) flags.push("--save-exact");
-      if (isGlobal) flags.push("--global");
-      if (registry) flags.push(`--registry=${registry}`);
-      if (pm === "npm") flags.push("--json");
+      const flags = composeInstallFlags(pm, {
+        ignoreScripts,
+        filter,
+        saveDev,
+        frozenLockfile,
+        dryRun,
+        production,
+        legacyPeerDeps,
+        force,
+        noAudit,
+        exact,
+        global: isGlobal,
+        registry,
+      });
 
       const subcommand = frozenLockfile && pm === "npm" ? "ci" : "install";
       const beforeLockfileHash = await getLockfileHash(cwd, pm);
@@ -211,7 +205,49 @@ export function assertInstallActuallyHappened(args: {
   );
 }
 
-function assertSafeRegistryUrl(url: string): void {
+interface InstallFlagOptions {
+  ignoreScripts?: boolean;
+  filter?: string;
+  saveDev?: boolean;
+  frozenLockfile?: boolean;
+  dryRun?: boolean;
+  production?: boolean;
+  legacyPeerDeps?: boolean;
+  force?: boolean;
+  noAudit?: boolean;
+  exact?: boolean;
+  global?: boolean;
+  registry?: string;
+}
+
+/** Exported for unit tests. */
+export function composeInstallFlags(
+  pm: "npm" | "pnpm" | "yarn",
+  opts: InstallFlagOptions,
+): string[] {
+  const flags: string[] = [];
+  if (opts.ignoreScripts) flags.push("--ignore-scripts");
+  if (pm === "pnpm" && opts.filter) flags.push(`--filter=${opts.filter}`);
+  if (opts.saveDev) flags.push("--save-dev");
+  if (opts.frozenLockfile && pm !== "npm") flags.push("--frozen-lockfile");
+  if (opts.dryRun) flags.push("--dry-run");
+  if (opts.production) {
+    if (pm === "npm") flags.push("--omit=dev");
+    else if (pm === "pnpm") flags.push("--prod");
+    else flags.push("--production");
+  }
+  if (opts.legacyPeerDeps && pm === "npm") flags.push("--legacy-peer-deps");
+  if (opts.force) flags.push("--force");
+  if (opts.noAudit) flags.push("--no-audit");
+  if (opts.exact) flags.push("--save-exact");
+  if (opts.global) flags.push("--global");
+  if (opts.registry) flags.push(`--registry=${opts.registry}`);
+  if (pm === "npm") flags.push("--json");
+  return flags;
+}
+
+/** Exported for unit tests. */
+export function assertSafeRegistryUrl(url: string): void {
   if (/^https:\/\//i.test(url)) return;
   if (/^http:\/\//i.test(url) && process.env.PARE_NPM_ALLOW_HTTP_REGISTRY === "true") {
     return;
@@ -222,7 +258,8 @@ function assertSafeRegistryUrl(url: string): void {
   );
 }
 
-async function getLockfileHash(
+/** Exported for unit tests. */
+export async function getLockfileHash(
   cwd: string,
   pm: "npm" | "pnpm" | "yarn",
 ): Promise<string | undefined> {


### PR DESCRIPTION
## Summary

Lifts `@paretools/npm` branch coverage from **68.74% → ~74.8%**, clearing the 70% threshold that has been blocking `ci-gate` (and PR #847's release) on every push to main since #842 added new install/error-detection code paths without test coverage.

## Root cause

PR #842 (`fix(npm,test,build): detect missing node_modules…`) added the `assertInstallActuallyHappened` guard and related logic to `packages/server-npm/src/tools/install.ts`. The new code paths weren't covered by tests, dropping global branches in the package below the 70% threshold defined in `packages/shared/vitest.shared.ts`. The failure was masked until PR #860 (pnpm pin) made the full CI matrix actually run; now `coverage` fails on every main push and `ci-gate` cascades.

## Change

1. Export `assertSafeRegistryUrl` and `getLockfileHash` for unit testing — matches the existing `assertInstallActuallyHappened` pattern (also exported with `/** Exported for unit tests. */`).
2. Extract the inline flag-composition logic from the install handler into a pure `composeInstallFlags(pm, opts)` helper. The runtime behavior of the install tool is unchanged — same flags produced for the same inputs.
3. Add `__tests__/install-helpers.test.ts` covering:
   - `assertSafeRegistryUrl` — https/HTTPS pass, http with/without `PARE_NPM_ALLOW_HTTP_REGISTRY=true`, ftp/file scheme rejection, error-message content.
   - `getLockfileHash` — sha256 for present pnpm/yarn/npm lockfiles, undefined when missing, hash differs across content.
   - `composeInstallFlags` — per-PM behavior for every flag (ignoreScripts, filter, saveDev, frozenLockfile, dryRun, production, legacyPeerDeps, force, noAudit, exact, global, registry), composition order, and the npm-specific `--json` / `ci`-subcommand interaction.

## Coverage delta (server-npm)

| metric    | before  | after  | threshold |
|-----------|---------|--------|-----------|
| branches  | 68.74%  | 74.83% | 70        |
| lines     | ~       | 88.36% | 80        |
| functions | ~       | 90%    | 80        |

`install.ts` specifically: branches **20.58% → 73.52%**, lines 26.41% → 59.25%.

## No changeset

Test-only + an internal refactor with no change to published API or runtime behavior, per CLAUDE.md ("internal-only changes (...test-only changes...) that don't affect published package behavior").

## Followup (separate issues)

- `packages/server-test/scripts/run-tests.mjs` swallows the vitest exit code — coverage threshold breaches in `@paretools/test` go silent. (Discovered while diagnosing this; should be filed separately.)

## Test plan

- [x] `pnpm --filter @paretools/npm test` — 381/381 pass locally
- [x] `pnpm --filter @paretools/npm test --coverage` — branches 74.83% (threshold 70)
- [x] `pnpm --filter @paretools/npm build` — clean
- [x] Lint + format on changed files — clean
- [ ] CI on this PR — coverage job specifically must go green
- [ ] After merge, main's coverage job goes green and unblocks PR #847