### PR TITLE
fix(python): resolve venv and python module tools

### DIFF
--- a/.changeset/fix-python-interpreter-resolution.md
+++ b/.changeset/fix-python-interpreter-resolution.md
@@ -1,0 +1,7 @@
+---
+"@paretools/shared": patch
+"@paretools/python": patch
+"@paretools/test": patch
+---
+
+Add shared Python interpreter resolution with project virtualenv detection, `python3` fallback, and `python -m <tool>` fallback for Python-backed tools when their executable is not on PATH.

--- a/packages/server-python/__tests__/integration.test.ts
+++ b/packages/server-python/__tests__/integration.test.ts
@@ -61,7 +61,10 @@ describe("@paretools/python integration", () => {
   describe("ruff-check", () => {
     it("returns structured data or a command-not-found error", async () => {
       const result = await client.callTool(
-        { name: "ruff-check", arguments: { path: resolve(__dirname, "../../..") } },
+        {
+          name: "ruff-check",
+          arguments: { path: resolve(__dirname, "../../.."), compact: false },
+        },
         undefined,
         CALL_TIMEOUT,
       );
@@ -105,7 +108,7 @@ describe("@paretools/python integration", () => {
   describe("mypy", () => {
     it("returns structured data or a command-not-found error", async () => {
       const result = await client.callTool(
-        { name: "mypy", arguments: { targets: ["nonexistent_dir_xyz"] } },
+        { name: "mypy", arguments: { targets: ["nonexistent_dir_xyz"], compact: false } },
         undefined,
         CALL_TIMEOUT,
       );
@@ -125,7 +128,7 @@ describe("@paretools/python integration", () => {
   describe("pip-audit", () => {
     it("returns structured data or a command-not-found error", async () => {
       const result = await client.callTool(
-        { name: "pip-audit", arguments: {} },
+        { name: "pip-audit", arguments: { compact: false } },
         undefined,
         CALL_TIMEOUT,
       );
@@ -144,7 +147,7 @@ describe("@paretools/python integration", () => {
   describe("pytest", () => {
     it("returns structured data or a command-not-found error", async () => {
       const result = await client.callTool(
-        { name: "pytest", arguments: { targets: ["nonexistent_test_dir_xyz"] } },
+        { name: "pytest", arguments: { targets: ["nonexistent_test_dir_xyz"], compact: false } },
         undefined,
         CALL_TIMEOUT,
       );
@@ -211,7 +214,10 @@ describe("@paretools/python integration", () => {
   describe("black", () => {
     it("returns structured data or a command-not-found error", async () => {
       const result = await client.callTool(
-        { name: "black", arguments: { targets: ["nonexistent_dir_xyz"], check: true } },
+        {
+          name: "black",
+          arguments: { targets: ["nonexistent_dir_xyz"], check: true, compact: false },
+        },
         undefined,
         CALL_TIMEOUT,
       );

--- a/packages/server-python/__tests__/p2-gaps.test.ts
+++ b/packages/server-python/__tests__/p2-gaps.test.ts
@@ -14,6 +14,8 @@ import { registerCondaTool } from "../src/tools/conda.js";
 import { registerMypyTool } from "../src/tools/mypy.js";
 import { registerPoetryTool } from "../src/tools/poetry.js";
 import { registerPyenvTool } from "../src/tools/pyenv.js";
+import { registerPytestTool } from "../src/tools/pytest.js";
+import { registerRuffTool } from "../src/tools/ruff.js";
 
 vi.mock("../src/lib/python-runner.js", () => ({
   pip: vi.fn(),
@@ -28,7 +30,7 @@ vi.mock("../src/lib/python-runner.js", () => ({
   pipAudit: vi.fn(),
 }));
 
-import { conda, mypy, poetry, pyenv } from "../src/lib/python-runner.js";
+import { conda, mypy, poetry, pyenv, pytest, ruff } from "../src/lib/python-runner.js";
 
 type ToolHandler = (
   input: Record<string, unknown>,
@@ -169,6 +171,28 @@ describe("Python P2 gaps", () => {
     expect(args).toContain("--disallow-untyped-defs");
     expect(args).toContain("--disallow-untyped-calls");
     expect(args).toContain("--warn-unreachable");
+  });
+
+  it("#891 passes pythonPath through to ruff-check", async () => {
+    const server = new FakeServer();
+    registerRuffTool(server as never);
+    const handler = server.tools.get("ruff-check")!.handler;
+    vi.mocked(ruff).mockResolvedValueOnce({ stdout: "[]", stderr: "", exitCode: 0 });
+
+    await handler({ pythonPath: ".venv/bin/python", compact: false });
+
+    expect(vi.mocked(ruff).mock.calls[0][2]).toBe(".venv/bin/python");
+  });
+
+  it("#891 passes pythonPath through to pytest", async () => {
+    const server = new FakeServer();
+    registerPytestTool(server as never);
+    const handler = server.tools.get("pytest")!.handler;
+    vi.mocked(pytest).mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+
+    await handler({ pythonPath: ".venv/bin/python", compact: false });
+
+    expect(vi.mocked(pytest).mock.calls[0][2]).toBe(".venv/bin/python");
   });
 
   it("#365 includes pip-audit skipped dependencies", () => {

--- a/packages/server-python/src/lib/python-runner.ts
+++ b/packages/server-python/src/lib/python-runner.ts
@@ -1,27 +1,31 @@
-import { run, type RunResult } from "@paretools/shared";
+import { run, runPythonTool, type RunResult } from "@paretools/shared";
 
-export async function pip(args: string[], cwd?: string): Promise<RunResult> {
-  return run("pip", args, { cwd, timeout: 180_000 });
+export async function pip(args: string[], cwd?: string, pythonPath?: string): Promise<RunResult> {
+  return runPythonTool("pip", "pip", args, { cwd, pythonPath, timeout: 180_000 });
 }
 
-export async function mypy(args: string[], cwd?: string): Promise<RunResult> {
-  return run("mypy", args, { cwd, timeout: 180_000 });
+export async function mypy(args: string[], cwd?: string, pythonPath?: string): Promise<RunResult> {
+  return runPythonTool("mypy", "mypy", args, { cwd, pythonPath, timeout: 180_000 });
 }
 
-export async function ruff(args: string[], cwd?: string): Promise<RunResult> {
-  return run("ruff", args, { cwd, timeout: 180_000 });
+export async function ruff(args: string[], cwd?: string, pythonPath?: string): Promise<RunResult> {
+  return runPythonTool("ruff", "ruff", args, { cwd, pythonPath, timeout: 180_000 });
 }
 
-export async function pytest(args: string[], cwd?: string): Promise<RunResult> {
-  return run("pytest", args, { cwd, timeout: 300_000 });
+export async function pytest(
+  args: string[],
+  cwd?: string,
+  pythonPath?: string,
+): Promise<RunResult> {
+  return runPythonTool("pytest", "pytest", args, { cwd, pythonPath, timeout: 300_000 });
 }
 
 export async function uv(args: string[], cwd?: string): Promise<RunResult> {
   return run("uv", args, { cwd, timeout: 180_000 });
 }
 
-export async function black(args: string[], cwd?: string): Promise<RunResult> {
-  return run("black", args, { cwd, timeout: 180_000 });
+export async function black(args: string[], cwd?: string, pythonPath?: string): Promise<RunResult> {
+  return runPythonTool("black", "black", args, { cwd, pythonPath, timeout: 180_000 });
 }
 
 export async function conda(args: string[], cwd?: string): Promise<RunResult> {
@@ -36,6 +40,10 @@ export async function poetry(args: string[], cwd?: string): Promise<RunResult> {
 }
 
 /** pip-audit is a standalone binary, NOT a pip subcommand. */
-export async function pipAudit(args: string[], cwd?: string): Promise<RunResult> {
-  return run("pip-audit", args, { cwd, timeout: 180_000 });
+export async function pipAudit(
+  args: string[],
+  cwd?: string,
+  pythonPath?: string,
+): Promise<RunResult> {
+  return runPythonTool("pip-audit", "pip_audit", args, { cwd, pythonPath, timeout: 180_000 });
 }

--- a/packages/server-python/src/tools/mypy.ts
+++ b/packages/server-python/src/tools/mypy.ts
@@ -24,6 +24,11 @@ export function registerMypyTool(server: McpServer) {
       annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
+        pythonPath: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Python interpreter path to use (overrides executable/PATH fallback)"),
         targets: z
           .array(z.string().max(INPUT_LIMITS.PATH_MAX))
           .max(INPUT_LIMITS.ARRAY_MAX)
@@ -128,6 +133,7 @@ export function registerMypyTool(server: McpServer) {
     },
     async (input) => {
       const path = input["path"] as string | undefined;
+      const pythonPath = input["pythonPath"] as string | undefined;
       const targets = input["targets"] as string[] | undefined;
       const strict = input["strict"] as boolean | undefined;
       const ignoreMissingImports = input["ignoreMissingImports"] as boolean | undefined;
@@ -153,6 +159,7 @@ export function registerMypyTool(server: McpServer) {
       for (const t of targets ?? []) {
         assertNoFlagInjection(t, "targets");
       }
+      if (pythonPath) assertNoFlagInjection(pythonPath, "pythonPath");
       if (configFile) assertNoFlagInjection(configFile, "configFile");
       if (pythonVersion) assertNoFlagInjection(pythonVersion, "pythonVersion");
       if (exclude) assertNoFlagInjection(exclude, "exclude");
@@ -189,7 +196,7 @@ export function registerMypyTool(server: McpServer) {
         args.push(...(targets || ["."]));
       }
 
-      const result = await mypy(args, cwd);
+      const result = await mypy(args, cwd, pythonPath);
       const data = parseMypyJsonOutput(result.stdout, result.exitCode);
       return compactDualOutput(
         data,

--- a/packages/server-python/src/tools/pytest.ts
+++ b/packages/server-python/src/tools/pytest.ts
@@ -29,6 +29,11 @@ export function registerPytestTool(server: McpServer) {
       annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
+        pythonPath: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Python interpreter path to use (overrides venv/PATH detection)"),
         targets: z
           .array(z.string().max(INPUT_LIMITS.PATH_MAX))
           .max(INPUT_LIMITS.ARRAY_MAX)
@@ -94,6 +99,7 @@ export function registerPytestTool(server: McpServer) {
     },
     async ({
       path,
+      pythonPath,
       targets,
       markers,
       keyword,
@@ -117,6 +123,7 @@ export function registerPytestTool(server: McpServer) {
       if (keyword) assertNoFlagInjection(keyword, "keyword");
       if (coverage) assertNoFlagInjection(coverage, "coverage");
       if (configFile) assertNoFlagInjection(configFile, "configFile");
+      if (pythonPath) assertNoFlagInjection(pythonPath, "pythonPath");
 
       const tbStyle = tracebackStyle || "short";
       const args = [`--tb=${tbStyle}`, "-q"];
@@ -134,7 +141,7 @@ export function registerPytestTool(server: McpServer) {
       if (configFile) args.push("-c", configFile);
       if (targets && targets.length > 0) args.push(...targets);
 
-      const result = await pytest(args, cwd);
+      const result = await pytest(args, cwd, pythonPath);
       const data = parsePytestOutput(result.stdout, result.stderr, result.exitCode);
       return compactDualOutput(
         data,

--- a/packages/server-python/src/tools/ruff-format.ts
+++ b/packages/server-python/src/tools/ruff-format.ts
@@ -70,6 +70,11 @@ export function registerRuffFormatTool(server: McpServer) {
           .optional()
           .describe("Override the configured indent width (--indent-width)"),
         path: projectPathInput,
+        pythonPath: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Python interpreter path to use (overrides executable/PATH fallback)"),
         config: configInput("Path to custom ruff config file"),
         targetVersion: z
           .string()
@@ -104,6 +109,7 @@ export function registerRuffFormatTool(server: McpServer) {
       isolated,
       indentWidth,
       path,
+      pythonPath,
       config,
       targetVersion,
       exclude,
@@ -116,6 +122,7 @@ export function registerRuffFormatTool(server: McpServer) {
         assertNoFlagInjection(p, "patterns");
       }
       if (config) assertNoFlagInjection(config, "config");
+      if (pythonPath) assertNoFlagInjection(pythonPath, "pythonPath");
       if (targetVersion) assertNoFlagInjection(targetVersion, "targetVersion");
       if (range) assertNoFlagInjection(range, "range");
       for (const e of exclude ?? []) {
@@ -138,7 +145,7 @@ export function registerRuffFormatTool(server: McpServer) {
         args.push("--exclude", e);
       }
 
-      const result = await ruff(args, cwd);
+      const result = await ruff(args, cwd, pythonPath);
       const data = parseRuffFormatOutput(result.stdout, result.stderr, result.exitCode);
       return compactDualOutput(
         data,

--- a/packages/server-python/src/tools/ruff.ts
+++ b/packages/server-python/src/tools/ruff.ts
@@ -25,6 +25,11 @@ export function registerRuffTool(server: McpServer) {
       annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
+        pythonPath: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Python interpreter path to use (overrides executable/PATH fallback)"),
         targets: z
           .array(z.string().max(INPUT_LIMITS.PATH_MAX))
           .max(INPUT_LIMITS.ARRAY_MAX)
@@ -90,6 +95,7 @@ export function registerRuffTool(server: McpServer) {
     },
     async ({
       path,
+      pythonPath,
       targets,
       fix,
       unsafeFixes,
@@ -110,6 +116,7 @@ export function registerRuffTool(server: McpServer) {
         assertNoFlagInjection(t, "targets");
       }
       if (config) assertNoFlagInjection(config, "config");
+      if (pythonPath) assertNoFlagInjection(pythonPath, "pythonPath");
       if (targetVersion) assertNoFlagInjection(targetVersion, "targetVersion");
       for (const s of select ?? []) {
         assertNoFlagInjection(s, "select");
@@ -137,7 +144,7 @@ export function registerRuffTool(server: McpServer) {
         args.push("--exclude", e);
       }
 
-      const result = await ruff(args, cwd);
+      const result = await ruff(args, cwd, pythonPath);
       const data = parseRuffJson(result.stdout, result.exitCode, result.stderr);
       return compactDualOutput(
         data,

--- a/packages/server-test/src/tools/coverage.ts
+++ b/packages/server-test/src/tools/coverage.ts
@@ -7,6 +7,7 @@ import {
   INPUT_LIMITS,
   compactInput,
   projectPathInput,
+  runPythonModule,
 } from "@paretools/shared";
 import { detectFramework, type Framework } from "../lib/detect.js";
 import { parsePytestCoverage, parsePytestCoverageJson } from "../lib/parsers/pytest.js";
@@ -211,6 +212,11 @@ export function registerCoverageTool(server: McpServer) {
       annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
+        interpreter: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Python interpreter path to use for pytest (overrides venv/PATH detection)"),
         framework: z
           .enum(["pytest", "jest", "vitest", "mocha"])
           .optional()
@@ -264,7 +270,19 @@ export function registerCoverageTool(server: McpServer) {
       },
       outputSchema: CoverageSchema,
     },
-    async ({ path, framework, branch, all, filter, source, exclude, failUnder, args, compact }) => {
+    async ({
+      path,
+      interpreter,
+      framework,
+      branch,
+      all,
+      filter,
+      source,
+      exclude,
+      failUnder,
+      args,
+      compact,
+    }) => {
       for (const s of source ?? []) {
         assertNoFlagInjection(s, "source");
       }
@@ -272,6 +290,7 @@ export function registerCoverageTool(server: McpServer) {
         assertNoFlagInjection(e, "exclude");
       }
       if (filter) assertNoFlagInjection(filter, "filter");
+      if (interpreter) assertNoFlagInjection(interpreter, "interpreter");
       if (args) {
         for (const arg of args) {
           assertNoFlagInjection(arg, "args");
@@ -298,7 +317,14 @@ export function registerCoverageTool(server: McpServer) {
       await mkdir(tempDir, { recursive: true });
 
       const { cmd, cmdArgs } = getCoverageCommand(detected, extraArgs, coverageJsonPath);
-      const result = await run(cmd, cmdArgs, { cwd, timeout: TEST_CLI_TIMEOUT_MS });
+      const result =
+        detected === "pytest"
+          ? await runPythonModule("pytest", cmdArgs.slice(2), {
+              cwd,
+              pythonPath: interpreter,
+              timeout: TEST_CLI_TIMEOUT_MS,
+            })
+          : await run(cmd, cmdArgs, { cwd, timeout: TEST_CLI_TIMEOUT_MS });
       const output = result.stdout + "\n" + result.stderr;
 
       let coverage;

--- a/packages/server-test/src/tools/run.ts
+++ b/packages/server-test/src/tools/run.ts
@@ -13,6 +13,7 @@ import {
   projectPathInput,
   configInput,
   coerceJsonArray,
+  runPythonModule,
 } from "@paretools/shared";
 import { detectFramework, type Framework } from "../lib/detect.js";
 import { assertNodeFrameworkAvailable } from "../lib/binary-check.js";
@@ -265,6 +266,11 @@ export function registerRunTool(server: McpServer) {
       annotations: { readOnlyHint: true },
       inputSchema: {
         path: projectPathInput,
+        interpreter: z
+          .string()
+          .max(INPUT_LIMITS.PATH_MAX)
+          .optional()
+          .describe("Python interpreter path to use for pytest (overrides venv/PATH detection)"),
         framework: z
           .enum(["pytest", "jest", "vitest", "mocha"])
           .optional()
@@ -356,6 +362,7 @@ export function registerRunTool(server: McpServer) {
     },
     async ({
       path,
+      interpreter,
       framework,
       filter,
       shard,
@@ -380,6 +387,9 @@ export function registerRunTool(server: McpServer) {
       }
       if (config) {
         assertNoFlagInjection(config, "config");
+      }
+      if (interpreter) {
+        assertNoFlagInjection(interpreter, "interpreter");
       }
       if (testNamePattern) {
         assertNoFlagInjection(testNamePattern, "testNamePattern");
@@ -422,7 +432,14 @@ export function registerRunTool(server: McpServer) {
         cmdArgs.push(`--outputFile=${tempPath}`);
       }
 
-      const result = await run(cmd, cmdArgs, { cwd, timeout: TEST_CLI_TIMEOUT_MS });
+      const result =
+        detected === "pytest"
+          ? await runPythonModule("pytest", cmdArgs.slice(2), {
+              cwd,
+              pythonPath: interpreter,
+              timeout: TEST_CLI_TIMEOUT_MS,
+            })
+          : await run(cmd, cmdArgs, { cwd, timeout: TEST_CLI_TIMEOUT_MS });
 
       // Combine stdout and stderr for parsing (some frameworks write to stderr)
       const output = result.stdout + "\n" + result.stderr;

--- a/packages/shared/__tests__/python.test.ts
+++ b/packages/shared/__tests__/python.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+vi.mock("../src/runner.js", () => ({
+  run: vi.fn(),
+}));
+
+import { run } from "../src/runner.js";
+import { pythonInterpreterCandidates, runPythonModule, runPythonTool } from "../src/python.js";
+
+const mockRun = vi.mocked(run);
+
+function ok() {
+  return { stdout: "", stderr: "", exitCode: 0 };
+}
+
+describe("python helpers", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tempDir = join(tmpdir(), `pare-python-helper-${randomUUID()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("prefers project venv interpreters before PATH fallbacks", async () => {
+    const python = join(tempDir, ".venv", "bin", "python");
+    await mkdir(join(tempDir, ".venv", "bin"), { recursive: true });
+    await writeFile(python, "");
+
+    expect(pythonInterpreterCandidates(tempDir, { platform: "linux" }).slice(0, 3)).toEqual([
+      python,
+      "python",
+      "python3",
+    ]);
+  });
+
+  it("falls back from missing tool executable to python -m module", async () => {
+    mockRun
+      .mockRejectedValueOnce(new Error('Command not found: "ruff". Ensure it is installed.'))
+      .mockResolvedValueOnce(ok());
+
+    await runPythonTool("ruff", "ruff", ["check", "."], { cwd: tempDir });
+
+    expect(mockRun.mock.calls[0]).toEqual(["ruff", ["check", "."], { cwd: tempDir }]);
+    expect(mockRun.mock.calls[1]).toEqual([
+      "python",
+      ["-m", "ruff", "check", "."],
+      { cwd: tempDir },
+    ]);
+  });
+
+  it("falls back from missing python to python3 for module execution", async () => {
+    mockRun
+      .mockRejectedValueOnce(new Error('Command not found: "python". Ensure it is installed.'))
+      .mockResolvedValueOnce(ok());
+
+    await runPythonModule("pytest", ["-v"], { cwd: tempDir });
+
+    expect(mockRun.mock.calls[0][0]).toBe("python");
+    expect(mockRun.mock.calls[1]).toEqual(["python3", ["-m", "pytest", "-v"], { cwd: tempDir }]);
+  });
+
+  it("uses explicit pythonPath without probing PATH commands", async () => {
+    mockRun.mockResolvedValueOnce(ok());
+
+    await runPythonTool("pytest", "pytest", ["-q"], {
+      cwd: tempDir,
+      pythonPath: "/custom/python",
+    });
+
+    expect(mockRun).toHaveBeenCalledOnce();
+    expect(mockRun).toHaveBeenCalledWith("/custom/python", ["-m", "pytest", "-q"], {
+      cwd: tempDir,
+    });
+  });
+
+  it("treats missing Python modules as command-not-found and tries the next interpreter", async () => {
+    mockRun
+      .mockResolvedValueOnce({ stdout: "", stderr: "No module named ruff", exitCode: 1 })
+      .mockResolvedValueOnce(ok());
+
+    await runPythonModule("ruff", ["check"], { cwd: tempDir });
+
+    expect(mockRun.mock.calls[0][0]).toBe("python");
+    expect(mockRun.mock.calls[1][0]).toBe("python3");
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,6 +17,7 @@ export {
   type RunOptions,
   type SpawnConfig,
 } from "./runner.js";
+export { pythonInterpreterCandidates, runPythonModule, runPythonTool } from "./python.js";
 export { stripAnsi } from "./ansi.js";
 export {
   coerceJsonArray,

--- a/packages/shared/src/python.ts
+++ b/packages/shared/src/python.ts
@@ -1,0 +1,99 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { run, type RunOptions, type RunResult } from "./runner.js";
+
+function isCommandNotFoundError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("Command not found:");
+}
+
+function isModuleNotFound(result: RunResult, moduleName: string): boolean {
+  if (result.exitCode === 0) return false;
+  const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`No module named ['"]?${escaped}['"]?`).test(result.stderr);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function toRunOptions(opts?: RunOptions & { pythonPath?: string }): RunOptions | undefined {
+  if (!opts) return undefined;
+  const runOpts: RunOptions = {};
+  if (opts.cwd !== undefined) runOpts.cwd = opts.cwd;
+  if (opts.timeout !== undefined) runOpts.timeout = opts.timeout;
+  if (opts.env !== undefined) runOpts.env = opts.env;
+  if (opts.stdin !== undefined) runOpts.stdin = opts.stdin;
+  if (opts.shell !== undefined) runOpts.shell = opts.shell;
+  if (opts.maxBuffer !== undefined) runOpts.maxBuffer = opts.maxBuffer;
+  if (opts.replaceEnv !== undefined) runOpts.replaceEnv = opts.replaceEnv;
+  return runOpts;
+}
+
+/** Returns Python interpreter candidates in preferred resolution order. */
+export function pythonInterpreterCandidates(
+  cwd: string = process.cwd(),
+  opts?: { explicit?: string; platform?: NodeJS.Platform },
+): string[] {
+  if (opts?.explicit) return [opts.explicit];
+
+  const platform = opts?.platform ?? process.platform;
+  const venvs = [".venv", "venv", "env"];
+  const candidates: string[] = [];
+
+  for (const venv of venvs) {
+    const dir = join(cwd, venv, platform === "win32" ? "Scripts" : "bin");
+    for (const name of platform === "win32" ? ["python.exe", "python"] : ["python", "python3"]) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate)) candidates.push(candidate);
+    }
+  }
+
+  candidates.push("python", "python3");
+  return unique(candidates);
+}
+
+/** Runs a Python module through the best available interpreter. */
+export async function runPythonModule(
+  moduleName: string,
+  args: string[],
+  opts?: RunOptions & { pythonPath?: string },
+): Promise<RunResult> {
+  let lastError: unknown;
+  const runOpts = toRunOptions(opts);
+  const pythonPath = opts?.pythonPath;
+  for (const python of pythonInterpreterCandidates(runOpts?.cwd, { explicit: pythonPath })) {
+    try {
+      const result = await run(python, ["-m", moduleName, ...args], runOpts);
+      if (isModuleNotFound(result, moduleName)) {
+        throw new Error(
+          `Command not found: "${moduleName}". Ensure it is installed in the selected Python environment.`,
+        );
+      }
+      return result;
+    } catch (error) {
+      if (!isCommandNotFoundError(error)) throw error;
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(`Command not found: "python"`);
+}
+
+/** Runs a Python tool executable, falling back to `python -m <module>` if missing. */
+export async function runPythonTool(
+  command: string,
+  moduleName: string,
+  args: string[],
+  opts?: RunOptions & { pythonPath?: string },
+): Promise<RunResult> {
+  if (opts?.pythonPath) {
+    return runPythonModule(moduleName, args, opts);
+  }
+  const runOpts = toRunOptions(opts);
+
+  try {
+    return await run(command, args, runOpts);
+  } catch (error) {
+    if (!isCommandNotFoundError(error)) throw error;
+    return runPythonModule(moduleName, args, opts);
+  }
+}


### PR DESCRIPTION
Refs #884. Refs #891.

## Summary

Adds shared Python interpreter resolution for Python-backed tools:

- detects project `.venv`, `venv`, and `env` interpreters before PATH fallbacks
- falls back from `python` to `python3` for `python -m <module>` execution
- falls back from missing `ruff`, `pytest`, `mypy`, `pip`, `pip-audit`, and `black` executables to `python -m <module>`
- exposes explicit override inputs for the affected tools: `pythonPath` in `pare-python` ruff/mypy/pytest tools and `interpreter` in `pare-test` pytest run/coverage

## Validation

- `pnpm --filter @paretools/shared exec vitest run __tests__/python.test.ts`
- `pnpm --filter @paretools/python exec vitest run __tests__/p2-gaps.test.ts`
- `pnpm --filter @paretools/python test`
- `pnpm --filter @paretools/test test:unit`
- `pnpm --filter @paretools/test exec vitest run __tests__/tools-helpers.test.ts`
- `pnpm --filter @paretools/shared build`
- `pnpm --filter @paretools/python build`
- `pnpm --filter @paretools/test build`

## Note

`pnpm --filter @paretools/test test` currently fails locally in the integration phase because the server-git package reports one failed test during the nested run; that appears separate from this Python interpreter change, so this PR is draft until CI confirms the branch status.
