### PR TITLE
fix(npm): drop --no-audit for pnpm/yarn

### DIFF
--- a/.changeset/fix-npm-install-no-audit-pnpm.md
+++ b/.changeset/fix-npm-install-no-audit-pnpm.md
@@ -1,0 +1,7 @@
+---
+"@paretools/npm": patch
+---
+
+`pare-npm install` no longer emits `--no-audit` for pnpm or yarn. The flag is npm-specific — pnpm install rejects it with `ERROR Unknown option: 'audit'`, and yarn install does not run an audit step either. With this change, `noAudit: true` is honoured on npm (still maps to `--no-audit`) and is a silent no-op on pnpm/yarn, where install never audits anyway. The tool description has been updated to reflect this.
+
+Resolves #872.

--- a/packages/server-npm/__tests__/install-helpers.test.ts
+++ b/packages/server-npm/__tests__/install-helpers.test.ts
@@ -177,16 +177,28 @@ describe("composeInstallFlags", () => {
     );
   });
 
-  it("force → --force, noAudit → --no-audit, exact → --save-exact, global → --global", () => {
+  it("force → --force, exact → --save-exact, global → --global (all PMs)", () => {
     const flags = composeInstallFlags("pnpm", {
       force: true,
-      noAudit: true,
       exact: true,
       global: true,
     });
-    expect(flags).toEqual(
-      expect.arrayContaining(["--force", "--no-audit", "--save-exact", "--global"]),
-    );
+    expect(flags).toEqual(expect.arrayContaining(["--force", "--save-exact", "--global"]));
+  });
+
+  it("noAudit → --no-audit only on npm (pnpm/yarn don't audit during install)", () => {
+    // npm: emits --no-audit
+    expect(composeInstallFlags("npm", { noAudit: true })).toContain("--no-audit");
+    // pnpm: silently dropped — pnpm install rejects --no-audit with "Unknown option: 'audit'" (#872)
+    expect(composeInstallFlags("pnpm", { noAudit: true })).not.toContain("--no-audit");
+    // yarn: silently dropped — yarn install does not audit
+    expect(composeInstallFlags("yarn", { noAudit: true })).not.toContain("--no-audit");
+  });
+
+  it("noAudit=false never emits --no-audit", () => {
+    expect(composeInstallFlags("npm", { noAudit: false })).not.toContain("--no-audit");
+    expect(composeInstallFlags("pnpm", { noAudit: false })).not.toContain("--no-audit");
+    expect(composeInstallFlags("yarn", { noAudit: false })).not.toContain("--no-audit");
   });
 
   it("registry → --registry=<value>", () => {

--- a/packages/server-npm/src/tools/install.ts
+++ b/packages/server-npm/src/tools/install.ts
@@ -77,7 +77,10 @@ export function registerInstallTool(server: McpServer) {
         noAudit: z
           .boolean()
           .optional()
-          .describe("Skip the automatic audit step to speed up installation (maps to --no-audit)"),
+          .describe(
+            "Skip the automatic audit step to speed up installation. Only npm runs an audit during install, so this maps to --no-audit on npm. " +
+              "On pnpm and yarn it is a silent no-op (audit is a separate command, not part of install).",
+          ),
         exact: z
           .boolean()
           .optional()
@@ -238,7 +241,11 @@ export function composeInstallFlags(
   }
   if (opts.legacyPeerDeps && pm === "npm") flags.push("--legacy-peer-deps");
   if (opts.force) flags.push("--force");
-  if (opts.noAudit) flags.push("--no-audit");
+  // --no-audit is npm-only. pnpm install does not audit (audit is a separate
+  // `pnpm audit` command) and rejects --no-audit with "Unknown option: 'audit'".
+  // yarn install also doesn't run an audit, so the flag is silently dropped
+  // there too. See #872.
+  if (opts.noAudit && pm === "npm") flags.push("--no-audit");
   if (opts.exact) flags.push("--save-exact");
   if (opts.global) flags.push("--global");
   if (opts.registry) flags.push(`--registry=${opts.registry}`);


### PR DESCRIPTION
Closes #872.

## Bug

`mcp__pare-npm__install` with `noAudit: true` errors out under pnpm:

```
ERROR  Unknown option: 'audit'
Did you mean 'dir'? Use "--config.unknown=value" to force an unknown option.
```

`--no-audit` is an npm-only flag. pnpm has no install-time audit (audit is the separate `pnpm audit` command), and yarn install doesn't audit either, so passing `--no-audit` to those PMs is at best a no-op and at worst (pnpm) a hard error.

The tool's docstring previously said `maps to --no-audit` with no caveat, so agents reasonably set it for any package manager.

## Fix

In `packages/server-npm/src/tools/install.ts`:

- `composeInstallFlags` now only emits `--no-audit` when `pm === "npm"`. For pnpm and yarn the flag is silently dropped — the user's intent ("skip audit during install") is already met because those PMs don't audit during install.
- Updated the `noAudit` parameter description to call out that the flag only takes effect on npm.

No schema change — `noAudit` stays an optional boolean. Defaulting to `false` (no flag emitted) is the safe path for non-npm PMs.

## Test plan

- [x] New unit test: `composeInstallFlags("npm", { noAudit: true })` includes `--no-audit`.
- [x] New unit test: `composeInstallFlags("pnpm", { noAudit: true })` and `composeInstallFlags("yarn", { noAudit: true })` do NOT include `--no-audit`.
- [x] New unit test: `noAudit: false` never emits `--no-audit` regardless of PM.
- [x] Updated the existing pnpm "force/noAudit/exact/global" assertion that previously baked in the buggy behavior — it now covers force/exact/global and leaves the noAudit semantics to the dedicated tests above.
- [x] `pnpm --filter @paretools/npm test`: all 383 tests pass.
- [x] `pnpm build`: clean.
- [x] ESLint and prettier: clean on changed files.
- [x] Changeset added (`@paretools/npm` patch).
