### PR TITLE
fix(github): guard list/view parsers against empty stdout

### DIFF
--- a/.changeset/fix-github-empty-stdout-parsers-905.md
+++ b/.changeset/fix-github-empty-stdout-parsers-905.md
@@ -1,0 +1,5 @@
+---
+"@paretools/github": patch
+---
+
+Guard list/view parsers against empty stdout from `gh` commands (e.g. `gh pr list --search`, `gh issue list`) that exit 0 with no output, instead of throwing "Unexpected end of JSON input". Closes #905.

--- a/packages/server-github/__tests__/parsers.test.ts
+++ b/packages/server-github/__tests__/parsers.test.ts
@@ -1670,3 +1670,88 @@ describe("parseRunRerun — job and failed-only modes", () => {
     expect(result.status).toBe("requested-full");
   });
 });
+
+// ── Empty / whitespace stdout guards (#905) ─────────────────────────
+//
+// Several `gh ... list` and `gh ... view` commands can exit 0 but print EMPTY
+// stdout (not `[]` / `{}`) when nothing matches — e.g. `gh pr list --search`,
+// `gh issue list`. Passing that to `JSON.parse` throws
+// "Unexpected end of JSON input". These parsers must treat empty/whitespace
+// input as an empty/default result rather than throwing.
+describe("empty/whitespace stdout guards (#905)", () => {
+  const EMPTY_INPUTS = ["", "   ", "\n"];
+
+  describe("array/list parsers return an empty list", () => {
+    for (const input of EMPTY_INPUTS) {
+      const label = JSON.stringify(input);
+
+      it(`parsePrList(${label})`, () => {
+        expect(() => parsePrList(input)).not.toThrow();
+        expect(parsePrList(input).prs).toEqual([]);
+      });
+
+      it(`parseIssueList(${label})`, () => {
+        expect(() => parseIssueList(input)).not.toThrow();
+        expect(parseIssueList(input).issues).toEqual([]);
+      });
+
+      it(`parseRunList(${label})`, () => {
+        expect(() => parseRunList(input)).not.toThrow();
+        expect(parseRunList(input).runs).toEqual([]);
+      });
+
+      it(`parseReleaseList(${label})`, () => {
+        expect(() => parseReleaseList(input)).not.toThrow();
+        expect(parseReleaseList(input).releases).toEqual([]);
+      });
+
+      it(`parseDiscussionList(${label})`, () => {
+        expect(() => parseDiscussionList(input)).not.toThrow();
+        expect(parseDiscussionList(input).discussions).toEqual([]);
+      });
+    }
+  });
+
+  describe("view/object parsers return a default result", () => {
+    for (const input of EMPTY_INPUTS) {
+      const label = JSON.stringify(input);
+
+      it(`parsePrView(${label})`, () => {
+        expect(() => parsePrView(input)).not.toThrow();
+        const result = parsePrView(input);
+        // Defaults are applied; array-bearing fields stay empty.
+        expect(result.checks).toEqual([]);
+        expect(result.mergeable).toBe("UNKNOWN");
+      });
+
+      it(`parsePrChecks(${label})`, () => {
+        expect(() => parsePrChecks(input, 7)).not.toThrow();
+        const result = parsePrChecks(input, 7);
+        expect(result.pr).toBe(7);
+        expect(result.checks).toEqual([]);
+        expect(result.summary.total).toBe(0);
+      });
+
+      it(`parseIssueView(${label})`, () => {
+        expect(() => parseIssueView(input)).not.toThrow();
+        const result = parseIssueView(input);
+        expect(result.labels).toEqual([]);
+        expect(result.assignees).toEqual([]);
+      });
+
+      it(`parseRunView(${label})`, () => {
+        expect(() => parseRunView(input)).not.toThrow();
+        const result = parseRunView(input);
+        expect(result.jobs).toEqual([]);
+      });
+
+      it(`parseRepoView(${label})`, () => {
+        expect(() => parseRepoView(input)).not.toThrow();
+        const result = parseRepoView(input);
+        expect(result.name).toBe("");
+        expect(result.defaultBranch).toBe("main");
+        expect(result.stars).toBe(0);
+      });
+    }
+  });
+});

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -30,11 +30,46 @@ import type {
 } from "../schemas/index.js";
 
 /**
+ * Safely parses JSON that is expected to be an array.
+ *
+ * Several `gh ... list` commands (e.g. `gh pr list --search`, `gh issue list`)
+ * exit 0 but print EMPTY stdout — not `[]` — when nothing matches. Passing that
+ * to `JSON.parse` throws "Unexpected end of JSON input". This helper treats
+ * empty/whitespace stdout as an empty array, and any non-array JSON value (null,
+ * object, etc.) as an empty array too, so list parsers never throw on it.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseJsonArray(json: string): any[] {
+  const trimmed = json.trim();
+  const raw = trimmed ? JSON.parse(trimmed) : [];
+  return Array.isArray(raw) ? raw : [];
+}
+
+/**
+ * Safely parses JSON that is expected to be a single object.
+ *
+ * `gh ... view --json` normally prints a JSON object, but a command can exit 0
+ * with EMPTY stdout in edge cases. Returning an empty object (instead of letting
+ * `JSON.parse("")` throw) lets view parsers fall back to their existing
+ * field-level defaults rather than crashing.
+ *
+ * Returns the parsed value typed as the original `JSON.parse` result so existing
+ * dynamic property access (`raw.foo?.bar`) continues to compile unchanged.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseJsonObject(json: string): any {
+  const trimmed = json.trim();
+  if (!trimmed) return {};
+  const raw = JSON.parse(trimmed);
+  return raw && typeof raw === "object" ? raw : {};
+}
+
+/**
  * Parses `gh pr view --json ...` output into structured PR view data.
  * Renames gh field names to our schema names (e.g., headRefName → headBranch).
  */
 export function parsePrView(json: string): PrViewResult {
-  const raw = JSON.parse(json);
+  const raw = parseJsonObject(json);
 
   const checks = (raw.statusCheckRollup ?? []).map(
     (c: {
@@ -109,8 +144,7 @@ export function parsePrView(json: string): PrViewResult {
  * Parses `gh pr list --json ...` output into structured PR list data.
  */
 export function parsePrList(json: string): PrListResult {
-  const raw = JSON.parse(json);
-  const items = Array.isArray(raw) ? raw : [];
+  const items = parseJsonArray(json);
 
   const prs = items.map(
     (pr: {
@@ -315,8 +349,7 @@ function classifyReviewError(stderr: string): PrReviewResult["errorType"] {
  * (determined by completedAt, then startedAt, with later entries winning ties).
  */
 export function parsePrChecks(json: string, pr: number): PrChecksResult {
-  const raw = JSON.parse(json);
-  const items = Array.isArray(raw) ? raw : [];
+  const items = parseJsonArray(json);
 
   const allChecks = items.map(
     (c: {
@@ -378,7 +411,7 @@ export function parsePrChecks(json: string, pr: number): PrChecksResult {
  * Parses `gh issue view --json ...` output into structured issue view data.
  */
 export function parseIssueView(json: string): IssueViewResult {
-  const raw = JSON.parse(json);
+  const raw = parseJsonObject(json);
 
   return {
     number: raw.number,
@@ -406,8 +439,7 @@ export function parseIssueView(json: string): IssueViewResult {
  * Parses `gh issue list --json ...` output into structured issue list data.
  */
 export function parseIssueList(json: string): IssueListResult {
-  const raw = JSON.parse(json);
-  const items = Array.isArray(raw) ? raw : [];
+  const items = parseJsonArray(json);
 
   const issues = items.map(
     (issue: {
@@ -585,7 +617,7 @@ export function parseIssueUpdate(
  * S-gap: Enhanced to include job steps, headSha, event, startedAt, attempt.
  */
 export function parseRunView(json: string): RunViewResult {
-  const raw = JSON.parse(json);
+  const raw = parseJsonObject(json);
 
   const jobs = (raw.jobs ?? []).map(
     (j: {
@@ -631,8 +663,7 @@ export function parseRunView(json: string): RunViewResult {
  * Parses `gh run list --json ...` output into structured run list data.
  */
 export function parseRunList(json: string): RunListResult {
-  const raw = JSON.parse(json);
-  const items = Array.isArray(raw) ? raw : [];
+  const items = parseJsonArray(json);
 
   const runs = items.map(
     (r: {
@@ -742,8 +773,7 @@ export function parseReleaseCreate(
  * avoid `Unknown JSON field: "url"` errors from gh. See issue #868.
  */
 export function parseReleaseList(json: string): ReleaseListResult {
-  const raw = JSON.parse(json);
-  const items = Array.isArray(raw) ? raw : [];
+  const items = parseJsonArray(json);
 
   const releases = items.map(
     (r: {
@@ -925,9 +955,7 @@ export function parseGistCreate(
  * rather than letting `JSON.parse("")` throw "Unexpected end of JSON input".
  */
 export function parseLabelList(json: string): LabelListResult {
-  const trimmed = json.trim();
-  const raw = trimmed ? JSON.parse(trimmed) : [];
-  const items = Array.isArray(raw) ? raw : [];
+  const items = parseJsonArray(json);
 
   const labels = items.map(
     (l: { name: string; description: string; color: string; isDefault: boolean }) => ({
@@ -972,7 +1000,7 @@ export function parseLabelCreate(
  * Renames gh field names to our schema names (e.g., stargazerCount -> stars).
  */
 export function parseRepoView(json: string): RepoViewResult {
-  const raw = JSON.parse(json);
+  const raw = parseJsonObject(json);
 
   return {
     name: raw.name ?? "",
@@ -1023,7 +1051,7 @@ export function parseRepoClone(
  * The GraphQL response contains a repository.discussions object with nodes and totalCount.
  */
 export function parseDiscussionList(json: string): DiscussionListResult {
-  const raw = JSON.parse(json);
+  const raw = parseJsonObject(json);
   const data = raw.data?.repository?.discussions ?? {};
   const nodes = Array.isArray(data.nodes) ? data.nodes : [];
 


### PR DESCRIPTION
## Summary

Several `gh ... list` and `gh ... view` commands (e.g. `gh pr list --search`, `gh issue list`) exit 0 but print **empty** stdout — not `[]`/`{}` — when nothing matches. The parsers called `JSON.parse(stdout)` with no guard, so `JSON.parse("")` threw `"Unexpected end of JSON input"`.

This mirrors the fix already applied to `parseLabelList` in #904.

### Changes
- Add two small shared helpers in `parsers.ts`:
  - `parseJsonArray(json)` — treats empty/whitespace input (and any non-array JSON) as `[]`.
  - `parseJsonObject(json)` — treats empty/whitespace input as `{}`, so view parsers fall back to their existing field-level defaults.
- Use `parseJsonArray` in the list parsers: `parsePrList`, `parseIssueList`, `parseRunList`, `parseReleaseList`, `parseDiscussionList`, and `parseLabelList` (refactored to share the helper).
- Use `parseJsonObject` in the view parsers: `parsePrView`, `parsePrChecks`, `parseIssueView`, `parseRunView`, `parseRepoView`.
- Behavior for valid non-empty input is unchanged.

### Tests
- Added a `#905` describe block asserting that `""`, `"   "`, and `"\n"` inputs return an empty/default result (no throw) for every touched parser.
- Full github package suite: 569 passing.

## Test plan
- [x] `pnpm --filter @paretools/github build`
- [x] `pnpm --filter @paretools/github test` (569 passing)
- [x] `pnpm --filter @paretools/github lint`
- [x] `prettier --check` on changed files

Closes #905.