### PR TITLE
fix: close child stdin without input

### DIFF
--- a/.changeset/fix-runner-stdin-eof.md
+++ b/.changeset/fix-runner-stdin-eof.md
@@ -1,0 +1,5 @@
+---
+"@paretools/shared": patch
+---
+
+Close child stdin when no input is provided so commands that wait for EOF, including Bun scripts, can exit normally.

--- a/packages/shared/__tests__/runner.test.ts
+++ b/packages/shared/__tests__/runner.test.ts
@@ -100,6 +100,21 @@ describe("run", () => {
       unlinkSync(stdinScript);
     }
   });
+
+  it("closes stdin when no data is provided", async () => {
+    const stdinScript = join(tmpdir(), "pare-test-stdin-eof.js");
+    writeFileSync(
+      stdinScript,
+      "process.stdin.on('end',()=>process.stdout.write('closed'));process.stdin.resume()",
+    );
+    try {
+      const result = await run("node", [stdinScript], { timeout: 1000 });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("closed");
+    } finally {
+      unlinkSync(stdinScript);
+    }
+  });
 });
 
 describe("run – env and edge cases", () => {

--- a/packages/shared/src/runner.ts
+++ b/packages/shared/src/runner.ts
@@ -656,7 +656,7 @@ export function run(cmd: string, args: string[], opts?: RunOptions): Promise<Run
     // process knows input is complete (e.g., `git commit --file -`).
     if (opts?.stdin != null) {
       child.stdin?.write(opts.stdin);
-      child.stdin?.end();
     }
+    child.stdin?.end();
   });
 }


### PR DESCRIPTION
## What does this PR do?

Closes child stdin even when callers do not provide input. This prevents commands that wait for EOF, including `bun run` scripts, from completing their work but remaining alive until Pare's timeout.

Adds a regression test that waits for stdin EOF without supplying an input payload.

## Type of change

- [ ] New server (`@paretools/<name>`)
- [ ] New tool in existing server
- [x] Bug fix
- [ ] Refactor / internal improvement
- [ ] Documentation
- [ ] CI/CD

## Checklist

- [ ] `pnpm build` passes
- [ ] `pnpm test` passes
- [x] Added/updated tests for new functionality
- [ ] All tools use `outputSchema` + `structuredContent`
- [ ] Human-readable `content` fallback included
- [x] Changeset added (`pnpm changeset`)

## Root cause

The shared runner always created a piped stdin stream but only closed it when `opts.stdin` was provided. Processes that wait for EOF therefore never emitted `close`, causing otherwise successful Pare tool calls to time out.

## Validation

- `pnpm --filter @paretools/shared test -- runner.test.ts` (438 tests passed)
- `pnpm --filter @paretools/shared build`
- `pnpm --filter @paretools/build build`
- Focused ESLint and Prettier checks
- Invoked the built `@paretools/build` MCP server against `bun run lint`; it succeeded in 0.6 seconds instead of timing out
