### PR TITLE
fix(github): resolve numeric strings and URLs in number echo fields

### DIFF
--- a/.changeset/fix-1017-github-number-echo.md
+++ b/.changeset/fix-1017-github-number-echo.md
@@ -1,0 +1,5 @@
+---
+"@paretools/github": patch
+---
+
+Fix PR/issue mutation tools echoing `number`/`prNumber` as `0` when the `number` input is passed as a string. A new `resolveNumber` helper resolves numeric strings, `#123` references, and PR/issue URLs to the actual number; branch names still resolve to `0`.

--- a/packages/server-github/__tests__/parsers.test.ts
+++ b/packages/server-github/__tests__/parsers.test.ts
@@ -12,7 +12,58 @@ import {
   parseRunList,
   parseLabelList,
   parseLabelCreate,
+  resolveNumber,
 } from "../src/lib/parsers.js";
+
+describe("resolveNumber", () => {
+  it("returns plain numbers unchanged", () => {
+    expect(resolveNumber(123)).toBe(123);
+  });
+
+  it("resolves numeric strings", () => {
+    expect(resolveNumber("123")).toBe(123);
+  });
+
+  it("resolves numeric strings with surrounding whitespace", () => {
+    expect(resolveNumber("  456 ")).toBe(456);
+  });
+
+  it("resolves hash-prefixed numbers", () => {
+    expect(resolveNumber("#123")).toBe(123);
+  });
+
+  it("resolves PR URLs", () => {
+    expect(resolveNumber("https://github.com/owner/repo/pull/1017")).toBe(1017);
+  });
+
+  it("resolves issue URLs", () => {
+    expect(resolveNumber("https://github.com/owner/repo/issues/42")).toBe(42);
+  });
+
+  it("resolves URLs with a trailing slash", () => {
+    expect(resolveNumber("https://github.com/owner/repo/pull/99/")).toBe(99);
+  });
+
+  it("resolves URLs with a query string", () => {
+    expect(resolveNumber("https://github.com/owner/repo/pull/7?diff=split")).toBe(7);
+  });
+
+  it("resolves URLs with a fragment", () => {
+    expect(resolveNumber("https://github.com/owner/repo/issues/8#issuecomment-1")).toBe(8);
+  });
+
+  it("resolves URL subpaths like /files", () => {
+    expect(resolveNumber("https://github.com/owner/repo/pull/55/files")).toBe(55);
+  });
+
+  it("returns 0 for branch names", () => {
+    expect(resolveNumber("feat/my-branch")).toBe(0);
+  });
+
+  it("returns 0 for branch names containing digits", () => {
+    expect(resolveNumber("fix/1017-github-number-echo")).toBe(0);
+  });
+});
 
 describe("parsePrView", () => {
   it("parses full PR view JSON", () => {

--- a/packages/server-github/src/lib/parsers.ts
+++ b/packages/server-github/src/lib/parsers.ts
@@ -65,6 +65,24 @@ function parseJsonObject(json: string): any {
 }
 
 /**
+ * Resolves a PR/issue selector (number, numeric string, "#123", or GitHub URL)
+ * to its numeric value for echoing in structured output.
+ *
+ * MCP tool inputs type `number` as a string (to also allow URLs and branch
+ * names), so a plain `typeof number === "number"` guard always fell through to
+ * `0` for MCP callers (issue #1017). Branch names have no derivable number and
+ * still resolve to `0`.
+ */
+export function resolveNumber(input: string | number): number {
+  if (typeof input === "number") return input;
+  const trimmed = input.trim();
+  if (/^#?\d+$/.test(trimmed)) return Number(trimmed.replace(/^#/, ""));
+  const urlMatch = /\/(?:pull|issues)\/(\d+)(?:\/|$|\?|#)/.exec(trimmed);
+  if (urlMatch) return Number(urlMatch[1]);
+  return 0; // branch names have no derivable number
+}
+
+/**
  * Parses `gh pr view --json ...` output into structured PR view data.
  * Renames gh field names to our schema names (e.g., headRefName → headBranch).
  */

--- a/packages/server-github/src/tools/issue-close.ts
+++ b/packages/server-github/src/tools/issue-close.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
-import { parseIssueClose } from "../lib/parsers.js";
+import { parseIssueClose, resolveNumber } from "../lib/parsers.js";
 import { formatIssueClose } from "../lib/formatters.js";
 import { IssueCloseResultSchema } from "../schemas/index.js";
 
@@ -52,7 +52,7 @@ export function registerIssueCloseTool(server: McpServer) {
       if (typeof number === "string") assertNoFlagInjection(number, "number");
 
       const selector = String(number);
-      const issueNum = typeof number === "number" ? number : 0;
+      const issueNum = resolveNumber(number);
 
       const args = ["issue", "close", selector];
       // Note: gh issue close only supports --comment, not --comment-file or stdin.

--- a/packages/server-github/src/tools/issue-comment.ts
+++ b/packages/server-github/src/tools/issue-comment.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
-import { parseComment } from "../lib/parsers.js";
+import { parseComment, resolveNumber } from "../lib/parsers.js";
 import { formatComment } from "../lib/formatters.js";
 import { CommentResultSchema } from "../schemas/index.js";
 
@@ -60,7 +60,7 @@ export function registerIssueCommentTool(server: McpServer) {
       if (typeof number === "string") assertNoFlagInjection(number, "number");
 
       const selector = String(number);
-      const issueNum = typeof number === "number" ? number : 0;
+      const issueNum = resolveNumber(number);
 
       const args = ["issue", "comment", selector, "--body-file", "-"];
       if (editLast) args.push("--edit-last");

--- a/packages/server-github/src/tools/issue-update.ts
+++ b/packages/server-github/src/tools/issue-update.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
-import { parseIssueUpdate } from "../lib/parsers.js";
+import { parseIssueUpdate, resolveNumber } from "../lib/parsers.js";
 import { formatIssueUpdate } from "../lib/formatters.js";
 import { EditResultSchema } from "../schemas/index.js";
 
@@ -175,7 +175,7 @@ export function registerIssueUpdateTool(server: McpServer) {
       }
 
       const selector = String(number);
-      const issueNum = typeof number === "number" ? number : 0;
+      const issueNum = resolveNumber(number);
       const updatedFields = [
         title ? "title" : undefined,
         body ? "body" : undefined,

--- a/packages/server-github/src/tools/pr-checks.ts
+++ b/packages/server-github/src/tools/pr-checks.ts
@@ -8,7 +8,7 @@ import {
   repoPathInput,
 } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
-import { parsePrChecks } from "../lib/parsers.js";
+import { parsePrChecks, resolveNumber } from "../lib/parsers.js";
 import { formatPrChecks, compactPrChecksMap, formatPrChecksCompact } from "../lib/formatters.js";
 import { PrChecksResultSchema, type PrChecksResult } from "../schemas/index.js";
 
@@ -232,7 +232,7 @@ export function registerPrChecksTool(server: McpServer) {
       if (typeof number === "string") assertNoFlagInjection(number, "number");
 
       const selector = String(number);
-      const prNum = typeof number === "number" ? number : 0;
+      const prNum = resolveNumber(number);
 
       // Note: gh rejects `--watch` together with `--json`, so we never pass
       // gh's native --watch. When watch=true the wrapper polls internally.

--- a/packages/server-github/src/tools/pr-close.ts
+++ b/packages/server-github/src/tools/pr-close.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
-import { parsePrClose } from "../lib/parsers.js";
+import { parsePrClose, resolveNumber } from "../lib/parsers.js";
 import { formatPrClose } from "../lib/formatters.js";
 import { PrCloseResultSchema } from "../schemas/index.js";
 
@@ -53,7 +53,7 @@ export function registerPrCloseTool(server: McpServer) {
       if (typeof number === "string") assertNoFlagInjection(number, "number");
 
       const selector = String(number);
-      const prNum = typeof number === "number" ? number : 0;
+      const prNum = resolveNumber(number);
 
       const args = ["pr", "close", selector];
       if (comment) args.push("--comment", comment);

--- a/packages/server-github/src/tools/pr-comment.ts
+++ b/packages/server-github/src/tools/pr-comment.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
-import { parseComment } from "../lib/parsers.js";
+import { parseComment, resolveNumber } from "../lib/parsers.js";
 import { formatComment } from "../lib/formatters.js";
 import { CommentResultSchema } from "../schemas/index.js";
 
@@ -63,7 +63,7 @@ export function registerPrCommentTool(server: McpServer) {
       if (typeof number === "string") assertNoFlagInjection(number, "number");
 
       const selector = String(number);
-      const prNum = typeof number === "number" ? number : 0;
+      const prNum = resolveNumber(number);
 
       const args = ["pr", "comment", selector, "--body-file", "-"];
       if (editLast) args.push("--edit-last");

--- a/packages/server-github/src/tools/pr-merge.ts
+++ b/packages/server-github/src/tools/pr-merge.ts
@@ -8,7 +8,7 @@ import {
   repoPathInput,
 } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
-import { parsePrMerge } from "../lib/parsers.js";
+import { parsePrMerge, resolveNumber } from "../lib/parsers.js";
 import { formatPrMerge } from "../lib/formatters.js";
 import { PrMergeResultSchema } from "../schemas/index.js";
 
@@ -117,7 +117,7 @@ export function registerPrMergeTool(server: McpServer) {
       if (typeof number === "string") assertNoFlagInjection(number, "number");
 
       const selector = String(number);
-      const prNum = typeof number === "number" ? number : 0;
+      const prNum = resolveNumber(number);
 
       const args = ["pr", "merge", selector, `--${method}`];
       if (deleteBranch) args.push("--delete-branch");

--- a/packages/server-github/src/tools/pr-ready.ts
+++ b/packages/server-github/src/tools/pr-ready.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
-import { parsePrReady } from "../lib/parsers.js";
+import { parsePrReady, resolveNumber } from "../lib/parsers.js";
 import { formatPrReady } from "../lib/formatters.js";
 import { PrReadyResultSchema } from "../schemas/index.js";
 
@@ -57,7 +57,7 @@ export function registerPrReadyTool(server: McpServer) {
       if (typeof number === "string") assertNoFlagInjection(number, "number");
 
       const selector = String(number);
-      const prNum = typeof number === "number" ? number : 0;
+      const prNum = resolveNumber(number);
 
       const args = ["pr", "ready", selector];
       if (undo) args.push("--undo");

--- a/packages/server-github/src/tools/pr-reopen.ts
+++ b/packages/server-github/src/tools/pr-reopen.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
-import { parsePrReopen } from "../lib/parsers.js";
+import { parsePrReopen, resolveNumber } from "../lib/parsers.js";
 import { formatPrReopen } from "../lib/formatters.js";
 import { PrReopenResultSchema } from "../schemas/index.js";
 
@@ -53,7 +53,7 @@ export function registerPrReopenTool(server: McpServer) {
       if (typeof number === "string") assertNoFlagInjection(number, "number");
 
       const selector = String(number);
-      const prNum = typeof number === "number" ? number : 0;
+      const prNum = resolveNumber(number);
 
       const args = ["pr", "reopen", selector];
       if (comment) args.push("--comment", comment);

--- a/packages/server-github/src/tools/pr-review.ts
+++ b/packages/server-github/src/tools/pr-review.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
-import { parsePrReview } from "../lib/parsers.js";
+import { parsePrReview, resolveNumber } from "../lib/parsers.js";
 import { formatPrReview } from "../lib/formatters.js";
 import { PrReviewResultSchema } from "../schemas/index.js";
 
@@ -60,7 +60,7 @@ export function registerPrReviewTool(server: McpServer) {
       }
 
       const selector = String(number);
-      const prNum = typeof number === "number" ? number : 0;
+      const prNum = resolveNumber(number);
 
       const args = ["pr", "review", selector, `--${event}`];
       if (repo) args.push("--repo", repo);

--- a/packages/server-github/src/tools/pr-update.ts
+++ b/packages/server-github/src/tools/pr-update.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
 import { ghCmd } from "../lib/gh-runner.js";
-import { parsePrUpdate } from "../lib/parsers.js";
+import { parsePrUpdate, resolveNumber } from "../lib/parsers.js";
 import { formatPrUpdate } from "../lib/formatters.js";
 import { EditResultSchema } from "../schemas/index.js";
 
@@ -174,7 +174,7 @@ export function registerPrUpdateTool(server: McpServer) {
       }
 
       const selector = String(number);
-      const prNum = typeof number === "number" ? number : 0;
+      const prNum = resolveNumber(number);
       const updatedFields = [
         title ? "title" : undefined,
         body ? "body" : undefined,


### PR DESCRIPTION
## Summary

The `number` input on `@paretools/github` PR/issue mutation tools is typed as a string (to allow URLs and branch names), so the guard `typeof number === "number" ? number : 0` was effectively always false for MCP callers — every mutation tool echoed `number: 0` / `prNumber: 0` in its structured output.

## Changes

- Added a `resolveNumber(input: string | number): number` helper in `packages/server-github/src/lib/parsers.ts` that resolves:
  - plain numbers (passed through)
  - numeric strings (`"123"`, with whitespace)
  - hash references (`"#123"`)
  - PR/issue URLs (`/pull/123`, `/issues/42`), including trailing slashes, query strings, fragments, and subpaths like `/pull/55/files`
  - branch names still resolve to `0` (no derivable number)
- Replaced the `typeof number === "number" ? number : 0` guard with `resolveNumber(number)` in all 11 affected tools: `pr-merge`, `pr-review`, `pr-comment`, `pr-checks`, `pr-close`, `pr-reopen`, `pr-ready`, `pr-update`, `issue-close`, `issue-comment`, `issue-update`.
- Verified `pr-create`/`issue-create` result parsing is unaffected — those derive the number from the URL that `gh` prints on stdout, which works correctly.
- Added 12 unit tests for `resolveNumber` in `packages/server-github/__tests__/parsers.test.ts`. No existing tests asserted the old `0` behavior.
- Changeset included (`@paretools/github` patch).

## Testing

- `pnpm --filter @paretools/github build` — clean
- `pnpm --filter @paretools/github test` — 27 files, 587 passed, 2 skipped
- `pnpm lint` — 0 errors (one pre-existing warning in `packages/shared`, untouched)
- `pnpm format:check` — clean

Closes #1017