### PR TITLE
docs: document python interpreter resolution

### DIFF
--- a/.changeset/docs-python-interpreter-resolution.md
+++ b/.changeset/docs-python-interpreter-resolution.md
@@ -1,0 +1,6 @@
+---
+"@paretools/python": patch
+"@paretools/test": patch
+---
+
+Document Python interpreter resolution order, virtualenv detection, `python -m` fallbacks, and explicit interpreter override inputs for Python-backed tools.

--- a/packages/server-python/README.md
+++ b/packages/server-python/README.md
@@ -61,6 +61,17 @@ Add to your MCP client config:
 }
 ```
 
+## Python Interpreter Resolution
+
+Python-backed tools prefer the project-local virtual environment before falling back to global commands. When a tool needs Python, Pare checks for interpreters in this order from the requested `path`:
+
+1. `.venv/bin/python`, `.venv/bin/python3` (or `.venv/Scripts/python.exe` on Windows)
+2. `venv/` and `env/` with the same platform-specific interpreter names
+3. `python`
+4. `python3`
+
+Tools such as `ruff-check`, `ruff-format`, `pytest`, `mypy`, `pip-install`, `pip-audit`, and `black` also fall back from a missing console script to `python -m <module>`. Use `pythonPath` on `ruff-check`, `ruff-format`, `pytest`, and `mypy` when a project needs an explicit interpreter override.
+
 ## All Pare Servers (244 tools)
 
 | Package                                                              | Tools                                                                       | Wraps                              |

--- a/packages/server-test/README.md
+++ b/packages/server-test/README.md
@@ -63,6 +63,12 @@ Add to your MCP client config:
 
 This package runs real downstream suites (including `@paretools/git` integration tests), so lower global limits like 120s can fail due to cumulative runtime on slower CI/Windows runners.
 
+## Pytest Interpreter Resolution
+
+For `framework: "pytest"`, `run` and `coverage` use the shared Python interpreter resolver. Pare checks `.venv/`, `venv/`, and `env/` under the requested `path` before falling back to `python` and then `python3`, and invokes pytest as `python -m pytest`.
+
+Use the `interpreter` input to point at a specific Python executable when auto-detection is not enough.
+
 ## Test Batching (Maintainers)
 
 - `pnpm test:unit` runs fast parser/formatter/helper tests


### PR DESCRIPTION
Closes #884.
Closes #891.

## Summary

Adds the missing README documentation for the Python interpreter resolution behavior implemented in #899:

- project virtualenv lookup order: `.venv`, `venv`, `env`
- fallback from `python` to `python3`
- fallback from missing console scripts to `python -m <module>`
- `pythonPath` and `interpreter` override inputs

## Validation

- `pnpm exec prettier --check packages/server-python/README.md packages/server-test/README.md .changeset/docs-python-interpreter-resolution.md`
