### PR TITLE
fix(github): support path for pr checks and diff

### DIFF
--- a/.changeset/fix-github-pr-path-param.md
+++ b/.changeset/fix-github-pr-path-param.md
@@ -1,0 +1,5 @@
+---
+"@paretools/github": patch
+---
+
+Allow `pr-checks` and `pr-diff` to accept the shared `path` parameter and run `gh` from that repository directory. Closes #896.

--- a/packages/server-github/__tests__/p2-gaps.test.ts
+++ b/packages/server-github/__tests__/p2-gaps.test.ts
@@ -227,6 +227,42 @@ describe("GitHub P2 gaps", () => {
     expect(out.structuredContent.errorType).toBe("permission-denied");
   });
 
+  it("#896 pr-checks accepts path as gh cwd", async () => {
+    const server = new FakeServer();
+    registerPrChecksTool(server as never);
+    const handler = server.tools.get("pr-checks")!.handler;
+    vi.mocked(ghCmd).mockResolvedValueOnce({
+      stdout: "[]",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    await handler({ number: "9", path: "/tmp/target-repo" });
+
+    expect(vi.mocked(ghCmd)).toHaveBeenCalledWith(
+      ["pr", "checks", "9", "--json", expect.any(String)],
+      "/tmp/target-repo",
+    );
+  });
+
+  it("#896 pr-checks watch accepts path as gh cwd", async () => {
+    const server = new FakeServer();
+    registerPrChecksTool(server as never);
+    const handler = server.tools.get("pr-checks")!.handler;
+    vi.mocked(ghCmd).mockResolvedValueOnce({
+      stdout: "[]",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    await handler({ number: "9", path: "/tmp/target-repo", watch: true });
+
+    expect(vi.mocked(ghCmd)).toHaveBeenCalledWith(
+      ["pr", "checks", "9", "--json", expect.any(String)],
+      "/tmp/target-repo",
+    );
+  });
+
   it("#284 returns typed pr-comment errors", async () => {
     const server = new FakeServer();
     registerPrCommentTool(server as never);
@@ -290,6 +326,21 @@ describe("GitHub P2 gaps", () => {
     expect(file.file).toBe("src/new name.ts");
     expect(file.oldFile).toBe("src/old name.ts");
     expect(file.status).toBe("renamed");
+  });
+
+  it("#896 pr-diff accepts path as gh cwd", async () => {
+    const server = new FakeServer();
+    registerPrDiffTool(server as never);
+    const handler = server.tools.get("pr-diff")!.handler;
+    vi.mocked(ghCmd).mockResolvedValueOnce({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    await handler({ number: "14", path: "/tmp/target-repo" });
+
+    expect(vi.mocked(ghCmd)).toHaveBeenCalledWith(["pr", "diff", "14"], "/tmp/target-repo");
   });
 
   it("#288 pr-list returns correct results", async () => {

--- a/packages/server-github/src/tools/pr-checks.ts
+++ b/packages/server-github/src/tools/pr-checks.ts
@@ -5,6 +5,7 @@ import {
   assertNoFlagInjection,
   INPUT_LIMITS,
   compactInput,
+  repoPathInput,
 } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
 import { parsePrChecks } from "../lib/parsers.js";
@@ -177,6 +178,7 @@ export function registerPrChecksTool(server: McpServer) {
           .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe("Repository in OWNER/REPO format (default: current repo)"),
+        path: repoPathInput,
         watch: z.coerce
           .boolean()
           .optional()
@@ -210,7 +212,9 @@ export function registerPrChecksTool(server: McpServer) {
       },
       outputSchema: PrChecksResultSchema,
     },
-    async ({ number, repo, watch, interval, watchTimeout, required, compact }) => {
+    async ({ number, repo, path, watch, interval, watchTimeout, required, compact }) => {
+      const cwd = path || process.cwd();
+
       if (repo) assertNoFlagInjection(repo, "repo");
       if (typeof number === "string") assertNoFlagInjection(number, "number");
 
@@ -228,7 +232,7 @@ export function registerPrChecksTool(server: McpServer) {
       if (watch) {
         const intervalSeconds = interval ?? DEFAULT_INTERVAL_SECONDS;
         const timeoutSeconds = watchTimeout ?? DEFAULT_WATCH_TIMEOUT_SECONDS;
-        const watchResult = await watchPrChecks(args, undefined, prNum, {
+        const watchResult = await watchPrChecks(args, cwd, prNum, {
           intervalMs: intervalSeconds * 1000,
           timeoutMs: timeoutSeconds * 1000,
         });
@@ -254,7 +258,7 @@ export function registerPrChecksTool(server: McpServer) {
         );
       }
 
-      const result = await ghCmd(args);
+      const result = await ghCmd(args, cwd);
 
       // Exit code 8 means checks are still pending — gh still returns valid JSON
       if (result.exitCode !== 0 && result.exitCode !== 8) {

--- a/packages/server-github/src/tools/pr-diff.ts
+++ b/packages/server-github/src/tools/pr-diff.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { compactDualOutput, INPUT_LIMITS, compactInput } from "@paretools/shared";
+import { compactDualOutput, INPUT_LIMITS, compactInput, repoPathInput } from "@paretools/shared";
 import { assertNoFlagInjection } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
 import { formatPrDiff, compactPrDiffMap, formatPrDiffCompact } from "../lib/formatters.js";
@@ -28,6 +28,7 @@ export function registerPrDiffTool(server: McpServer) {
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
           .describe("Repository in OWNER/REPO format (default: current repo)"),
+        path: repoPathInput,
         full: z
           .boolean()
           .optional()
@@ -41,7 +42,9 @@ export function registerPrDiffTool(server: McpServer) {
       },
       outputSchema: PrDiffResultSchema,
     },
-    async ({ number, repo, full, nameOnly, compact }) => {
+    async ({ number, repo, path, full, nameOnly, compact }) => {
+      const cwd = path || process.cwd();
+
       if (repo) {
         assertNoFlagInjection(repo, "repo");
       }
@@ -60,7 +63,7 @@ export function registerPrDiffTool(server: McpServer) {
       if (repo) diffArgs.push("--repo", repo);
       if (nameOnly) diffArgs.push("--name-only");
 
-      const result = await ghCmd(diffArgs, { cwd: process.cwd() });
+      const result = await ghCmd(diffArgs, cwd);
 
       if (result.exitCode !== 0) {
         throw new Error(`gh pr diff failed: ${result.stderr}`);


### PR DESCRIPTION
Closes #896.

## Summary

Adds the shared `path` input to `pare-github` `pr-checks` and `pr-diff`, matching sibling tools that can target a local clone by cwd.

- `pr-checks` passes `path` through to `gh` for both normal and `watch` modes
- `pr-diff` runs `gh pr diff` from the provided repo path
- adds P2 regression coverage for both tools

## Validation

- `pnpm --filter @paretools/github exec vitest run __tests__/p2-gaps.test.ts`
- `pnpm --filter @paretools/github exec vitest run __tests__/pr-checks.test.ts __tests__/pr-checks-watch.test.ts __tests__/pr-diff.test.ts`
- `pnpm --filter @paretools/github test`
- `pnpm --filter @paretools/github build`
- `pnpm exec prettier --check packages/server-github/src/tools/pr-checks.ts packages/server-github/src/tools/pr-diff.ts packages/server-github/__tests__/p2-gaps.test.ts .changeset/fix-github-pr-path-param.md`
