### PR TITLE
fix(git): make path authoritative for worktree cwd resolution (#876)

### DIFF
--- a/.changeset/fix-git-worktree-cwd-876.md
+++ b/.changeset/fix-git-worktree-cwd-876.md
@@ -1,0 +1,6 @@
+---
+"@paretools/git": patch
+"@paretools/shared": patch
+---
+
+Clarify that the `path` parameter is authoritative: when omitted, repo-scoped tools operate on the server's own process working directory (its launch dir), not the caller's cwd. Callers in a git worktree or other directory must pass `path` explicitly to avoid operating on the wrong repository. Adds a regression test, documents the behavior in mutating git tool descriptions and the README, and updates the shared `repoPathInput` schema description. Closes #876.

--- a/packages/server-git/README.md
+++ b/packages/server-git/README.md
@@ -41,6 +41,32 @@ Add to your MCP client config:
 }
 ```
 
+## The `path` parameter is authoritative
+
+Every tool accepts an optional `path` parameter pointing at the target repository
+or git worktree. **When `path` is omitted, the server operates on its own process
+working directory** — i.e. the directory the MCP server was launched in, **not the
+directory of the client that issued the call.**
+
+An MCP server is a long-lived process and fundamentally cannot know the calling
+client's current directory. This matters when the caller runs somewhere other than
+the server's launch directory — most notably inside a **git worktree** (e.g. a
+background agent following an isolated-worktree workflow):
+
+- Read tools (`status`, `diff`, `log`, …) will report the launch-dir repo, which
+  can look misleadingly "clean" while your worktree is dirty.
+- Mutating tools (`checkout`, `commit`, `add`, `reset`, `branch`, …) will operate
+  on the launch-dir repo — for example moving a branch in the **wrong** worktree.
+
+**Always pass `path` explicitly** when calling from a worktree, subdirectory, or any
+location other than where the server was launched:
+
+```jsonc
+// Correct — operates on the caller's worktree
+status   { "path": "/path/to/my/worktree" }
+checkout { "path": "/path/to/my/worktree", "branch": "feature", "create": true }
+```
+
 ## Example
 
 **`status` output:**

--- a/packages/server-git/__tests__/worktree-cwd.test.ts
+++ b/packages/server-git/__tests__/worktree-cwd.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { resolve, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const PKG_DIR = resolve(__dirname, "..");
+const SERVER_PATH = resolve(__dirname, "../dist/index.js");
+const CALL_TIMEOUT = 180_000;
+
+let built = false;
+function ensureBuiltArtifacts() {
+  if (built) return;
+  execFileSync("pnpm", ["build"], {
+    cwd: PKG_DIR,
+    encoding: "utf-8",
+    shell: process.platform === "win32",
+  });
+  built = true;
+}
+
+function gitIn(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8" });
+}
+
+/**
+ * Regression coverage for #876.
+ *
+ * pare-git is a long-lived MCP server: its `process.cwd()` is its launch dir,
+ * NOT the calling client's directory. The reported symptoms were:
+ *   - `status` reported clean on a dirty worktree (it actually read the launch dir)
+ *   - `checkout` created/moved branches in the parent worktree (data-corruption risk)
+ *
+ * Because an MCP server cannot know the client's cwd, the contract is that `path`
+ * is authoritative. These tests assert:
+ *   1. With explicit `path`, tools operate on THAT worktree (status sees the
+ *      dirty worktree; checkout creates the branch in the worktree, leaving the
+ *      main repo's HEAD untouched).
+ *   2. With `path` omitted, tools operate on the server's launch dir — which is
+ *      why callers in worktrees MUST pass `path`.
+ */
+describe("@paretools/git worktree cwd resolution (#876)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+  let mainRepo: string;
+  let worktree: string;
+
+  beforeAll(async () => {
+    ensureBuiltArtifacts();
+
+    // Build a main repo with one commit on a known branch.
+    mainRepo = mkdtempSync(join(tmpdir(), "pare-git-876-main-"));
+    gitIn(mainRepo, ["init", "-b", "main-branch"]);
+    gitIn(mainRepo, ["config", "user.email", "test@test.com"]);
+    gitIn(mainRepo, ["config", "user.name", "Test"]);
+    writeFileSync(join(mainRepo, "file.txt"), "initial\n");
+    gitIn(mainRepo, ["add", "-A"]);
+    gitIn(mainRepo, ["commit", "-m", "init"]);
+
+    // Add a nested worktree checked out on its own branch.
+    worktree = join(mainRepo, "..", `pare-git-876-wt-${process.pid}`);
+    gitIn(mainRepo, ["worktree", "add", "-b", "wt-branch", worktree]);
+
+    // Launch the server with cwd = the MAIN repo (simulating: server launched
+    // in the main checkout, while the agent client lives in the worktree).
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [SERVER_PATH],
+      stderr: "pipe",
+      cwd: mainRepo,
+    });
+    client = new Client({ name: "test-client", version: "1.0.0" });
+    await client.connect(transport);
+  }, 180_000);
+
+  afterAll(async () => {
+    await transport?.close();
+    try {
+      gitIn(mainRepo, ["worktree", "remove", "--force", worktree]);
+    } catch {
+      /* best-effort */
+    }
+    rmSync(mainRepo, { recursive: true, force: true });
+    rmSync(worktree, { recursive: true, force: true });
+  }, 30_000);
+
+  it("status with explicit path reports the worktree's dirty state, not the clean main repo", async () => {
+    // Dirty ONLY the worktree.
+    writeFileSync(join(worktree, "dirty.txt"), "uncommitted\n");
+
+    const result = await client.callTool(
+      { name: "status", arguments: { path: worktree } },
+      undefined,
+      { timeout: CALL_TIMEOUT },
+    );
+    const sc = result.structuredContent as Record<string, unknown>;
+
+    expect(sc.branch).toBe("wt-branch");
+    expect(sc.clean).toBe(false);
+    expect(sc.untracked).toContain("dirty.txt");
+  });
+
+  it("status without path operates on the server's launch dir (main repo), proving path is authoritative", async () => {
+    // The main repo has no uncommitted changes — only the worktree is dirty.
+    const result = await client.callTool({ name: "status", arguments: {} }, undefined, {
+      timeout: CALL_TIMEOUT,
+    });
+    const sc = result.structuredContent as Record<string, unknown>;
+
+    // It reads the launch dir (main repo), NOT the dirty worktree. This is the
+    // documented behavior callers must account for by passing `path`.
+    expect(sc.branch).toBe("main-branch");
+    expect(sc.untracked).not.toContain("dirty.txt");
+  });
+
+  it("checkout with explicit path creates the branch in the worktree and leaves the main repo untouched", async () => {
+    const mainHeadBefore = gitIn(mainRepo, ["rev-parse", "--abbrev-ref", "HEAD"]).trim();
+    expect(mainHeadBefore).toBe("main-branch");
+
+    const result = await client.callTool(
+      {
+        name: "checkout",
+        arguments: { path: worktree, branch: "feature-876", create: true },
+      },
+      undefined,
+      { timeout: CALL_TIMEOUT },
+    );
+    const sc = result.structuredContent as Record<string, unknown>;
+    expect(sc.success).toBe(true);
+
+    // The worktree moved to the new branch...
+    const wtHead = gitIn(worktree, ["rev-parse", "--abbrev-ref", "HEAD"]).trim();
+    expect(wtHead).toBe("feature-876");
+
+    // ...and the MAIN repo's HEAD is unchanged (no parent-worktree corruption).
+    const mainHeadAfter = gitIn(mainRepo, ["rev-parse", "--abbrev-ref", "HEAD"]).trim();
+    expect(mainHeadAfter).toBe("main-branch");
+  });
+});

--- a/packages/server-git/src/tools/add.ts
+++ b/packages/server-git/src/tools/add.ts
@@ -19,7 +19,7 @@ export function registerAddTool(server: McpServer) {
     {
       title: "Git Add",
       description:
-        "Stages files for commit. Returns structured data with count and list of staged files, including how many were newly staged.",
+        "Stages files for commit. Returns structured data with count and list of staged files, including how many were newly staged. Pass `path` to target a specific repo or worktree — when omitted, operates on the server's own working directory, not the caller's (see #876).",
       annotations: { readOnlyHint: false },
       inputSchema: {
         path: repoPathInput,

--- a/packages/server-git/src/tools/branch.ts
+++ b/packages/server-git/src/tools/branch.ts
@@ -19,7 +19,8 @@ export function registerBranchTool(server: McpServer) {
     "branch",
     {
       title: "Git Branch",
-      description: "Lists, creates, renames, or deletes branches. Returns structured branch data.",
+      description:
+        "Lists, creates, renames, or deletes branches. Returns structured branch data. Pass `path` to target a specific repo or worktree — when omitted, operates on the server's own working directory, not the caller's (see #876).",
       annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,

--- a/packages/server-git/src/tools/checkout.ts
+++ b/packages/server-git/src/tools/checkout.ts
@@ -13,7 +13,7 @@ export function registerCheckoutTool(server: McpServer) {
     {
       title: "Git Checkout",
       description:
-        "Switches branches or restores files. Returns structured data with ref, previous ref, whether a new branch was created, and detached HEAD status.",
+        "Switches branches or restores files. Returns structured data with ref, previous ref, whether a new branch was created, and detached HEAD status. Pass `path` to target a specific repo or worktree — when omitted, operates on the server's own working directory, not the caller's, which can move branches in the wrong worktree (see #876).",
       annotations: { readOnlyHint: false },
       inputSchema: {
         path: repoPathInput,

--- a/packages/server-git/src/tools/commit.ts
+++ b/packages/server-git/src/tools/commit.ts
@@ -13,7 +13,7 @@ export function registerCommitTool(server: McpServer) {
     {
       title: "Git Commit",
       description:
-        "Creates a commit with the given message. Returns structured data with hash, message, and change statistics.",
+        "Creates a commit with the given message. Returns structured data with hash, message, and change statistics. Pass `path` to target a specific repo or worktree — when omitted, operates on the server's own working directory, not the caller's (see #876).",
       annotations: { readOnlyHint: false },
       inputSchema: {
         path: repoPathInput,

--- a/packages/server-git/src/tools/reset.ts
+++ b/packages/server-git/src/tools/reset.ts
@@ -13,7 +13,7 @@ export function registerResetTool(server: McpServer) {
     {
       title: "Git Reset",
       description:
-        "Resets the current HEAD to a specified state. Supports soft, mixed, hard, merge, and keep modes. The 'hard' mode requires confirm=true as a safety guard since it permanently discards changes. Returns structured data with the ref, mode, and list of affected files.",
+        "Resets the current HEAD to a specified state. Supports soft, mixed, hard, merge, and keep modes. The 'hard' mode requires confirm=true as a safety guard since it permanently discards changes. Returns structured data with the ref, mode, and list of affected files. Pass `path` to target a specific repo or worktree — when omitted, operates on the server's own working directory, not the caller's (see #876).",
       annotations: { destructiveHint: true },
       inputSchema: {
         path: repoPathInput,

--- a/packages/shared/__tests__/input-schemas.test.ts
+++ b/packages/shared/__tests__/input-schemas.test.ts
@@ -68,8 +68,12 @@ describe("repoPathInput", () => {
     expect(repoPathInput.safeParse("a".repeat(INPUT_LIMITS.PATH_MAX + 1)).success).toBe(false);
   });
 
-  it("has the expected description", () => {
-    expect(repoPathInput.description).toBe("Repository path");
+  it("has a description that documents the authoritative-path / worktree caveat", () => {
+    // The description must warn callers that omitting `path` targets the
+    // server's own cwd (its launch dir), not the caller's — see #876.
+    expect(repoPathInput.description).toMatch(/^Repository path\./);
+    expect(repoPathInput.description).toContain("Authoritative");
+    expect(repoPathInput.description).toContain("worktree");
   });
 });
 

--- a/packages/shared/src/input-schemas.ts
+++ b/packages/shared/src/input-schemas.ts
@@ -24,12 +24,23 @@ export const projectPathInput = z
   .optional()
   .describe("Project root path");
 
-/** `path` for servers whose root concept is a repository (git, github, security). */
+/**
+ * `path` for servers whose root concept is a repository (git, github, security).
+ *
+ * IMPORTANT: This is authoritative. When omitted, the server operates on its own
+ * process working directory — which for a long-lived MCP server is its launch
+ * directory, NOT the calling client's directory. Callers running in a git
+ * worktree, subdirectory, or any location other than where the server was
+ * launched MUST pass `path` explicitly, or operations will silently target the
+ * wrong repository (see issue #876).
+ */
 export const repoPathInput = z
   .string()
   .max(INPUT_LIMITS.PATH_MAX)
   .optional()
-  .describe("Repository path");
+  .describe(
+    "Repository path. Authoritative — when omitted, the server uses its own process working directory (its launch dir, not the caller's cwd). Callers in a git worktree or other directory MUST pass this explicitly to avoid operating on the wrong repo.",
+  );
 
 /** `path` for servers whose root concept is a working directory (docker, http, process, search). */
 export const cwdPathInput = z


### PR DESCRIPTION
## Summary

Fixes #876, where `pare-git` tools silently operated on the wrong repository when called from a nested git worktree without an explicit `path` (e.g. `status` reported clean on a dirty worktree; `checkout` moved a branch in the *parent* worktree — a data-corruption-class bug for the worktree-isolation workflow).

## Root cause and the MCP tradeoff

Every server-git tool already resolves `cwd = path || process.cwd()` and consistently forwards `cwd` to `git` (audited all 29 tools — none ignore `path` or hardcode a directory). The bug is the *omitted-path fallback*: an MCP server is a **long-lived process** whose `process.cwd()` is its **launch directory**, not the calling client's directory. A client that lives in a worktree (a background agent) cannot have its cwd inferred by the server — the server fundamentally has no channel to learn it.

Because we cannot magically infer the caller's cwd, the correct, low-risk fix is to make the contract **explicit and discoverable** rather than introduce a speculative/unsafe inference:

- **`path` is authoritative.** When omitted, tools operate on the server's own process cwd (its launch dir). Callers in a worktree/subdirectory MUST pass `path`.

## Changes

- **Shared schema** — `repoPathInput` description now documents that `path` is authoritative and that the omitted case targets the server's launch dir, not the caller's cwd. (Shared by git/github/security, so all repo-scoped servers benefit.)
- **Mutating git tool descriptions** — `checkout`, `commit`, `add`, `reset`, `branch` now warn that omitting `path` operates on the server's working dir (with the worktree gotcha called out for `checkout`).
- **server-git README** — new "The `path` parameter is authoritative" section explaining the long-lived-process tradeoff and the worktree pitfall, with correct usage examples.
- **Regression test** — `packages/server-git/__tests__/worktree-cwd.test.ts` launches the MCP server with cwd = a main repo, creates a nested worktree, and asserts:
  1. `status` with explicit `path` reports the dirty worktree (not the clean launch-dir repo);
  2. `status` without `path` reads the launch dir (proving `path` is authoritative);
  3. `checkout` with explicit `path` creates the branch in the worktree and leaves the main repo's HEAD untouched (the dangerous symptom from the issue).

## Verification

- `pnpm --filter @paretools/shared build` and `pnpm --filter @paretools/git build` — clean.
- New regression test: 3/3 pass. Shared `input-schemas` test: 36/36 pass.
- Lint + format-check clean on all changed files.
- Note: one pre-existing fidelity test (`parseLogGraph preserves commit data from real repo output`) is flaky against the repo's current merge-commit topology at HEAD and is unrelated to this change (it touches no files modified here).

Closes #876.