### PR TITLE
fix(build): vite-build success tracks exit code; advisory stderr maps to warnings

### DIFF
--- a/.changeset/vite-build-exit-code-success.md
+++ b/.changeset/vite-build-exit-code-success.md
@@ -1,0 +1,5 @@
+---
+"@paretools/build": patch
+---
+
+fix(build): vite-build success now tracks the process exit code; advisory stderr (rolldown-vite chunk-size / ineffective-dynamic-import) maps to warnings and never flips success, and a failed build always populates errors[]

--- a/packages/server-build/__tests__/vite-build.test.ts
+++ b/packages/server-build/__tests__/vite-build.test.ts
@@ -47,6 +47,30 @@ const VITE_WARNING_OUTPUT = [
 
 const VITE_SINGLE_FILE = ["dist/bundle.js     12.50 kB │ gzip: 4.20 kB"].join("\n");
 
+// rolldown-vite@8 (Vite 8) advisory stderr on an otherwise successful build.
+// The process exits 0 and writes dist; the only stderr is non-fatal advice.
+// See #915.
+const ROLLDOWN_ADVISORY_STDERR = [
+  "[INEFFECTIVE_DYNAMIC_IMPORT] src/App.tsx is dynamically imported by src/main.tsx but also statically imported by src/index.tsx, dynamic import will not move module into another chunk.",
+  "(!) Some chunks are larger than 500 kB after minification. Consider:",
+  "  - Using dynamic import() to code-split the application",
+].join("\n");
+
+const ROLLDOWN_ADVISORY_STDOUT = [
+  "vite v8.0.0 building for production...",
+  "✓ 128 modules transformed.",
+  "dist/index.html                   0.46 kB │ gzip:  0.30 kB",
+  "dist/assets/index-abc123.js     612.11 kB │ gzip: 190.42 kB",
+  "✓ built in 0.60s",
+].join("\n");
+
+// A genuine rolldown-vite failure whose error text matches none of the generic
+// error heuristics — the parser must still populate errors[] (via fallback).
+const ROLLDOWN_UNMATCHED_FAILURE_STDERR = [
+  '[UNRESOLVED_IMPORT] Could not resolve "./missing" from "src/main.tsx"',
+  "https://rolldown.rs/guide/errors#unresolved-import",
+].join("\n");
+
 // ---------------------------------------------------------------------------
 // Parser tests
 // ---------------------------------------------------------------------------
@@ -169,6 +193,51 @@ describe("parseViteBuildOutput", () => {
   it("preserves duration exactly", () => {
     const result = parseViteBuildOutput("", "", 0, 7.891);
     expect(result.duration).toBe(7.891);
+  });
+
+  // #915: rolldown-vite@8 emits advisory-only stderr on a successful (exit 0)
+  // build. success must track the exit code, advisories must land in warnings[],
+  // and errors[] must stay empty.
+  it("reports success:true for a rolldown-vite build with advisory-only stderr (#915)", () => {
+    const result = parseViteBuildOutput(ROLLDOWN_ADVISORY_STDOUT, ROLLDOWN_ADVISORY_STDERR, 0, 0.6);
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings!.length).toBeGreaterThanOrEqual(2);
+
+    const warningText = result.warnings!.join(" ");
+    expect(warningText).toContain("INEFFECTIVE_DYNAMIC_IMPORT");
+    expect(warningText).toContain("larger than 500 kB");
+
+    // The output-file summary lines are still parsed.
+    expect(result.outputs!.length).toBe(2);
+  });
+
+  it("never flips success to false based on advisory stderr alone (#915)", () => {
+    // Advisories on stderr with a zero exit code must remain a success.
+    const result = parseViteBuildOutput("", ROLLDOWN_ADVISORY_STDERR, 0, 0.6);
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings!.length).toBeGreaterThan(0);
+  });
+
+  // #915: a non-zero exit must always yield a populated errors[] so the result
+  // is never internally inconsistent, even when rolldown's error text matches
+  // none of the generic error heuristics (fallback extraction).
+  it("populates errors[] on a genuine failure with unmatched error text (#915)", () => {
+    const result = parseViteBuildOutput("", ROLLDOWN_UNMATCHED_FAILURE_STDERR, 1, 0.4);
+
+    expect(result.success).toBe(false);
+    expect(result.errors!.length).toBeGreaterThan(0);
+    expect(result.errors!.join(" ")).toContain("Could not resolve");
+    // No spurious warnings for a hard failure.
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("guarantees a non-empty errors[] even when a failed build produced no diagnostics (#915)", () => {
+    const result = parseViteBuildOutput("", "", 1, 0.1);
+    expect(result.success).toBe(false);
+    expect(result.errors!.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/server-build/src/lib/parsers.ts
+++ b/packages/server-build/src/lib/parsers.ts
@@ -346,6 +346,41 @@ export function parseEsbuildMetafile(content: string): EsbuildMetafile | undefin
 const VITE_OUTPUT_RE =
   /^\s*(.+?)\s{2,}(\d+[\d.]*\s*[kKmMgG]?[bB])(?:\s*[|│]\s*gzip:\s*(\d+[\d.]*\s*[kKmMgG]?[bB]))?/;
 
+/** Advisory (non-fatal) notices emitted by Vite / rolldown-vite that must be
+ *  classified as warnings — never errors — and must NEVER flip `success`.
+ *  These are surfaced by successful builds (exit 0) and are purely informational.
+ *  See #915 (rolldown-vite@8 advisory stderr misreported as a failure). */
+const VITE_ADVISORY_PATTERNS: RegExp[] = [
+  // rolldown-vite: "[INEFFECTIVE_DYNAMIC_IMPORT] <file> is dynamically imported ..."
+  /^\[INEFFECTIVE_DYNAMIC_IMPORT]/,
+  // Mixed static/dynamic import notice (may appear with or without the code prefix)
+  /dynamically imported by .+ but also statically imported/i,
+  // Chunk-size advisory, with or without the leading "(!)" prefix
+  /chunks are larger than\s+\d+/i,
+];
+
+function isViteAdvisoryLine(line: string): boolean {
+  return matchesAny(line, VITE_ADVISORY_PATTERNS);
+}
+
+/** Extracts fallback error text from a failed Vite build whose diagnostics did
+ *  not match any known error heuristic (e.g. rolldown-vite's error format).
+ *  Guarantees a non-empty, actionable `errors[]` so a `success:false` result is
+ *  never internally inconsistent. See #915. */
+function extractViteFallbackErrors(stderr: string, stdout: string): string[] {
+  const source = stderr.trim() ? stderr : stdout;
+  const candidates = source
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .filter((l) => !isViteAdvisoryLine(l) && !isWarningLine(l))
+    .filter((l) => !VITE_OUTPUT_RE.test(l));
+  if (candidates.length === 0) {
+    return ["Vite build failed with a non-zero exit code."];
+  }
+  return candidates;
+}
+
 /** Parses a human-readable size string (e.g. "45.2 kB", "1.5 MB", "320 B") into bytes.
  *  Returns undefined if the string cannot be parsed. */
 export function parseSizeToBytes(sizeStr: string): number | undefined {
@@ -374,6 +409,10 @@ export function parseViteBuildOutput(
   exitCode: number,
   duration: number,
 ): ViteBuildResult {
+  // `success` tracks the `vite build` process EXIT CODE only. Advisory stderr
+  // (chunk-size notice, ineffective-dynamic-import, etc.) must never flip this.
+  const success = exitCode === 0;
+
   const outputs: ViteOutputFile[] = [];
   const errors: string[] = [];
   const warnings: string[] = [];
@@ -397,19 +436,33 @@ export function parseViteBuildOutput(
       }
     }
 
-    // Collect error and warning lines
     const trimmed = line.trim();
     if (!trimmed) continue;
 
-    if (isErrorLine(trimmed)) {
-      errors.push(trimmed);
-    } else if (isWarningLine(trimmed)) {
+    // Advisory notices and warnings are collected regardless of exit code and
+    // are NEVER treated as errors.
+    if (isViteAdvisoryLine(trimmed) || isWarningLine(trimmed)) {
       warnings.push(trimmed);
+      continue;
+    }
+
+    // Only classify error lines on a genuine failure. On a successful build
+    // (exit 0) stray "error"-looking text must not surface as an error — the
+    // result would otherwise be internally inconsistent (success:true + errors).
+    if (!success && isErrorLine(trimmed)) {
+      errors.push(trimmed);
     }
   }
 
+  // A failed build must always surface at least one actionable error, even when
+  // Vite/rolldown's error text doesn't match our line heuristics. This keeps a
+  // `success:false` result from ever being emitted with an empty `errors[]`.
+  if (!success && errors.length === 0) {
+    errors.push(...extractViteFallbackErrors(stderr, stdout));
+  }
+
   return {
-    success: exitCode === 0,
+    success,
     duration,
     outputs,
     errors,


### PR DESCRIPTION
## Bug

`vite-build` could return an internally inconsistent result — `{"success":false,"outputs":[],"errors":[],"warnings":[]}` — for a Vite 8 (rolldown-vite) project whose `vite build` exits 0 and writes `dist`. The only stderr in the report was non-fatal advisory output (`[INEFFECTIVE_DYNAMIC_IMPORT]`, `(!) Some chunks are larger than 500 kB`). A `success:false` with **both** `errors[]` and `warnings[]` empty gives the agent nothing to act on.

## Root cause

`parseViteBuildOutput` derives `success` from the process exit code, but two gaps made the result inconsistent for rolldown-vite:

1. **Advisory stderr wasn't recognized.** rolldown-vite@8's `[INEFFECTIVE_DYNAMIC_IMPORT]` notice matched none of the warning heuristics, so it was silently dropped instead of landing in `warnings[]`.
2. **A failed build could yield an empty `errors[]`.** When the exit code was non-zero but rolldown's error text matched none of the generic error patterns, `errors[]` stayed empty — producing the reported `success:false` + empty `errors[]` inconsistency.

## Fix (`packages/server-build/src/lib/parsers.ts`)

- `success` is derived strictly from the process **exit code** (unchanged semantics, now explicit).
- Rolldown/Vite advisories (chunk-size notice, ineffective/mixed static+dynamic import) are classified as **warnings** and never as errors, so advisory stderr can never flip `success`.
- Error lines are only collected on a **genuine failure** (non-zero exit). On success, stray "error"-looking text can't surface as an error.
- On failure with no matched error lines, the parser falls back to the raw stderr/stdout so **`errors[]` is always populated when `success` is false**.

Result invariants: `success:true` ⟹ empty `errors[]`; `success:false` ⟹ non-empty `errors[]`; advisory stderr → `warnings[]`.

## Tests (`packages/server-build/__tests__/vite-build.test.ts`)

- rolldown-vite@8 advisory-only stderr + exit 0 → `success:true`, warnings populated (`INEFFECTIVE_DYNAMIC_IMPORT` + chunk-size), no errors, output files still parsed.
- advisory stderr alone never flips `success` to false.
- genuine failure with unmatched error text (`[UNRESOLVED_IMPORT]`) → `success:false`, `errors[]` populated via fallback, no spurious warnings.
- failed build with no diagnostics still yields a non-empty `errors[]`.

All 270 `@paretools/build` tests pass; package builds clean; lint/format clean.

Closes #915
