### PR TITLE
feat(github): add secrets and variables tools

### DIFF
--- a/.changeset/add-github-secrets-variables.md
+++ b/.changeset/add-github-secrets-variables.md
@@ -1,0 +1,5 @@
+---
+"@paretools/github": minor
+---
+
+Add first-class GitHub Actions secret and variable management tools: `secret-set`, `secret-list`, `secret-delete`, `variable-set`, `variable-list`, and `variable-delete`. Secret and variable set operations send values through stdin; secret values are masked from structured output. Closes #883.

--- a/packages/server-github/README.md
+++ b/packages/server-github/README.md
@@ -7,18 +7,24 @@
 
 Part of the [Pare](https://github.com/Dave-London/Pare) suite of MCP servers.
 
-## Tools (8)
+## Tools
 
-| Tool           | Description                                              |
-| -------------- | -------------------------------------------------------- |
-| `pr-view`      | View PR details with checks, review decision, diff stats |
-| `pr-list`      | List PRs with state/author/label filters                 |
-| `pr-create`    | Create a pull request with title, body, base/head        |
-| `issue-view`   | View issue details with labels, assignees, body          |
-| `issue-list`   | List issues with state/label/assignee filters            |
-| `issue-create` | Create an issue with title, body, labels                 |
-| `run-view`     | View workflow run details with job statuses              |
-| `run-list`     | List workflow runs with branch/status filters            |
+| Tool              | Description                                                |
+| ----------------- | ---------------------------------------------------------- |
+| `pr-view`         | View PR details with checks, review decision, diff stats   |
+| `pr-list`         | List PRs with state/author/label filters                   |
+| `pr-create`       | Create a pull request with title, body, base/head          |
+| `issue-view`      | View issue details with labels, assignees, body            |
+| `issue-list`      | List issues with state/label/assignee filters              |
+| `issue-create`    | Create an issue with title, body, labels                   |
+| `run-view`        | View workflow run details with job statuses                |
+| `run-list`        | List workflow runs with branch/status filters              |
+| `secret-set`      | Set a repo, org, or environment GitHub Actions secret      |
+| `secret-list`     | List secret names and metadata; values are never returned  |
+| `secret-delete`   | Delete a repo, org, or environment GitHub Actions secret   |
+| `variable-set`    | Set a repo, org, or environment GitHub Actions variable    |
+| `variable-list`   | List variable names, values, and metadata                  |
+| `variable-delete` | Delete a repo, org, or environment GitHub Actions variable |
 
 ## Quick Start
 
@@ -57,6 +63,33 @@ Add to your MCP client config:
   "additions": 150,
   "deletions": 20,
   "changedFiles": 5
+}
+```
+
+**`secret-set` input:**
+
+```json
+{
+  "name": "MAXMIND_LICENSE_KEY",
+  "value": "license-key-value",
+  "repo": "owner/repo"
+}
+```
+
+Secret values are sent to `gh secret set` via stdin and are not returned in structured output. For organization scope, pass `org` and optional `visibility` / `repos`; for environment scope, pass `repo` and `env`.
+
+**`variable-list` output:**
+
+```json
+{
+  "scope": "repo",
+  "variables": [
+    {
+      "name": "PUBLIC_URL",
+      "value": "https://example.com",
+      "updatedAt": "2026-01-01T00:00:00Z"
+    }
+  ]
 }
 ```
 

--- a/packages/server-github/__tests__/integration.test.ts
+++ b/packages/server-github/__tests__/integration.test.ts
@@ -27,7 +27,7 @@ describe("@paretools/github integration", () => {
     await transport.close();
   }, 30_000);
 
-  it("lists all 30 tools", async () => {
+  it("lists all 36 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
@@ -61,6 +61,12 @@ describe("@paretools/github integration", () => {
       "run-list",
       "run-rerun",
       "run-view",
+      "secret-delete",
+      "secret-list",
+      "secret-set",
+      "variable-delete",
+      "variable-list",
+      "variable-set",
     ]);
   });
 

--- a/packages/server-github/__tests__/secrets-variables.test.ts
+++ b/packages/server-github/__tests__/secrets-variables.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  registerSecretDeleteTool,
+  registerSecretListTool,
+  registerSecretSetTool,
+  registerVariableDeleteTool,
+  registerVariableListTool,
+  registerVariableSetTool,
+} from "../src/tools/secrets-variables.js";
+
+vi.mock("../src/lib/gh-runner.js", () => ({
+  ghCmd: vi.fn(),
+}));
+
+import { ghCmd } from "../src/lib/gh-runner.js";
+
+type ToolHandler = (
+  input: Record<string, unknown>,
+) => Promise<{ structuredContent: Record<string, unknown> }>;
+
+class FakeServer {
+  tools = new Map<string, { handler: ToolHandler }>();
+
+  registerTool(name: string, _config: Record<string, unknown>, handler: ToolHandler) {
+    this.tools.set(name, { handler });
+  }
+}
+
+function registerAll(server: FakeServer) {
+  registerSecretSetTool(server as never);
+  registerSecretListTool(server as never);
+  registerSecretDeleteTool(server as never);
+  registerVariableSetTool(server as never);
+  registerVariableListTool(server as never);
+  registerVariableDeleteTool(server as never);
+}
+
+describe("secrets and variables tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets repository secrets via stdin without echoing the value", async () => {
+    const server = new FakeServer();
+    registerAll(server);
+    vi.mocked(ghCmd).mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+
+    const out = await server.tools.get("secret-set")!.handler({
+      name: "MAXMIND_LICENSE_KEY",
+      value: "super-secret",
+      repo: "owner/repo",
+      path: "/tmp/repo",
+    });
+
+    expect(ghCmd).toHaveBeenCalledWith(
+      ["secret", "set", "MAXMIND_LICENSE_KEY", "--repo", "owner/repo"],
+      { cwd: "/tmp/repo", stdin: "super-secret" },
+    );
+    expect(out.structuredContent).toMatchObject({
+      name: "MAXMIND_LICENSE_KEY",
+      action: "set",
+      scope: "repo",
+      secretValueMasked: true,
+    });
+    expect(JSON.stringify(out.structuredContent)).not.toContain("super-secret");
+  });
+
+  it("sets organization secrets with visibility and selected repositories", async () => {
+    const server = new FakeServer();
+    registerAll(server);
+    vi.mocked(ghCmd).mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+
+    await server.tools.get("secret-set")!.handler({
+      name: "DEPLOY_TOKEN",
+      value: "secret",
+      org: "acme",
+      visibility: "selected",
+      repos: ["web", "api"],
+      app: "actions",
+    });
+
+    expect(ghCmd).toHaveBeenCalledWith(
+      [
+        "secret",
+        "set",
+        "DEPLOY_TOKEN",
+        "--org",
+        "acme",
+        "--visibility",
+        "selected",
+        "--repos",
+        "web,api",
+        "--app",
+        "actions",
+      ],
+      { cwd: expect.any(String), stdin: "secret" },
+    );
+  });
+
+  it("lists environment secrets", async () => {
+    const server = new FakeServer();
+    registerAll(server);
+    vi.mocked(ghCmd).mockResolvedValueOnce({
+      stdout: JSON.stringify([{ name: "TOKEN", updatedAt: "2026-01-01T00:00:00Z" }]),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const out = await server.tools.get("secret-list")!.handler({
+      repo: "owner/repo",
+      env: "production",
+    });
+
+    expect(ghCmd).toHaveBeenCalledWith(
+      [
+        "secret",
+        "list",
+        "--json",
+        "name,updatedAt,visibility,numSelectedRepos,selectedReposURL",
+        "--repo",
+        "owner/repo",
+        "--env",
+        "production",
+      ],
+      expect.any(String),
+    );
+    expect(out.structuredContent).toMatchObject({
+      scope: "environment",
+      secrets: [{ name: "TOKEN", updatedAt: "2026-01-01T00:00:00Z" }],
+    });
+  });
+
+  it("deletes organization secrets", async () => {
+    const server = new FakeServer();
+    registerAll(server);
+    vi.mocked(ghCmd).mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+
+    const out = await server.tools.get("secret-delete")!.handler({
+      name: "DEPLOY_TOKEN",
+      org: "acme",
+    });
+
+    expect(ghCmd).toHaveBeenCalledWith(
+      ["secret", "delete", "DEPLOY_TOKEN", "--org", "acme"],
+      expect.any(String),
+    );
+    expect(out.structuredContent).toMatchObject({
+      name: "DEPLOY_TOKEN",
+      action: "delete",
+      scope: "org",
+      secretValueMasked: true,
+    });
+  });
+
+  it("sets variables via stdin", async () => {
+    const server = new FakeServer();
+    registerAll(server);
+    vi.mocked(ghCmd).mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+
+    const out = await server.tools.get("variable-set")!.handler({
+      name: "PUBLIC_URL",
+      value: "https://example.com",
+      repo: "owner/repo",
+    });
+
+    expect(ghCmd).toHaveBeenCalledWith(["variable", "set", "PUBLIC_URL", "--repo", "owner/repo"], {
+      cwd: expect.any(String),
+      stdin: "https://example.com",
+    });
+    expect(out.structuredContent).toMatchObject({
+      name: "PUBLIC_URL",
+      action: "set",
+      scope: "repo",
+    });
+  });
+
+  it("lists organization variables with values", async () => {
+    const server = new FakeServer();
+    registerAll(server);
+    vi.mocked(ghCmd).mockResolvedValueOnce({
+      stdout: JSON.stringify([
+        { name: "PUBLIC_URL", value: "https://example.com", updatedAt: "2026-01-01T00:00:00Z" },
+      ]),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const out = await server.tools.get("variable-list")!.handler({ org: "acme" });
+
+    expect(ghCmd).toHaveBeenCalledWith(
+      [
+        "variable",
+        "list",
+        "--json",
+        "name,value,createdAt,updatedAt,visibility,numSelectedRepos,selectedReposURL",
+        "--org",
+        "acme",
+      ],
+      expect.any(String),
+    );
+    expect(out.structuredContent).toMatchObject({
+      scope: "org",
+      variables: [{ name: "PUBLIC_URL", value: "https://example.com" }],
+    });
+  });
+
+  it("deletes environment variables", async () => {
+    const server = new FakeServer();
+    registerAll(server);
+    vi.mocked(ghCmd).mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+
+    const out = await server.tools.get("variable-delete")!.handler({
+      name: "PUBLIC_URL",
+      repo: "owner/repo",
+      env: "production",
+    });
+
+    expect(ghCmd).toHaveBeenCalledWith(
+      ["variable", "delete", "PUBLIC_URL", "--repo", "owner/repo", "--env", "production"],
+      expect.any(String),
+    );
+    expect(out.structuredContent).toMatchObject({
+      name: "PUBLIC_URL",
+      action: "delete",
+      scope: "environment",
+    });
+  });
+
+  it("returns typed permission errors", async () => {
+    const server = new FakeServer();
+    registerAll(server);
+    vi.mocked(ghCmd).mockResolvedValueOnce({
+      stdout: "",
+      stderr: "HTTP 403: requires admin:org scope",
+      exitCode: 1,
+    });
+
+    const out = await server.tools.get("secret-list")!.handler({ org: "acme" });
+
+    expect(out.structuredContent).toMatchObject({
+      scope: "org",
+      errorType: "permission-denied",
+    });
+  });
+});

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -24,6 +24,10 @@ import type {
   ApiResult,
   LabelListResult,
   LabelCreateResult,
+  SecretListResult,
+  SecretMutationResult,
+  VariableListResult,
+  VariableMutationResult,
   RepoViewResult,
   RepoCloneResult,
   DiscussionListResult,
@@ -628,6 +632,45 @@ export function formatLabelCreate(data: LabelCreateResult): string {
   const descPart = data.description ? ` — ${data.description}` : "";
   const errorPart = data.errorType ? ` [error: ${data.errorType}]` : "";
   return `Created label "${data.name}"${colorPart}${descPart}${errorPart}`;
+}
+
+// ── Actions secrets / variables ─────────────────────────────────────
+
+export function formatSecretList(data: SecretListResult): string {
+  const total = data.secrets.length;
+  if (total === 0) return `No ${data.scope} secrets found.`;
+  const lines = [`${total} ${data.scope} secrets:`];
+  for (const secret of data.secrets) {
+    const updated = secret.updatedAt ? ` updated ${secret.updatedAt}` : "";
+    const visibility = secret.visibility ? ` (${secret.visibility})` : "";
+    lines.push(`  ${secret.name}${visibility}${updated}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatSecretMutation(data: SecretMutationResult): string {
+  const verb = data.action === "set" ? "Set" : "Deleted";
+  const errorPart = data.errorType ? ` [error: ${data.errorType}]` : "";
+  return `${verb} ${data.scope} secret "${data.name}"${errorPart}`;
+}
+
+export function formatVariableList(data: VariableListResult): string {
+  const total = data.variables.length;
+  if (total === 0) return `No ${data.scope} variables found.`;
+  const lines = [`${total} ${data.scope} variables:`];
+  for (const variable of data.variables) {
+    const value = variable.value !== undefined ? `=${variable.value}` : "";
+    const updated = variable.updatedAt ? ` updated ${variable.updatedAt}` : "";
+    const visibility = variable.visibility ? ` (${variable.visibility})` : "";
+    lines.push(`  ${variable.name}${value}${visibility}${updated}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatVariableMutation(data: VariableMutationResult): string {
+  const verb = data.action === "set" ? "Set" : "Deleted";
+  const errorPart = data.errorType ? ` [error: ${data.errorType}]` : "";
+  return `${verb} ${data.scope} variable "${data.name}"${errorPart}`;
 }
 
 /** Formats run view with log output. */

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -540,6 +540,74 @@ export const LabelCreateResultSchema = z.object({
 
 export type LabelCreateResult = z.infer<typeof LabelCreateResultSchema>;
 
+// ── Actions secret / variable schemas ───────────────────────────────
+
+const GithubConfigScopeSchema = z.enum(["repo", "org", "environment"]);
+const GithubConfigErrorSchema = z.enum(["not-found", "permission-denied", "validation", "unknown"]);
+
+/** Zod schema for a single GitHub Actions secret item. Values are never exposed by GitHub. */
+export const SecretItemSchema = z.object({
+  name: z.string(),
+  updatedAt: z.string().optional(),
+  visibility: z.string().optional(),
+  numSelectedRepos: z.number().optional(),
+  selectedReposURL: z.string().optional(),
+});
+
+/** Zod schema for structured secret-list output. */
+export const SecretListResultSchema = z.object({
+  secrets: z.array(SecretItemSchema),
+  scope: GithubConfigScopeSchema,
+  errorType: GithubConfigErrorSchema.optional(),
+  errorMessage: z.string().optional(),
+});
+
+export type SecretListResult = z.infer<typeof SecretListResultSchema>;
+
+/** Zod schema for structured secret set/delete output. */
+export const SecretMutationResultSchema = z.object({
+  name: z.string(),
+  action: z.enum(["set", "delete"]),
+  scope: GithubConfigScopeSchema,
+  secretValueMasked: z.literal(true),
+  errorType: GithubConfigErrorSchema.optional(),
+  errorMessage: z.string().optional(),
+});
+
+export type SecretMutationResult = z.infer<typeof SecretMutationResultSchema>;
+
+/** Zod schema for a single GitHub Actions variable item. */
+export const VariableItemSchema = z.object({
+  name: z.string(),
+  value: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  visibility: z.string().optional(),
+  numSelectedRepos: z.number().optional(),
+  selectedReposURL: z.string().optional(),
+});
+
+/** Zod schema for structured variable-list output. */
+export const VariableListResultSchema = z.object({
+  variables: z.array(VariableItemSchema),
+  scope: GithubConfigScopeSchema,
+  errorType: GithubConfigErrorSchema.optional(),
+  errorMessage: z.string().optional(),
+});
+
+export type VariableListResult = z.infer<typeof VariableListResultSchema>;
+
+/** Zod schema for structured variable set/delete output. */
+export const VariableMutationResultSchema = z.object({
+  name: z.string(),
+  action: z.enum(["set", "delete"]),
+  scope: GithubConfigScopeSchema,
+  errorType: GithubConfigErrorSchema.optional(),
+  errorMessage: z.string().optional(),
+});
+
+export type VariableMutationResult = z.infer<typeof VariableMutationResultSchema>;
+
 // ── Repo schemas ────────────────────────────────────────────────────
 
 /** Zod schema for structured repo-view output. */

--- a/packages/server-github/src/tools/index.ts
+++ b/packages/server-github/src/tools/index.ts
@@ -35,6 +35,14 @@ import { registerLabelCreateTool } from "./label-create.js";
 import { registerRepoViewTool } from "./repo-view.js";
 import { registerRepoCloneTool } from "./repo-clone.js";
 import { registerDiscussionListTool } from "./discussion-list.js";
+import {
+  registerSecretDeleteTool,
+  registerSecretListTool,
+  registerSecretSetTool,
+  registerVariableDeleteTool,
+  registerVariableListTool,
+  registerVariableSetTool,
+} from "./secrets-variables.js";
 
 const TOOL_DEFS: Array<{
   name: string;
@@ -195,6 +203,40 @@ const TOOL_DEFS: Array<{
     description:
       "Creates a new repository label. Returns structured data with label name, description, color, and URL.",
     register: registerLabelCreateTool,
+  },
+  {
+    name: "secret-set",
+    description:
+      "Sets a repository, organization, or environment GitHub Actions secret. Secret values are sent via stdin and never returned.",
+    register: registerSecretSetTool,
+  },
+  {
+    name: "secret-list",
+    description:
+      "Lists repository, organization, or environment secret names and metadata. Secret values are never exposed.",
+    register: registerSecretListTool,
+  },
+  {
+    name: "secret-delete",
+    description: "Deletes a repository, organization, or environment GitHub Actions secret.",
+    register: registerSecretDeleteTool,
+  },
+  {
+    name: "variable-set",
+    description:
+      "Sets a repository, organization, or environment GitHub Actions variable. Variables are not secret.",
+    register: registerVariableSetTool,
+  },
+  {
+    name: "variable-list",
+    description:
+      "Lists repository, organization, or environment GitHub Actions variables with values and metadata.",
+    register: registerVariableListTool,
+  },
+  {
+    name: "variable-delete",
+    description: "Deletes a repository, organization, or environment GitHub Actions variable.",
+    register: registerVariableDeleteTool,
   },
   {
     name: "repo-view",

--- a/packages/server-github/src/tools/secrets-variables.ts
+++ b/packages/server-github/src/tools/secrets-variables.ts
@@ -1,0 +1,399 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
+import { ghCmd } from "../lib/gh-runner.js";
+import {
+  SecretListResultSchema,
+  SecretMutationResultSchema,
+  VariableListResultSchema,
+  VariableMutationResultSchema,
+  type SecretListResult,
+  type SecretMutationResult,
+  type VariableListResult,
+  type VariableMutationResult,
+} from "../schemas/index.js";
+import {
+  formatSecretList,
+  formatSecretMutation,
+  formatVariableList,
+  formatVariableMutation,
+} from "../lib/formatters.js";
+
+const SECRET_LIST_FIELDS = "name,updatedAt,visibility,numSelectedRepos,selectedReposURL";
+const VARIABLE_LIST_FIELDS =
+  "name,value,createdAt,updatedAt,visibility,numSelectedRepos,selectedReposURL";
+
+const visibilityInput = z
+  .enum(["all", "private", "selected"])
+  .optional()
+  .describe("Organization visibility: all, private, or selected");
+const appInput = z
+  .enum(["actions", "codespaces", "dependabot"])
+  .optional()
+  .describe("GitHub app scope for secrets: actions, codespaces, or dependabot");
+const reposInput = z
+  .array(z.string().max(INPUT_LIMITS.SHORT_STRING_MAX))
+  .max(INPUT_LIMITS.ARRAY_MAX)
+  .optional()
+  .describe(
+    "Repositories that can access an organization secret/variable when visibility=selected",
+  );
+
+type ConfigScope = "repo" | "org" | "environment";
+type ConfigError = "not-found" | "permission-denied" | "validation" | "unknown";
+
+function classifyConfigError(text: string): ConfigError {
+  const lower = text.toLowerCase();
+  if (/not found|could not resolve|unknown repository|unknown environment/.test(lower)) {
+    return "not-found";
+  }
+  if (/forbidden|permission|403|must have admin rights|requires.*scope|oauth/.test(lower)) {
+    return "permission-denied";
+  }
+  if (/validation|invalid|required|unprocessable|visibility|repository/.test(lower)) {
+    return "validation";
+  }
+  return "unknown";
+}
+
+function scopeFor(org?: string, env?: string): ConfigScope {
+  if (org) return "org";
+  if (env) return "environment";
+  return "repo";
+}
+
+function assertScopeInputs(name: string, repo?: string, org?: string, env?: string) {
+  assertNoFlagInjection(name, "name");
+  if (repo) assertNoFlagInjection(repo, "repo");
+  if (org) assertNoFlagInjection(org, "org");
+  if (env) assertNoFlagInjection(env, "env");
+  if (org && env) {
+    throw new Error("Use either org or env scope, not both.");
+  }
+}
+
+function addScopeArgs(args: string[], repo?: string, org?: string, env?: string) {
+  if (repo) args.push("--repo", repo);
+  if (org) args.push("--org", org);
+  if (env) args.push("--env", env);
+}
+
+function addOrgVisibilityArgs(
+  args: string[],
+  org: string | undefined,
+  visibility: "all" | "private" | "selected" | undefined,
+  repos: string[] | undefined,
+) {
+  if (!org) return;
+  if (visibility) args.push("--visibility", visibility);
+  if (repos && repos.length > 0) {
+    for (const repo of repos) assertNoFlagInjection(repo, "repos");
+    args.push("--repos", repos.join(","));
+  }
+}
+
+function mutationError<T extends SecretMutationResult | VariableMutationResult>(
+  base: T,
+  result: { stdout: string; stderr: string },
+): T {
+  const combined = `${result.stdout}\n${result.stderr}`.trim();
+  return {
+    ...base,
+    errorType: classifyConfigError(combined),
+    errorMessage: combined || "gh command failed",
+  };
+}
+
+function listError<T extends SecretListResult | VariableListResult>(
+  base: T,
+  result: { stdout: string; stderr: string },
+): T {
+  const combined = `${result.stdout}\n${result.stderr}`.trim();
+  return {
+    ...base,
+    errorType: classifyConfigError(combined),
+    errorMessage: combined || "gh command failed",
+  };
+}
+
+export function registerSecretSetTool(server: McpServer) {
+  server.registerTool(
+    "secret-set",
+    {
+      title: "Secret Set",
+      description:
+        "Sets a repository, organization, or environment GitHub Actions secret. Secret values are sent via stdin and never returned.",
+      annotations: { openWorldHint: true },
+      inputSchema: {
+        name: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Secret name"),
+        value: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Secret value"),
+        repo: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Repository in OWNER/REPO format (default: current repo)"),
+        org: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Organization"),
+        env: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Deployment environment name"),
+        visibility: visibilityInput,
+        repos: reposInput,
+        app: appInput,
+        path: repoPathInput,
+      },
+      outputSchema: SecretMutationResultSchema,
+    },
+    async ({ name, value, repo, org, env, visibility, repos, app, path }) => {
+      const cwd = path || process.cwd();
+      assertScopeInputs(name, repo, org, env);
+      if (app) assertNoFlagInjection(app, "app");
+
+      const scope = scopeFor(org, env);
+      const args = ["secret", "set", name];
+      addScopeArgs(args, repo, org, env);
+      addOrgVisibilityArgs(args, org, visibility, repos);
+      if (app) args.push("--app", app);
+
+      const base: SecretMutationResult = { name, action: "set", scope, secretValueMasked: true };
+      const result = await ghCmd(args, { cwd, stdin: value });
+      if (result.exitCode !== 0) {
+        return dualOutput(mutationError(base, result), formatSecretMutation);
+      }
+      return dualOutput(base, formatSecretMutation);
+    },
+  );
+}
+
+export function registerSecretListTool(server: McpServer) {
+  server.registerTool(
+    "secret-list",
+    {
+      title: "Secret List",
+      description:
+        "Lists repository, organization, or environment secret names and metadata. Secret values are not exposed by GitHub.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      inputSchema: {
+        repo: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Repository in OWNER/REPO format (default: current repo)"),
+        org: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Organization"),
+        env: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Deployment environment name"),
+        app: appInput,
+        path: repoPathInput,
+      },
+      outputSchema: SecretListResultSchema,
+    },
+    async ({ repo, org, env, app, path }) => {
+      const cwd = path || process.cwd();
+      assertScopeInputs("secret-list", repo, org, env);
+      if (app) assertNoFlagInjection(app, "app");
+
+      const scope = scopeFor(org, env);
+      const args = ["secret", "list", "--json", SECRET_LIST_FIELDS];
+      addScopeArgs(args, repo, org, env);
+      if (app) args.push("--app", app);
+
+      const result = await ghCmd(args, cwd);
+      const base: SecretListResult = { secrets: [], scope };
+      if (result.exitCode !== 0) {
+        return dualOutput(listError(base, result), formatSecretList);
+      }
+      return dualOutput(
+        { secrets: JSON.parse(result.stdout) as SecretListResult["secrets"], scope },
+        formatSecretList,
+      );
+    },
+  );
+}
+
+export function registerSecretDeleteTool(server: McpServer) {
+  server.registerTool(
+    "secret-delete",
+    {
+      title: "Secret Delete",
+      description: "Deletes a repository, organization, or environment GitHub Actions secret.",
+      annotations: { openWorldHint: true },
+      inputSchema: {
+        name: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Secret name"),
+        repo: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Repository in OWNER/REPO format (default: current repo)"),
+        org: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Organization"),
+        env: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Deployment environment name"),
+        app: appInput,
+        path: repoPathInput,
+      },
+      outputSchema: SecretMutationResultSchema,
+    },
+    async ({ name, repo, org, env, app, path }) => {
+      const cwd = path || process.cwd();
+      assertScopeInputs(name, repo, org, env);
+      if (app) assertNoFlagInjection(app, "app");
+
+      const scope = scopeFor(org, env);
+      const args = ["secret", "delete", name];
+      addScopeArgs(args, repo, org, env);
+      if (app) args.push("--app", app);
+
+      const base: SecretMutationResult = {
+        name,
+        action: "delete",
+        scope,
+        secretValueMasked: true,
+      };
+      const result = await ghCmd(args, cwd);
+      if (result.exitCode !== 0) {
+        return dualOutput(mutationError(base, result), formatSecretMutation);
+      }
+      return dualOutput(base, formatSecretMutation);
+    },
+  );
+}
+
+export function registerVariableSetTool(server: McpServer) {
+  server.registerTool(
+    "variable-set",
+    {
+      title: "Variable Set",
+      description:
+        "Sets a repository, organization, or environment GitHub Actions variable. Variables are not secret and may be visible in logs.",
+      annotations: { openWorldHint: true },
+      inputSchema: {
+        name: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Variable name"),
+        value: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Variable value"),
+        repo: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Repository in OWNER/REPO format (default: current repo)"),
+        org: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Organization"),
+        env: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Deployment environment name"),
+        visibility: visibilityInput,
+        repos: reposInput,
+        path: repoPathInput,
+      },
+      outputSchema: VariableMutationResultSchema,
+    },
+    async ({ name, value, repo, org, env, visibility, repos, path }) => {
+      const cwd = path || process.cwd();
+      assertScopeInputs(name, repo, org, env);
+
+      const scope = scopeFor(org, env);
+      const args = ["variable", "set", name];
+      addScopeArgs(args, repo, org, env);
+      addOrgVisibilityArgs(args, org, visibility, repos);
+
+      const base: VariableMutationResult = { name, action: "set", scope };
+      const result = await ghCmd(args, { cwd, stdin: value });
+      if (result.exitCode !== 0) {
+        return dualOutput(mutationError(base, result), formatVariableMutation);
+      }
+      return dualOutput(base, formatVariableMutation);
+    },
+  );
+}
+
+export function registerVariableListTool(server: McpServer) {
+  server.registerTool(
+    "variable-list",
+    {
+      title: "Variable List",
+      description:
+        "Lists repository, organization, or environment GitHub Actions variables with values and metadata.",
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      inputSchema: {
+        repo: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Repository in OWNER/REPO format (default: current repo)"),
+        org: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Organization"),
+        env: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Deployment environment name"),
+        path: repoPathInput,
+      },
+      outputSchema: VariableListResultSchema,
+    },
+    async ({ repo, org, env, path }) => {
+      const cwd = path || process.cwd();
+      assertScopeInputs("variable-list", repo, org, env);
+
+      const scope = scopeFor(org, env);
+      const args = ["variable", "list", "--json", VARIABLE_LIST_FIELDS];
+      addScopeArgs(args, repo, org, env);
+
+      const result = await ghCmd(args, cwd);
+      const base: VariableListResult = { variables: [], scope };
+      if (result.exitCode !== 0) {
+        return dualOutput(listError(base, result), formatVariableList);
+      }
+      return dualOutput(
+        { variables: JSON.parse(result.stdout) as VariableListResult["variables"], scope },
+        formatVariableList,
+      );
+    },
+  );
+}
+
+export function registerVariableDeleteTool(server: McpServer) {
+  server.registerTool(
+    "variable-delete",
+    {
+      title: "Variable Delete",
+      description: "Deletes a repository, organization, or environment GitHub Actions variable.",
+      annotations: { openWorldHint: true },
+      inputSchema: {
+        name: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).describe("Variable name"),
+        repo: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Repository in OWNER/REPO format (default: current repo)"),
+        org: z.string().max(INPUT_LIMITS.SHORT_STRING_MAX).optional().describe("Organization"),
+        env: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe("Deployment environment name"),
+        path: repoPathInput,
+      },
+      outputSchema: VariableMutationResultSchema,
+    },
+    async ({ name, repo, org, env, path }) => {
+      const cwd = path || process.cwd();
+      assertScopeInputs(name, repo, org, env);
+
+      const scope = scopeFor(org, env);
+      const args = ["variable", "delete", name];
+      addScopeArgs(args, repo, org, env);
+
+      const base: VariableMutationResult = { name, action: "delete", scope };
+      const result = await ghCmd(args, cwd);
+      if (result.exitCode !== 0) {
+        return dualOutput(mutationError(base, result), formatVariableMutation);
+      }
+      return dualOutput(base, formatVariableMutation);
+    },
+  );
+}


### PR DESCRIPTION
Closes #883.

## Summary

Adds first-class `pare-github` tools for GitHub Actions secrets and variables:

- `secret-set`, `secret-list`, `secret-delete`
- `variable-set`, `variable-list`, `variable-delete`
- repo, org, and environment scopes
- org visibility and selected repository inputs for set operations
- secret values sent via stdin and masked from structured output
- README examples and minor changeset

## Validation

- `pnpm --filter @paretools/github exec vitest run __tests__/secrets-variables.test.ts`
- `pnpm --filter @paretools/github test`
- `pnpm --filter @paretools/github build`
- `pnpm exec prettier --check packages/server-github/src/tools/secrets-variables.ts packages/server-github/src/tools/index.ts packages/server-github/src/schemas/index.ts packages/server-github/src/lib/formatters.ts packages/server-github/__tests__/secrets-variables.test.ts packages/server-github/__tests__/integration.test.ts packages/server-github/README.md .changeset/add-github-secrets-variables.md`
