### PR TITLE
fix(process): include truncated stdout/stderr in compact run output

### DIFF
--- a/.changeset/fix-983-process-compact-output.md
+++ b/.changeset/fix-983-process-compact-output.md
@@ -1,0 +1,5 @@
+---
+"@paretools/process": patch
+---
+
+Include stdout/stderr in compact `run` output instead of silently dropping them. Compact mode (the default) previously returned only `{exitCode, success, timedOut}`, making a successful command's output indistinguishable from a command that printed nothing. Each stream is now included, truncated to a small budget (first 40 lines + last 10 lines, with an 8KB per-stream byte cap). When truncation occurs, `stdoutTruncated`/`stderrTruncated` and `stdoutTotalLines`/`stderrTotalLines` are set so an agent knows to re-run with `compact:false` for the full output; when output fits the budget it is included whole with no truncation flags. The compact human-readable text now shows the (truncated) output as well.

--- a/packages/server-process/__tests__/compact.test.ts
+++ b/packages/server-process/__tests__/compact.test.ts
@@ -7,7 +7,7 @@ import type { ProcessRunResultInternal } from "../src/schemas/index.js";
 // ---------------------------------------------------------------------------
 
 describe("compactRunMap", () => {
-  it("keeps exitCode, success, timedOut; drops command, duration, stdout, stderr", () => {
+  it("keeps exitCode, success, timedOut, stdout; drops command, duration", () => {
     const data: ProcessRunResultInternal = {
       command: "node",
       exitCode: 0,
@@ -23,11 +23,15 @@ describe("compactRunMap", () => {
     expect(compact.success).toBe(true);
     expect(compact.exitCode).toBe(0);
     expect(compact.timedOut).toBe(false);
+    // Short output is passed through whole, with no truncation flags
+    expect(compact.stdout).toBe("Hello, world!\nLine 2\nLine 3");
+    expect(compact.stdoutTruncated).toBeUndefined();
+    expect(compact.stdoutTotalLines).toBeUndefined();
+    // Empty stderr is omitted entirely
+    expect(compact).not.toHaveProperty("stderr");
     // Verify dropped fields
     expect(compact).not.toHaveProperty("command");
     expect(compact).not.toHaveProperty("duration");
-    expect(compact).not.toHaveProperty("stdout");
-    expect(compact).not.toHaveProperty("stderr");
   });
 
   it("preserves signal when present", () => {
@@ -46,10 +50,10 @@ describe("compactRunMap", () => {
 
     expect(compact.timedOut).toBe(true);
     expect(compact.signal).toBe("SIGTERM");
+    expect(compact.stderr).toBe("timed out");
     expect(compact).not.toHaveProperty("command");
     expect(compact).not.toHaveProperty("duration");
     expect(compact).not.toHaveProperty("stdout");
-    expect(compact).not.toHaveProperty("stderr");
   });
 
   it("handles failed command with no signal", () => {
@@ -68,10 +72,10 @@ describe("compactRunMap", () => {
     expect(compact.success).toBe(false);
     expect(compact.exitCode).toBe(1);
     expect(compact.signal).toBeUndefined();
+    expect(compact.stderr).toBe("command failed");
     expect(compact).not.toHaveProperty("command");
     expect(compact).not.toHaveProperty("duration");
     expect(compact).not.toHaveProperty("stdout");
-    expect(compact).not.toHaveProperty("stderr");
   });
 
   it("preserves truncated flag when true", () => {

--- a/packages/server-process/__tests__/formatters.test.ts
+++ b/packages/server-process/__tests__/formatters.test.ts
@@ -118,7 +118,7 @@ describe("formatRun", () => {
 // ── Compact mappers and formatters ───────────────────────────────────
 
 describe("compactRunMap", () => {
-  it("keeps exitCode, success, timedOut; drops command, duration, stdout, stderr", () => {
+  it("keeps exitCode, success, timedOut, stdout, stderr; drops command, duration", () => {
     const data: ProcessRunResultInternal = {
       command: "echo",
       success: true,
@@ -134,10 +134,111 @@ describe("compactRunMap", () => {
     expect(compact.success).toBe(true);
     expect(compact.exitCode).toBe(0);
     expect(compact.timedOut).toBe(false);
+    expect(compact.stdout).toBe("lots of output...");
+    expect(compact.stderr).toBe("some warnings");
+    expect(compact.stdoutTruncated).toBeUndefined();
+    expect(compact.stderrTruncated).toBeUndefined();
     expect(compact).not.toHaveProperty("command");
     expect(compact).not.toHaveProperty("duration");
+  });
+
+  it("passes short output through whole with no truncation flags", () => {
+    const stdout = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join("\n");
+    const data: ProcessRunResultInternal = {
+      command: "ls",
+      success: true,
+      exitCode: 0,
+      stdout,
+      duration: 20,
+      timedOut: false,
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.stdout).toBe(stdout);
+    expect(compact.stdoutTruncated).toBeUndefined();
+    expect(compact.stdoutTotalLines).toBeUndefined();
+  });
+
+  it("truncates long stdout to head+tail and sets truncation fields", () => {
+    const stdout = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`).join("\n");
+    const data: ProcessRunResultInternal = {
+      command: "cat",
+      success: true,
+      exitCode: 0,
+      stdout,
+      duration: 20,
+      timedOut: false,
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.stdoutTruncated).toBe(true);
+    expect(compact.stdoutTotalLines).toBe(200);
+    expect(compact.stdout).toContain("line 1\n");
+    expect(compact.stdout).toContain("line 40");
+    expect(compact.stdout).toContain("line 191");
+    expect(compact.stdout).toContain("line 200");
+    expect(compact.stdout).toContain("... (150 lines omitted) ...");
+    expect(compact.stdout).not.toContain("line 41\n");
+    expect(compact.stdout).not.toContain("line 190\n");
+  });
+
+  it("truncates long stderr independently of stdout", () => {
+    const stderr = Array.from({ length: 100 }, (_, i) => `err ${i + 1}`).join("\n");
+    const data: ProcessRunResultInternal = {
+      command: "node",
+      success: false,
+      exitCode: 1,
+      stdout: "short",
+      stderr,
+      duration: 20,
+      timedOut: false,
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.stdout).toBe("short");
+    expect(compact.stdoutTruncated).toBeUndefined();
+    expect(compact.stderrTruncated).toBe(true);
+    expect(compact.stderrTotalLines).toBe(100);
+    expect(compact.stderr).toContain("... (50 lines omitted) ...");
+  });
+
+  it("applies the 8KB byte cap to few very long lines", () => {
+    const stdout = "x".repeat(20_000);
+    const data: ProcessRunResultInternal = {
+      command: "cat",
+      success: true,
+      exitCode: 0,
+      stdout,
+      duration: 20,
+      timedOut: false,
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.stdoutTruncated).toBe(true);
+    expect(compact.stdoutTotalLines).toBe(1);
+    expect((compact.stdout as string).length).toBeLessThan(8192 + 32);
+    expect(compact.stdout).toContain("... (truncated)");
+  });
+
+  it("omits stdout/stderr entirely when there is no output", () => {
+    const data: ProcessRunResultInternal = {
+      command: "true",
+      success: true,
+      exitCode: 0,
+      duration: 10,
+      timedOut: false,
+    };
+
+    const compact = compactRunMap(data);
+
     expect(compact).not.toHaveProperty("stdout");
     expect(compact).not.toHaveProperty("stderr");
+    expect(compact.stdoutTruncated).toBeUndefined();
+    expect(compact.stderrTruncated).toBeUndefined();
   });
 
   it("preserves signal and timedOut", () => {
@@ -275,5 +376,34 @@ describe("formatRunCompact", () => {
     });
     expect(output).toContain("process: exit code 1.");
     expect(output).toContain("[output truncated: maxBuffer exceeded]");
+  });
+
+  it("includes stdout and stderr in the text output", () => {
+    const output = formatRunCompact({
+      exitCode: 0,
+      success: true,
+      timedOut: false,
+      stdout: "hello world",
+      stderr: "a warning",
+    });
+    expect(output).toContain("process: success.");
+    expect(output).toContain("hello world");
+    expect(output).toContain("a warning");
+  });
+
+  it("shows truncation notices with total line counts", () => {
+    const output = formatRunCompact({
+      exitCode: 0,
+      success: true,
+      timedOut: false,
+      stdout: "first lines...",
+      stdoutTruncated: true,
+      stdoutTotalLines: 500,
+      stderr: "err lines...",
+      stderrTruncated: true,
+      stderrTotalLines: 120,
+    });
+    expect(output).toContain("[stdout truncated: 500 total lines; re-run with compact:false");
+    expect(output).toContain("[stderr truncated: 120 total lines; re-run with compact:false");
   });
 });

--- a/packages/server-process/__tests__/integration.test.ts
+++ b/packages/server-process/__tests__/integration.test.ts
@@ -56,6 +56,9 @@ describe("@paretools/process integration", () => {
       expect(sc.success).toBe(true);
       expect(sc.exitCode).toBe(0);
       expect(sc.timedOut).toBe(false);
+      // Compact mode (the default) must still include stdout (issue #983)
+      expect(sc.stdout).toContain("42");
+      expect(sc.stdoutTruncated).toBeUndefined();
     });
 
     it("returns exit code for a failing command", async () => {

--- a/packages/server-process/src/lib/formatters.ts
+++ b/packages/server-process/src/lib/formatters.ts
@@ -59,24 +59,88 @@ export function formatRun(data: ProcessRunResultInternal): string {
 
 // ── Compact types, mappers, and formatters ───────────────────────────
 
-/** Compact run: schema-compatible fields only. Drop stdout/stderr and Internal fields. */
+/** Compact output budget: keep the first N lines and last N lines of each stream. */
+export const COMPACT_HEAD_LINES = 40;
+export const COMPACT_TAIL_LINES = 10;
+/** Compact output budget: hard byte cap per stream (applied after line trimming). */
+export const COMPACT_BYTE_CAP = 8192;
+
+/**
+ * Truncates a stream to the compact budget: first 40 lines + last 10 lines,
+ * then a hard 8KB byte cap. Returns the (possibly truncated) text, whether
+ * truncation occurred, and the total line count of the original text.
+ */
+function truncateForCompact(text: string): {
+  text: string;
+  truncated: boolean;
+  totalLines: number;
+} {
+  const lines = text.split("\n");
+  const totalLines = lines.length;
+  let out = text;
+  let truncated = false;
+
+  if (totalLines > COMPACT_HEAD_LINES + COMPACT_TAIL_LINES) {
+    const omitted = totalLines - COMPACT_HEAD_LINES - COMPACT_TAIL_LINES;
+    out = [
+      ...lines.slice(0, COMPACT_HEAD_LINES),
+      `... (${omitted} lines omitted) ...`,
+      ...lines.slice(totalLines - COMPACT_TAIL_LINES),
+    ].join("\n");
+    truncated = true;
+  }
+
+  if (out.length > COMPACT_BYTE_CAP) {
+    out = out.slice(0, COMPACT_BYTE_CAP) + "\n... (truncated)";
+    truncated = true;
+  }
+
+  return { text: out, truncated, totalLines };
+}
+
+/** Compact run: schema-compatible fields only. stdout/stderr kept, truncated to a small budget. */
 export interface ProcessRunCompact {
   [key: string]: unknown;
   exitCode: number;
   success: boolean;
   timedOut: boolean;
+  stdout?: string;
+  stderr?: string;
+  stdoutTruncated?: boolean;
+  stderrTruncated?: boolean;
+  stdoutTotalLines?: number;
+  stderrTotalLines?: number;
   truncated?: boolean;
   signal?: string;
 }
 
 export function compactRunMap(data: ProcessRunResultInternal): ProcessRunCompact {
-  return {
+  const compact: ProcessRunCompact = {
     exitCode: data.exitCode,
     success: data.success,
     timedOut: data.timedOut,
     truncated: data.truncated,
     signal: data.signal,
   };
+
+  if (data.stdout) {
+    const t = truncateForCompact(data.stdout);
+    compact.stdout = t.text;
+    if (t.truncated) {
+      compact.stdoutTruncated = true;
+      compact.stdoutTotalLines = t.totalLines;
+    }
+  }
+  if (data.stderr) {
+    const t = truncateForCompact(data.stderr);
+    compact.stderr = t.text;
+    if (t.truncated) {
+      compact.stderrTruncated = true;
+      compact.stderrTotalLines = t.totalLines;
+    }
+  }
+
+  return compact;
 }
 
 export function formatRunCompact(data: ProcessRunCompact): string {
@@ -92,6 +156,23 @@ export function formatRunCompact(data: ProcessRunCompact): string {
 
   if (data.truncated) {
     parts.push("  [output truncated: maxBuffer exceeded]");
+  }
+
+  if (data.stdout) {
+    parts.push(data.stdout);
+    if (data.stdoutTruncated) {
+      parts.push(
+        `  [stdout truncated: ${data.stdoutTotalLines} total lines; re-run with compact:false for full output]`,
+      );
+    }
+  }
+  if (data.stderr) {
+    parts.push(data.stderr);
+    if (data.stderrTruncated) {
+      parts.push(
+        `  [stderr truncated: ${data.stderrTotalLines} total lines; re-run with compact:false for full output]`,
+      );
+    }
   }
 
   return parts.join("\n");

--- a/packages/server-process/src/schemas/index.ts
+++ b/packages/server-process/src/schemas/index.ts
@@ -11,6 +11,14 @@ export const ProcessRunResultSchema = z.object({
   timedOut: z.boolean(),
   truncated: z.boolean().optional(),
   signal: z.string().optional(),
+  /** Whether stdout was truncated to the compact output budget. Re-run with compact:false for full output. */
+  stdoutTruncated: z.boolean().optional(),
+  /** Whether stderr was truncated to the compact output budget. Re-run with compact:false for full output. */
+  stderrTruncated: z.boolean().optional(),
+  /** Total number of stdout lines before compact truncation (only set when stdoutTruncated). */
+  stdoutTotalLines: z.number().optional(),
+  /** Total number of stderr lines before compact truncation (only set when stderrTruncated). */
+  stderrTotalLines: z.number().optional(),
 });
 
 export type ProcessRunResult = z.infer<typeof ProcessRunResultSchema>;


### PR DESCRIPTION
## Summary

`compactRunMap` in `@paretools/process` dropped stdout/stderr entirely, and `compact` defaults to true — so for most runs the agent got back only exit status, indistinguishable from a command that printed nothing. For a command runner, stdout is usually the whole point of the call.

Compact mode now keeps both streams, truncated to a small budget, with explicit truncation indicators:

- **Budget**: first 40 lines + last 10 lines per stream (with a `... (N lines omitted) ...` marker in between), plus a hard 8KB per-stream byte cap (marked `... (truncated)`).
- **Flags**: when truncated, `stdoutTruncated: true` / `stdoutTotalLines: <n>` (same for stderr) are set, so an agent knows to re-run with `compact:false` for the full output. Field names follow the existing `stdoutTruncated`/`stderrTruncated` optional-boolean pattern from `@paretools/go`.
- **Passthrough**: output that fits the budget is included whole, with the flags omitted (matching the omit-when-false schema style used elsewhere).
- The Zod output schema gained the four optional fields, and the compact human formatter now shows the (truncated) output plus truncation notices.

## Before / After

`{command: "python", args: ["-c", "print('hello')"]}` (default compact mode):

Before:
```json
{"exitCode":0,"success":true,"timedOut":false}
```

After:
```json
{"exitCode":0,"success":true,"timedOut":false,"stdout":"hello"}
```

And for a command printing 200 lines:
```json
{"exitCode":0,"success":true,"timedOut":false,"stdout":"line 1\n...line 40\n... (150 lines omitted) ...\nline 191\n...line 200","stdoutTruncated":true,"stdoutTotalLines":200}
```

## Verification

- `pnpm --filter @paretools/shared build && pnpm --filter @paretools/process build` — clean
- `@paretools/process` tests: 92/92 passing (new unit tests cover short-output passthrough, head+tail truncation with flags, independent stderr truncation, 8KB byte cap, and empty output; the default-compact integration test now asserts stdout is present)
- ESLint: 0 errors, 0 warnings; Prettier format check clean
- Changeset included (`patch`)

Closes #983