### PR TITLE
fix(github): wire pr-diff full and nameOnly modes

### DIFF
--- a/.changeset/fix-github-pr-diff-modes-907.md
+++ b/.changeset/fix-github-pr-diff-modes-907.md
@@ -1,0 +1,5 @@
+---
+"@paretools/github": patch
+---
+
+Fix pr-diff so full=true returns patch/hunk content and nameOnly=true returns the changed file paths. Closes #907.

--- a/packages/server-github/__tests__/pr-diff.test.ts
+++ b/packages/server-github/__tests__/pr-diff.test.ts
@@ -1,7 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { parsePrDiffNumstat } from "../src/lib/parsers.js";
 import { formatPrDiff, compactPrDiffMap, formatPrDiffCompact } from "../src/lib/formatters.js";
-import type { PrDiffResult } from "../src/schemas/index.js";
+import { PrDiffResultSchema, type PrDiffResult } from "../src/schemas/index.js";
+
+vi.mock("../src/lib/gh-runner.js", () => ({
+  ghCmd: vi.fn(),
+}));
+
+import { ghCmd } from "../src/lib/gh-runner.js";
+import { registerPrDiffTool } from "../src/tools/pr-diff.js";
 
 // ── Parser tests ────────────────────────────────────────────────────
 
@@ -145,5 +152,83 @@ describe("compactPrDiff", () => {
     const text = formatPrDiffCompact(compact);
     expect(text).toContain("1 files changed");
     expect(text).toContain("src/index.ts +10 -2");
+  });
+});
+
+// ── Tool handler tests: full / nameOnly modes (issue #907) ──────────
+
+type ToolHandler = (params: Record<string, unknown>) => Promise<{
+  content: unknown[];
+  structuredContent: unknown;
+}>;
+
+class FakeServer {
+  tools = new Map<string, { handler: ToolHandler }>();
+  registerTool(name: string, _config: Record<string, unknown>, handler: ToolHandler) {
+    this.tools.set(name, { handler });
+  }
+}
+
+function mockGh(stdout: string, stderr = "", exitCode = 0) {
+  vi.mocked(ghCmd).mockResolvedValueOnce({ stdout, stderr, exitCode });
+}
+
+const SIMPLE_DIFF = `diff --git a/src/index.ts b/src/index.ts
+index abc1234..def5678 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -1,3 +1,4 @@
+ import { foo } from "bar";
++import { baz } from "qux";
+
+ export function main() {
+-  return foo();
++  return baz(foo());
+ }
+`;
+
+describe("pr-diff tool: full / nameOnly modes", () => {
+  let handler: ToolHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const server = new FakeServer();
+    registerPrDiffTool(server as never);
+    handler = server.tools.get("pr-diff")!.handler;
+  });
+
+  it("full: true includes patch chunks even in default compact mode", async () => {
+    mockGh(SIMPLE_DIFF);
+    const result = await handler({ number: "123", full: true });
+    const parsed = PrDiffResultSchema.parse(result.structuredContent);
+    expect(parsed.files).toHaveLength(1);
+    expect(parsed.files[0].chunks).toBeDefined();
+    expect(parsed.files[0].chunks!.length).toBeGreaterThan(0);
+    expect(parsed.files[0].chunks![0].header).toMatch(/^@@/);
+    expect(parsed.files[0].chunks![0].lines).toContain("+import { baz }");
+  });
+
+  it("default (no full) omits chunks", async () => {
+    mockGh(SIMPLE_DIFF);
+    const result = await handler({ number: "123" });
+    const parsed = PrDiffResultSchema.parse(result.structuredContent);
+    expect(parsed.files[0].chunks).toBeUndefined();
+  });
+
+  it("nameOnly passes --name-only and returns the changed file paths", async () => {
+    mockGh("src/index.ts\nsrc/utils.ts\nREADME.md\n");
+    const result = await handler({ number: "123", nameOnly: true });
+    const args = vi.mocked(ghCmd).mock.calls[0][0];
+    expect(args).toContain("--name-only");
+    const parsed = PrDiffResultSchema.parse(result.structuredContent);
+    expect(parsed.files.map((f) => f.file)).toEqual(["src/index.ts", "src/utils.ts", "README.md"]);
+    expect(parsed.files.every((f) => f.status === "modified")).toBe(true);
+  });
+
+  it("nameOnly with empty output returns no files", async () => {
+    mockGh("");
+    const result = await handler({ number: "123", nameOnly: true });
+    const parsed = PrDiffResultSchema.parse(result.structuredContent);
+    expect(parsed.files).toEqual([]);
   });
 });

--- a/packages/server-github/src/tools/pr-diff.ts
+++ b/packages/server-github/src/tools/pr-diff.ts
@@ -16,7 +16,7 @@ export function registerPrDiffTool(server: McpServer) {
     {
       title: "PR Diff",
       description:
-        "Returns file-level diff statistics for a pull request. Use full=true for patch content.",
+        "Returns file-level diff statistics for a pull request. Use full=true for patch/hunk content, or nameOnly=true for just the changed file paths.",
       annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         number: z
@@ -54,11 +54,9 @@ export function registerPrDiffTool(server: McpServer) {
 
       const selector = String(number);
 
-      // Get numstat for structured file-level stats
-      const numstatArgs = ["pr", "diff", selector, "--patch=false"];
-      if (repo) numstatArgs.push("--repo", repo);
-
-      // We use a two-pass approach: first get numstat, then optionally get full patch
+      // Build the gh invocation. `--name-only` emits a bare filename list;
+      // otherwise gh emits a unified patch that we parse for stats (and, when
+      // full=true, hunk content).
       const diffArgs = ["pr", "diff", selector];
       if (repo) diffArgs.push("--repo", repo);
       if (nameOnly) diffArgs.push("--name-only");
@@ -72,15 +70,18 @@ export function registerPrDiffTool(server: McpServer) {
       // S-gap: Detect truncation
       const truncated = result.stdout.length >= MAX_DIFF_SIZE;
 
-      // Parse the unified diff output to extract numstat-like data
-      const diff = parsePrDiffFromPatch(result.stdout);
+      // `--name-only` returns one path per line, not a unified diff, so it must
+      // be parsed differently (the patch parser would yield a single empty entry).
+      const diff = nameOnly
+        ? parsePrDiffNameOnly(result.stdout)
+        : parsePrDiffFromPatch(result.stdout);
       // S-gap: Set truncation flag
       if (truncated) {
         diff.truncated = true;
       }
 
       // If full patch requested, attach chunk data
-      if (full && diff.files.length > 0) {
+      if (full && !nameOnly && diff.files.length > 0) {
         const filePatches = result.stdout.split(/^diff --git /m).filter(Boolean);
         for (const patch of filePatches) {
           const fileMatch = patch.match(/b\/(.+)\n/);
@@ -106,13 +107,18 @@ export function registerPrDiffTool(server: McpServer) {
         }
       }
 
+      // When full patch content is requested, force the full (non-compact) schema
+      // so the parsed chunks survive — the compact projection drops chunks, which
+      // would otherwise make full=true a no-op (issue #907).
+      const forceFullSchema = compact === false || full === true;
+
       return compactDualOutput(
         diff,
         result.stdout,
         formatPrDiff,
         compactPrDiffMap,
         formatPrDiffCompact,
-        compact === false,
+        forceFullSchema,
       );
     },
   );
@@ -204,4 +210,26 @@ function parsePrDiffFromPatch(patchOutput: string): PrDiffResult {
   return {
     files,
   };
+}
+
+/**
+ * Parses `gh pr diff --name-only` output into structured PR diff data.
+ * The `--name-only` format is a bare list of changed file paths, one per line,
+ * with no status or line-count information available. Each file is reported with
+ * zeroed stats and a "modified" status since gh does not distinguish add/delete
+ * in name-only mode.
+ */
+function parsePrDiffNameOnly(stdout: string): PrDiffResult {
+  const files = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((file) => ({
+      file,
+      status: "modified" as const,
+      additions: 0,
+      deletions: 0,
+    }));
+
+  return { files };
 }

--- a/tests/smoke/mocked/github-pr-tools-1.smoke.test.ts
+++ b/tests/smoke/mocked/github-pr-tools-1.smoke.test.ts
@@ -5,10 +5,10 @@
  * validating argument construction, output schema compliance,
  * flag injection blocking, and edge case handling.
  *
- * 76 scenarios total:
+ * 78 scenarios total:
  *   pr-comment: 13
  *   pr-create:  25
- *   pr-diff:    17
+ *   pr-diff:    19
  *   pr-list:    21
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -413,7 +413,7 @@ describe("Smoke: github.pr-create", () => {
 });
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-// Section 11: pr-diff (17 scenarios)
+// Section 11: pr-diff (19 scenarios)
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 /** Minimal unified diff for a single modified file */
@@ -552,11 +552,14 @@ describe("Smoke: github.pr-diff", () => {
   });
 
   // ── S7: Name only mode ────────────────────────────────────────────
-  it("S7 [P1] nameOnly passes --name-only flag", async () => {
+  it("S7 [P1] nameOnly passes --name-only flag and returns file paths", async () => {
     mockGh("src/index.ts\nsrc/utils.ts\n");
-    await callAndValidate({ number: "123", nameOnly: true });
+    const { parsed } = await callAndValidate({ number: "123", nameOnly: true });
     const args = vi.mocked(ghCmd).mock.calls[0][0];
     expect(args).toContain("--name-only");
+    // issue #907: nameOnly must return the actual changed file paths,
+    // not a single empty-filename entry.
+    expect(parsed.files.map((f) => f.file)).toEqual(["src/index.ts", "src/utils.ts"]);
   });
 
   // ── S8: File status detection (added) ─────────────────────────────
@@ -639,6 +642,28 @@ describe("Smoke: github.pr-diff", () => {
     await callAndValidate({ number: "feature-branch" });
     const args = vi.mocked(ghCmd).mock.calls[0][0];
     expect(args).toContain("feature-branch");
+  });
+
+  // ── S18: full=true preserves chunks under default (compact) mode ──
+  // Regression for issue #907: full=true previously had its chunks stripped by
+  // the compact projection because callers did not also pass compact:false.
+  it("S18 [P0] full: true preserves chunks even in default compact mode", async () => {
+    mockGh(SIMPLE_DIFF);
+    const result = await handler({ number: "123", full: true });
+    const parsed = PrDiffResultSchema.parse(result.structuredContent);
+    expect(parsed.files[0].chunks).toBeDefined();
+    expect(parsed.files[0].chunks!.length).toBeGreaterThan(0);
+    expect(parsed.files[0].chunks![0].header).toMatch(/^@@/);
+    expect(parsed.files[0].chunks![0].lines).toContain("+import { baz }");
+  });
+
+  // ── S19: nameOnly returns file paths in default compact mode ─────
+  // Regression for issue #907: nameOnly returned a single empty-filename entry.
+  it("S19 [P0] nameOnly returns file paths in default compact mode", async () => {
+    mockGh("src/index.ts\nsrc/utils.ts\n");
+    const result = await handler({ number: "123", nameOnly: true });
+    const parsed = PrDiffResultSchema.parse(result.structuredContent);
+    expect(parsed.files.map((f) => f.file)).toEqual(["src/index.ts", "src/utils.ts"]);
   });
 });
 


### PR DESCRIPTION
## Summary

`pr-diff` ignored both `full=true` and `nameOnly=true` and returned the same file-level numstat array in every mode.

- `full=true` parsed hunk content into `chunks`, but the compact projection (the default output mode) strips `chunks` — so unless the caller also passed `compact=false`, the patch content was silently dropped. Now `full=true` forces the full (non-compact) schema so chunks survive.
- `nameOnly=true` ran `gh pr diff --name-only` (a bare filename list), but that output was fed to the unified-diff parser, which produced a single empty-filename entry. Added a dedicated `parsePrDiffNameOnly` parser that returns the changed file paths.

Default behavior (neither flag) is unchanged.

## Changes

- `packages/server-github/src/tools/pr-diff.ts`: force full schema when `full=true`; route `--name-only` output through a new name-only parser; updated tool description.
- `packages/server-github/__tests__/pr-diff.test.ts`: handler-level tests for full (default compact) and nameOnly modes.
- `tests/smoke/mocked/github-pr-tools-1.smoke.test.ts`: strengthened S7 and added S18/S19 regression scenarios.
- Changeset (`@paretools/github` patch).

## Test plan

- [x] `pnpm --filter @paretools/github build`
- [x] `pnpm --filter @paretools/github test` (573 passed)
- [x] `pnpm smoke` (2324 passed)
- [x] `pnpm lint` on changed package files (0 errors)
- [x] prettier format-check on changed files

Closes #907.