### PR TITLE
fix(github): release-list rejects unsupported "url" json field

### DIFF
--- a/.changeset/fix-release-list-url-field.md
+++ b/.changeset/fix-release-list-url-field.md
@@ -1,0 +1,5 @@
+---
+"@paretools/github": patch
+---
+
+Fix `release-list` always failing with `Unknown JSON field: "url"`. The `url` field is not a valid `--json` field for `gh release list` (only `gh release view` exposes it). Removed `url` from the requested gh fields, parser, and output schema. Use `release-view` if you need a release URL. Closes #868.

--- a/docs/tool-schemas/github/release-list.md
+++ b/docs/tool-schemas/github/release-list.md
@@ -1,14 +1,18 @@
 # github > release-list
 
-Lists GitHub releases for a repository. Returns structured list with tag, name, draft/prerelease status, publish date, and URL.
+Lists GitHub releases for a repository. Returns structured list with tag, name, draft/prerelease/latest status, publish date, and creation date.
 
-**Command**: `gh release list --json tagName,name,isDraft,isPrerelease,publishedAt,url --limit 10`
+**Command**: `gh release list --json tagName,name,isDraft,isPrerelease,publishedAt,isLatest,createdAt --limit 10`
+
+> Note: `gh release list --json` does NOT expose a `url` field. Only
+> `gh release view --json` does. Use the `release-view` tool to get a
+> release URL.
 
 ## Input Parameters
 
 | Parameter | Type    | Default      | Description                                                |
 | --------- | ------- | ------------ | ---------------------------------------------------------- |
-| `limit`   | number  | `10`         | Maximum number of releases to return                       |
+| `limit`   | number  | `30`         | Maximum number of releases to return                       |
 | `repo`    | string  | current repo | Repository in owner/repo format                            |
 | `path`    | string  | cwd          | Repository path                                            |
 | `compact` | boolean | `true`       | Auto-compact when structured output exceeds raw CLI tokens |
@@ -44,7 +48,8 @@ v1.0.0   v1.0.0   about 1 month ago   false  false
       "draft": false,
       "prerelease": false,
       "publishedAt": "2025-01-13T10:00:00Z",
-      "url": "https://github.com/owner/repo/releases/tag/v1.2.0"
+      "isLatest": true,
+      "createdAt": "2025-01-13T09:00:00Z"
     },
     {
       "tag": "v1.1.0",
@@ -52,7 +57,8 @@ v1.0.0   v1.0.0   about 1 month ago   false  false
       "draft": false,
       "prerelease": false,
       "publishedAt": "2025-01-01T10:00:00Z",
-      "url": "https://github.com/owner/repo/releases/tag/v1.1.0"
+      "isLatest": false,
+      "createdAt": "2025-01-01T09:00:00Z"
     },
     {
       "tag": "v1.0.0",
@@ -60,10 +66,10 @@ v1.0.0   v1.0.0   about 1 month ago   false  false
       "draft": false,
       "prerelease": false,
       "publishedAt": "2024-12-15T10:00:00Z",
-      "url": "https://github.com/owner/repo/releases/tag/v1.0.0"
+      "isLatest": false,
+      "createdAt": "2024-12-15T09:00:00Z"
     }
-  ],
-  "total": 3
+  ]
 }
 ```
 
@@ -82,8 +88,7 @@ v1.0.0   v1.0.0   about 1 month ago   false  false
     { "tag": "v1.2.0", "name": "v1.2.0", "draft": false, "prerelease": false },
     { "tag": "v1.1.0", "name": "v1.1.0", "draft": false, "prerelease": false },
     { "tag": "v1.0.0", "name": "v1.0.0", "draft": false, "prerelease": false }
-  ],
-  "total": 3
+  ]
 }
 ```
 
@@ -100,6 +105,7 @@ v1.0.0   v1.0.0   about 1 month ago   false  false
 
 ## Notes
 
-- Compact mode drops `publishedAt` and `url`, keeping `tag`, `name`, `draft`, and `prerelease`
+- Compact mode drops `publishedAt`, `isLatest`, and `createdAt`, keeping `tag`, `name`, `draft`, and `prerelease`
 - Field names are mapped from gh CLI names: `tagName` to `tag`, `isDraft` to `draft`, `isPrerelease` to `prerelease`
 - Use the `repo` parameter to list releases from any repository
+- The release `url` is not available — use `release-view` if you need it

--- a/packages/server-github/__tests__/formatters.test.ts
+++ b/packages/server-github/__tests__/formatters.test.ts
@@ -1076,7 +1076,6 @@ describe("formatReleaseList", () => {
           draft: false,
           prerelease: false,
           publishedAt: "2024-01-15",
-          url: "https://url",
           isLatest: true,
         },
         {
@@ -1085,7 +1084,6 @@ describe("formatReleaseList", () => {
           draft: true,
           prerelease: true,
           publishedAt: "2024-01-10",
-          url: "https://url",
         },
       ],
     };
@@ -1110,7 +1108,6 @@ describe("compactReleaseList", () => {
           draft: false,
           prerelease: false,
           publishedAt: "2024-01-01",
-          url: "https://url",
         },
       ],
     };

--- a/packages/server-github/__tests__/p2-gaps.test.ts
+++ b/packages/server-github/__tests__/p2-gaps.test.ts
@@ -417,7 +417,6 @@ describe("GitHub P2 gaps", () => {
           isDraft: false,
           isPrerelease: false,
           publishedAt: "2025-01-01T00:00:00Z",
-          url: "u1",
         },
       ]),
       stderr: "",
@@ -426,6 +425,13 @@ describe("GitHub P2 gaps", () => {
 
     const out = await handler({ limit: 1, compact: false });
     expect((out.structuredContent.releases as unknown[]).length).toBe(1);
+    // Verify tool requests gh fields supported by `gh release list --json`.
+    // `url` is NOT a valid field for release list (only for release view).
+    const ghCall = vi.mocked(ghCmd).mock.calls[0];
+    const args = ghCall[0] as string[];
+    const fieldsArg = args[args.indexOf("--json") + 1];
+    expect(fieldsArg).not.toContain("url");
+    expect(fieldsArg).toContain("tagName");
   });
 
   it("#296 run-list returns correct results", async () => {

--- a/packages/server-github/__tests__/release-list.test.ts
+++ b/packages/server-github/__tests__/release-list.test.ts
@@ -18,7 +18,6 @@ describe("parseReleaseList", () => {
         isDraft: false,
         isPrerelease: false,
         publishedAt: "2024-01-15T10:00:00Z",
-        url: "https://github.com/owner/repo/releases/tag/v1.0.0",
       },
       {
         tagName: "v0.9.0-beta",
@@ -26,7 +25,6 @@ describe("parseReleaseList", () => {
         isDraft: false,
         isPrerelease: true,
         publishedAt: "2024-01-10T08:00:00Z",
-        url: "https://github.com/owner/repo/releases/tag/v0.9.0-beta",
       },
     ]);
 
@@ -39,8 +37,10 @@ describe("parseReleaseList", () => {
       draft: false,
       prerelease: false,
       publishedAt: "2024-01-15T10:00:00Z",
-      url: "https://github.com/owner/repo/releases/tag/v1.0.0",
+      isLatest: undefined,
+      createdAt: undefined,
     });
+    expect(result.releases[0]).not.toHaveProperty("url");
     expect(result.releases[1].tag).toBe("v0.9.0-beta");
     expect(result.releases[1].prerelease).toBe(true);
   });
@@ -58,7 +58,6 @@ describe("parseReleaseList", () => {
         isDraft: true,
         isPrerelease: false,
         publishedAt: "",
-        url: "https://github.com/owner/repo/releases/tag/v2.0.0",
       },
     ]);
 
@@ -66,6 +65,7 @@ describe("parseReleaseList", () => {
 
     expect(result.releases[0].draft).toBe(true);
     expect(result.releases[0].prerelease).toBe(false);
+    expect(result.releases[0]).not.toHaveProperty("url");
   });
 
   it("handles missing optional fields with defaults", () => {
@@ -79,8 +79,26 @@ describe("parseReleaseList", () => {
       draft: false,
       prerelease: false,
       publishedAt: "",
-      url: "",
+      isLatest: undefined,
+      createdAt: undefined,
     });
+  });
+
+  it("ignores unexpected fields like url if present in input", () => {
+    // Defensive: even if a future gh release exposes url, parser should
+    // not include it in output to keep schema stable.
+    const json = JSON.stringify([
+      {
+        tagName: "v1.0.0",
+        name: "R1",
+        isDraft: false,
+        isPrerelease: false,
+        publishedAt: "2024-01-01",
+        url: "https://example.com/should-not-leak",
+      },
+    ]);
+    const result = parseReleaseList(json);
+    expect(result.releases[0]).not.toHaveProperty("url");
   });
 });
 
@@ -96,7 +114,6 @@ describe("formatReleaseList", () => {
           draft: false,
           prerelease: false,
           publishedAt: "2024-01-15T10:00:00Z",
-          url: "https://github.com/owner/repo/releases/tag/v1.0.0",
         },
       ],
     };
@@ -119,7 +136,6 @@ describe("formatReleaseList", () => {
           draft: true,
           prerelease: true,
           publishedAt: "2024-02-01T00:00:00Z",
-          url: "https://github.com/owner/repo/releases/tag/v2.0.0-alpha",
         },
       ],
     };
@@ -136,7 +152,6 @@ describe("formatReleaseList", () => {
           draft: true,
           prerelease: false,
           publishedAt: "",
-          url: "https://url",
         },
       ],
     };
@@ -158,7 +173,6 @@ describe("compactReleaseList", () => {
           draft: false,
           prerelease: false,
           publishedAt: "2024-01-15T10:00:00Z",
-          url: "https://github.com/owner/repo/releases/tag/v1.0.0",
         },
       ],
     };

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -736,7 +736,10 @@ export function parseReleaseCreate(
 
 /**
  * Parses `gh release list --json ...` output into structured release list data.
- * S-gap: Enhanced to include isLatest and createdAt.
+ *
+ * Note: `gh release list --json` does not expose a `url` field — only
+ * `gh release view --json` does. We intentionally omit it from the output to
+ * avoid `Unknown JSON field: "url"` errors from gh. See issue #868.
  */
 export function parseReleaseList(json: string): ReleaseListResult {
   const raw = JSON.parse(json);
@@ -749,7 +752,6 @@ export function parseReleaseList(json: string): ReleaseListResult {
       isDraft: boolean;
       isPrerelease: boolean;
       publishedAt: string;
-      url: string;
       isLatest?: boolean;
       createdAt?: string;
     }) => ({
@@ -758,8 +760,6 @@ export function parseReleaseList(json: string): ReleaseListResult {
       draft: r.isDraft ?? false,
       prerelease: r.isPrerelease ?? false,
       publishedAt: r.publishedAt ?? "",
-      url: r.url ?? "",
-      // S-gap fields
       isLatest: r.isLatest ?? undefined,
       createdAt: r.createdAt ?? undefined,
     }),

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -472,8 +472,8 @@ export const ReleaseListItemSchema = z.object({
   draft: z.boolean(),
   prerelease: z.boolean(),
   publishedAt: z.string().optional(),
-  url: z.string().optional(),
-  // S-gap: Add isLatest, createdAt
+  // Note: `url` is intentionally omitted — `gh release list --json` does not
+  // expose a `url` field. Use `release-view` for release URLs. See issue #868.
   isLatest: z.boolean().optional(),
   createdAt: z.string().optional(),
 });

--- a/packages/server-github/src/tools/release-list.ts
+++ b/packages/server-github/src/tools/release-list.ts
@@ -16,8 +16,10 @@ import {
 } from "../lib/formatters.js";
 import { ReleaseListResultSchema } from "../schemas/index.js";
 
-// S-gap: Add isLatest and createdAt to JSON fields
-const RELEASE_LIST_FIELDS = "tagName,name,isDraft,isPrerelease,publishedAt,url,isLatest,createdAt";
+// `url` is intentionally omitted: `gh release list --json` does not expose a `url`
+// field (only `gh release view` does), and including it caused the CLI to error
+// with `Unknown JSON field: "url"`. See issue #868.
+const RELEASE_LIST_FIELDS = "tagName,name,isDraft,isPrerelease,publishedAt,isLatest,createdAt";
 
 /** Registers the `release-list` tool on the given MCP server. */
 export function registerReleaseListTool(server: McpServer) {
@@ -26,7 +28,7 @@ export function registerReleaseListTool(server: McpServer) {
     {
       title: "Release List",
       description:
-        "Lists GitHub releases for a repository. Returns structured list with tag, name, draft/prerelease/latest status, publish date, creation date, and URL.",
+        "Lists GitHub releases for a repository. Returns structured list with tag, name, draft/prerelease/latest status, publish date, and creation date.",
       annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         // S-gap P1: Align default limit to CLI default (30)

--- a/tests/smoke/fixtures/github/release-list/s01-releases.txt
+++ b/tests/smoke/fixtures/github/release-list/s01-releases.txt
@@ -4,19 +4,17 @@
     "name": "v1.2.0",
     "isDraft": false,
     "isPrerelease": false,
+    "isLatest": true,
     "createdAt": "2026-02-10T12:00:00Z",
-    "publishedAt": "2026-02-10T12:05:00Z",
-    "author": { "login": "maintainer" },
-    "url": "https://github.com/owner/repo/releases/tag/v1.2.0"
+    "publishedAt": "2026-02-10T12:05:00Z"
   },
   {
     "tagName": "v1.1.0",
     "name": "v1.1.0",
     "isDraft": false,
     "isPrerelease": false,
+    "isLatest": false,
     "createdAt": "2026-01-15T10:00:00Z",
-    "publishedAt": "2026-01-15T10:05:00Z",
-    "author": { "login": "maintainer" },
-    "url": "https://github.com/owner/repo/releases/tag/v1.1.0"
+    "publishedAt": "2026-01-15T10:05:00Z"
   }
 ]

--- a/tests/smoke/mocked/github-run-release-tools.smoke.test.ts
+++ b/tests/smoke/mocked/github-run-release-tools.smoke.test.ts
@@ -94,13 +94,14 @@ const SAMPLE_RUN_VIEW_JSON = {
   attempt: 1,
 };
 
+// Note: `url` is intentionally absent — `gh release list --json` does not
+// expose a `url` field (only `gh release view` does). See issue #868.
 const SAMPLE_RELEASE = {
   tagName: "v1.0.0",
   name: "Release 1.0.0",
   isDraft: false,
   isPrerelease: false,
   publishedAt: "2026-02-17T10:00:00Z",
-  url: "https://github.com/owner/repo/releases/tag/v1.0.0",
   isLatest: true,
   createdAt: "2026-02-17T09:00:00Z",
 };
@@ -906,9 +907,22 @@ describe("Smoke: github.release-list", () => {
     const { parsed } = await callAndValidate({ compact: false });
     const rel = parsed.releases[0];
     expect(rel.publishedAt).toBe("2026-02-17T10:00:00Z");
-    expect(rel.url).toContain("releases/tag/v1.0.0");
+    // `url` is not exposed by `gh release list --json` (see #868).
+    expect(rel).not.toHaveProperty("url");
     expect(rel.isLatest).toBe(true);
     expect(rel.createdAt).toBe("2026-02-17T09:00:00Z");
+  });
+
+  // S13 [P0] Regression for #868: `--json` field list excludes `url`
+  it("S13 [P0] does not request unsupported url field", async () => {
+    mockGh(JSON.stringify([SAMPLE_RELEASE]));
+    await callAndValidate({});
+    const args = vi.mocked(ghCmd).mock.calls[0][0];
+    const fieldsArg = args[args.indexOf("--json") + 1];
+    expect(fieldsArg).not.toContain("url");
+    expect(fieldsArg).toContain("tagName");
+    expect(fieldsArg).toContain("isLatest");
+    expect(fieldsArg).toContain("createdAt");
   });
 
   // S12 [P2] Custom limit

--- a/tests/smoke/scenarios/github-tools.md
+++ b/tests/smoke/scenarios/github-tools.md
@@ -1064,17 +1064,18 @@ Reference: `tests/smoke/scenarios/github-pr-checks.md` for format precedent.
 | 8   | totalAvailable count     | `{ limit: 5 }`                 | `totalAvailable` populated from probe query                        | P1       | complete |
 | 9   | Compact vs full output   | `{ compact: false }`           | Full schema output                                                 | P1       | complete |
 | 10  | Cross-repo listing       | `{ repo: "owner/repo" }`       | --repo flag passed                                                 | P1       | complete |
-| 11  | Release fields populated | `{ }`                          | Each release has `publishedAt`, `url`, `isLatest`, `createdAt`     | P1       | complete |
+| 11  | Release fields populated | `{ }`                          | Each release has `publishedAt`, `isLatest`, `createdAt` (no `url`) | P1       | complete |
 | 12  | Custom limit             | `{ limit: 5 }`                 | At most 5 releases returned                                        | P2       | complete |
+| 13  | No `url` in --json args  | `{ }`                          | Regression for #868: `--json` field list excludes `url`            | P0       | complete |
 
 ### Summary
 
 | Priority  | Count  |
 | --------- | ------ |
-| P0        | 4      |
+| P0        | 5      |
 | P1        | 7      |
 | P2        | 1      |
-| **Total** | **12** |
+| **Total** | **13** |
 
 ---
 
@@ -1329,10 +1330,10 @@ Reference: `tests/smoke/scenarios/github-pr-checks.md` for format precedent.
 | 15  | pr-update      | 17      | 9       | 1      | 27      |
 | 16  | pr-view        | 6       | 9       | 2      | 17      |
 | 17  | release-create | 12      | 9       | 4      | 25      |
-| 18  | release-list   | 4       | 7       | 1      | 12      |
+| 18  | release-list   | 5       | 7       | 1      | 13      |
 | 19  | run-list       | 9       | 10      | 2      | 21      |
 | 20  | run-rerun      | 7       | 3       | 1      | 11      |
 | 21  | run-view       | 6       | 8       | 1      | 15      |
 | 22  | label-list     | 6       | 4       | 0      | 10      |
 | 23  | label-create   | 9       | 2       | 1      | 12      |
-|     | **Totals**     | **215** | **159** | **37** | **411** |
+|     | **Totals**     | **216** | **159** | **37** | **412** |


### PR DESCRIPTION
## Summary

- `pare-github release-list` always failed with `gh release list failed: Unknown JSON field: "url"`. Closes #868.
- `gh release list --json` does NOT expose a `url` field — only `gh release view --json` does. The `RELEASE_LIST_FIELDS` constant requested `url`, which gh rejected, so the tool was unusable.
- Removed `url` from the requested `--json` fields, the parser output, and the `ReleaseListItemSchema`. Use `release-view` if you need a release URL.
- Added regression tests asserting the `--json` field list does not contain `url`.

## Changes

- `packages/server-github/src/tools/release-list.ts` — drop `url` from `RELEASE_LIST_FIELDS`; update tool description.
- `packages/server-github/src/schemas/index.ts` — drop `url` from `ReleaseListItemSchema`.
- `packages/server-github/src/lib/parsers.ts` — drop `url` from `parseReleaseList` output (parser ignores it even if gh ever sends it back).
- Tests updated in `packages/server-github/__tests__/{release-list,formatters,p2-gaps}.test.ts` and `tests/smoke/mocked/github-run-release-tools.smoke.test.ts`. Added two regression cases (one in p2-gaps, one in smoke S13) that fail the build if `url` ever sneaks back into the field list.
- Smoke fixture `tests/smoke/fixtures/github/release-list/s01-releases.txt` updated to match what `gh release list --json` actually returns (it had `url` and `author`, which gh does not expose for list).
- Docs updated: `docs/tool-schemas/github/release-list.md` and `tests/smoke/scenarios/github-tools.md`.
- Changeset: `.changeset/fix-release-list-url-field.md` (`@paretools/github` patch).

## Test plan

- [x] `pnpm --filter @paretools/github test` (527/527 pass)
- [x] Smoke tests for release-list: `pnpm vitest tests/smoke/mocked/github-run-release-tools.smoke.test.ts tests/smoke/suite/github-tools.recorded.test.ts` (101/101 pass)
- [x] `pnpm --filter @paretools/github build`
- [x] `pnpm format:check` clean for changed files
- [x] `pnpm lint` clean for changed files (one pre-existing warning that the `tests/smoke` path isn't in the eslint config — unrelated)
- [ ] Caller verifies end-to-end via the rebuilt MCP server

## Notes for reviewer

While working on this I hit two pare-tool issues worth noting:

1. **`pare-git status` (without explicit `path`) reported a worktree as `clean: true` despite 11 dirty files.** Passing `path` explicitly returned correct data. This points at a cwd-resolution issue inside the git server when called from a nested worktree. Happy to file a separate issue with reproduction.
2. **`pare-git checkout -c` (without explicit `path`) created the new branch but checked it out in a *different* worktree** (the parent repo's main worktree), leaving the calling worktree on its old branch. Same root cause as #1, almost certainly. The bad branch was cleaned up; the user's main worktree was restored to `fix/multi-bug-batch`.

Neither blocks this fix, but if you'd like I can split them off as `bug` issues.