### PR TITLE
test(git): make log-graph fidelity test robust to merge topology

### DIFF
--- a/packages/server-git/__tests__/fidelity.test.ts
+++ b/packages/server-git/__tests__/fidelity.test.ts
@@ -1022,8 +1022,13 @@ describe("fidelity: git log-graph (fixture-based)", () => {
     const raw = gitRaw(["log", "--graph", "--oneline", "--decorate", "--max-count=5"]);
     const result = parseLogGraph(raw);
 
-    // Cross-check with oneline output for commit count
-    const rawOneline = gitRaw(["log", "--oneline", "--max-count=5"]);
+    // Cross-check with an independent oneline traversal. `--graph` implies
+    // --topo-order, whereas a plain `git log` is reverse-chronological, so in a
+    // repo containing merge commits the two orderings can select *different*
+    // 5-commit windows — making this assertion fail non-deterministically on
+    // whatever local HEAD it runs against. Force --topo-order here so both
+    // traversals cover the same commits regardless of branch topology.
+    const rawOneline = gitRaw(["log", "--oneline", "--topo-order", "--max-count=5"]);
     const rawHashes = rawOneline
       .trim()
       .split("\n")
@@ -1032,7 +1037,8 @@ describe("fidelity: git log-graph (fixture-based)", () => {
 
     const graphHashes = result.commits.filter((c) => c.hashShort !== "").map((c) => c.hashShort);
 
-    // Every hash from oneline should appear in graph output
+    // Every hash from the (topo-ordered) oneline output must appear in the
+    // parsed graph output — i.e. parseLogGraph drops no commits.
     for (const hash of rawHashes) {
       expect(graphHashes).toContain(hash);
     }


### PR DESCRIPTION
## What

Fixes the flaky `parseLogGraph preserves commit data from real repo output` fidelity test in `server-git`. This is the failing test you hit while reviewing #961/#963/#964 — it's the same test in each, run as part of the monorepo suite.

## Why it fails

The test compares two git traversals of the current repo:
- `git log --graph --oneline …` — `--graph` **implies `--topo-order`**.
- `git log --oneline …` — plain, **reverse-chronological**.

In a repo with merge commits, those two orderings select **different** N-commit windows, so a hash in one is missing from the other and the assertion fails. It's non-deterministic — it depends on whatever local HEAD it runs against, which is why it passes on some checkouts and fails on others (and is skipped entirely in CI via the `hasParentCommit()` shallow-clone guard, so CI never caught it).

Reproduced at commit `36988e58`:
```
graph (topo) window:      36988e58 520b397c 80d9a86d a9d89d40 dde60d67
oneline (chronological):  36988e58 520b397c 80d9a86d a9d89d40 64d6e5ba   ← 64d6e5ba ∉ graph → FAIL
oneline (--topo-order):   36988e58 520b397c 80d9a86d a9d89d40 dde60d67   ← identical → PASS
```

## Fix

Add `--topo-order` to the oneline cross-check so both traversals cover the same commits regardless of branch topology. One-line change plus an explanatory comment.

## Verification

`server-git` suite: **699/699** (was 698/699). Test-only change — no changeset, no published-behavior impact.

## Note

This doesn't block the other PRs — the test is skipped in CI (shallow clone), so #961/#963/#964's CI is already green apart from `audit` (which clears on "Update branch" now that #960 is merged). This just makes local/full-clone runs clean so the failure stops distracting review.