### PR TITLE
fix(deps): bump hono override to >=4.12.25 (fixes nightly audit, CVE-2026-54290)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "pnpm": {
     "overrides": {
       "minimatch": ">=10.2.3",
-      "hono": ">=4.12.14",
+      "hono": ">=4.12.25",
       "@hono/node-server": ">=1.19.13",
       "qs": ">=6.14.2",
       "rollup": ">=4.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   minimatch: '>=10.2.3'
-  hono: '>=4.12.14'
+  hono: '>=4.12.25'
   '@hono/node-server': '>=1.19.13'
   qs: '>=6.14.2'
   rollup: '>=4.59.0'
@@ -1134,7 +1134,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.14'
+      hono: '>=4.12.25'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2212,8 +2212,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -3553,9 +3553,9 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@1.19.13(hono@4.12.15)':
+  '@hono/node-server@1.19.13(hono@4.12.27)':
     dependencies:
-      hono: 4.12.15
+      hono: 4.12.27
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -3736,7 +3736,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.15)
+      '@hono/node-server': 1.19.13(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -3746,7 +3746,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.15
+      hono: 4.12.27
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4675,7 +4675,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.15: {}
+  hono@4.12.27: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## What

Bumps the `hono` pnpm override from `>=4.12.14` to `>=4.12.25`. The lockfile re-resolves `hono` from `4.12.15` → `4.12.27`.

## Why

The **Nightly Full Suite** `audit` job (Trivy `fs` scan of `pnpm-lock.yaml`, `--exit-code 1` on HIGH/CRITICAL) has failed every day since ~2026-06-10 on a single finding:

```
hono  CVE-2026-54290  HIGH  fixed  4.12.15 -> 4.12.25
hono: CORS Middleware reflects any Origin with credentials
```

`hono` is a transitive dependency pulled in via `@modelcontextprotocol/sdk` → `@hono/node-server`, so no package declares it directly. The existing override just needed its floor raised past the fixed version.

## Scope / changeset

Lockfile-level security pin only — no published `package.json` changes, consistent with the other entries in the `pnpm.overrides` block (minimatch, qs, rollup, …). No changeset needed.

## Verification

- `pnpm install --lockfile-only` re-resolves `hono@4.12.27` (≥ 4.12.25 fix).
- Lockfile diff is minimal (9 lines, all `hono` references).
- Trivy not installed locally, but the flagged version is removed at the source, which is exactly what the audit gate checks.

## Impact

Clears the recurring nightly failure and closes out the auto-filed backlog (#925, #927, #929, #933, #936–#940, #943–#949, #952, #953, #957, #958, #959).