### PR TITLE
chore(deps): bump github/codeql-action to 4.37.0 (init/autobuild/analyze together)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,12 +21,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
         with:
           languages: javascript-typescript
 
-      - uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+      - uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
 
-      - uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
## What does this PR do?

Bumps all three `github/codeql-action` steps in `.github/workflows/codeql.yml` — `init`, `autobuild`, and `analyze` — from 4.36.0 to **4.37.0** (`99df26d4f13ea111d4ec1a7dddef6063f76b97e9`) in a single change.

## Why consolidate?

CodeQL requires `init`, `autobuild`, and `analyze` to run on the **same** version. Dependabot opened these as three separate per-step PRs (#987, #988, #990), so each one bumps only one step and leaves the other two on 4.36.0 — which fails the `Analyze (JavaScript/TypeScript)` step on a version mismatch. They can only pass when bumped together, which is what this PR does.

The matching `upload-sarif` bump (#989, in `scorecard.yml`) already merged.

## Type of change

- [x] CI/CD

## Closes

- Closes #987
- Closes #988
- Closes #990
