### PR TITLE
fix(test): surface load failures and allow flag-prefixed passthrough args

### DIFF
--- a/.changeset/test-load-failure-and-passthrough-args.md
+++ b/.changeset/test-load-failure-and-passthrough-args.md
@@ -1,0 +1,5 @@
+---
+"@paretools/test": patch
+---
+
+fix(test): surface load/collection failures instead of reporting silent green, and allow flag-prefixed passthrough args

--- a/packages/server-test/__tests__/formatters.test.ts
+++ b/packages/server-test/__tests__/formatters.test.ts
@@ -138,6 +138,20 @@ describe("formatTestRun", () => {
     expect(output).toContain("0 failed");
     expect(output).toContain("5 skipped");
   });
+
+  it("shows ERROR (not PASS) when a load failure error is present", () => {
+    const run: TestRun = {
+      framework: "vitest",
+      summary: { total: 0, passed: 0, failed: 0, skipped: 0, duration: 0 },
+      failures: [],
+      error: "Test runner exited with code 1 but reported no tests.\nSyntaxError: boom",
+    };
+    const output = formatTestRun(run);
+
+    expect(output).toContain("ERROR");
+    expect(output).not.toMatch(/\bPASS\b/);
+    expect(output).toContain("exited with code 1");
+  });
 });
 
 describe("formatCoverage", () => {

--- a/packages/server-test/__tests__/load-failure.test.ts
+++ b/packages/server-test/__tests__/load-failure.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the "silent green" guard: a test runner that exits non-zero but
+ * reports zero tests (a load/collection failure, or a filter that matched
+ * nothing) must NOT be reported as a passing run. See issues #928 and #931.
+ */
+import { describe, it, expect } from "vitest";
+import { surfaceLoadFailure } from "../src/tools/run.js";
+import type { TestRun } from "../src/schemas/index.js";
+
+const zeroRun: TestRun = {
+  framework: "vitest",
+  summary: { total: 0, passed: 0, failed: 0, skipped: 0, duration: 0 },
+  failures: [],
+};
+
+describe("surfaceLoadFailure", () => {
+  it("flags a suite that fails to load (non-zero exit, zero tests)", () => {
+    const result = {
+      exitCode: 1,
+      stdout: "",
+      stderr: "SyntaxError: Unexpected token in tests/broken.test.ts",
+    };
+    const flagged = surfaceLoadFailure(zeroRun, result);
+
+    expect(flagged.error).toBeDefined();
+    expect(flagged.error).toMatch(/exited with code 1/);
+    expect(flagged.error).toMatch(/failed to load or collect/);
+    // The stderr detail must be surfaced so the agent sees the real cause.
+    expect(flagged.error).toContain("SyntaxError");
+  });
+
+  it("does NOT read as a pass — error field distinguishes it from green", () => {
+    const flagged = surfaceLoadFailure(zeroRun, { exitCode: 1, stdout: "", stderr: "boom" });
+    // Zero totals alone would read as PASS; the error field is what prevents that.
+    expect(flagged.summary.total).toBe(0);
+    expect(flagged.summary.failed).toBe(0);
+    expect(flagged.error).toBeTruthy();
+  });
+
+  it("flags a filter that matched no tests (pytest exit code 5)", () => {
+    const pytestRun: TestRun = { ...zeroRun, framework: "pytest" };
+    const flagged = surfaceLoadFailure(pytestRun, {
+      exitCode: 5,
+      stdout: "no tests ran in 0.01s",
+      stderr: "",
+    });
+    expect(flagged.error).toMatch(/exited with code 5/);
+    // Falls back to stdout when stderr is empty.
+    expect(flagged.error).toContain("no tests ran");
+  });
+
+  it("does not flag a clean run with zero tests but exit code 0 (passWithNoTests)", () => {
+    const flagged = surfaceLoadFailure(zeroRun, { exitCode: 0, stdout: "", stderr: "" });
+    expect(flagged.error).toBeUndefined();
+    expect(flagged).toEqual(zeroRun);
+  });
+
+  it("does not flag a run that reported real tests (non-zero exit, tests present)", () => {
+    const failingRun: TestRun = {
+      framework: "vitest",
+      summary: { total: 3, passed: 2, failed: 1, skipped: 0, duration: 0.5 },
+      failures: [{ name: "does thing", message: "expected true" }],
+    };
+    const flagged = surfaceLoadFailure(failingRun, { exitCode: 1, stdout: "", stderr: "" });
+    expect(flagged.error).toBeUndefined();
+    expect(flagged).toEqual(failingRun);
+  });
+
+  it("does not flag a passing run (exit 0 with tests)", () => {
+    const passingRun: TestRun = {
+      framework: "jest",
+      summary: { total: 5, passed: 5, failed: 0, skipped: 0, duration: 1 },
+      failures: [],
+    };
+    const flagged = surfaceLoadFailure(passingRun, { exitCode: 0, stdout: "", stderr: "" });
+    expect(flagged.error).toBeUndefined();
+  });
+
+  it("truncates very long output detail", () => {
+    const huge = "x".repeat(5000);
+    const flagged = surfaceLoadFailure(zeroRun, { exitCode: 1, stdout: "", stderr: huge });
+    expect(flagged.error).toContain("output truncated");
+    expect(flagged.error!.length).toBeLessThan(huge.length);
+  });
+});

--- a/packages/server-test/__tests__/security.test.ts
+++ b/packages/server-test/__tests__/security.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
-import { assertNoFlagInjection, INPUT_LIMITS } from "@paretools/shared";
+import { assertNoFlagInjection, assertSafePassthroughArg, INPUT_LIMITS } from "@paretools/shared";
 
 /** Malicious inputs that must be rejected by every guarded parameter. */
 const MALICIOUS_INPUTS = [
@@ -54,26 +54,40 @@ describe("security: test run — filter validation", () => {
   });
 });
 
-describe("security: test run — args validation", () => {
-  it("rejects flag-like args", () => {
-    for (const malicious of MALICIOUS_INPUTS) {
-      expect(() => assertNoFlagInjection(malicious, "args")).toThrow(/must not start with "-"/);
+describe("security: test run — args passthrough validation", () => {
+  // The `args` field is an explicit passthrough: leading `-`/`--` flags are the
+  // caller's intent (e.g. `-p no:logfire` to disable a pytest plugin). Because
+  // execFile does not spawn a shell, these are not shell-interpreted. Only NUL
+  // and newline control characters are rejected. See issue #931.
+  it("accepts legitimate framework flags", () => {
+    const flags = [
+      "-p",
+      "no:logfire",
+      "-p no:cacheprovider",
+      "--maxfail=2",
+      "--no-header",
+      "-rA",
+      "--tb=short",
+    ];
+    for (const flag of flags) {
+      expect(() => assertSafePassthroughArg(flag, "args")).not.toThrow();
     }
   });
 
-  it("accepts safe args values", () => {
+  it("accepts safe non-flag args values", () => {
     for (const safe of SAFE_INPUTS) {
-      expect(() => assertNoFlagInjection(safe, "args")).not.toThrow();
+      expect(() => assertSafePassthroughArg(safe, "args")).not.toThrow();
+    }
+  });
+
+  it("rejects args containing NUL or newline control characters", () => {
+    for (const bad of ["foo\0bar", "line1\nline2", "carriage\rreturn"]) {
+      expect(() => assertSafePassthroughArg(bad, "args")).toThrow(/NUL or newline/);
     }
   });
 
   it("includes the parameter name in the error message", () => {
-    expect(() => assertNoFlagInjection("--bail", "args")).toThrow(/args/);
-  });
-
-  it("includes the invalid value in the error message", () => {
-    expect(() => assertNoFlagInjection("--bail", "args")).toThrow(/--bail/);
-    expect(() => assertNoFlagInjection("-x", "args")).toThrow(/-x/);
+    expect(() => assertSafePassthroughArg("bad\0", "args")).toThrow(/args/);
   });
 });
 

--- a/packages/server-test/__tests__/tool-params.test.ts
+++ b/packages/server-test/__tests__/tool-params.test.ts
@@ -80,9 +80,13 @@ describe("tool parameter handling", () => {
       expect(summary.total).toEqual(expect.any(Number));
     }, 300_000);
 
-    it("rejects flag-like args to prevent flag injection", async () => {
+    it("accepts flag-like passthrough args (no flag-injection rejection)", async () => {
       const gitPkgPath = resolve(__dirname, "../../server-git");
-      // args[] elements are validated with assertNoFlagInjection to prevent injection
+      // `args` is an explicit passthrough field: leading-dash framework flags
+      // are the caller's intent and must NOT be rejected as flag injection.
+      // Previously "--"-prefixed args were blocked; issue #931 loosened this so
+      // legitimate flags (e.g. pytest's `-p no:logfire`) work. execFile means
+      // args are never shell-interpreted.
       const result = await client.callTool(
         {
           name: "run",
@@ -90,14 +94,35 @@ describe("tool parameter handling", () => {
             path: gitPkgPath,
             framework: "vitest",
             filter: "parsers",
-            args: ["--bail", "1"],
+            args: ["--no-color"],
           },
         },
         undefined,
         CALL_TIMEOUT,
       );
 
-      // Should error — flag-like args are blocked by assertNoFlagInjection
+      // Must NOT be rejected by validation — the flag is passed through to vitest.
+      expect(result.isError).toBeFalsy();
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc?.framework).toBe("vitest");
+    }, 300_000);
+
+    it("rejects args containing control characters", async () => {
+      const gitPkgPath = resolve(__dirname, "../../server-git");
+      // NUL/newline are still rejected — they can corrupt argument boundaries.
+      const result = await client.callTool(
+        {
+          name: "run",
+          arguments: {
+            path: gitPkgPath,
+            framework: "vitest",
+            args: ["line1\nline2"],
+          },
+        },
+        undefined,
+        CALL_TIMEOUT,
+      );
+
       expect(result.isError).toBe(true);
     }, 300_000);
 

--- a/packages/server-test/src/lib/formatters.ts
+++ b/packages/server-test/src/lib/formatters.ts
@@ -2,10 +2,14 @@ import type { TestRun, Coverage, PlaywrightResult } from "../schemas/index.js";
 
 /** Formats structured test run results into a human-readable summary with pass/fail counts and failure details. */
 export function formatTestRun(r: TestRun): string {
-  const status = r.summary.failed > 0 ? "FAIL" : "PASS";
+  const status = r.error ? "ERROR" : r.summary.failed > 0 ? "FAIL" : "PASS";
   const parts = [
     `${status} (${r.framework}) ${r.summary.total} tests: ${r.summary.passed} passed, ${r.summary.failed} failed, ${r.summary.skipped} skipped [${r.summary.duration}s]`,
   ];
+
+  if (r.error) {
+    parts.push(`  ${r.error.split("\n")[0]}`);
+  }
 
   for (const f of r.failures) {
     const loc = f.file ? `${f.file}${f.line ? `:${f.line}` : ""}` : "";
@@ -45,6 +49,7 @@ export interface TestRunCompact {
     duration: number;
   };
   failures: Array<{ name: string; message?: string }>;
+  error?: string;
 }
 
 export function compactTestRunMap(r: TestRun): TestRunCompact {
@@ -55,14 +60,19 @@ export function compactTestRunMap(r: TestRun): TestRunCompact {
       name: f.name,
       ...(f.message ? { message: f.message } : {}),
     })),
+    ...(r.error ? { error: r.error } : {}),
   };
 }
 
 export function formatTestRunCompact(r: TestRunCompact): string {
-  const status = r.summary.failed > 0 ? "FAIL" : "PASS";
+  const status = r.error ? "ERROR" : r.summary.failed > 0 ? "FAIL" : "PASS";
   const parts = [
     `${status} (${r.framework}) ${r.summary.total} tests: ${r.summary.passed} passed, ${r.summary.failed} failed, ${r.summary.skipped} skipped [${r.summary.duration}s]`,
   ];
+
+  if (r.error) {
+    parts.push(`  ${r.error.split("\n")[0]}`);
+  }
 
   for (const f of r.failures) {
     parts.push(`  FAIL ${f.name}${f.message ? `: ${f.message}` : ""}`);

--- a/packages/server-test/src/schemas/index.ts
+++ b/packages/server-test/src/schemas/index.ts
@@ -34,6 +34,12 @@ export const TestRunSchema = z.object({
       }),
     )
     .optional(),
+  /**
+   * Present when the runner exited non-zero but reported no tests — i.e. the
+   * suite failed to load/collect (import/syntax error) or a filter matched
+   * nothing. A run with this field set MUST NOT be treated as a pass.
+   */
+  error: z.string().optional(),
 });
 
 export type TestRun = z.infer<typeof TestRunSchema>;

--- a/packages/server-test/src/tools/run.ts
+++ b/packages/server-test/src/tools/run.ts
@@ -8,6 +8,7 @@ import {
   compactDualOutput,
   run,
   assertNoFlagInjection,
+  assertSafePassthroughArg,
   INPUT_LIMITS,
   compactInput,
   projectPathInput,
@@ -22,7 +23,7 @@ import { parseJestJson } from "../lib/parsers/jest.js";
 import { parseVitestJson } from "../lib/parsers/vitest.js";
 import { parseMochaJson } from "../lib/parsers/mocha.js";
 import { formatTestRun, compactTestRunMap, formatTestRunCompact } from "../lib/formatters.js";
-import { TestRunSchema } from "../schemas/index.js";
+import { TestRunSchema, type TestRun } from "../schemas/index.js";
 import { TEST_CLI_TIMEOUT_MS } from "../lib/timeouts.js";
 
 /** Exported for unit testing. */
@@ -255,6 +256,41 @@ export function buildRunExtraArgs(
   return extraArgs;
 }
 
+/**
+ * Detects a "silent green" load/collection failure and attaches a top-level
+ * `error` so callers never mistake it for a pass.
+ *
+ * When a test file throws at import/collection time (syntax error, bad import),
+ * or a filter matches no tests, the runner exits non-zero but the parsed totals
+ * are `{ total: 0, failed: 0 }` — which reads as PASS. If the runner exited
+ * non-zero AND no tests/failures were parsed, we surface an `error` describing
+ * the failure (with the runner's stderr/stdout for context).
+ *
+ * Exported for unit testing. See issues #928 and #931.
+ */
+export function surfaceLoadFailure(
+  testRun: TestRun,
+  result: { exitCode: number; stdout: string; stderr: string },
+): TestRun {
+  const noResults = testRun.summary.total === 0 && testRun.failures.length === 0;
+  if (result.exitCode === 0 || !noResults) {
+    return testRun;
+  }
+
+  const detail = (result.stderr.trim() || result.stdout.trim()).trim();
+  const MAX_DETAIL = 2000;
+  const truncated =
+    detail.length > MAX_DETAIL ? `${detail.slice(0, MAX_DETAIL)}\n… (output truncated)` : detail;
+
+  const message =
+    `Test runner exited with code ${result.exitCode} but reported no tests. ` +
+    `The suite likely failed to load or collect (import/syntax error), or a filter matched no tests. ` +
+    `This is not a passing run.` +
+    (truncated ? `\n${truncated}` : "");
+
+  return { ...testRun, error: message };
+}
+
 /** Registers the `run` tool on the given MCP server. */
 export function registerRunTool(server: McpServer) {
   server.registerTool(
@@ -395,8 +431,12 @@ export function registerRunTool(server: McpServer) {
         assertNoFlagInjection(testNamePattern, "testNamePattern");
       }
       if (args) {
+        // `args` is an explicit passthrough field: the caller intends these to
+        // reach the test runner verbatim, so leading `-`/`--` flags (e.g.
+        // `-p no:logfire`) are allowed. Only NUL/newline control chars are
+        // rejected. See assertSafePassthroughArg.
         for (const arg of args) {
-          assertNoFlagInjection(arg, "args");
+          assertSafePassthroughArg(arg, "args");
         }
       }
 
@@ -445,26 +485,43 @@ export function registerRunTool(server: McpServer) {
       const output = result.stdout + "\n" + result.stderr;
 
       let testRun;
-      switch (detected) {
-        case "pytest":
-          testRun = parsePytestOutput(output);
-          break;
-        case "jest": {
-          const jsonStr = await readJsonOutput(tempPath, output);
-          testRun = parseJestJson(jsonStr);
-          break;
+      try {
+        switch (detected) {
+          case "pytest":
+            testRun = parsePytestOutput(output);
+            break;
+          case "jest": {
+            const jsonStr = await readJsonOutput(tempPath, output);
+            testRun = parseJestJson(jsonStr);
+            break;
+          }
+          case "vitest": {
+            const jsonStr = await readJsonOutput(tempPath, output);
+            testRun = parseVitestJson(jsonStr);
+            break;
+          }
+          case "mocha": {
+            const jsonStr = extractJson(output);
+            testRun = parseMochaJson(jsonStr);
+            break;
+          }
         }
-        case "vitest": {
-          const jsonStr = await readJsonOutput(tempPath, output);
-          testRun = parseVitestJson(jsonStr);
-          break;
-        }
-        case "mocha": {
-          const jsonStr = extractJson(output);
-          testRun = parseMochaJson(jsonStr);
-          break;
-        }
+      } catch (parseError) {
+        // If parsing produced no usable output but the runner succeeded, the
+        // error is genuine (e.g. misconfiguration) — rethrow. If the runner
+        // exited non-zero, the missing/invalid JSON is itself a load/collection
+        // failure, so synthesize an empty run that surfaceLoadFailure will flag.
+        if (result.exitCode === 0) throw parseError;
+        testRun = {
+          framework: detected,
+          summary: { total: 0, passed: 0, failed: 0, skipped: 0, duration: 0 },
+          failures: [],
+        };
       }
+
+      // Guard against "silent green": a non-zero exit with zero parsed tests
+      // must not read as a pass (issues #928, #931).
+      testRun = surfaceLoadFailure(testRun, result);
 
       return compactDualOutput(
         testRun,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -22,6 +22,7 @@ export { stripAnsi } from "./ansi.js";
 export {
   coerceJsonArray,
   assertNoFlagInjection,
+  assertSafePassthroughArg,
   assertValidSortKey,
   assertValidLogOpts,
   assertAllowedCommand,

--- a/packages/shared/src/validation.ts
+++ b/packages/shared/src/validation.ts
@@ -28,6 +28,25 @@ export function assertNoFlagInjection(value: string, paramName: string): void {
 }
 
 /**
+ * Validates a passthrough argument destined for a subprocess invoked via `execFile`.
+ *
+ * Unlike {@link assertNoFlagInjection}, a leading `-`/`--` is permitted, because a
+ * passthrough arg is the caller's explicit intent to forward a framework flag
+ * (e.g. `-p no:logfire` to disable a pytest plugin). Since `execFile` does not
+ * spawn a shell, args are never shell-interpreted, so shell metacharacters are
+ * harmless. The only rejected patterns are NUL and newline/carriage-return
+ * control characters, which are never valid inside a single CLI argument and can
+ * corrupt argument boundaries or downstream config parsing.
+ */
+export function assertSafePassthroughArg(value: string, paramName: string): void {
+  if (/[\0\r\n]/.test(value)) {
+    throw new Error(
+      `Invalid ${paramName}: "${value}". Arguments must not contain NUL or newline characters.`,
+    );
+  }
+}
+
+/**
  * Validates that a git sort key is safe. Git sort keys may start with `-` (meaning
  * descending order), e.g. `-creatordate`, `-committerdate`, `version:refname`.
  * Only allows alphanumeric chars, colons, dots, and underscores (with optional leading `-`).


### PR DESCRIPTION
## Summary

Fixes two related bugs in `@paretools/test`'s `run` tool. Both stem from a missing "non-zero exit with zero parsed tests" signal, so they share one detection path.

### Bug A — silent green on a suite that fails to load (#928)

**Root cause:** When a test file throws at import/collection time (syntax error, bad import), vitest/pytest exit non-zero but report no individual test failures. The parser produced `{ total: 0, failed: 0 }`, and nothing inspected the process exit code — so a broken suite surfaced as a PASS.

**Fix:** After parsing, `surfaceLoadFailure()` checks the runner's exit code. If it exited non-zero **and** parsed totals are `0` with no failures, it attaches a top-level `error` field (added to `TestRunSchema`) that includes the runner's stderr/stdout. Formatters render this as an `ERROR` status line instead of `PASS`. The JSON-parse path is also wrapped: if output can't be parsed but the runner exited non-zero, an empty run is synthesized and flagged rather than throwing an opaque error.

### Bug B — passthrough args rejected + zero-match filter looked green (#931)

**Root cause 1:** Every element of the explicit `args` array was validated with `assertNoFlagInjection`, which rejects any token starting with `-`. That blocked legitimate framework flags like pytest's `-p no:logfire`.

**Fix 1:** New `assertSafePassthroughArg` validator in `@paretools/shared`. Because `args` is an explicit passthrough field and `execFile` never spawns a shell (args are not shell-interpreted), leading-dash flags are the caller's intent and are allowed. It still rejects NUL/newline control characters, which can corrupt argument boundaries. `filter`, `config`, `interpreter`, etc. keep the stricter `assertNoFlagInjection` guard.

**Root cause 2:** A valid filter that matches no tests exits non-zero (pytest exit code 5) with `0/0/0`, which read as green.

**Fix 2:** This is the same condition as Bug A — `surfaceLoadFailure()` now flags exit-non-zero-with-zero-tests, so a zero-match filter no longer reads as a pass.

## Tests added

- `__tests__/load-failure.test.ts` — `surfaceLoadFailure` flags load failures and zero-match filters, surfaces stderr/stdout detail, truncates long output, and leaves clean runs, real-failure runs, and `passWithNoTests` (exit 0) runs untouched.
- `__tests__/security.test.ts` — rewritten `args` section: legitimate flags (`-p no:logfire`, `--maxfail=2`, …) are accepted; NUL/newline args are rejected.
- `__tests__/tool-params.test.ts` — a `--no-color` passthrough flag is accepted (no injection rejection); control-char args are rejected.
- `__tests__/formatters.test.ts` — a run with an `error` renders as `ERROR`, not `PASS`.

## Verification

`tsc` clean; `@paretools/test` suite green except one pre-existing, unrelated failure: the integration test runs `server-git`'s **full** suite through the built server, and `server-git`'s `parseLogGraph` fidelity fixture independently fails on a hard-coded commit hash in this worktree (confirmed by running `server-git` directly — 698/699, same single failure). Not touched by this change.

Closes #928
Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)