### PR TITLE
Fix compact bun pm ls output schema

### DIFF
--- a/.changeset/fix-bun-pm-ls-compact-schema.md
+++ b/.changeset/fix-bun-pm-ls-compact-schema.md
@@ -1,0 +1,7 @@
+---
+"@paretools/bun": patch
+---
+
+fix(bun): include `packages` in the compact `pm ls` output so it satisfies the pm-ls output schema
+
+The compact projection for `bun pm ls` omitted the `packages` field, so the compacted `structuredContent` no longer matched `BunPmLsResult`. Declare `packages: []` on the compact shape so the compact output stays schema-valid.

--- a/packages/server-bun/__tests__/formatters.test.ts
+++ b/packages/server-bun/__tests__/formatters.test.ts
@@ -361,4 +361,20 @@ describe("compactPmLsMap + formatPmLsCompact", () => {
     };
     expect(formatPmLsCompact(compactPmLsMap(data))).toContain("1 packages");
   });
+
+  it("keeps compact output compatible with pm-ls schema", () => {
+    const data: BunPmLsResult = {
+      success: true,
+      packages: [{ name: "a", version: "1.0.0" }],
+      total: 1,
+      duration: 50,
+    };
+
+    expect(compactPmLsMap(data)).toEqual({
+      success: true,
+      packages: [],
+      total: 1,
+      duration: 50,
+    });
+  });
 });

--- a/packages/server-bun/src/lib/formatters.ts
+++ b/packages/server-bun/src/lib/formatters.ts
@@ -294,6 +294,7 @@ export function formatOutdatedCompact(data: BunOutdatedCompact): string {
 export interface BunPmLsCompact {
   [key: string]: unknown;
   success: boolean;
+  packages: [];
   total: number;
   duration: number;
 }
@@ -301,6 +302,7 @@ export interface BunPmLsCompact {
 export function compactPmLsMap(data: BunPmLsResult): BunPmLsCompact {
   return {
     success: data.success,
+    packages: [],
     total: data.total,
     duration: data.duration,
   };


### PR DESCRIPTION
## Summary
- include an empty packages array in compact bun pm ls output so it satisfies the pm-ls output schema
- add a formatter regression test for the compact payload shape

## Why
The pm-ls tool declares BunPmLsResultSchema as its output schema, which requires packages. compactPmLsMap omitted packages, causing MCP output validation failures when compact mode was used.

## Verification
- pnpm --filter @paretools/bun exec vitest run __tests__/formatters.test.ts
- pnpm --filter @paretools/shared build && pnpm --filter @paretools/bun build
- pnpm --filter @paretools/bun test