### PR TITLE
[codex] fix bun compact package schemas

### DIFF
--- a/.changeset/fix-bun-compact-package-schemas.md
+++ b/.changeset/fix-bun-compact-package-schemas.md
@@ -1,0 +1,5 @@
+---
+"@paretools/bun": patch
+---
+
+fix(bun): allow compact outdated and pm ls output to omit package details

--- a/docs/tool-schemas/bun/outdated.md
+++ b/docs/tool-schemas/bun/outdated.md
@@ -131,5 +131,5 @@ All packages are up to date.
 ## Notes
 
 - Each outdated package includes `name`, `current`, `latest`, and optionally `wanted` version fields
-- Compact mode drops the `packages` array, keeping only `success`, `total`, and `duration`
+- Compact mode omits the `packages` array, keeping only `success`, `total`, and `duration`
 - The `wanted` field represents the highest version matching the semver range in package.json

--- a/docs/tool-schemas/bun/pm-ls.md
+++ b/docs/tool-schemas/bun/pm-ls.md
@@ -134,5 +134,5 @@ $ bun pm ls
 
 - The `all` flag shows transitive dependencies in addition to direct dependencies
 - Each package entry includes `name` and optionally `version`
-- Compact mode drops the `packages` array, keeping only `success`, `total`, and `duration`
-- The `total` field reflects the count of packages in the `packages` array
+- Compact mode omits the `packages` array, keeping only `success`, `total`, and `duration`
+- The `total` field reflects the package count; in full mode, it matches the `packages` array length

--- a/packages/server-bun/__tests__/formatters.test.ts
+++ b/packages/server-bun/__tests__/formatters.test.ts
@@ -25,6 +25,7 @@ import {
   compactPmLsMap,
   formatPmLsCompact,
 } from "../src/lib/formatters.js";
+import { BunOutdatedResultSchema, BunPmLsResultSchema } from "../src/schemas/index.js";
 import type {
   BunRunResult,
   BunTestResult,
@@ -323,6 +324,20 @@ describe("compactOutdatedMap + formatOutdatedCompact", () => {
     const data: BunOutdatedResult = { success: true, packages: [], total: 0, duration: 50 };
     expect(formatOutdatedCompact(compactOutdatedMap(data))).toContain("all up to date");
   });
+
+  it("keeps compact output compatible with the outdated schema", () => {
+    const data: BunOutdatedResult = {
+      success: true,
+      packages: [{ name: "a", current: "1.0.0", latest: "2.0.0" }],
+      total: 1,
+      duration: 50,
+    };
+
+    const compact = compactOutdatedMap(data);
+
+    expect(compact).not.toHaveProperty("packages");
+    expect(BunOutdatedResultSchema.parse(compact)).toEqual(compact);
+  });
 });
 
 // ── Pm Ls ───────────────────────────────────────────────────────────
@@ -360,5 +375,19 @@ describe("compactPmLsMap + formatPmLsCompact", () => {
       duration: 50,
     };
     expect(formatPmLsCompact(compactPmLsMap(data))).toContain("1 packages");
+  });
+
+  it("keeps compact output compatible with the pm-ls schema", () => {
+    const data: BunPmLsResult = {
+      success: true,
+      packages: [{ name: "a", version: "1.0.0" }],
+      total: 1,
+      duration: 50,
+    };
+
+    const compact = compactPmLsMap(data);
+
+    expect(compact).not.toHaveProperty("packages");
+    expect(BunPmLsResultSchema.parse(compact)).toEqual(compact);
   });
 });

--- a/packages/server-bun/src/lib/formatters.ts
+++ b/packages/server-bun/src/lib/formatters.ts
@@ -104,7 +104,7 @@ export function formatOutdated(data: BunOutdatedResult): string {
 
   const lines: string[] = [];
   lines.push(`bun outdated: ${data.total} packages outdated (${data.duration}ms)`);
-  for (const p of data.packages) {
+  for (const p of data.packages ?? []) {
     const wanted = p.wanted ? ` (wanted: ${p.wanted})` : "";
     lines.push(`  ${p.name}: ${p.current} -> ${p.latest}${wanted}`);
   }
@@ -117,7 +117,7 @@ export function formatPmLs(data: BunPmLsResult): string {
 
   const lines: string[] = [];
   lines.push(`bun pm ls: ${data.total} packages (${data.duration}ms)`);
-  for (const p of data.packages) {
+  for (const p of data.packages ?? []) {
     lines.push(`  ${p.name}${p.version ? `@${p.version}` : ""}`);
   }
   return lines.join("\n");

--- a/packages/server-bun/src/schemas/index.ts
+++ b/packages/server-bun/src/schemas/index.ts
@@ -109,7 +109,7 @@ export const BunOutdatedEntrySchema = z.object({
 /** Zod schema for structured `bun outdated` output. */
 export const BunOutdatedResultSchema = z.object({
   success: z.boolean(),
-  packages: z.array(BunOutdatedEntrySchema),
+  packages: z.array(BunOutdatedEntrySchema).optional(),
   total: z.number(),
   duration: z.number(),
 });
@@ -126,7 +126,7 @@ export const BunPmLsEntrySchema = z.object({
 /** Zod schema for structured `bun pm ls` output. */
 export const BunPmLsResultSchema = z.object({
   success: z.boolean(),
-  packages: z.array(BunPmLsEntrySchema),
+  packages: z.array(BunPmLsEntrySchema).optional(),
   total: z.number(),
   duration: z.number(),
 });


### PR DESCRIPTION
## Summary
- make `bun outdated` and `bun pm ls` package detail arrays optional in their output schemas so compact mode can honestly omit them
- keep full formatters safe when given schema-compatible compact-shaped data
- add formatter/schema regression tests for both compact outputs
- update Bun tool schema docs and add a changeset

## Why
Compact mode for these tools intentionally drops detailed package rows and keeps only summary fields like `success`, `total`, and `duration`. The schemas still required `packages`, which made the declared contract reject the compact shape. Adding `packages: []` would satisfy validation but would be misleading when `total > 0`.

## Verification
- `pnpm --filter @paretools/bun exec vitest run __tests__/formatters.test.ts`
- `pnpm --filter @paretools/shared build`
- `pnpm --filter @paretools/bun build`
- `pnpm --filter @paretools/bun test`
- `pnpm --filter @paretools/bun lint`
- `pnpm exec prettier --check packages/server-bun/src/schemas/index.ts packages/server-bun/src/lib/formatters.ts packages/server-bun/__tests__/formatters.test.ts docs/tool-schemas/bun/pm-ls.md docs/tool-schemas/bun/outdated.md .changeset/fix-bun-compact-package-schemas.md`
- direct smoke: parsed real `bun pm ls` and `bun outdated` output, compacted it, and validated both compact payloads against the updated schemas
