### PR TITLE
feat(github): add pr-checks `conclusion` field + non-throwing watch timeout (closes #932)

### DIFF
--- a/.changeset/pr-checks-conclusion.md
+++ b/.changeset/pr-checks-conclusion.md
@@ -1,0 +1,7 @@
+---
+"@paretools/github": minor
+---
+
+feat(github): add a top-level `conclusion` to `pr-checks` and make watch-mode timeouts non-throwing
+
+`pr-checks` now returns `conclusion` (`"passed" | "failed" | "pending" | "timed_out"`) derived from the check buckets, so callers can branch on the aggregate outcome without re-deriving it from `summary`. In `watch` mode, hitting `watchTimeout` now returns the latest snapshot with `timedOut: true`, `conclusion: "timed_out"`, and `errorType: "watch-timeout"` instead of throwing — making "drive this PR to green" fully expressible as a single tool call whose result you branch on. Closes #932.

--- a/packages/server-github/__tests__/pr-checks-watch.test.ts
+++ b/packages/server-github/__tests__/pr-checks-watch.test.ts
@@ -222,4 +222,74 @@ describe("pr-checks tool handler — watch path", () => {
     expect(out.structuredContent.pollCount).toBe(1);
     expect(typeof out.structuredContent.waitedSeconds).toBe("number");
   });
+
+  it("sets conclusion=passed and timedOut=false when all checks pass (watch)", async () => {
+    vi.mocked(ghCmd).mockResolvedValueOnce({
+      stdout: checksJson([{ name: "lint", state: "SUCCESS", bucket: "pass" }]),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const server = new FakeServer();
+    registerPrChecksTool(server as never);
+    const handler = server.tools.get("pr-checks")!.handler;
+
+    const out = await handler({ number: "12", watch: true, interval: 5 });
+    expect(out.structuredContent.conclusion).toBe("passed");
+    expect(out.structuredContent.timedOut).toBe(false);
+  });
+
+  it("sets conclusion=failed when a check is failing (watch)", async () => {
+    vi.mocked(ghCmd).mockResolvedValueOnce({
+      stdout: checksJson([
+        { name: "lint", state: "SUCCESS", bucket: "pass" },
+        { name: "test", state: "FAILURE", bucket: "fail" },
+      ]),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const server = new FakeServer();
+    registerPrChecksTool(server as never);
+    const handler = server.tools.get("pr-checks")!.handler;
+
+    const out = await handler({ number: "12", watch: true, interval: 5 });
+    expect(out.structuredContent.conclusion).toBe("failed");
+    expect(out.structuredContent.timedOut).toBe(false);
+  });
+
+  it("returns a structured timed_out snapshot instead of throwing on timeout", async () => {
+    // Always pending → the watch loop hits its deadline.
+    vi.mocked(ghCmd).mockResolvedValue({
+      stdout: checksJson([{ name: "build", state: "PENDING", bucket: "pending" }]),
+      stderr: "",
+      exitCode: 8,
+    });
+
+    const server = new FakeServer();
+    registerPrChecksTool(server as never);
+    const handler = server.tools.get("pr-checks")!.handler;
+
+    // interval floor is 5s, watchTimeout 1s → the deadline check trips on the
+    // first iteration (0 + 5000 > 1000), so the loop never actually sleeps.
+    const out = await handler({ number: "12", watch: true, interval: 5, watchTimeout: 1 });
+    expect(out.structuredContent.timedOut).toBe(true);
+    expect(out.structuredContent.conclusion).toBe("timed_out");
+    expect(out.structuredContent.errorType).toBe("watch-timeout");
+  });
+
+  it("sets conclusion on a one-shot (non-watch) snapshot", async () => {
+    vi.mocked(ghCmd).mockResolvedValueOnce({
+      stdout: checksJson([{ name: "lint", state: "SUCCESS", bucket: "pass" }]),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const server = new FakeServer();
+    registerPrChecksTool(server as never);
+    const handler = server.tools.get("pr-checks")!.handler;
+
+    const out = await handler({ number: "12" });
+    expect(out.structuredContent.conclusion).toBe("passed");
+  });
 });

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -172,6 +172,8 @@ export function compactPrChecksMap(data: PrChecksResult): PrChecksCompact {
     pr: data.pr,
     checks: data.checks ?? [],
     summary,
+    ...(data.conclusion ? { conclusion: data.conclusion } : {}),
+    ...(data.timedOut !== undefined ? { timedOut: data.timedOut } : {}),
     ...(data.errorType ? { errorType: data.errorType } : {}),
     ...(data.errorMessage ? { errorMessage: data.errorMessage } : {}),
     ...(data.pollCount !== undefined ? { pollCount: data.pollCount } : {}),

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -284,6 +284,15 @@ export const PrChecksResultSchema = z.object({
     .enum(["not-found", "permission-denied", "in-progress", "watch-timeout", "unknown"])
     .optional(),
   errorMessage: z.string().optional(),
+  /**
+   * Aggregate outcome derived from the check buckets, so callers can branch
+   * without re-deriving from `summary`: "passed" (all terminal, none failed),
+   * "failed" (at least one failed/cancelled), "pending" (checks still running),
+   * or "timed_out" (watch mode hit its deadline with checks still pending).
+   */
+  conclusion: z.enum(["passed", "failed", "pending", "timed_out"]).optional(),
+  /** True when watch mode returned because it hit `watchTimeout` (checks still pending). */
+  timedOut: z.boolean().optional(),
   /** Number of times the wrapper polled gh (only set when watch=true). */
   pollCount: z.number().optional(),
   /** Total wall-clock seconds spent in the watch loop (only set when watch=true). */

--- a/packages/server-github/src/tools/pr-checks.ts
+++ b/packages/server-github/src/tools/pr-checks.ts
@@ -44,6 +44,19 @@ function pendingCheckNames(data: PrChecksResult): string[] {
     .map((c) => c.name);
 }
 
+/**
+ * Aggregate outcome from the summary buckets so callers can branch without
+ * re-deriving. `failed` wins over `pending` (a red check is actionable even
+ * while others run); `pending` means at least one check is still non-terminal.
+ */
+function deriveConclusion(data: PrChecksResult): "passed" | "failed" | "pending" {
+  const summary = data.summary;
+  if (!summary) return "pending";
+  if (summary.failed > 0 || summary.cancelled > 0) return "failed";
+  if (summary.pending > 0) return "pending";
+  return "passed";
+}
+
 /** Sleeps for `ms` milliseconds. Exposed via parameter for testability. */
 function defaultSleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -166,7 +179,7 @@ export function registerPrChecksTool(server: McpServer) {
     {
       title: "PR Checks",
       description:
-        "Lists check/status results for a pull request. Returns structured data with check names, states, URLs, and summary counts (passed, failed, pending). When watch=true, polls internally until all checks complete (or timeout).",
+        'Lists check/status results for a pull request. Returns structured data with check names, states, URLs, summary counts (passed, failed, pending), and a top-level `conclusion` ("passed" | "failed" | "pending" | "timed_out") for easy branching. When watch=true, polls internally until all checks complete or watchTimeout elapses; on timeout it returns the latest snapshot with `timedOut: true` and `conclusion: "timed_out"` rather than throwing.',
       annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         number: z
@@ -238,13 +251,31 @@ export function registerPrChecksTool(server: McpServer) {
         });
 
         if (watchResult.timedOut) {
-          throw new Error(
-            `pr-checks watch timed out after ${timeoutSeconds}s — checks still pending: ${watchResult.pending.join(", ") || "(none reported)"}`,
+          // Return a structured snapshot rather than throwing, so callers can
+          // branch on `conclusion`/`timedOut` instead of catching an exception.
+          const data: PrChecksResult = {
+            ...watchResult.data,
+            conclusion: "timed_out",
+            timedOut: true,
+            errorType: "watch-timeout",
+            errorMessage: `Watch timed out after ${timeoutSeconds}s — checks still pending: ${watchResult.pending.join(", ") || "(none reported)"}`,
+            pollCount: watchResult.pollCount,
+            waitedSeconds: Math.round(watchResult.waitedSeconds * 100) / 100,
+          };
+          return compactDualOutput(
+            data,
+            JSON.stringify(data.checks ?? []),
+            formatPrChecks,
+            compactPrChecksMap,
+            formatPrChecksCompact,
+            compact === false,
           );
         }
 
         const data: PrChecksResult = {
           ...watchResult.data,
+          conclusion: deriveConclusion(watchResult.data),
+          timedOut: false,
           pollCount: watchResult.pollCount,
           waitedSeconds: Math.round(watchResult.waitedSeconds * 100) / 100,
         };
@@ -279,9 +310,10 @@ export function registerPrChecksTool(server: McpServer) {
         );
       }
 
-      let data;
+      let data: PrChecksResult;
       try {
         data = parsePrChecks(result.stdout, prNum);
+        data.conclusion = deriveConclusion(data);
       } catch {
         const combined = `${result.stdout}\n${result.stderr}`.trim();
         return compactDualOutput(


### PR DESCRIPTION
## What

Two additive improvements to `mcp__pare-github__pr-checks`, completing the remaining asks from #932 (the sibling watch-mode issue #930 shipped already and is now closed):

1. **Top-level `conclusion`** — `"passed" | "failed" | "pending" | "timed_out"`, derived from the check buckets. Callers can branch on the aggregate outcome without re-deriving it from `summary`. Populated on both the one-shot and watch paths.
2. **Non-throwing watch timeout** — when `watch` mode hits `watchTimeout`, it now returns the latest snapshot with `timedOut: true`, `conclusion: "timed_out"`, and `errorType: "watch-timeout"` instead of throwing. The output schema already reserved the `"watch-timeout"` error type, so this just wires up the structured-timeout contract that was intended.

This makes "drive this PR to green" fully expressible as a single tool call whose structured result you branch on — no exception handling, no re-deriving pass/fail.

## Why

Per #932: an agent driving a PR to merge needs a first-class outcome signal. Previously it had to re-derive pass/fail from the summary buckets, and a watch timeout threw (hard to branch on from a tool call).

## Changes

- `schemas/index.ts` — add `conclusion` + `timedOut` to `PrChecksResultSchema`.
- `tools/pr-checks.ts` — `deriveConclusion()` helper; populate `conclusion` on one-shot + watch success paths; return structured `timed_out` snapshot instead of throwing.
- `lib/formatters.ts` — include `conclusion`/`timedOut` in the compact output map (they were being stripped).
- Tool description updated to document the new fields/behavior.

## Tests

`pr-checks-watch.test.ts`: **11 passing** (added 5 — passed/failed conclusion in watch, structured timed_out snapshot, one-shot conclusion). Full `@paretools/github` suite green (577, after rebuilding `dist` for the tool-count integration test). Changeset included (`minor`).

Closes #932.