### PR TITLE
fix(github,git): coerce numeric inputs and add ahead/behind to status

### DIFF
--- a/.changeset/fix-pare-git-status-ahead-behind.md
+++ b/.changeset/fix-pare-git-status-ahead-behind.md
@@ -1,0 +1,11 @@
+---
+"@paretools/git": patch
+---
+
+`pare-git status` now returns `ahead` and `behind` integer fields whenever an upstream is configured — including in the synced case (`0`/`0`), where they were previously omitted. When there is no upstream, both fields are explicitly `null` to distinguish "no tracking branch" from "synced".
+
+This eliminates the need for follow-up `pare-git log` / GitHub-compare round-trips just to answer "is this branch fully pushed?" during worktree audits and similar housekeeping.
+
+The `GitStatusSchema` now allows `ahead`/`behind` to be `number | null | undefined` (previously `number | undefined`).
+
+Resolves #834 (sub-bug 3).

--- a/.changeset/fix-pare-github-numeric-input-coercion.md
+++ b/.changeset/fix-pare-github-numeric-input-coercion.md
@@ -1,0 +1,9 @@
+---
+"@paretools/github": patch
+---
+
+Fix `pr-list`'s `limit` input rejecting JSON-number values (`"expected number, received string"`) and apply the same defensive `z.coerce.number()` pattern across other `pare-github` tools that take numeric inputs (`issue-list`, `run-list`, `label-list`, `release-list`, `discussion-list`, `repo-clone`).
+
+Workaround was to omit the param. After this fix, callers can pass numbers as JSON numbers or numeric strings interchangeably, matching the existing `run-view`/`run-rerun` behavior.
+
+Resolves #861.

--- a/packages/server-git/__tests__/parsers.test.ts
+++ b/packages/server-git/__tests__/parsers.test.ts
@@ -57,7 +57,8 @@ describe("parseStatus", () => {
     expect(result.branch).toBe("feature");
     expect(result.upstream).toBe("origin/feature");
     expect(result.ahead).toBe(2);
-    expect(result.behind).toBeUndefined();
+    // Upstream exists with no [behind N] in the branch line → defaults to 0.
+    expect(result.behind).toBe(0);
     expect(result.staged).toEqual([
       { file: "src/index.ts", status: "modified" },
       { file: "src/new.ts", status: "added" },
@@ -107,6 +108,36 @@ describe("parseStatus", () => {
     const result = parseStatus("", "## new-branch");
     expect(result.branch).toBe("new-branch");
     expect(result.upstream).toBeUndefined();
+    // No upstream → null distinguishes from "synced" (which is 0).
+    expect(result.ahead).toBeNull();
+    expect(result.behind).toBeNull();
+  });
+
+  it("handles in-sync branch (upstream, no [ahead/behind] brackets) → ahead=0, behind=0", () => {
+    const result = parseStatus("", "## main...origin/main");
+    expect(result.branch).toBe("main");
+    expect(result.upstream).toBe("origin/main");
+    expect(result.ahead).toBe(0);
+    expect(result.behind).toBe(0);
+  });
+
+  it("handles ahead-only branch (synced behind)", () => {
+    const result = parseStatus("", "## main...origin/main [ahead 3]");
+    expect(result.ahead).toBe(3);
+    expect(result.behind).toBe(0);
+  });
+
+  it("handles behind-only branch (synced ahead)", () => {
+    const result = parseStatus("", "## main...origin/main [behind 5]");
+    expect(result.ahead).toBe(0);
+    expect(result.behind).toBe(5);
+  });
+
+  it("detached HEAD has no upstream → ahead=null, behind=null", () => {
+    const result = parseStatus("", "## HEAD (no branch)");
+    expect(result.branch).toBe("HEAD");
+    expect(result.ahead).toBeNull();
+    expect(result.behind).toBeNull();
   });
 });
 

--- a/packages/server-git/src/lib/parsers.ts
+++ b/packages/server-git/src/lib/parsers.ts
@@ -107,8 +107,9 @@ export function parseStatusV2(stdout: string): GitStatus {
 
   let branch = "unknown";
   let upstream: string | undefined;
-  let ahead: number | undefined;
-  let behind: number | undefined;
+  // null = no upstream / no branch.ab line; explicit number = parsed value.
+  let ahead: number | null = null;
+  let behind: number | null = null;
 
   for (const line of lines) {
     if (line.startsWith("# ")) {
@@ -193,17 +194,19 @@ export function parseStatusV2(stdout: string): GitStatus {
 function parseBranchFromPorcelain(line: string): {
   name: string;
   upstream?: string;
-  ahead?: number;
-  behind?: number;
+  ahead: number | null;
+  behind: number | null;
 } {
   // "## main...origin/main [ahead 2, behind 1]"
-  // "## main"
+  // "## main...origin/main"               (synced — no brackets)
+  // "## main"                              (no upstream)
   // "## HEAD (no branch)"
   const stripped = line.replace(/^## /, "");
   const dotIndex = stripped.indexOf("...");
 
   if (dotIndex === -1) {
-    return { name: stripped.split(" ")[0] };
+    // No upstream tracking — explicit null distinguishes "no upstream" from "synced".
+    return { name: stripped.split(" ")[0], ahead: null, behind: null };
   }
 
   const name = stripped.slice(0, dotIndex);
@@ -213,11 +216,12 @@ function parseBranchFromPorcelain(line: string): {
   const aheadMatch = rest.match(/ahead (\d+)/);
   const behindMatch = rest.match(/behind (\d+)/);
 
+  // Upstream exists — default to 0 when no [ahead/behind] brackets are emitted.
   return {
     name,
     upstream,
-    ahead: aheadMatch ? parseInt(aheadMatch[1], 10) : undefined,
-    behind: behindMatch ? parseInt(behindMatch[1], 10) : undefined,
+    ahead: aheadMatch ? parseInt(aheadMatch[1], 10) : 0,
+    behind: behindMatch ? parseInt(behindMatch[1], 10) : 0,
   };
 }
 

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -5,8 +5,8 @@ export const GitStatusSchema = z.object({
   branch: z.string(),
   porcelainVersion: z.enum(["v1", "v2"]).optional(),
   upstream: z.string().optional(),
-  ahead: z.number().optional(),
-  behind: z.number().optional(),
+  ahead: z.number().nullable().optional(),
+  behind: z.number().nullable().optional(),
   staged: z.array(
     z.object({
       file: z.string(),

--- a/packages/server-github/src/tools/discussion-list.ts
+++ b/packages/server-github/src/tools/discussion-list.ts
@@ -67,7 +67,7 @@ export function registerDiscussionListTool(server: McpServer) {
           .string()
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .describe("Repository in OWNER/REPO format"),
-        limit: z
+        limit: z.coerce
           .number()
           .optional()
           .default(20)

--- a/packages/server-github/src/tools/issue-list.ts
+++ b/packages/server-github/src/tools/issue-list.ts
@@ -30,7 +30,7 @@ export function registerIssueListTool(server: McpServer) {
           .optional()
           .default("open")
           .describe("Filter by issue state (default: open)"),
-        limit: z
+        limit: z.coerce
           .number()
           .optional()
           .default(30)

--- a/packages/server-github/src/tools/label-list.ts
+++ b/packages/server-github/src/tools/label-list.ts
@@ -23,7 +23,7 @@ export function registerLabelListTool(server: McpServer) {
         "Lists repository labels. Returns structured data with label name, description, color, and default status.",
       annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
-        limit: z
+        limit: z.coerce
           .number()
           .optional()
           .default(30)

--- a/packages/server-github/src/tools/pr-list.ts
+++ b/packages/server-github/src/tools/pr-list.ts
@@ -31,7 +31,7 @@ export function registerPrListTool(server: McpServer) {
           .optional()
           .default("open")
           .describe("Filter by PR state (default: open)"),
-        limit: z
+        limit: z.coerce
           .number()
           .optional()
           .default(30)

--- a/packages/server-github/src/tools/release-list.ts
+++ b/packages/server-github/src/tools/release-list.ts
@@ -30,7 +30,7 @@ export function registerReleaseListTool(server: McpServer) {
       annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         // S-gap P1: Align default limit to CLI default (30)
-        limit: z
+        limit: z.coerce
           .number()
           .optional()
           .default(30)

--- a/packages/server-github/src/tools/repo-clone.ts
+++ b/packages/server-github/src/tools/repo-clone.ts
@@ -35,7 +35,7 @@ export function registerRepoCloneTool(server: McpServer) {
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe("Target directory for the clone"),
-        depth: z
+        depth: z.coerce
           .number()
           .optional()
           .describe("Create a shallow clone with this many commits (passed as -- --depth=N)"),

--- a/packages/server-github/src/tools/run-list.ts
+++ b/packages/server-github/src/tools/run-list.ts
@@ -26,7 +26,7 @@ export function registerRunListTool(server: McpServer) {
         "Lists workflow runs with optional filters. Returns structured list with run ID, status, conclusion, and workflow details.",
       annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
-        limit: z
+        limit: z.coerce
           .number()
           .optional()
           .default(20)

--- a/tests/smoke/mocked/git-status.smoke.test.ts
+++ b/tests/smoke/mocked/git-status.smoke.test.ts
@@ -186,8 +186,9 @@ describe("Smoke: git.status", () => {
     const { parsed } = await callAndValidate({});
     expect(parsed.branch).toBe("feature-branch");
     expect(parsed.upstream).toBeUndefined();
-    expect(parsed.ahead).toBeUndefined();
-    expect(parsed.behind).toBeUndefined();
+    // No upstream → explicit null distinguishes from "synced" (which is 0).
+    expect(parsed.ahead).toBeNull();
+    expect(parsed.behind).toBeNull();
   });
 
   // ── Scenario 18: Merge conflict (UU) ───────────────────────────────

--- a/tests/smoke/suite/git-status.recorded.test.ts
+++ b/tests/smoke/suite/git-status.recorded.test.ts
@@ -193,8 +193,9 @@ describe("Recorded: git.status", () => {
     const { parsed } = await callAndValidate({});
     expect(parsed.branch).toBe("feature-branch");
     expect(parsed.upstream).toBeUndefined();
-    expect(parsed.ahead).toBeUndefined();
-    expect(parsed.behind).toBeUndefined();
+    // No upstream → explicit null distinguishes from "synced" (which is 0).
+    expect(parsed.ahead).toBeNull();
+    expect(parsed.behind).toBeNull();
   });
 
   it("S17 [recorded] new branch with no commits", async () => {


### PR DESCRIPTION
## Summary

Bundles two related Pare-tool quality bugs surfaced during today's PR/release audit, plus closes two related issues that turned out to be already-fixed or non-reproducible.

| # | What | Code? |
|---|---|---|
| #861 | `pare-github pr-list` `limit` rejects JSON-number values + apply same fix to other numeric params | ✅ |
| #834.3 | `pare-git status` add `ahead`/`behind` integer fields | ✅ |
| #834.2 | `pare-git branch.forceDelete` schema/behavior | ❌ already works (verified) |
| #863 | `server-test/run-tests.mjs` swallows vitest exit code | ❌ not reproducible |

#834.1 (`pare-docker` missing 6+ tools — login/logout/tag/push/save/load) is deferred to a follow-up — too big to land cleanly in this batch.

## #861 — pare-github numeric input coercion

`pr-list`'s `limit` parameter rejected JSON-number values with `"expected number, received string"` because its Zod schema used `z.number()` strictly while the MCP framework's serialization path sometimes hands the value over as a string. Workaround: omit the param.

Apply the existing `z.coerce.number()` pattern (already used by `run-view`/`run-rerun` for `id`/`runId`, and `pr-checks` for `interval`/`watchTimeout`) to all numeric input params:

- `pr-list` (`limit`)
- `issue-list` (`limit`)
- `run-list` (`limit`)
- `label-list` (`limit`)
- `release-list` (`limit`)
- `discussion-list` (`limit`)
- `repo-clone` (`depth`)

Schemas now consistently accept JSON numbers or numeric strings.

## #834.3 — pare-git status ahead/behind

`pare-git status` now returns `ahead`/`behind` integer fields whenever an upstream is configured, **including the synced case (0/0)** where they were previously omitted in v1 output. When there is no upstream, both fields are explicit `null` to distinguish "no tracking branch" from "synced".

This eliminates the 78 follow-up `pare-git log` round-trips described in the issue (worktree audit answering "is this branch fully pushed?").

| Branch state | `ahead` | `behind` |
|---|---|---|
| Upstream synced (no `[ahead/behind]` brackets) | `0` | `0` |
| `[ahead 3]` only | `3` | `0` |
| `[behind 5]` only | `0` | `5` |
| `[ahead 2, behind 1]` | `2` | `1` |
| No upstream | `null` | `null` |
| Detached HEAD | `null` | `null` |

Schema: `GitStatusSchema.ahead`/`behind` are now `number \| null \| undefined` (was `number \| undefined`).

5 new cases in `parsers.test.ts` cover the matrix above. v2 parser already returned correct values when `branch.ab` was emitted; this PR aligns its no-upstream path to also return `null`.

## #834.2 — branch.forceDelete (verified working, no code change)

Re-tested all three failure modes the issue reported:

| Invocation | Result (current main + this branch) |
|---|---|
| `forceDelete: "<name>"` (string) | ✅ deletes with `-D` |
| `forceDelete: true, delete: ["a","b"]` | ✅ deletes both with `-D` |
| `delete: ["a","b"]` alone | ✅ deletes both with `-d` |

8/8 existing integration tests in `__tests__/integration.test.ts` (`branch forceDelete` + `branch batch delete`) pass. Issue was filed 2026-04-27, before #664 (string acceptance) and #802 (batch delete) landed. Closing as stale.

## #863 — server-test exit code propagation (not reproducible)

The reported numbers (lines 72.35%, branches 61.17%) don't match current state. Direct verification on this branch:

- `pnpm exec vitest run --coverage` (server-test): exit `1` on test failure, exit `0` on pass with thresholds met. Script propagates correctly.
- `@paretools/test` actual coverage: 80.87 / 75.94 / 87.23 / 81.45 — all above thresholds (80/70/80/80).

Closing as not-reproducible.

## Validation

- [x] `pnpm --filter @paretools/github test` — 526/526 pass
- [x] `pnpm --filter @paretools/git test` — 691/692 pass; 1 unrelated pre-existing fragile fidelity test (`parseLogGraph preserves commit data from real repo output`) — depends on local git state, not touched by this PR
- [x] tsc on both packages — clean
- [x] eslint on both packages — clean (90 files checked)
- [x] prettier — clean
- [x] build — clean

## Changesets

- `@paretools/github`: patch (numeric input coercion)
- `@paretools/git`: patch (status ahead/behind)

## Test plan

- [ ] CI on this PR passes
- [ ] After merge, manually verify `mcp__pare-github__pr-list({ limit: 15 })` accepts numeric `limit`
- [ ] After merge, manually verify `mcp__pare-git__status` returns `ahead`/`behind` on a tracked branch (synced and out-of-sync), and `null`/`null` on a no-upstream branch