### PR TITLE
fix(release): sync server.json versions to package.json (MCP Registry drift)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,10 @@ jobs:
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
+          # Use our version script (changeset version + server.json sync) instead
+          # of the action's default `changeset version`, so the "version packages"
+          # PR keeps each server.json version aligned with its package.json.
+          version: pnpm version-packages
           publish: pnpm release
           title: "chore: version packages"
           commit: "chore: version packages"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && tsx scripts/sync-server-versions.ts",
     "release": "turbo run build && changeset publish",
     "canary": "changeset version --snapshot canary",
     "changelog": "tsx scripts/aggregate-changelog.ts",
@@ -31,6 +31,8 @@
     "docs:api": "typedoc",
     "sync-tool-counts": "tsx scripts/sync-tool-counts.ts",
     "sync-tool-counts:check": "tsx scripts/sync-tool-counts.ts --check",
+    "sync-server-versions": "tsx scripts/sync-server-versions.ts",
+    "sync-server-versions:check": "tsx scripts/sync-server-versions.ts --check",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/server-bazel/server.json
+++ b/packages/server-bazel/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.Dave-London/pare-bazel",
   "description": "Pare Bazel — Structured Bazel build system operations as typed JSON.",
   "repository": { "url": "https://github.com/Dave-London/Pare", "source": "github" },
-  "version": "0.10.2",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/bazel",
-      "version": "0.10.2",
+      "version": "0.21.0",
       "transport": { "type": "stdio" }
     }
   ]

--- a/packages/server-build/server.json
+++ b/packages/server-build/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/build",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-bun/server.json
+++ b/packages/server-bun/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.10.2",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/bun",
-      "version": "0.10.2",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-cargo/server.json
+++ b/packages/server-cargo/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/cargo",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-cmake/server.json
+++ b/packages/server-cmake/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.Dave-London/pare-cmake",
   "description": "Pare CMake — Structured CMake/CTest build system operations as typed JSON.",
   "repository": { "url": "https://github.com/Dave-London/Pare", "source": "github" },
-  "version": "0.10.2",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/cmake",
-      "version": "0.10.2",
+      "version": "0.21.0",
       "transport": { "type": "stdio" }
     }
   ]

--- a/packages/server-db/server.json
+++ b/packages/server-db/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.10.2",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/db",
-      "version": "0.10.2",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-deno/server.json
+++ b/packages/server-deno/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.Dave-London/pare-deno",
   "description": "Pare Deno — Structured Deno runtime operations as typed JSON.",
   "repository": { "url": "https://github.com/Dave-London/Pare", "source": "github" },
-  "version": "0.10.2",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/deno",
-      "version": "0.10.2",
+      "version": "0.21.0",
       "transport": { "type": "stdio" }
     }
   ]

--- a/packages/server-docker/server.json
+++ b/packages/server-docker/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/docker",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-dotnet/server.json
+++ b/packages/server-dotnet/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.Dave-London/pare-dotnet",
   "description": "Pare .NET — Structured .NET CLI operations as typed JSON.",
   "repository": { "url": "https://github.com/Dave-London/Pare", "source": "github" },
-  "version": "0.10.2",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/dotnet",
-      "version": "0.10.2",
+      "version": "0.21.0",
       "transport": { "type": "stdio" }
     }
   ]

--- a/packages/server-git/server.json
+++ b/packages/server-git/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/git",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-github/server.json
+++ b/packages/server-github/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/github",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-go/server.json
+++ b/packages/server-go/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/go",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-http/server.json
+++ b/packages/server-http/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/http",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-infra/server.json
+++ b/packages/server-infra/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.10.2",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/infra",
-      "version": "0.10.2",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-jvm/server.json
+++ b/packages/server-jvm/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.10.2",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/jvm",
-      "version": "0.10.2",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-lint/server.json
+++ b/packages/server-lint/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/lint",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-make/server.json
+++ b/packages/server-make/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/make",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-nix/server.json
+++ b/packages/server-nix/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.11.0",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/nix",
-      "version": "0.11.0",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-npm/server.json
+++ b/packages/server-npm/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/npm",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-process/server.json
+++ b/packages/server-process/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/process",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-python/server.json
+++ b/packages/server-python/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/python",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-remote/server.json
+++ b/packages/server-remote/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.10.2",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/remote",
-      "version": "0.10.2",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-ruby/server.json
+++ b/packages/server-ruby/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.10.2",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/ruby",
-      "version": "0.10.2",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-search/server.json
+++ b/packages/server-search/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/search",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-security/server.json
+++ b/packages/server-security/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.1.0",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/security",
-      "version": "0.1.0",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-swift/server.json
+++ b/packages/server-swift/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.11.0",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/swift",
-      "version": "0.11.0",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/server-test/server.json
+++ b/packages/server-test/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Dave-London/Pare",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@paretools/test",
-      "version": "0.8.1",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       }

--- a/scripts/sync-server-versions.ts
+++ b/scripts/sync-server-versions.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env npx tsx
+/**
+ * Sync each package's `server.json` version to its `package.json` version.
+ *
+ * The MCP Registry publish (`mcp-publisher publish`) reads the version from
+ * `server.json`, but `changeset version` only bumps `package.json`. Nothing
+ * kept the two in sync, so every `server.json` drifted behind npm (by as much
+ * as a dozen minor versions). Because the MCP Registry is immutable per
+ * version, that silently either republishes stale metadata or fails the
+ * publish outright.
+ *
+ * This aligns the top-level `version` and every `packages[].version` in each
+ * `server.json` with its sibling `package.json`. It runs as part of
+ * `version-packages` (so the "chore: version packages" PR carries the bump),
+ * and `--check` guards against drift in CI.
+ *
+ * Only the version string is rewritten — all other bytes (descriptions,
+ * schema URL, transport) are left untouched.
+ *
+ * Usage:
+ *   pnpm sync-server-versions          # update files in place
+ *   pnpm sync-server-versions --check  # exit 1 if any server.json is stale (CI)
+ */
+
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const ROOT = resolve(__dirname, "..");
+const PACKAGES_DIR = resolve(ROOT, "packages");
+
+const check = process.argv.includes("--check");
+
+// Matches `"version": "1.2.3"` (with optional pre-release/build metadata),
+// capturing the key/quote prefix and the closing quote so only the value is
+// rewritten. In an MCP server.json the `version` key appears only for the
+// server and its package entries, so a global replace is safe.
+const VERSION_RE = /("version":\s*")\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?(")/g;
+
+const stale: string[] = [];
+const updated: string[] = [];
+
+for (const entry of readdirSync(PACKAGES_DIR)) {
+  const dir = resolve(PACKAGES_DIR, entry);
+  const serverJsonPath = resolve(dir, "server.json");
+  const packageJsonPath = resolve(dir, "package.json");
+  if (!existsSync(serverJsonPath) || !existsSync(packageJsonPath)) continue;
+
+  const pkgVersion = JSON.parse(readFileSync(packageJsonPath, "utf-8")).version as string;
+  if (!pkgVersion) continue;
+
+  const content = readFileSync(serverJsonPath, "utf-8");
+  const next = content.replace(VERSION_RE, `$1${pkgVersion}$2`);
+
+  if (next !== content) {
+    const rel = `packages/${entry}/server.json`;
+    if (check) {
+      stale.push(rel);
+    } else {
+      writeFileSync(serverJsonPath, next, "utf-8");
+      updated.push(rel);
+    }
+  }
+}
+
+if (check) {
+  if (stale.length > 0) {
+    console.error("server.json versions out of sync with package.json:");
+    for (const f of stale) console.error(`  ${f}`);
+    console.error("\nRun `pnpm sync-server-versions` to fix.");
+    process.exit(1);
+  }
+  console.log("All server.json versions are in sync.");
+} else if (updated.length > 0) {
+  console.log("Synced server.json versions:");
+  for (const f of updated) console.log(`  ${f}`);
+} else {
+  console.log("All server.json versions are in sync.");
+}


### PR DESCRIPTION
## What

Adds a `sync-server-versions` script that keeps each package's `server.json` version aligned with its `package.json`, wires it into the release flow, and runs it to fix the current drift (all 27 → `0.21.0`).

## Why (a real latent release bug)

The MCP Registry publish (`mcp-publisher publish`, Step 7 of the publishing procedure) reads the version from **`server.json`**, but `changeset version` only bumps **`package.json`**. Nothing kept the two in sync, so every `server.json` had silently drifted behind npm:

```
server-build   server.json 0.8.1   vs package.json 0.21.0
server-security server.json 0.1.0  vs package.json 0.21.0
server-git     server.json 0.8.1   vs package.json 0.21.0
… all 27 mismatched (0.1.0 – 0.11.0)
```

Since the **MCP Registry is immutable per version**, this means each release either republished stale metadata or silently failed the registry publish. Caught while auditing the 0.21.0 release (npm + GitHub Releases were fine; the registry side was not).

## Fix

- **`scripts/sync-server-versions.ts`** — rewrites the top-level `version` and every `packages[].version` in each `server.json` to match its `package.json`. Version-string edits only (a scoped regex); descriptions, schema URL, and transport are left byte-for-byte untouched. Includes a `--check` mode.
- **`version-packages`** now chains the sync (`changeset version && tsx scripts/sync-server-versions.ts`), and `release.yml` points `changesets/action`'s `version:` input at it — so every future "chore: version packages" PR carries the `server.json` bumps automatically and this can't drift again.
- Ran it: **27 `server.json` files → `0.21.0`.**

## Notes

- **No changeset:** this is registry-metadata + tooling; it changes no npm package behavior (and doesn't touch `package.json` versions).
- Unblocks the pending **0.21.0 MCP Registry publish** — after this merges, `mcp-publisher publish` per server will push the correct version.
- **Separate pre-existing bug spotted, not fixed here:** the `description` fields contain a double-encoded em-dash (`ג€”` → should be `—`), so registry listings show mojibake. Worth a follow-up cleanup.
- `sync-server-versions:check` is available to add to CI as a guard if you want belt-and-suspenders.