### PR TITLE
test(shared): raise stdin-EOF test timeout to fix Windows CI flake

### DIFF
--- a/packages/shared/__tests__/runner.test.ts
+++ b/packages/shared/__tests__/runner.test.ts
@@ -108,7 +108,7 @@ describe("run", () => {
       "process.stdin.on('end',()=>process.stdout.write('closed'));process.stdin.resume()",
     );
     try {
-      const result = await run("node", [stdinScript], { timeout: 1000 });
+      const result = await run("node", [stdinScript], { timeout: 10000 });
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toBe("closed");
     } finally {


### PR DESCRIPTION
## What does this PR do?

Raises the runner timeout in the `closes stdin when no data is provided` test (added in #986) from **1000ms to 10000ms**.

## Root cause

The test spawns `node` with a hard 1000ms runner timeout:

```ts
const result = await run("node", [stdinScript], { timeout: 1000 });
```

On the **Windows** CI runner, Node's cold-start plus the stdin-EOF round-trip intermittently exceeds 1s, so the runner kills the child before it echoes `closed`. The test then fails with a spurious:

```
Error: Command "node" timed out after 1000ms and was killed (SIGTERM).
```

#986's own CI happened to pass Windows, but the flake now surfaces on `main` and on every PR branched from it (observed failing on #982 and #992, both unrelated dependency bumps).

## Fix

The timeout is only a kill-switch ceiling — on the normal (passing) path the test completes in a few hundred ms, so raising the ceiling doesn't slow the suite. 10s gives Windows ample headroom, matching what other spawn-based tests in this file already allow.

## Type of change

- [x] Test-only fix

No changeset — test-only change, no published-package behavior affected.
