### PR TITLE
fix(build): tsc never returns a contextless success:false (closes #965)

### DIFF
--- a/.changeset/tsc-unactionable-failure.md
+++ b/.changeset/tsc-unactionable-failure.md
@@ -1,0 +1,16 @@
+---
+"@paretools/build": patch
+---
+
+fix(build): tsc never returns a contextless `success:false` — surface failure detail
+
+When `tsc` exits non-zero without emitting parseable diagnostics (a tsconfig
+error like `TS18003 No inputs were found`, a crash, or an npx/binary resolution
+failure), the result was `{success:false, diagnostics:[]}` — and the compact
+formatter even rendered it as "TypeScript: no errors found." `parseTscOutput`
+now attaches the raw stderr (or stdout, or a generic exit-code message) as a
+new optional `error` field whenever a failed run has no diagnostics, and the
+full/compact formatters surface it instead of implying success. Enforces the
+same "success:false ⟹ actionable output" invariant the vite-build tool got.
+The pure missing-binary case is already handled by the `assertBinaryAvailable`
+preflight. Closes #965.

--- a/packages/server-build/__tests__/compact.test.ts
+++ b/packages/server-build/__tests__/compact.test.ts
@@ -115,12 +115,43 @@ describe("compactTscMap", () => {
     expect(compact.warnings).toBe(0);
     expect(compact.diagnostics).toEqual([]);
   });
+
+  // #965: propagate the failure detail through the compact projection.
+  it("carries the error field for a diagnostic-less failure", () => {
+    const data: TscResult = {
+      success: false,
+      diagnostics: [],
+      errors: 0,
+      warnings: 0,
+      error: "error TS18003: No inputs were found.",
+    };
+
+    const compact = compactTscMap(data);
+    expect(compact.success).toBe(false);
+    expect(compact.error).toBe("error TS18003: No inputs were found.");
+  });
 });
 
 describe("formatTscCompact", () => {
   it("formats clean result", () => {
     const compact = { success: true, errors: 0, warnings: 0, diagnostics: [] };
     expect(formatTscCompact(compact)).toBe("TypeScript: no errors found.");
+  });
+
+  // #965: a failed run with no parseable diagnostics must NOT read as
+  // "no errors found" just because the error/warning counts are zero.
+  it("shows the failure instead of 'no errors found' when a run failed silently", () => {
+    const compact = {
+      success: false,
+      errors: 0,
+      warnings: 0,
+      diagnostics: [],
+      error: "error TS18003: No inputs were found in config file 'tsconfig.json'.",
+    };
+    const output = formatTscCompact(compact);
+    expect(output).not.toContain("no errors found");
+    expect(output).toContain("TypeScript check failed");
+    expect(output).toContain("TS18003");
   });
 
   it("formats compact diagnostics with file:line only", () => {

--- a/packages/server-build/__tests__/parsers.test.ts
+++ b/packages/server-build/__tests__/parsers.test.ts
@@ -41,6 +41,40 @@ describe("parseTscOutput", () => {
     expect(result.success).toBe(true);
     expect(result.diagnostics).toHaveLength(0);
     expect(result.diagnostics).toEqual([]);
+    expect(result.error).toBeUndefined();
+  });
+
+  // #965: a non-zero exit with no parseable diagnostics must never be a bare,
+  // contextless result — attach the raw stderr as `error`.
+  it("surfaces stderr as error when tsc fails without diagnostics (#965)", () => {
+    const stderr = "error TS18003: No inputs were found in config file 'tsconfig.json'.";
+    const result = parseTscOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.error).toBe(stderr);
+  });
+
+  it("falls back to stdout, then a generic message, when a failed run is silent (#965)", () => {
+    const fromStdout = parseTscOutput("some non-diagnostic stdout noise", "", 2);
+    expect(fromStdout.success).toBe(false);
+    expect(fromStdout.error).toBe("some non-diagnostic stdout noise");
+
+    const silent = parseTscOutput("", "", 2);
+    expect(silent.success).toBe(false);
+    expect(silent.error).toContain("exited with code 2");
+  });
+
+  it("does not attach error when diagnostics were parsed", () => {
+    const result = parseTscOutput("src/a.ts(1,1): error TS2307: Cannot find module.", "", 2);
+    expect(result.success).toBe(false);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("does not attach error on a successful run", () => {
+    const result = parseTscOutput("", "", 0);
+    expect(result.error).toBeUndefined();
   });
 
   it("parses errors from multiple files", () => {

--- a/packages/server-build/src/lib/formatters.ts
+++ b/packages/server-build/src/lib/formatters.ts
@@ -21,6 +21,12 @@ export function formatTsc(data: TscResult): string {
     return "TypeScript: no errors found.";
   }
 
+  // Non-zero exit with no parseable diagnostics — surface the raw failure
+  // instead of an empty "0 errors" summary that reads as success. (#965)
+  if (!data.success && data.diagnostics.length === 0 && data.error) {
+    return `TypeScript check failed (no diagnostics parsed):\n${data.error}`;
+  }
+
   const fileSummary = data.totalFiles !== undefined ? ` in ${data.totalFiles} files` : "";
   const lines = [`TypeScript: ${data.errors} errors, ${data.warnings} warnings${fileSummary}`];
   for (const d of data.diagnostics ?? []) {
@@ -195,6 +201,7 @@ export interface TscCompact {
   errors: number;
   warnings: number;
   diagnostics: Array<{ file: string; line: number; severity: string }>;
+  error?: string;
 }
 
 const TSC_COMPACT_DIAG_LIMIT = 10;
@@ -209,11 +216,18 @@ export function compactTscMap(data: TscResult): TscCompact {
       line: d.line,
       severity: d.severity,
     })),
+    ...(data.error ? { error: data.error } : {}),
   };
 }
 
 export function formatTscCompact(data: TscCompact): string {
-  if (data.errors === 0 && data.warnings === 0) return "TypeScript: no errors found.";
+  // A failed run with no parseable diagnostics must not read as success. (#965)
+  if (data.error && data.diagnostics.length === 0) {
+    return `TypeScript check failed:\n${data.error}`;
+  }
+  if (data.success && data.errors === 0 && data.warnings === 0) {
+    return "TypeScript: no errors found.";
+  }
 
   const lines = [`TypeScript: ${data.errors} errors, ${data.warnings} warnings`];
   for (const d of data.diagnostics) {

--- a/packages/server-build/src/lib/parsers.ts
+++ b/packages/server-build/src/lib/parsers.ts
@@ -63,15 +63,29 @@ export function parseTscOutput(stdout: string, stderr: string, exitCode: number)
 
   const errors = diagnostics.filter((d) => d.severity === "error").length;
   const warnings = diagnostics.filter((d) => d.severity === "warning").length;
+  const success = exitCode === 0;
 
-  return {
-    success: exitCode === 0,
+  const result: TscResult = {
+    success,
     diagnostics,
     totalFiles,
     emittedFiles: emittedFiles.length > 0 ? emittedFiles : undefined,
     errors,
     warnings,
   };
+
+  // Invariant: a non-zero exit must never surface as a bare, contextless
+  // result. When tsc fails without emitting any parseable diagnostics — a
+  // tsconfig error (e.g. TS18003 "No inputs were found"), a crash, or an
+  // npx/binary resolution failure — an empty diagnostics list reads as
+  // "no errors found". Attach the raw stderr so `success:false` always carries
+  // something actionable. (#965)
+  if (!success && diagnostics.length === 0) {
+    const detail = (stderr.trim() || stdout.trim()).trim();
+    result.error = detail || `tsc exited with code ${exitCode} but produced no diagnostics.`;
+  }
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server-build/src/schemas/index.ts
+++ b/packages/server-build/src/schemas/index.ts
@@ -20,6 +20,10 @@ export const TscResultSchema = z.object({
   emittedFiles: z.array(z.string()).optional(),
   errors: z.number(),
   warnings: z.number(),
+  /** Raw failure detail when tsc exits non-zero without emitting parseable
+   *  diagnostics (e.g. a tsconfig error or crash) — keeps `success:false` from
+   *  ever being contextless. */
+  error: z.string().optional(),
 });
 
 /** Full tsc diagnostic -- always returned by the parser. */
@@ -42,6 +46,7 @@ export interface TscResult {
   emittedFiles?: string[];
   errors: number;
   warnings: number;
+  error?: string;
 }
 
 /** Zod schema for structured build command output with success status, duration, errors, and warnings.


### PR DESCRIPTION
## What

Fixes #965. `mcp__pare-build__tsc` could return `{"success":false,"diagnostics":[]}` with no explanation, and the compact formatter rendered that as **"TypeScript: no errors found."** — a failed check reported as clean.

## Root cause

`parseTscOutput` only populates `diagnostics` from lines matching the `file(line,col): error TSxxxx` pattern. When `tsc` exits non-zero **without** such lines — a tsconfig error (`TS18003 No inputs were found`), a crash, an `npx`/binary-resolution failure — `diagnostics` is empty and `errors`/`warnings` are 0. `formatTscCompact` keyed its "no errors found" message off those zero counts (not `success`), so it actively contradicted the failure.

## Fix

- **New optional `error` field** on `TscResultSchema` / `TscResult`.
- `parseTscOutput`: when `exitCode !== 0 && diagnostics.length === 0`, attach the raw stderr (→ stdout → a generic `exited with code N` message) as `error`. So `success:false` always carries something actionable.
- `formatTsc` / `formatTscCompact` surface that `error` instead of implying success; `compactTscMap` propagates it.
- Enforces the same **"success:false ⟹ actionable output"** invariant vite-build got in #915.

The pure *missing-binary* case #965 mentions is already handled upstream by the `assertBinaryAvailable` preflight in `build-runner.ts` (throws an actionable "run install" error) — this PR covers the residual "ran and failed silently" path.

## Tests

+6 in `parsers.test.ts` / `compact.test.ts` (stderr→error, stdout/generic fallbacks, no-error-when-diagnostics-present, no-error-on-success, compact propagation, and the "not `no errors found`" formatter fix). Full `@paretools/build` suite **276/276**; `tsc` clean. Changeset included (`patch`).

Closes #965.