### PR TITLE
fix(search): support file paths in `path` param

### DIFF
--- a/.changeset/fix-search-file-path-handling.md
+++ b/.changeset/fix-search-file-path-handling.md
@@ -1,0 +1,5 @@
+---
+"@paretools/search": patch
+---
+
+Fix `pare-search__search` and `pare-search__count` crashing with `spawn ENOTDIR` when `path` points to a file. The runner previously used the supplied `path` as the child process `cwd` unconditionally, which fails when `path` is a file. The runner now resolves a file path into a parent-directory `cwd` plus a basename positional argument so ripgrep searches just that file (matching the schema's "Directory or file to search in" contract). Closes [#871](https://github.com/Dave-London/Pare/issues/871).

--- a/packages/server-search/__tests__/integration.test.ts
+++ b/packages/server-search/__tests__/integration.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { resolve } from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
@@ -69,6 +71,76 @@ describe("@paretools/search integration", () => {
         const sc = result.structuredContent as Record<string, unknown>;
         expect(sc).toBeDefined();
         expect(Array.isArray(sc.files)).toBe(true);
+      }
+    });
+  });
+
+  // Regression test for issue #871: search/count should accept a file path
+  // for the `path` parameter without crashing with `spawn ENOTDIR`.
+  describe("search with file path (issue #871)", () => {
+    let fixtureDir: string;
+    let fixtureFile: string;
+
+    beforeAll(() => {
+      fixtureDir = mkdtempSync(join(tmpdir(), "pare-search-file-path-"));
+      fixtureFile = join(fixtureDir, "fixture.txt");
+      writeFileSync(fixtureFile, "alpha\nfast-uri@3.1.2\nbeta\n");
+    });
+
+    afterAll(() => {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    });
+
+    it("search: accepts a file path and returns matches without ENOTDIR", async () => {
+      const result = await client.callTool(
+        {
+          name: "search",
+          arguments: {
+            pattern: "fast-uri",
+            path: fixtureFile,
+          },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        const text = content[0]?.text ?? "";
+        // We tolerate "rg not installed", but never the spawn ENOTDIR crash.
+        expect(text).not.toMatch(/ENOTDIR/);
+        expect(text).toMatch(/rg|ripgrep|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.totalMatches).toBe("number");
+        expect((sc.totalMatches as number) >= 1).toBe(true);
+      }
+    });
+
+    it("count: accepts a file path and returns counts without ENOTDIR", async () => {
+      const result = await client.callTool(
+        {
+          name: "count",
+          arguments: {
+            pattern: "fast-uri",
+            path: fixtureFile,
+          },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      if (result.isError) {
+        const content = result.content as Array<{ type: string; text: string }>;
+        const text = content[0]?.text ?? "";
+        expect(text).not.toMatch(/ENOTDIR/);
+        expect(text).toMatch(/rg|ripgrep|command|not found/i);
+      } else {
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc).toBeDefined();
+        expect(typeof sc.totalMatches).toBe("number");
+        expect((sc.totalMatches as number) >= 1).toBe(true);
       }
     });
   });

--- a/packages/server-search/__tests__/search-runner.test.ts
+++ b/packages/server-search/__tests__/search-runner.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 // Mock @paretools/shared's run function to simulate ENOENT errors
 vi.mock("@paretools/shared", async () => {
@@ -10,7 +13,7 @@ vi.mock("@paretools/shared", async () => {
 });
 
 import { run } from "@paretools/shared";
-import { rgCmd, fdCmd, jqCmd } from "../src/lib/search-runner.js";
+import { rgCmd, fdCmd, jqCmd, resolveSearchTarget } from "../src/lib/search-runner.js";
 
 const mockRun = vi.mocked(run);
 
@@ -87,5 +90,73 @@ describe("search-runner install hints", () => {
 
     const result = await rgCmd(["--json", "pattern", "."]);
     expect(result).toEqual({ exitCode: 0, stdout: "result", stderr: "" });
+  });
+});
+
+describe("resolveSearchTarget", () => {
+  // Set up a fixture tree:
+  //   <tmp>/file.txt   (a file)
+  //   <tmp>/sub/       (a directory)
+  let root: string;
+  let filePath: string;
+  let subDir: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "pare-search-target-"));
+    filePath = join(root, "file.txt");
+    writeFileSync(filePath, "hello world\n");
+    subDir = join(root, "sub");
+    mkdirSync(subDir);
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns process.cwd() and '.' when path is undefined", () => {
+    const result = resolveSearchTarget(undefined);
+    expect(result.cwd).toBe(process.cwd());
+    expect(result.target).toBe(".");
+    expect(result.isFile).toBe(false);
+  });
+
+  it("returns process.cwd() and '.' when path is an empty string", () => {
+    const result = resolveSearchTarget("");
+    expect(result.cwd).toBe(process.cwd());
+    expect(result.target).toBe(".");
+    expect(result.isFile).toBe(false);
+  });
+
+  it("uses the path as cwd and '.' as target when path is an existing directory", () => {
+    const result = resolveSearchTarget(subDir);
+    expect(result.cwd).toBe(subDir);
+    expect(result.target).toBe(".");
+    expect(result.isFile).toBe(false);
+  });
+
+  it("splits a file path into parent dir cwd + basename target (regression: spawn ENOTDIR)", () => {
+    // This is the core fix for issue #871. Previously the runner used
+    // `path` directly as cwd, causing `spawn ENOTDIR` when path was a file.
+    const result = resolveSearchTarget(filePath);
+    expect(result.cwd).toBe(root);
+    expect(result.target).toBe("file.txt");
+    expect(result.isFile).toBe(true);
+  });
+
+  it("falls back to process.cwd() + raw path when path does not exist", () => {
+    const missing = join(root, "does-not-exist.txt");
+    const result = resolveSearchTarget(missing);
+    expect(result.cwd).toBe(process.cwd());
+    expect(result.target).toBe(missing);
+    expect(result.isFile).toBe(false);
+  });
+
+  it("resolves relative directory paths to absolute cwd", () => {
+    // process.cwd() is always a directory, so passing "." should yield an
+    // absolute cwd matching it and target ".".
+    const result = resolveSearchTarget(".");
+    expect(result.cwd).toBe(process.cwd());
+    expect(result.target).toBe(".");
+    expect(result.isFile).toBe(false);
   });
 });

--- a/packages/server-search/src/lib/search-runner.ts
+++ b/packages/server-search/src/lib/search-runner.ts
@@ -1,3 +1,5 @@
+import { statSync } from "node:fs";
+import { dirname, basename, isAbsolute, resolve } from "node:path";
 import { run, type RunResult } from "@paretools/shared";
 
 /** Platform-specific install hints for commands used by the search package. */
@@ -56,6 +58,53 @@ async function runWithInstallHint(
 
 export async function rgCmd(args: string[], cwd?: string): Promise<RunResult> {
   return runWithInstallHint("rg", args, { cwd, timeout: 180_000 });
+}
+
+/**
+ * Resolves a user-supplied `path` parameter into a `cwd` and a positional
+ * `target` argument suitable for ripgrep/fd.
+ *
+ * Behavior:
+ * - If `path` is undefined/empty → cwd = process.cwd(), target = "."
+ *   (search current dir, isFile = false).
+ * - If `path` is an existing directory → cwd = path, target = "."
+ *   (search recursively, isFile = false).
+ * - If `path` is an existing file → cwd = parent dir, target = basename
+ *   (search just that file, isFile = true). Spawning with cwd pointed at a
+ *   file is what produces the `spawn ENOTDIR` crash, so we split it.
+ * - If `path` does not exist → cwd = process.cwd(), target = path
+ *   (isFile = false). Let ripgrep surface its own "no such file" error
+ *   rather than crashing the spawn.
+ *
+ * The `isFile` flag lets callers add ripgrep flags like `--with-filename`
+ * when needed (rg's `--count` omits the filename when given a single file
+ * positional, which breaks the count parser).
+ */
+export function resolveSearchTarget(path?: string): {
+  cwd: string;
+  target: string;
+  isFile: boolean;
+} {
+  if (!path) {
+    return { cwd: process.cwd(), target: ".", isFile: false };
+  }
+
+  const absolute = isAbsolute(path) ? path : resolve(process.cwd(), path);
+
+  try {
+    const stat = statSync(absolute);
+    if (stat.isDirectory()) {
+      return { cwd: absolute, target: ".", isFile: false };
+    }
+    // It's a file (or symlink/special file) — split into parent + basename so
+    // the child process spawn doesn't fail with ENOTDIR.
+    return { cwd: dirname(absolute), target: basename(absolute), isFile: true };
+  } catch {
+    // Path doesn't exist (or isn't accessible). Fall back to passing the
+    // raw path as a positional argument from the current working directory
+    // so ripgrep itself emits the user-facing "no such file" message.
+    return { cwd: process.cwd(), target: path, isFile: false };
+  }
 }
 
 export async function fdCmd(args: string[], cwd?: string): Promise<RunResult> {

--- a/packages/server-search/src/tools/count.ts
+++ b/packages/server-search/src/tools/count.ts
@@ -7,7 +7,7 @@ import {
   compactInput,
   pathInput,
 } from "@paretools/shared";
-import { rgCmd } from "../lib/search-runner.js";
+import { rgCmd, resolveSearchTarget } from "../lib/search-runner.js";
 import { parseRgCountOutput } from "../lib/parsers.js";
 import { formatCount, compactCountMap, formatCountCompact } from "../lib/formatters.js";
 import { CountResultSchema } from "../schemas/index.js";
@@ -115,8 +115,18 @@ export function registerCountTool(server: McpServer) {
       if (type) assertNoFlagInjection(type, "type");
       if (!fixedStrings) validateRegexPattern(pattern);
 
-      const cwd = path || process.cwd();
+      // Resolve `path` into a cwd + positional target. When `path` points at
+      // a file, we cannot use it as cwd (child process spawn would fail with
+      // ENOTDIR), so we split into parent dir + basename instead.
+      const { cwd, target, isFile } = resolveSearchTarget(path);
       const args = countMatches ? ["--count-matches"] : ["--count"];
+
+      // When ripgrep is given a single file positional, --count emits just
+      // the count (no `file:count` prefix), which the parser cannot read.
+      // Force the filename prefix so the parser still works.
+      if (isFile) {
+        args.push("--with-filename");
+      }
 
       if (!caseSensitive) {
         args.push("--ignore-case");
@@ -160,9 +170,10 @@ export function registerCountTool(server: McpServer) {
 
       args.push(pattern);
 
-      // Always pass "." as the search path so rg searches the directory
-      // instead of reading from stdin (which hangs when stdin is piped)
-      args.push(".");
+      // Always pass an explicit search target so rg searches files instead of
+      // reading from stdin (which hangs when stdin is piped). For directories
+      // this is "." (relative to cwd); for files it's the basename.
+      args.push(target);
       const result = await rgCmd(args, cwd);
 
       // rg exits with code 1 when no matches are found — that's not an error

--- a/packages/server-search/src/tools/search.ts
+++ b/packages/server-search/src/tools/search.ts
@@ -7,7 +7,7 @@ import {
   compactInput,
   pathInput,
 } from "@paretools/shared";
-import { rgCmd } from "../lib/search-runner.js";
+import { rgCmd, resolveSearchTarget } from "../lib/search-runner.js";
 import { parseRgJsonOutput } from "../lib/parsers.js";
 import { formatSearch, compactSearchMap, formatSearchCompact } from "../lib/formatters.js";
 import { SearchResultSchema } from "../schemas/index.js";
@@ -114,7 +114,10 @@ export function registerSearchTool(server: McpServer) {
       if (type) assertNoFlagInjection(type, "type");
       if (!fixedStrings) validateRegexPattern(pattern);
 
-      const cwd = path || process.cwd();
+      // Resolve `path` into a cwd + positional target. When `path` points at
+      // a file, we cannot use it as cwd (child process spawn would fail with
+      // ENOTDIR), so we split into parent dir + basename instead.
+      const { cwd, target } = resolveSearchTarget(path);
       const args = ["--json"];
 
       if (!caseSensitive) {
@@ -171,9 +174,10 @@ export function registerSearchTool(server: McpServer) {
 
       args.push(pattern);
 
-      // Always pass "." as the search path so rg searches the directory
-      // instead of reading from stdin (which hangs when stdin is piped)
-      args.push(".");
+      // Always pass an explicit search target so rg searches files instead of
+      // reading from stdin (which hangs when stdin is piped). For directories
+      // this is "." (relative to cwd); for files it's the basename.
+      args.push(target);
       const result = await rgCmd(args, cwd);
 
       // rg exits with code 1 when no matches are found — that's not an error

--- a/tests/smoke/mocked/small-servers-1.smoke.test.ts
+++ b/tests/smoke/mocked/small-servers-1.smoke.test.ts
@@ -54,6 +54,11 @@ vi.mock("../../../packages/server-search/src/lib/search-runner.js", () => ({
   rgCmd: vi.fn(),
   fdCmd: vi.fn(),
   jqCmd: vi.fn(),
+  resolveSearchTarget: (path?: string) => ({
+    cwd: path || process.cwd(),
+    target: ".",
+    isFile: false,
+  }),
 }));
 
 // ── Mock curl runner ────────────────────────────────────────────────────────

--- a/tests/smoke/suite/small-servers.recorded.test.ts
+++ b/tests/smoke/suite/small-servers.recorded.test.ts
@@ -30,6 +30,11 @@ vi.mock("../../../packages/server-search/src/lib/search-runner.js", () => ({
   rgCmd: vi.fn(),
   fdCmd: vi.fn(),
   jqCmd: vi.fn(),
+  resolveSearchTarget: (path?: string) => ({
+    cwd: path || process.cwd(),
+    target: ".",
+    isFile: false,
+  }),
 }));
 
 // ── Mock curl runner ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #871.

`pare-search__search` and `pare-search__count` crashed with `spawn ENOTDIR` whenever `path` pointed at a file, even though the schema documented `path` as "Directory or file to search in".

The runner used `path` as the child process `cwd` unconditionally — but `cwd` must be a directory, so any file path crashed at spawn time. (Note: this same bug was previously closed via #827/PR #832/#843 with a changelog entry, but the actual code change never landed in `search.ts`/`count.ts`. The runner still had `cwd = path` and `args.push(".")`. #871 is the same bug resurfacing on 2026-05-10.)

## Fix

New `resolveSearchTarget()` helper in `lib/search-runner.ts`:

- **directory** -> `cwd = path`, `target = "."` (unchanged behavior, recursive search)
- **file** -> `cwd = parent dir`, `target = basename` (no more ENOTDIR)
- **missing / empty** -> falls through to ripgrep so the user sees rg's own "no such file" error rather than a Node spawn crash

`count.ts` additionally pushes `--with-filename` when `isFile === true`, because `rg --count <file>` emits just a count with no `file:` prefix, which the existing parser cannot read.

`search.ts` needs no extra flag — `rg --json` already includes `path` for single-file searches.

`find.ts` (fd) is intentionally untouched: its schema says "Directory to search in" only, so file inputs there are out of scope for this PR.

## Test plan

- [x] New unit tests for `resolveSearchTarget()` covering: undefined, empty string, existing directory, existing file (regression), missing path, relative path
- [x] New integration tests that spawn the real MCP server and exercise both `search` and `count` with a file path — they assert the result is **not** an `ENOTDIR` error and that matches are returned (when `rg` is installed)
- [x] `pnpm --filter @paretools/search test` -> 87 passed
- [x] `pnpm build` -> green across 30 packages
- [x] `pnpm format:check` -> clean
- [x] `pnpm --filter @paretools/search lint` -> clean
- [ ] Parent agent will exercise the live MCP tool with a real file path to confirm the original repro from #871 no longer crashes