### PR TITLE
fix(deps): bump fast-uri to >=3.1.2 (CVE-2026-6321, CVE-2026-6322)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
       "flatted": ">=3.4.2",
       "express-rate-limit": ">=8.2.2",
       "path-to-regexp": ">=8.4.0",
-      "brace-expansion": ">=5.0.5"
+      "brace-expansion": ">=5.0.5",
+      "fast-uri": ">=3.1.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   express-rate-limit: '>=8.2.2'
   path-to-regexp: '>=8.4.0'
   brace-expansion: '>=5.0.5'
+  fast-uri: '>=3.1.2'
 
 importers:
 
@@ -2261,8 +2262,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -4395,14 +4396,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4816,7 +4817,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

Closes #867 — nightly Trivy suite flagged 2 HIGH CVEs in `fast-uri@3.1.0`:

- **CVE-2026-6321** — path traversal allows bypass of security policies (fixed in 3.1.1)
- **CVE-2026-6322** — `normalize()` decodes percent-encoded authority delimiters (fixed in 3.1.2)

## Fix

Adds `"fast-uri": ">=3.1.2"` to `pnpm.overrides` in root `package.json`, mirroring the established pattern used for `rollup`, `minimatch`, etc. Lockfile regenerated; verified locally that `fast-uri@3.1.0` is gone and replaced by `3.1.2` (two locations in `pnpm-lock.yaml`).

## Why no changeset

`pnpm.overrides` only affects this workspace's lockfile, not the resolution that consumers of `@paretools/*` see. Per `CLAUDE.md`, dev/lockfile-only changes that don't affect published package behavior do not require a changeset.

## Test plan

- [ ] CI passes (the Trivy `audit` job is the canonical test for this change)
- [ ] No transitive dep regressions in install (`added: 0, removed: 0`)
