### PR TITLE
fix(git): make worktree list listVerbose work without --porcelain conflict

### DIFF
--- a/.changeset/fix-git-worktree-listverbose-906.md
+++ b/.changeset/fix-git-worktree-listverbose-906.md
@@ -1,0 +1,5 @@
+---
+"@paretools/git": patch
+---
+
+Fix `worktree` list with `listVerbose=true` crashing on git's `--verbose`/`--porcelain` conflict; locked/prunable detail (including prunable reason) is now surfaced via the porcelain parser. Closes #906.

--- a/packages/server-git/__tests__/p2-gaps.test.ts
+++ b/packages/server-git/__tests__/p2-gaps.test.ts
@@ -523,4 +523,56 @@ describe("Git P2 gaps", () => {
     await handler({ action: "repair", repairPaths: ["/tmp/a", "/tmp/b"] });
     expect(vi.mocked(git).mock.calls[0][0]).toEqual(["worktree", "repair", "/tmp/a", "/tmp/b"]);
   });
+
+  it("#906 worktree list with listVerbose never passes -v alongside --porcelain", async () => {
+    const server = new FakeServer();
+    registerWorktreeTool(server as never);
+    const handler = server.tools.get("worktree")!.handler;
+    // Porcelain output already carries the locked/prunable detail that -v surfaces.
+    vi.mocked(git).mockResolvedValueOnce({
+      stdout: [
+        "worktree /home/user/repo",
+        "HEAD abc1234567890abcdef1234567890abcdef123456",
+        "branch refs/heads/main",
+        "",
+        "worktree /home/user/repo-locked",
+        "HEAD def5678901234567890abcdef1234567890abcdef",
+        "branch refs/heads/feature",
+        "locked maintenance window",
+        "",
+        "worktree /home/user/repo-stale",
+        "HEAD 0123456789abcdef0123456789abcdef01234567",
+        "branch refs/heads/old",
+        "prunable gitdir file points to non-existent location",
+        "",
+      ].join("\n"),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = (await handler({ action: "list", listVerbose: true, compact: false })) as {
+      structuredContent: {
+        worktrees: Array<{
+          path: string;
+          locked?: boolean;
+          lockReason?: string;
+          prunable?: boolean;
+          prunableReason?: string;
+        }>;
+      };
+    };
+
+    // The flag conflict (#906) is avoided: only --porcelain is passed, never -v.
+    expect(vi.mocked(git).mock.calls[0][0]).toEqual(["worktree", "list", "--porcelain"]);
+    expect(vi.mocked(git).mock.calls[0][0]).not.toContain("-v");
+    expect(vi.mocked(git).mock.calls[0][0]).not.toContain("--verbose");
+
+    // Locked/prunable detail is surfaced in the structured output.
+    const worktrees = result.structuredContent.worktrees;
+    expect(worktrees).toHaveLength(3);
+    expect(worktrees[1].locked).toBe(true);
+    expect(worktrees[1].lockReason).toBe("maintenance window");
+    expect(worktrees[2].prunable).toBe(true);
+    expect(worktrees[2].prunableReason).toBe("gitdir file points to non-existent location");
+  });
 });

--- a/packages/server-git/__tests__/parsers.test.ts
+++ b/packages/server-git/__tests__/parsers.test.ts
@@ -1621,6 +1621,21 @@ describe("parseWorktreeList — locked/prunable fields", () => {
 
     const result = parseWorktreeList(stdout);
     expect(result.worktrees[0].prunable).toBe(true);
+    expect(result.worktrees[0].prunableReason).toBeUndefined();
+  });
+
+  it("parses prunable worktree with reason (#906)", () => {
+    const stdout = [
+      "worktree /home/user/repo-stale",
+      "HEAD abc1234567890abcdef1234567890abcdef123456",
+      "branch refs/heads/old-branch",
+      "prunable gitdir file points to non-existent location",
+      "",
+    ].join("\n");
+
+    const result = parseWorktreeList(stdout);
+    expect(result.worktrees[0].prunable).toBe(true);
+    expect(result.worktrees[0].prunableReason).toBe("gitdir file points to non-existent location");
   });
 
   it("parses locked and prunable worktree", () => {

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -702,7 +702,11 @@ export function formatWorktreeList(w: GitWorktreeListFull): string {
       const bare = wt.bare ? " [bare]" : "";
       const branch = wt.branch ? ` (${wt.branch})` : "";
       const locked = wt.locked ? (wt.lockReason ? ` [locked: ${wt.lockReason}]` : " [locked]") : "";
-      const prunable = wt.prunable ? " [prunable]" : "";
+      const prunable = wt.prunable
+        ? wt.prunableReason
+          ? ` [prunable: ${wt.prunableReason}]`
+          : " [prunable]"
+        : "";
       return `${wt.path}  ${wt.head.slice(0, 8)}${branch}${bare}${locked}${prunable}`;
     })
     .join("\n");

--- a/packages/server-git/src/lib/parsers.ts
+++ b/packages/server-git/src/lib/parsers.ts
@@ -1763,6 +1763,7 @@ export function parseWorktreeList(stdout: string): GitWorktreeListFull {
     let locked: boolean | undefined;
     let lockReason: string | undefined;
     let prunable: boolean | undefined;
+    let prunableReason: string | undefined;
 
     for (const line of lines) {
       if (line.startsWith("worktree ")) {
@@ -1782,6 +1783,8 @@ export function parseWorktreeList(stdout: string): GitWorktreeListFull {
         if (reason) lockReason = reason;
       } else if (line === "prunable" || line.startsWith("prunable ")) {
         prunable = true;
+        const reason = line.slice("prunable".length).trim();
+        if (reason) prunableReason = reason;
       }
     }
 
@@ -1793,6 +1796,7 @@ export function parseWorktreeList(stdout: string): GitWorktreeListFull {
       ...(locked ? { locked } : {}),
       ...(lockReason ? { lockReason } : {}),
       ...(prunable ? { prunable } : {}),
+      ...(prunableReason ? { prunableReason } : {}),
     };
   });
 

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -597,6 +597,7 @@ export const GitWorktreeEntrySchema = z.object({
   locked: z.boolean().optional(),
   lockReason: z.string().optional(),
   prunable: z.boolean().optional(),
+  prunableReason: z.string().optional(),
 });
 
 /** Zod schema for structured git worktree list output. */
@@ -614,6 +615,7 @@ export type GitWorktreeListFull = {
     locked?: boolean;
     lockReason?: string;
     prunable?: boolean;
+    prunableReason?: string;
   }>;
 };
 

--- a/packages/server-git/src/tools/worktree.ts
+++ b/packages/server-git/src/tools/worktree.ts
@@ -73,7 +73,9 @@ export function registerWorktreeTool(server: McpServer) {
         listVerbose: z
           .boolean()
           .optional()
-          .describe("Verbose list output showing locked/prunable details (-v on list)"),
+          .describe(
+            "Include locked/prunable details on list. Always surfaced via the porcelain parser; this flag is accepted for compatibility and never passes git's -v (which conflicts with --porcelain).",
+          ),
         reason: z
           .string()
           .max(INPUT_LIMITS.STRING_MAX)
@@ -98,8 +100,12 @@ export function registerWorktreeTool(server: McpServer) {
       const action = params.action || "list";
 
       if (action === "list") {
+        // `--porcelain` already emits the `locked <reason>` and `prunable <reason>`
+        // attribute lines that `-v/--verbose` surfaces in the human format, and git
+        // rejects `--verbose` alongside `--porcelain` (they are mutually exclusive).
+        // So we never pass `-v` here — `listVerbose` is honored by the porcelain parser,
+        // which captures the locked/prunable detail into the structured output. See #906.
         const listArgs = ["worktree", "list", "--porcelain"];
-        if (params.listVerbose) listArgs.push("-v");
         const result = await git(listArgs, cwd);
 
         if (result.exitCode !== 0) {

--- a/tests/smoke/mocked/git-tools-4.smoke.test.ts
+++ b/tests/smoke/mocked/git-tools-4.smoke.test.ts
@@ -915,16 +915,25 @@ describe("Smoke: git.worktree", () => {
     expect(args).toContain("--reason=in use by CI");
   });
 
-  // S14: Verbose list
-  it("S14 [P2] listVerbose passes -v flag", async () => {
+  // S14: Verbose list — #906: -v conflicts with --porcelain, so listVerbose must
+  // never pass -v. Locked/prunable detail is surfaced via the porcelain parser instead.
+  it("S14 [P2] listVerbose surfaces locked/prunable detail without passing -v", async () => {
     mockGit(
       "worktree /home/user/project\nHEAD abc1234567890abcdef1234567890abcdef123456\nbranch refs/heads/main\n\n" +
         "worktree /home/user/project-wt\nHEAD def5678901234567890abcdef1234567890abcdef\nbranch refs/heads/feature\nlocked in use\n\n",
     );
 
-    await callAndValidate({ listVerbose: true });
+    const { parsed } = await callAndValidate({ listVerbose: true, compact: false });
     const args = vi.mocked(git).mock.calls[0][0];
-    expect(args).toContain("-v");
+    // git rejects --verbose alongside --porcelain, so -v must not be passed.
+    expect(args).toEqual(["worktree", "list", "--porcelain"]);
+    expect(args).not.toContain("-v");
+    expect(args).not.toContain("--verbose");
+
+    // Locked detail comes through the porcelain parser.
+    const worktrees = parsed.worktrees as Array<Record<string, unknown>>;
+    expect(worktrees[1].locked).toBe(true);
+    expect(worktrees[1].lockReason).toBe("in use");
   });
 
   // S15: Compact vs full output


### PR DESCRIPTION
## Summary

The `worktree` tool with `action=list` and `listVerbose=true` crashed:

```
git worktree list failed: fatal: options '--verbose' and '--porcelain' cannot be used together
```

The list implementation always passes `--porcelain` (for structured parsing) but also added `-v` when `listVerbose=true`; git rejects that combination, leaving `listVerbose` unusable.

## Fix

- Never emit `-v` alongside `--porcelain`. `git worktree list --porcelain` already emits the `locked <reason>` and `prunable <reason>` attribute lines that `--verbose` surfaces, so the porcelain parser captures the locked/prunable detail and `listVerbose` is honored without the flag conflict.
- Parse the `prunable <reason>` detail into a new optional `prunableReason` field (schema + formatter updated) so verbose detail is fully surfaced.
- `listVerbose` is kept in the input schema for compatibility; its description now documents that it is honored via the porcelain parser and never passes git's `-v`.

## Tests

- New parser test: `prunable <reason>` is captured into `prunableReason`.
- New tool test (#906): `action=list listVerbose=true` invokes git with only `["worktree", "list", "--porcelain"]` (never `-v`/`--verbose`) and returns structured locked/prunable detail without error.
- Full `@paretools/git` suite passes (695 tests).

## Test plan

- [x] `pnpm --filter @paretools/git build`
- [x] `pnpm --filter @paretools/git test`
- [x] lint + format:check clean on changed files

Closes #906.