### PR TITLE
fix(git): preserve blob file content in `show` compact mode (closes #926)

### DIFF
--- a/.changeset/git-show-blob-compact.md
+++ b/.changeset/git-show-blob-compact.md
@@ -1,0 +1,15 @@
+---
+"@paretools/git": patch
+---
+
+fix(git): return file content from `show` with `file` + `ref` in compact mode
+
+`git show` with a `file` argument (blob extraction, e.g. `HEAD:src/index.ts`)
+returned empty content in the default compact mode — the compact projection
+used a commit-shaped map that emitted only an empty `hashShort` and a
+`"blob ref:file"` message, dropping `fileContent` entirely. Because the raw
+content and the structured payload are near-identical in size, the dual-output
+helper always selected the compact branch, so the content was effectively never
+returned unless `compact: false` was passed. `compactShowMap` now preserves
+`fileContent` and object metadata for non-commit objects (blob/tag/tree). Also
+raised the `file` input cap from 255 to 4096 chars to match `path`. Closes #926.

--- a/packages/server-git/__tests__/compact.test.ts
+++ b/packages/server-git/__tests__/compact.test.ts
@@ -209,6 +209,44 @@ describe("compactShowMap", () => {
     const compact = compactShowMap(show);
     expect(compact.hashShort).toBe("abc123d");
   });
+
+  // Gap #926: blob extraction (git show <ref>:<file>) must not lose fileContent
+  // in compact mode — previously the commit-shaped projection returned only an
+  // empty hashShort + "blob ref:file" message with no content.
+  it("preserves fileContent and metadata for a blob (file extraction)", () => {
+    const show: GitShow = {
+      objectType: "blob",
+      objectName: "origin/dev:.github/workflows/deploy.yml",
+      objectSize: 42,
+      file: ".github/workflows/deploy.yml",
+      fileContent: "name: deploy\non: push\n",
+      message: "blob origin/dev:.github/workflows/deploy.yml",
+    };
+
+    const compact = compactShowMap(show);
+
+    expect(compact.objectType).toBe("blob");
+    expect(compact.file).toBe(".github/workflows/deploy.yml");
+    expect(compact.fileContent).toBe("name: deploy\non: push\n");
+    expect(compact.objectSize).toBe(42);
+    // No empty commit hash for a blob.
+    expect(compact).not.toHaveProperty("hashShort");
+  });
+
+  it("preserves the payload for a non-commit object (tag)", () => {
+    const show: GitShow = {
+      objectType: "tag",
+      objectName: "v1.2.3",
+      message: "Release v1.2.3",
+    };
+
+    const compact = compactShowMap(show);
+
+    expect(compact.objectType).toBe("tag");
+    expect(compact.objectName).toBe("v1.2.3");
+    expect(compact.message).toBe("Release v1.2.3");
+    expect(compact).not.toHaveProperty("hashShort");
+  });
 });
 
 describe("formatShowCompact", () => {
@@ -223,6 +261,19 @@ describe("formatShowCompact", () => {
     expect(output).toContain("abc1234 Fix parser bug");
     expect(output).toContain("Author: Jane <j@e.com>");
     expect(output).toContain("Date: 2h ago");
+  });
+
+  it("renders blob file content instead of an empty commit line (#926)", () => {
+    const output = formatShowCompact({
+      objectType: "blob",
+      objectName: "HEAD:src/index.ts",
+      objectSize: 20,
+      file: "src/index.ts",
+      fileContent: "export const x = 1;\n",
+      message: "blob HEAD:src/index.ts",
+    });
+    expect(output).toContain("src/index.ts");
+    expect(output).toContain("export const x = 1;");
   });
 });
 

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -296,13 +296,32 @@ export function formatBranchCompact(b: GitBranchCompact): string {
 /** Compact show: hashShort + message + author + date, no diff. */
 export interface GitShowCompact {
   [key: string]: unknown;
-  hashShort: string;
+  hashShort?: string;
   message: string;
   author?: string;
   date?: string;
+  objectType?: GitShow["objectType"];
+  objectName?: string;
+  objectSize?: number;
+  file?: string;
+  fileContent?: string;
 }
 
 export function compactShowMap(s: GitShow): GitShowCompact {
+  // Non-commit objects (blob / tag / tree) carry their payload in fileContent
+  // or message, not in a commit hash. The commit-shaped compact projection
+  // would drop that payload entirely — returning an empty hashShort and no
+  // content — so preserve the object fields instead. (Gap #926)
+  if (s.objectType && s.objectType !== "commit") {
+    return {
+      objectType: s.objectType,
+      message: s.message.split("\n")[0],
+      ...(s.objectName ? { objectName: s.objectName } : {}),
+      ...(s.objectSize !== undefined ? { objectSize: s.objectSize } : {}),
+      ...(s.file ? { file: s.file } : {}),
+      ...(s.fileContent !== undefined ? { fileContent: s.fileContent } : {}),
+    };
+  }
   return {
     hashShort: s.hashShort ?? (s.hash ?? "").slice(0, 7),
     message: s.message.split("\n")[0],
@@ -312,7 +331,17 @@ export function compactShowMap(s: GitShow): GitShowCompact {
 }
 
 export function formatShowCompact(s: GitShowCompact): string {
-  const parts = [`${s.hashShort} ${s.message}`];
+  // Blob extraction: surface the file content (the whole point of the call).
+  if (s.objectType && s.objectType !== "commit") {
+    if (s.fileContent !== undefined) {
+      const size = s.objectSize !== undefined ? ` (${s.objectSize} bytes)` : "";
+      const header = `── ${s.file ?? s.objectName ?? "blob"} @ ${s.objectName ?? "unknown"}${size} ──`;
+      return `${header}\n${s.fileContent}`;
+    }
+    const name = s.objectName ? ` ${s.objectName}` : "";
+    return `${s.objectType}${name}\n${s.message}`;
+  }
+  const parts = [`${s.hashShort ?? ""} ${s.message}`.trim()];
   if (s.author) parts.push(`Author: ${s.author}`);
   if (s.date) parts.push(`Date: ${s.date}`);
   return parts.join("\n");

--- a/packages/server-git/src/tools/show.ts
+++ b/packages/server-git/src/tools/show.ts
@@ -38,7 +38,7 @@ export function registerShowTool(server: McpServer) {
           .describe("Commit hash, branch, or tag (default: HEAD)"),
         file: z
           .string()
-          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .max(INPUT_LIMITS.PATH_MAX)
           .optional()
           .describe(
             "File path to extract from the ref (e.g., 'src/index.ts'). Returns raw file content at that ref.",


### PR DESCRIPTION
## What

`mcp__pare-git__show` with a `file` + `ref` (blob extraction, e.g. `HEAD:src/index.ts`) returned empty content in the **default compact mode** — e.g. `{"hashShort":"","message":"blob origin/dev:.github/workflows/deploy.yml"}` with no file content.

## Root cause

The blob path builds a correct structured object with `fileContent`, but the compact projection (`compactShowMap`) used a commit-shaped map that only emits `hashShort` / `message` / `author` / `date` — silently dropping `fileContent`, `file`, and the object metadata, and emitting an empty `hashShort` for a hashless blob.

Worse, it wasn't opt-in: `compactDualOutput` selects the compact branch whenever `structuredTokens >= rawTokens`. For blob extraction the full payload (metadata + `fileContent`) is always marginally larger than the raw content alone, so it **always** took the compact branch — meaning blob content was effectively unreachable unless the caller explicitly passed `compact: false`.

## Fix

- `compactShowMap` now branches on non-commit `objectType` (blob / tag / tree) and preserves `fileContent` + `objectName` / `objectSize` / `file` / `message` (no empty `hashShort`).
- `formatShowCompact` renders the file content for blobs (with a `── file @ ref (N bytes) ──` header) instead of an empty commit line.
- Raised the `file` input cap from 255 → 4096 chars to match `path` (the reporter flagged the mismatch).

The output schema (`GitShowSchema`) already permitted these fields, so this is purely a projection fix — no schema change.

## Tests

Added to `compact.test.ts`: blob compact mapping preserves `fileContent`/metadata and omits `hashShort`; tag (non-commit) mapping preserves payload; `formatShowCompact` renders blob content. `tsc` clean; `compact` suite 35/35.

> Note: one unrelated `log-graph` fidelity test fails in my local checkout because it asserts against live repo SHAs and I have extra local branches — it's in a different code path, untouched here, and passes on a clean CI checkout (the nightly's test jobs are green; only its audit job fails, addressed in #960).

Closes #926.