### PR TITLE
feat(git): safe worktree cleanup — ancestry, per-worktree status, prune-merged

### DIFF
--- a/.changeset/safe-worktree-cleanup.md
+++ b/.changeset/safe-worktree-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@paretools/git": minor
+---
+
+Add safe worktree-cleanup primitives (#921): `branch` gains an opt-in `mergedInto` ancestry check (per-branch `merged`/`unmerged`), `worktree list` gains opt-in `withStatus` (dirty/ahead/behind/unpushed) and `mergedInto` enrichment, and a new `worktree` action `prune-merged {base, requireClean}` batch-removes merged-clean worktrees while refusing dirty, unmerged, locked, bare, main, and current worktrees.

--- a/packages/server-git/__tests__/cleanup.test.ts
+++ b/packages/server-git/__tests__/cleanup.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseRevListCount,
+  worktreePathsEqual,
+  normalizeWorktreePath,
+  decidePruneMerged,
+} from "../src/lib/parsers.js";
+import { formatBranch, formatWorktreeList, formatWorktreePrune } from "../src/lib/formatters.js";
+import type { GitBranchFull, GitWorktreeListFull } from "../src/schemas/index.js";
+
+// ── Part 1: ancestry / merged predicate helpers ──────────────────────────
+
+describe("parseRevListCount", () => {
+  it("parses a plain integer count", () => {
+    expect(parseRevListCount("0\n")).toBe(0);
+    expect(parseRevListCount("3\n")).toBe(3);
+    expect(parseRevListCount("42")).toBe(42);
+  });
+
+  it("returns 0 for empty or non-numeric output", () => {
+    expect(parseRevListCount("")).toBe(0);
+    expect(parseRevListCount("\n")).toBe(0);
+    expect(parseRevListCount("fatal: bad revision")).toBe(0);
+  });
+});
+
+describe("formatBranch with merged predicate", () => {
+  it("marks a merged branch with [merged]", () => {
+    const b: GitBranchFull = {
+      current: "main",
+      branches: [{ name: "feature", current: false, merged: true, unmerged: 0 }],
+    };
+    expect(formatBranch(b)).toBe("  feature [merged]");
+  });
+
+  it("marks an unmerged branch with [unmerged N]", () => {
+    const b: GitBranchFull = {
+      current: "main",
+      branches: [{ name: "feature", current: false, merged: false, unmerged: 3 }],
+    };
+    expect(formatBranch(b)).toBe("  feature [unmerged 3]");
+  });
+
+  it("leaves default output byte-for-byte unchanged when merged is undefined", () => {
+    const b: GitBranchFull = {
+      current: "main",
+      branches: [
+        { name: "main", current: true, upstream: "origin/main" },
+        { name: "feature", current: false },
+      ],
+    };
+    expect(formatBranch(b)).toBe("* main -> origin/main\n  feature");
+  });
+});
+
+// ── Part 2: per-worktree status rendering ─────────────────────────────────
+
+describe("formatWorktreeList with status enrichment", () => {
+  it("appends a status suffix when enrichment fields are present", () => {
+    const w: GitWorktreeListFull = {
+      worktrees: [
+        {
+          path: "/repo/wt",
+          head: "abcdef1234567890",
+          branch: "feature",
+          bare: false,
+          dirty: true,
+          ahead: 2,
+          behind: 1,
+          unpushed: 2,
+          merged: false,
+        },
+      ],
+    };
+    expect(formatWorktreeList(w)).toBe(
+      "/repo/wt  abcdef12 (feature) [dirty, ahead 2, behind 1, unpushed 2, unmerged]",
+    );
+  });
+
+  it("keeps default output byte-for-byte unchanged with no status fields", () => {
+    const w: GitWorktreeListFull = {
+      worktrees: [{ path: "/repo", head: "abcdef1234567890", branch: "main", bare: false }],
+    };
+    expect(formatWorktreeList(w)).toBe("/repo  abcdef12 (main)");
+  });
+});
+
+// ── Part 3: prune-merged decision + rendering ─────────────────────────────
+
+describe("normalizeWorktreePath / worktreePathsEqual", () => {
+  it("normalizes separators, trailing slash, and case", () => {
+    expect(normalizeWorktreePath("C:\\Repo\\WT\\")).toBe("c:/repo/wt");
+  });
+
+  it("treats equivalent paths as equal across separators and casing", () => {
+    expect(worktreePathsEqual("C:\\repo\\wt", "c:/repo/wt/")).toBe(true);
+    expect(worktreePathsEqual("/repo/a", "/repo/b")).toBe(false);
+  });
+});
+
+describe("decidePruneMerged", () => {
+  const opts = { mainPath: "/repo", currentPath: "/repo", requireClean: true };
+
+  it("removes a merged, clean worktree", () => {
+    const [r] = decidePruneMerged(
+      [{ path: "/repo/wt", branch: "done", bare: false, merged: true, dirty: false }],
+      opts,
+    );
+    expect(r).toEqual({ path: "/repo/wt", branch: "done", removed: true });
+  });
+
+  it("skips an unmerged worktree", () => {
+    const [r] = decidePruneMerged(
+      [{ path: "/repo/wt", branch: "wip", bare: false, merged: false, dirty: false }],
+      opts,
+    );
+    expect(r).toMatchObject({ removed: false, reason: "not-merged" });
+  });
+
+  it("skips a dirty worktree when requireClean is set", () => {
+    const [r] = decidePruneMerged(
+      [{ path: "/repo/wt", branch: "done", bare: false, merged: true, dirty: true }],
+      opts,
+    );
+    expect(r).toMatchObject({ removed: false, reason: "dirty" });
+  });
+
+  it("removes a dirty merged worktree when requireClean is false", () => {
+    const [r] = decidePruneMerged(
+      [{ path: "/repo/wt", branch: "done", bare: false, merged: true, dirty: true }],
+      { ...opts, requireClean: false },
+    );
+    expect(r.removed).toBe(true);
+  });
+
+  it("refuses the main worktree", () => {
+    const [r] = decidePruneMerged(
+      [{ path: "/repo", branch: "main", bare: false, merged: true, dirty: false }],
+      opts,
+    );
+    expect(r).toMatchObject({ removed: false, reason: "main" });
+  });
+
+  it("refuses the current worktree", () => {
+    const [r] = decidePruneMerged(
+      [{ path: "/repo/here", branch: "cur", bare: false, merged: true, dirty: false }],
+      { mainPath: "/repo", currentPath: "/repo/here", requireClean: true },
+    );
+    expect(r).toMatchObject({ removed: false, reason: "current" });
+  });
+
+  it("refuses a bare worktree", () => {
+    const [r] = decidePruneMerged(
+      [{ path: "/repo.git", branch: "", bare: true, merged: true, dirty: false }],
+      opts,
+    );
+    expect(r).toMatchObject({ removed: false, reason: "bare" });
+  });
+
+  it("refuses a locked worktree", () => {
+    const [r] = decidePruneMerged(
+      [{ path: "/repo/wt", branch: "done", bare: false, locked: true, merged: true, dirty: false }],
+      opts,
+    );
+    expect(r).toMatchObject({ removed: false, reason: "locked" });
+  });
+
+  it("classifies a mixed batch correctly", () => {
+    const results = decidePruneMerged(
+      [
+        { path: "/repo", branch: "main", bare: false, merged: true, dirty: false },
+        { path: "/repo/a", branch: "a", bare: false, merged: true, dirty: false },
+        { path: "/repo/b", branch: "b", bare: false, merged: false, dirty: false },
+        { path: "/repo/c", branch: "c", bare: false, merged: true, dirty: true },
+      ],
+      opts,
+    );
+    expect(results.map((r) => [r.branch, r.removed, r.reason])).toEqual([
+      ["main", false, "main"],
+      ["a", true, undefined],
+      ["b", false, "not-merged"],
+      ["c", false, "dirty"],
+    ]);
+  });
+});
+
+describe("formatWorktreePrune", () => {
+  it("summarizes removed and skipped worktrees", () => {
+    const out = formatWorktreePrune({
+      base: "main",
+      results: [
+        { path: "/repo/a", branch: "a", removed: true },
+        { path: "/repo/b", branch: "b", removed: false, reason: "not-merged" },
+      ],
+    });
+    expect(out).toBe(
+      [
+        "prune-merged (base main): removed 1, skipped 1",
+        "  removed: /repo/a (a)",
+        "  skipped [not-merged]: /repo/b (b)",
+      ].join("\n"),
+    );
+  });
+});

--- a/packages/server-git/__tests__/worktree-cleanup-integration.test.ts
+++ b/packages/server-git/__tests__/worktree-cleanup-integration.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { resolve, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const PKG_DIR = resolve(__dirname, "..");
+const SERVER_PATH = resolve(__dirname, "../dist/index.js");
+const CALL_TIMEOUT = 180_000;
+
+let built = false;
+function ensureBuiltArtifacts() {
+  if (built) return;
+  execFileSync("pnpm", ["build"], {
+    cwd: PKG_DIR,
+    encoding: "utf-8",
+    shell: process.platform === "win32",
+  });
+  built = true;
+}
+
+function gitIn(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8" });
+}
+
+/**
+ * End-to-end coverage for the #921 safe-worktree-cleanup capabilities:
+ *   Part 1 — branch `mergedInto`: per-branch merged/unmerged ancestry.
+ *   Part 2 — worktree list `withStatus` / `mergedInto` enrichment.
+ *   Part 3 — worktree `prune-merged`: removes merged-clean worktrees, skips
+ *            dirty and unmerged ones, and refuses the main/current worktree.
+ */
+describe("@paretools/git worktree safe cleanup (#921)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+  let mainRepo: string;
+  let wtMerged: string;
+  let wtUnmerged: string;
+  let wtDirty: string;
+
+  beforeAll(async () => {
+    ensureBuiltArtifacts();
+
+    // Main repo on branch `trunk` with one commit.
+    mainRepo = mkdtempSync(join(tmpdir(), "pare-git-921-main-"));
+    gitIn(mainRepo, ["init", "-b", "trunk"]);
+    gitIn(mainRepo, ["config", "user.email", "test@test.com"]);
+    gitIn(mainRepo, ["config", "user.name", "Test"]);
+    writeFileSync(join(mainRepo, "file.txt"), "initial\n");
+    gitIn(mainRepo, ["add", "-A"]);
+    gitIn(mainRepo, ["commit", "-m", "init"]);
+
+    // wt-merged: HEAD == trunk ⇒ fully merged into trunk. Left clean.
+    wtMerged = join(mainRepo, "..", `pare-git-921-merged-${process.pid}`);
+    gitIn(mainRepo, ["worktree", "add", "-b", "wt-merged", wtMerged, "trunk"]);
+
+    // wt-unmerged: adds a commit not in trunk ⇒ NOT an ancestor of trunk.
+    wtUnmerged = join(mainRepo, "..", `pare-git-921-unmerged-${process.pid}`);
+    gitIn(mainRepo, ["worktree", "add", "-b", "wt-unmerged", wtUnmerged, "trunk"]);
+    writeFileSync(join(wtUnmerged, "extra.txt"), "wip\n");
+    gitIn(wtUnmerged, ["add", "-A"]);
+    gitIn(wtUnmerged, ["commit", "-m", "wip commit"]);
+
+    // wt-dirty: HEAD == trunk (merged) but has an uncommitted file ⇒ dirty.
+    wtDirty = join(mainRepo, "..", `pare-git-921-dirty-${process.pid}`);
+    gitIn(mainRepo, ["worktree", "add", "-b", "wt-dirty", wtDirty, "trunk"]);
+    writeFileSync(join(wtDirty, "uncommitted.txt"), "dirty\n");
+
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [SERVER_PATH],
+      stderr: "pipe",
+      cwd: mainRepo,
+    });
+    client = new Client({ name: "test-client", version: "1.0.0" });
+    await client.connect(transport);
+  }, 180_000);
+
+  afterAll(async () => {
+    await transport?.close();
+    for (const wt of [wtMerged, wtUnmerged, wtDirty]) {
+      try {
+        gitIn(mainRepo, ["worktree", "remove", "--force", wt]);
+      } catch {
+        /* best-effort */
+      }
+      rmSync(wt, { recursive: true, force: true });
+    }
+    rmSync(mainRepo, { recursive: true, force: true });
+  }, 30_000);
+
+  it("Part 1: branch mergedInto flags merged vs unmerged branches", async () => {
+    const result = await client.callTool(
+      { name: "branch", arguments: { path: mainRepo, mergedInto: "trunk" } },
+      undefined,
+      { timeout: CALL_TIMEOUT },
+    );
+    const sc = result.structuredContent as { branches: Array<Record<string, unknown>> };
+    const byName = new Map(sc.branches.map((b) => [b.name as string, b]));
+
+    expect(byName.get("wt-merged")?.merged).toBe(true);
+    expect(byName.get("wt-merged")?.unmerged).toBe(0);
+    expect(byName.get("wt-unmerged")?.merged).toBe(false);
+    expect(byName.get("wt-unmerged")?.unmerged).toBe(1);
+    expect(byName.get("trunk")?.merged).toBe(true);
+  });
+
+  it("Part 2: worktree list withStatus reports dirty + unpushed per worktree", async () => {
+    const result = await client.callTool(
+      { name: "worktree", arguments: { path: mainRepo, withStatus: true, mergedInto: "trunk" } },
+      undefined,
+      { timeout: CALL_TIMEOUT },
+    );
+    const sc = result.structuredContent as { worktrees: Array<Record<string, unknown>> };
+    const byBranch = new Map(sc.worktrees.map((w) => [w.branch as string, w]));
+
+    // Dirty flag is present for every worktree and correct for the dirty one.
+    expect(byBranch.get("wt-dirty")?.dirty).toBe(true);
+    expect(byBranch.get("wt-merged")?.dirty).toBe(false);
+
+    // merged flag reflects ancestry into trunk.
+    expect(byBranch.get("wt-merged")?.merged).toBe(true);
+    expect(byBranch.get("wt-unmerged")?.merged).toBe(false);
+
+    // unpushed is a number (no remotes ⇒ all local commits count as unpushed).
+    expect(typeof byBranch.get("wt-unmerged")?.unpushed).toBe("number");
+  });
+
+  it("Part 3: prune-merged removes merged-clean, skips dirty/unmerged, refuses main", async () => {
+    const result = await client.callTool(
+      {
+        name: "worktree",
+        arguments: { path: mainRepo, action: "prune-merged", base: "trunk" },
+      },
+      undefined,
+      { timeout: CALL_TIMEOUT },
+    );
+    const sc = result.structuredContent as {
+      action: string;
+      base: string;
+      results: Array<{ path: string; branch?: string; removed: boolean; reason?: string }>;
+    };
+    expect(sc.action).toBe("prune-merged");
+
+    const byBranch = new Map(sc.results.map((r) => [r.branch, r]));
+
+    // Merged + clean ⇒ removed.
+    expect(byBranch.get("wt-merged")?.removed).toBe(true);
+    expect(existsSync(wtMerged)).toBe(false);
+
+    // Unmerged ⇒ never removed.
+    expect(byBranch.get("wt-unmerged")?.removed).toBe(false);
+    expect(byBranch.get("wt-unmerged")?.reason).toBe("not-merged");
+    expect(existsSync(wtUnmerged)).toBe(true);
+
+    // Dirty ⇒ skipped under the default requireClean guard.
+    expect(byBranch.get("wt-dirty")?.removed).toBe(false);
+    expect(byBranch.get("wt-dirty")?.reason).toBe("dirty");
+    expect(existsSync(wtDirty)).toBe(true);
+
+    // The main/current worktree is refused outright.
+    const mainResult = sc.results.find((r) => r.branch === "trunk");
+    expect(mainResult?.removed).toBe(false);
+    expect(["main", "current"]).toContain(mainResult?.reason);
+    expect(existsSync(mainRepo)).toBe(true);
+  });
+});

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -26,6 +26,7 @@ import type {
   GitTagMutate,
   GitWorktreeListFull,
   GitWorktree,
+  GitWorktreePruneResult,
   GitSubmodule,
   GitArchive,
   GitClean,
@@ -85,7 +86,14 @@ export function formatBranch(b: GitBranchFull): string {
     .map((br) => {
       const prefix = br.current ? "* " : "  ";
       const upstream = br.upstream ? ` -> ${br.upstream}` : "";
-      return `${prefix}${br.name}${upstream}`;
+      // Only present when `mergedInto` was requested — keeps default output unchanged.
+      const merged =
+        br.merged === undefined
+          ? ""
+          : br.merged
+            ? " [merged]"
+            : ` [unmerged${br.unmerged ? ` ${br.unmerged}` : ""}]`;
+      return `${prefix}${br.name}${upstream}${merged}`;
     })
     .join("\n");
 }
@@ -694,6 +702,21 @@ export function formatBisect(b: GitBisect): string {
 
 // ── Worktree formatters ────────────────────────────────────────────────
 
+/**
+ * Builds the optional per-worktree status suffix (dirty/ahead/behind/unpushed/merged).
+ * Returns "" when no status fields are present so default output stays unchanged.
+ */
+function formatWorktreeStatusSuffix(wt: GitWorktreeListFull["worktrees"][number]): string {
+  const parts: string[] = [];
+  if (wt.dirty !== undefined) parts.push(wt.dirty ? "dirty" : "clean");
+  if (wt.ahead !== undefined || wt.behind !== undefined) {
+    parts.push(`ahead ${wt.ahead ?? 0}, behind ${wt.behind ?? 0}`);
+  }
+  if (wt.unpushed !== undefined) parts.push(`unpushed ${wt.unpushed}`);
+  if (wt.merged !== undefined) parts.push(wt.merged ? "merged" : "unmerged");
+  return parts.length > 0 ? ` [${parts.join(", ")}]` : "";
+}
+
 /** Formats structured git worktree list data into a human-readable worktree listing. */
 export function formatWorktreeList(w: GitWorktreeListFull): string {
   if (w.worktrees.length === 0) return "No worktrees found";
@@ -707,7 +730,8 @@ export function formatWorktreeList(w: GitWorktreeListFull): string {
           ? ` [prunable: ${wt.prunableReason}]`
           : " [prunable]"
         : "";
-      return `${wt.path}  ${wt.head.slice(0, 8)}${branch}${bare}${locked}${prunable}`;
+      const status = formatWorktreeStatusSuffix(wt);
+      return `${wt.path}  ${wt.head.slice(0, 8)}${branch}${bare}${locked}${prunable}${status}`;
     })
     .join("\n");
 }
@@ -739,6 +763,25 @@ export function formatWorktree(w: GitWorktree): string {
   const head = w.head ? ` at ${w.head}` : "";
   const target = w.targetPath ? ` -> '${w.targetPath}'` : "";
   return `${action}Worktree at '${w.path}'${target}${branch}${head}`;
+}
+
+/** Formats the result of a `worktree prune-merged` batch operation. */
+export function formatWorktreePrune(w: {
+  base?: string;
+  results?: GitWorktreePruneResult[];
+}): string {
+  const results = w.results ?? [];
+  const removed = results.filter((r) => r.removed);
+  const skipped = results.filter((r) => !r.removed);
+  const lines = [
+    `prune-merged (base ${w.base ?? "?"}): removed ${removed.length}, skipped ${skipped.length}`,
+  ];
+  for (const r of results) {
+    const label = r.removed ? "removed" : `skipped [${r.reason ?? "unknown"}]`;
+    const branch = r.branch ? ` (${r.branch})` : "";
+    lines.push(`  ${label}: ${r.path}${branch}`);
+  }
+  return lines.join("\n");
 }
 
 // ── Bisect run formatter ────────────────────────────────────────────────

--- a/packages/server-git/src/lib/parsers.ts
+++ b/packages/server-git/src/lib/parsers.ts
@@ -24,6 +24,7 @@ import type {
   GitBisect,
   GitWorktreeListFull,
   GitWorktree,
+  GitWorktreePruneResult,
   ReflogAction,
   GitSubmoduleEntry,
   GitClean,
@@ -1821,6 +1822,67 @@ export function parseWorktreeResult(
     branch,
     ...(head ? { head } : {}),
   };
+}
+
+/** Parses the numeric output of `git rev-list --count <range>` into an integer (0 on empty/invalid). */
+export function parseRevListCount(stdout: string): number {
+  const n = parseInt(stdout.trim(), 10);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+/**
+ * Normalizes a worktree path for cross-platform equality comparison:
+ * backslashes → forward slashes, strip trailing slash, lowercase (git worktree
+ * paths land on case-insensitive filesystems on Windows/macOS).
+ */
+export function normalizeWorktreePath(p: string): string {
+  return p.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}
+
+/** True when two worktree paths refer to the same location (after normalization). */
+export function worktreePathsEqual(a: string, b: string): boolean {
+  return normalizeWorktreePath(a) === normalizeWorktreePath(b);
+}
+
+/**
+ * Pure safe-cleanup decision for `worktree prune-merged`.
+ *
+ * Given the parsed worktree entries — each annotated with `merged` (HEAD fully
+ * contained in the base ref) and `dirty` — decides which worktrees may be
+ * removed. Guards: never touch the bare repo, the main worktree, the current
+ * worktree, or a locked worktree; never remove an unmerged worktree; and never
+ * remove a dirty worktree when `requireClean` is set. Returns a per-path result.
+ */
+export function decidePruneMerged(
+  worktrees: Array<{
+    path: string;
+    branch: string;
+    bare: boolean;
+    locked?: boolean;
+    merged?: boolean;
+    dirty?: boolean;
+  }>,
+  opts: { mainPath: string; currentPath: string; requireClean: boolean },
+): GitWorktreePruneResult[] {
+  return worktrees.map((wt) => {
+    const base: { path: string; branch?: string } = {
+      path: wt.path,
+      ...(wt.branch ? { branch: wt.branch } : {}),
+    };
+    const skip = (reason: GitWorktreePruneResult["reason"]): GitWorktreePruneResult => ({
+      ...base,
+      removed: false,
+      reason,
+    });
+
+    if (wt.bare) return skip("bare");
+    if (worktreePathsEqual(wt.path, opts.mainPath)) return skip("main");
+    if (worktreePathsEqual(wt.path, opts.currentPath)) return skip("current");
+    if (wt.locked) return skip("locked");
+    if (!wt.merged) return skip("not-merged");
+    if (opts.requireClean && wt.dirty) return skip("dirty");
+    return { ...base, removed: true };
+  });
 }
 
 /** Parses `git bisect run <cmd>` output into structured bisect run result data. */

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -72,6 +72,10 @@ export const GitBranchEntrySchema = z.object({
   current: z.boolean(),
   upstream: z.string().optional(),
   lastCommit: z.string().optional(),
+  /** Whether this branch is fully contained in the `mergedInto` ref (opt-in). */
+  merged: z.boolean().optional(),
+  /** Count of commits on this branch not yet in the `mergedInto` ref (opt-in). */
+  unmerged: z.number().optional(),
 });
 
 /** Zod schema for structured git branch output listing all branches and the current branch. */
@@ -82,7 +86,14 @@ export const GitBranchSchema = z.object({
 
 /** Full branch data (always returned by parser, before compact projection). */
 export type GitBranchFull = {
-  branches: Array<{ name: string; current: boolean; upstream?: string; lastCommit?: string }>;
+  branches: Array<{
+    name: string;
+    current: boolean;
+    upstream?: string;
+    lastCommit?: string;
+    merged?: boolean;
+    unmerged?: number;
+  }>;
   current: string;
 };
 
@@ -598,6 +609,16 @@ export const GitWorktreeEntrySchema = z.object({
   lockReason: z.string().optional(),
   prunable: z.boolean().optional(),
   prunableReason: z.string().optional(),
+  /** Whether the worktree has uncommitted changes (opt-in via withStatus). */
+  dirty: z.boolean().optional(),
+  /** Commits ahead of the tracked upstream (present only when an upstream exists). */
+  ahead: z.number().optional(),
+  /** Commits behind the tracked upstream (present only when an upstream exists). */
+  behind: z.number().optional(),
+  /** Commits on HEAD not reachable from any remote-tracking branch (opt-in). */
+  unpushed: z.number().optional(),
+  /** Whether the worktree HEAD is fully contained in the `mergedInto` ref (opt-in). */
+  merged: z.boolean().optional(),
 });
 
 /** Zod schema for structured git worktree list output. */
@@ -616,6 +637,11 @@ export type GitWorktreeListFull = {
     lockReason?: string;
     prunable?: boolean;
     prunableReason?: string;
+    dirty?: boolean;
+    ahead?: number;
+    behind?: number;
+    unpushed?: number;
+    merged?: boolean;
   }>;
 };
 
@@ -624,7 +650,9 @@ export type GitWorktreeList = z.infer<typeof GitWorktreeListSchema>;
 /** Zod schema for structured git worktree add/remove output. */
 export const GitWorktreeSchema = z.object({
   success: z.boolean(),
-  action: z.enum(["add", "remove", "lock", "unlock", "prune", "move", "repair"]).optional(),
+  action: z
+    .enum(["add", "remove", "lock", "unlock", "prune", "move", "repair", "prune-merged"])
+    .optional(),
   path: z.string(),
   targetPath: z.string().optional(),
   branch: z.string(),
@@ -632,6 +660,19 @@ export const GitWorktreeSchema = z.object({
 });
 
 export type GitWorktree = z.infer<typeof GitWorktreeSchema>;
+
+/** Zod schema for a single per-worktree result of the prune-merged batch operation. */
+export const GitWorktreePruneResultSchema = z.object({
+  path: z.string(),
+  branch: z.string().optional(),
+  removed: z.boolean(),
+  /** Why the worktree was skipped (only present when removed=false). */
+  reason: z
+    .enum(["not-merged", "dirty", "locked", "main", "current", "bare", "remove-failed"])
+    .optional(),
+});
+
+export type GitWorktreePruneResult = z.infer<typeof GitWorktreePruneResultSchema>;
 
 /** Unified Zod schema for all worktree tool output (list + mutate actions).
  *  Uses a single z.object() with optional fields instead of z.union(),
@@ -642,7 +683,9 @@ export const GitWorktreeOutputSchema = z.object({
   /** Present for mutate actions. */
   success: z.boolean().optional(),
   /** Action performed (only present for mutate operations). */
-  action: z.enum(["add", "remove", "lock", "unlock", "prune", "move", "repair"]).optional(),
+  action: z
+    .enum(["add", "remove", "lock", "unlock", "prune", "move", "repair", "prune-merged"])
+    .optional(),
   /** Worktree path (present for mutate actions). */
   path: z.string().optional(),
   /** Target path (only present for move action). */
@@ -651,6 +694,10 @@ export const GitWorktreeOutputSchema = z.object({
   branch: z.string().optional(),
   /** HEAD commit (present for mutate actions). */
   head: z.string().optional(),
+  /** Base ref evaluated (only present for prune-merged). */
+  base: z.string().optional(),
+  /** Per-worktree removal results (only present for prune-merged). */
+  results: z.array(GitWorktreePruneResultSchema).optional(),
 });
 
 /** Type alias for remote mutate results (uses unified GitRemoteSchema). */

--- a/packages/server-git/src/tools/branch.ts
+++ b/packages/server-git/src/tools/branch.ts
@@ -9,7 +9,7 @@ import {
 } from "@paretools/shared";
 import { assertNoFlagInjection, assertValidSortKey } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
-import { parseBranch } from "../lib/parsers.js";
+import { parseBranch, parseRevListCount } from "../lib/parsers.js";
 import { formatBranch, compactBranchMap, formatBranchCompact } from "../lib/formatters.js";
 import { GitBranchSchema } from "../schemas/index.js";
 
@@ -85,6 +85,13 @@ export function registerBranchTool(server: McpServer) {
           .boolean()
           .optional()
           .describe("Filter to branches not merged into HEAD (--no-merged)"),
+        mergedInto: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "Opt-in ancestry check: for each listed branch, add `merged` (fully contained in this ref) and `unmerged` (commit count not yet in the ref). Safe-delete predicate for cleanup workflows.",
+          ),
         remotes: z.boolean().optional().describe("List remote branches only (-r)"),
         verbose: z.boolean().optional().describe("Verbose branch listing (-v)"),
         force: z.coerce
@@ -114,6 +121,7 @@ export function registerBranchTool(server: McpServer) {
       forceDelete,
       merged,
       noMerged,
+      mergedInto,
       remotes,
       verbose,
       force,
@@ -220,13 +228,31 @@ export function registerBranchTool(server: McpServer) {
       }
 
       const branches = parseBranch(result.stdout);
+
+      // Opt-in ancestry / merged predicate (#921). For each branch, count the
+      // commits it carries that are NOT yet in `mergedInto`. Zero ⇒ the branch
+      // is fully contained in the ref (safe to delete). `git rev-list --count
+      // <ref>..<branch>` yields both the boolean and the unmerged count.
+      if (mergedInto) {
+        assertNoFlagInjection(mergedInto, "mergedInto");
+        for (const br of branches.branches) {
+          // Skip placeholder rows like "(HEAD detached at abc123)".
+          if (!br.name || br.name.startsWith("(")) continue;
+          const rev = await git(["rev-list", "--count", `${mergedInto}..${br.name}`], cwd);
+          if (rev.exitCode !== 0) continue;
+          const unmerged = parseRevListCount(rev.stdout);
+          br.merged = unmerged === 0;
+          br.unmerged = unmerged;
+        }
+      }
+
       return compactDualOutput(
         branches,
         result.stdout,
         formatBranch,
         compactBranchMap,
         formatBranchCompact,
-        compact === false,
+        compact === false || !!mergedInto,
       );
     },
   );

--- a/packages/server-git/src/tools/worktree.ts
+++ b/packages/server-git/src/tools/worktree.ts
@@ -9,14 +9,65 @@ import {
   repoPathInput,
 } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
-import { parseWorktreeList, parseWorktreeResult } from "../lib/parsers.js";
+import {
+  parseWorktreeList,
+  parseWorktreeResult,
+  parseRevListCount,
+  decidePruneMerged,
+  worktreePathsEqual,
+} from "../lib/parsers.js";
 import {
   formatWorktreeList,
   compactWorktreeListMap,
   formatWorktreeListCompact,
   formatWorktree,
+  formatWorktreePrune,
 } from "../lib/formatters.js";
+import type { GitWorktreeListFull } from "../schemas/index.js";
 import { GitWorktreeOutputSchema } from "../schemas/index.js";
+
+type WorktreeEntry = GitWorktreeListFull["worktrees"][number];
+
+/**
+ * Enriches a single worktree entry with per-worktree status (#921):
+ *   - dirty:    `git status --porcelain` in the worktree is non-empty
+ *   - ahead/behind: `git rev-list --left-right --count @{u}...HEAD` (upstream vs HEAD).
+ *     Omitted when the worktree has no upstream (rev-list exits non-zero).
+ *   - unpushed: commits on HEAD not reachable from any remote-tracking branch
+ *   - merged:   worktree HEAD is an ancestor of `mergedInto`
+ * Bare worktrees have no working tree, so status/ahead fields are skipped for them.
+ */
+async function enrichWorktreeStatus(
+  wt: WorktreeEntry,
+  cwd: string,
+  opts: { withStatus: boolean; mergedInto?: string },
+): Promise<void> {
+  if (opts.mergedInto && wt.head) {
+    const anc = await git(["merge-base", "--is-ancestor", wt.head, opts.mergedInto], cwd);
+    // exit 0 = ancestor (merged), 1 = not, other = error (leave undefined).
+    if (anc.exitCode === 0) wt.merged = true;
+    else if (anc.exitCode === 1) wt.merged = false;
+  }
+
+  if (!opts.withStatus || wt.bare) return;
+
+  const status = await git(["status", "--porcelain"], wt.path);
+  if (status.exitCode === 0) wt.dirty = status.stdout.trim().length > 0;
+
+  // ahead/behind relative to the tracked upstream; @{u} fails without one.
+  const ab = await git(["rev-list", "--left-right", "--count", "@{u}...HEAD"], wt.path);
+  if (ab.exitCode === 0) {
+    const nums = ab.stdout.trim().split(/\s+/);
+    if (nums.length === 2) {
+      wt.behind = parseRevListCount(nums[0]);
+      wt.ahead = parseRevListCount(nums[1]);
+    }
+  }
+
+  // Commits reachable from HEAD but not from any remote — true "at risk" count.
+  const unpushed = await git(["rev-list", "--count", "HEAD", "--not", "--remotes"], wt.path);
+  if (unpushed.exitCode === 0) wt.unpushed = parseRevListCount(unpushed.stdout);
+}
 
 /** Registers the `worktree` tool on the given MCP server. */
 export function registerWorktreeTool(server: McpServer) {
@@ -25,15 +76,27 @@ export function registerWorktreeTool(server: McpServer) {
     {
       title: "Git Worktree",
       description:
-        "Lists, adds, removes, locks, unlocks, or prunes git worktrees for managing multiple working trees. Returns structured data with worktree paths, branches, and HEAD commits.",
+        "Lists, adds, removes, locks, unlocks, or prunes git worktrees for managing multiple working trees. Returns structured data with worktree paths, branches, and HEAD commits. On list, pass withStatus for per-worktree {dirty, ahead, behind, unpushed} and/or mergedInto for a per-worktree merged flag. Use action=prune-merged {base, requireClean} for safe batch cleanup.",
       annotations: { readOnlyHint: false },
       inputSchema: {
         path: repoPathInput,
         action: z
-          .enum(["list", "add", "remove", "lock", "unlock", "prune", "move", "repair"])
+          .enum([
+            "list",
+            "add",
+            "remove",
+            "lock",
+            "unlock",
+            "prune",
+            "move",
+            "repair",
+            "prune-merged",
+          ])
           .optional()
           .default("list")
-          .describe("Worktree action to perform (default: list)"),
+          .describe(
+            "Worktree action to perform (default: list). 'prune-merged' safely batch-removes worktrees whose HEAD is merged into `base`.",
+          ),
         worktreePath: z
           .string()
           .max(INPUT_LIMITS.PATH_MAX)
@@ -53,7 +116,30 @@ export function registerWorktreeTool(server: McpServer) {
           .string()
           .max(INPUT_LIMITS.SHORT_STRING_MAX)
           .optional()
-          .describe("Base ref for the new branch (used with add + createBranch)"),
+          .describe(
+            "Base ref. With add+createBranch: the new branch's start point. With action=prune-merged: the ref a worktree must be merged into to be eligible for removal (required).",
+          ),
+        withStatus: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "On list: enrich each worktree with { dirty, ahead, behind, unpushed }. Off by default to keep output lean.",
+          ),
+        mergedInto: z
+          .string()
+          .max(INPUT_LIMITS.SHORT_STRING_MAX)
+          .optional()
+          .describe(
+            "On list: add `merged` per worktree (is its HEAD an ancestor of this ref). Useful alongside withStatus for safe cleanup triage.",
+          ),
+        requireClean: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "For action=prune-merged: only remove worktrees that are clean (no uncommitted changes). Default true. When false, dirty merged worktrees are force-removed.",
+          ),
         force: z
           .boolean()
           .optional()
@@ -113,14 +199,97 @@ export function registerWorktreeTool(server: McpServer) {
         }
 
         const worktreeList = parseWorktreeList(result.stdout);
+
+        // Opt-in per-worktree enrichment (#921). Keeps default output unchanged.
+        const withStatus = params.withStatus === true;
+        const mergedInto = params.mergedInto;
+        if (mergedInto) assertNoFlagInjection(mergedInto, "mergedInto");
+        if (withStatus || mergedInto) {
+          await Promise.all(
+            worktreeList.worktrees.map((wt) =>
+              enrichWorktreeStatus(wt, cwd, { withStatus, mergedInto }),
+            ),
+          );
+        }
+
         return compactDualOutput(
           worktreeList,
           result.stdout,
           formatWorktreeList,
           compactWorktreeListMap,
           formatWorktreeListCompact,
-          params.compact === false,
+          // Force full schema when enriched so status/merged fields survive compaction.
+          params.compact === false || withStatus || !!mergedInto,
         );
+      }
+
+      if (action === "prune-merged") {
+        const baseRef = params.base;
+        if (!baseRef) {
+          throw new Error("'base' is required for worktree prune-merged");
+        }
+        assertNoFlagInjection(baseRef, "base");
+        // requireClean defaults to true (safety); only an explicit false opts out.
+        const requireClean = params.requireClean !== false;
+
+        const listResult = await git(["worktree", "list", "--porcelain"], cwd);
+        if (listResult.exitCode !== 0) {
+          throw new Error(`git worktree list failed: ${listResult.stderr}`);
+        }
+        const { worktrees } = parseWorktreeList(listResult.stdout);
+
+        // The first porcelain entry is always the main worktree; the current
+        // worktree is the one containing cwd. Both are protected from removal.
+        const mainPath = worktrees[0]?.path ?? "";
+        const top = await git(["rev-parse", "--show-toplevel"], cwd);
+        const currentPath = top.exitCode === 0 ? top.stdout.trim() : cwd;
+
+        // Annotate merged + dirty only for real removal candidates. Protected
+        // worktrees (bare/main/current/locked) are short-circuited by
+        // decidePruneMerged, so we skip their git calls entirely.
+        await Promise.all(
+          worktrees.map(async (wt) => {
+            if (
+              wt.bare ||
+              wt.locked ||
+              worktreePathsEqual(wt.path, mainPath) ||
+              worktreePathsEqual(wt.path, currentPath)
+            ) {
+              return;
+            }
+            const anc = await git(["merge-base", "--is-ancestor", wt.head, baseRef], cwd);
+            wt.merged = anc.exitCode === 0;
+            if (requireClean) {
+              const st = await git(["status", "--porcelain"], wt.path);
+              // Treat an unreadable worktree as dirty (fail safe).
+              wt.dirty = st.exitCode === 0 ? st.stdout.trim().length > 0 : true;
+            }
+          }),
+        );
+
+        const decisions = decidePruneMerged(worktrees, { mainPath, currentPath, requireClean });
+
+        // Execute removals for the entries cleared by the decision function.
+        for (const decision of decisions) {
+          if (!decision.removed) continue;
+          const rmArgs = ["worktree", "remove"];
+          // Only opting out of the clean guard uses --force (dirty merged trees).
+          if (!requireClean) rmArgs.push("--force");
+          rmArgs.push(decision.path);
+          const rm = await git(rmArgs, cwd);
+          if (rm.exitCode !== 0) {
+            decision.removed = false;
+            decision.reason = "remove-failed";
+          }
+        }
+
+        const output = {
+          success: true,
+          action: "prune-merged" as const,
+          base: baseRef,
+          results: decisions,
+        };
+        return dualOutput(output, formatWorktreePrune);
       }
 
       if (action === "add") {


### PR DESCRIPTION
## Summary

Adds the three primitives a **safe** worktree cleanup needs (motivated by #921 — cleaning up ~60 worktrees), so agents no longer have to shell out to raw git. Every addition is **opt-in**: default output for `branch` and `worktree list` is byte-for-byte unchanged.

## Part 1 — ancestry / merged predicate (`branch`)

New opt-in input `mergedInto: <ref>`. When set, each returned branch gains `merged: boolean` (is it fully contained in the ref) and `unmerged: number` (commits not yet in the ref). Both come from a single `git rev-list --count <ref>..<branch>` per branch — zero ⇒ merged. The ref is `assertNoFlagInjection`-guarded; placeholder rows like `(HEAD detached …)` are skipped. Full schema is forced when `mergedInto` is set so the fields survive compaction.

## Part 2 — per-worktree status (`worktree list`)

New opt-in `withStatus: true` enriches each entry with `{ dirty, ahead, behind, unpushed }`:
- `dirty` — `git status --porcelain` non-empty
- `ahead`/`behind` — `git rev-list --left-right --count @{u}...HEAD`; **omitted** when the worktree has no upstream (handled gracefully)
- `unpushed` — `git rev-list --count HEAD --not --remotes` (commits reachable from HEAD but no remote — the true "at risk if removed" count, independent of upstream tracking)

Bonus (implemented): an optional `mergedInto` on `worktree list` adds `merged?: boolean` per worktree via `git merge-base --is-ancestor <head> <ref>`.

## Part 3 — batch / conditional removal (`worktree prune-merged`)

New action `prune-merged { base, requireClean }` — the one-shot safe cleanup. Lists worktrees, then for each **candidate** checks merged (HEAD is an ancestor of `base`) and, when `requireClean` (default **true**), clean. Returns per-path `results` (removed, or skipped with a reason). Guards, all enforced by the pure `decidePruneMerged`:
- never removes an **unmerged** worktree (regardless of flags)
- never removes a **dirty** worktree when `requireClean` (an unreadable status fails safe → treated as dirty)
- never removes the **bare**, **main** (first porcelain entry), **current** (`rev-parse --show-toplevel`), or **locked** worktree
- `requireClean: false` opts into force-removing dirty *merged* worktrees

## Part 4 — shell-hook substring bug (N/A)

The issue noted a hook that matched `git merge` as a substring and wrongly blocked `git merge-base`. Grepped the repo: Pare ships **no** such command-blocking hook/wrapper (only a docs table in `rules/CLAUDE.md` mapping `git merge` → `pare-git merge`, and a lint-staged `pre-commit`). Nothing to fix — this is a consumer-side hook.

## Tests

- `__tests__/cleanup.test.ts` — pure units: `parseRevListCount`, `worktreePathsEqual`/`normalizeWorktreePath`, `decidePruneMerged` (merged-clean removed; unmerged/dirty/main/current/bare/locked refused; `requireClean:false` force path; mixed batch), plus `formatBranch`/`formatWorktreeList` byte-for-byte-unchanged defaults and the prune summary formatter.
- `__tests__/worktree-cleanup-integration.test.ts` — real-repo end-to-end via the MCP client (mirrors `worktree-cwd.test.ts`): Part 1 merged vs unmerged branch, Part 2 `withStatus`+`mergedInto`, Part 3 removes merged-clean / skips dirty+unmerged / refuses main.

## Verification

- `tsc` clean; `pnpm --filter @paretools/git build` green.
- git-server suite: **720/721 pass**. The single failure is the pre-existing `log-graph` **fidelity** test that asserts against live-repo SHAs in a shared checkout — not related to this change.
- ESLint clean, Prettier formatted.

Closes #921
