### PR TITLE
fix(git): order checkout track flag before branch operands

### DIFF
--- a/.changeset/fix-git-checkout-track-startpoint.md
+++ b/.changeset/fix-git-checkout-track-startpoint.md
@@ -1,0 +1,5 @@
+---
+"@paretools/git": patch
+---
+
+Fix checkout branch creation with `track` and `startPoint` so flags are ordered before branch operands.

--- a/packages/server-git/__tests__/p2-gaps.test.ts
+++ b/packages/server-git/__tests__/p2-gaps.test.ts
@@ -141,6 +141,33 @@ describe("Git P2 gaps", () => {
     expect(vi.mocked(git).mock.calls[1][0][0]).toBe("switch");
   });
 
+  it("#890 falls back to checkout with track before branch creation operands", async () => {
+    const server = new FakeServer();
+    registerCheckoutTool(server as never);
+    const handler = server.tools.get("checkout")!.handler;
+    vi.mocked(git)
+      .mockResolvedValueOnce({ stdout: "main\n", stderr: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "", stderr: "Switched to a new branch", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "release/v0.4.27\n", stderr: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+
+    await handler({
+      branch: "release/v0.4.27",
+      create: true,
+      startPoint: "origin/release/v0.4.27",
+      track: true,
+      useSwitch: true,
+    });
+
+    expect(vi.mocked(git).mock.calls[1][0]).toEqual([
+      "checkout",
+      "--track",
+      "-b",
+      "release/v0.4.27",
+      "origin/release/v0.4.27",
+    ]);
+  });
+
   it("#249 returns newCommitHash from cherry-pick output", () => {
     const out = parseCherryPick("[main abc1234] pick commit", "", 0, ["deadbeef"]);
     expect(out.newCommitHash).toBe("abc1234");

--- a/packages/server-git/src/tools/checkout.ts
+++ b/packages/server-git/src/tools/checkout.ts
@@ -101,10 +101,11 @@ export function registerCheckoutTool(server: McpServer) {
         return dualOutput(checkoutResult, formatCheckout);
       }
 
-      // git switch has two tag-related incompatibilities vs git checkout:
+      // git switch has a few start-point incompatibilities vs git checkout:
       //   1. `git switch -c <branch> <tag>` → "a branch is expected, got tag" (#666)
       //   2. `git switch --detach <tag>` → "reference is not a branch" on older git (#669)
-      // Use git checkout for both cases; it handles all ref types universally.
+      //   3. `git switch -c <branch> --track <startPoint>` can parse `--track` as a ref (#890)
+      // Use git checkout for these cases; it handles all ref types universally.
       const needsCheckoutForStartPoint = Boolean(
         startPoint && (create || forceCreate) && preferSwitch,
       );
@@ -122,9 +123,9 @@ export function registerCheckoutTool(server: McpServer) {
       }
       const args = [cmd];
       if (force) args.push(cmd === "switch" ? "--discard-changes" : "--force");
-      if (createFlag) args.push(createFlag);
       if (track) args.push("--track");
       if (detach) args.push("--detach");
+      if (createFlag) args.push(createFlag);
       args.push(branch);
       if (startPoint && (create || forceCreate)) args.push(startPoint);
 


### PR DESCRIPTION
Closes #890.

## Summary

Fixes `git/checkout` when callers pass `create: true`, `track: true`, `useSwitch: true`, and a `startPoint`.

The tool already falls back from `git switch` to `git checkout` for start-point branch creation, but it still emitted the branch creation flag before `--track`. Git can then parse `--track` as an operand in this shape. The command builder now emits flags before branch operands:

```bash
git checkout --track -b <branch> <startPoint>
```

## Validation

- `pnpm --filter @paretools/git test -- p2-gaps`
- `pnpm --filter @paretools/git build`
- `pnpm exec prettier --check packages/server-git/src/tools/checkout.ts packages/server-git/__tests__/p2-gaps.test.ts .changeset/fix-git-checkout-track-startpoint.md`
