### PR TITLE
fix: handle empty stdout in parseLabelList when gh search matches zero labels (#903)

### DIFF
--- a/.changeset/fix-github-label-list-empty-stdout.md
+++ b/.changeset/fix-github-label-list-empty-stdout.md
@@ -1,0 +1,5 @@
+---
+"@paretools/github": patch
+---
+
+Fix `label-list` crashing with "Unexpected end of JSON input" when `--search` matches zero labels. `gh label list --search <term>` exits 0 but prints empty stdout (not `[]`); `parseLabelList` now treats empty/whitespace-only output as an empty list. Closes #903.

--- a/packages/server-github/__tests__/parsers.test.ts
+++ b/packages/server-github/__tests__/parsers.test.ts
@@ -868,6 +868,16 @@ describe("parseLabelList", () => {
     expect(result.labels).toEqual([]);
   });
 
+  it("handles empty stdout (gh label list --search returns nothing when no match)", () => {
+    // `gh label list --search <term>` exits 0 but prints empty stdout when no
+    // labels match. Ensure we return an empty list rather than throwing
+    // "Unexpected end of JSON input".
+    expect(() => parseLabelList("")).not.toThrow();
+    expect(parseLabelList("").labels).toEqual([]);
+    expect(parseLabelList("   ").labels).toEqual([]);
+    expect(parseLabelList("\n").labels).toEqual([]);
+  });
+
   it("handles missing optional fields", () => {
     const json = JSON.stringify([{ name: "test" }]);
 

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -920,9 +920,13 @@ export function parseGistCreate(
 
 /**
  * Parses `gh label list --json ...` output into structured label list data.
+ * Handles empty stdout gracefully: `gh label list --search <term>` exits 0 but
+ * prints nothing (not `[]`) when no labels match. Treat that as an empty list
+ * rather than letting `JSON.parse("")` throw "Unexpected end of JSON input".
  */
 export function parseLabelList(json: string): LabelListResult {
-  const raw = JSON.parse(json);
+  const trimmed = json.trim();
+  const raw = trimmed ? JSON.parse(trimmed) : [];
   const items = Array.isArray(raw) ? raw : [];
 
   const labels = items.map(


### PR DESCRIPTION
## What does this PR do?

`gh label list --search <term>` exits 0 but prints empty stdout (not `[]`) when no
labels match. `parseLabelList` passed that empty string directly to `JSON.parse`, which
threw `"Unexpected end of JSON input"`, crashing every "does label X exist?" lookup
whenever the label was absent.

## Type of change

- [x] Bug fix

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] All tools use `outputSchema` + `structuredContent`
- [ ] Human-readable `content` fallback included
- [x] Changeset added (`pnpm changeset`)

## Changes

- `packages/server-github/src/lib/parsers.ts`: trim input and treat empty/whitespace-only string as `[]` before calling `JSON.parse`
- `packages/server-github/__tests__/parsers.test.ts`: four new assertions for `""`, `"   "`, and `"\n"` inputs

Fixes #903