### PR TITLE
fix(python): surface pytest collection errors and add env/extraArgs passthrough

### DIFF
--- a/.changeset/fix-984-pytest-diagnostics-env.md
+++ b/.changeset/fix-984-pytest-diagnostics-env.md
@@ -1,0 +1,9 @@
+---
+"@paretools/python": minor
+---
+
+pytest: surface collection/startup error diagnostics and add `env`/`extraArgs` inputs (#984)
+
+- When a pytest run fails with no test results (e.g. `ModuleNotFoundError` from a src-layout project missing `PYTHONPATH`, or a broken plugin crashing at startup), the tool now includes `exitCode` and an `errorOutput` diagnostic (capped tail of the most informative output stream) instead of a silent all-zero result.
+- New `env` input: extra environment variables merged over the parent environment (e.g. `{"PYTHONPATH": "src"}`).
+- New `extraArgs` input: additional pytest CLI arguments passed through verbatim (e.g. `["-p", "no:logfire"]`).

--- a/packages/server-python/__tests__/compact.test.ts
+++ b/packages/server-python/__tests__/compact.test.ts
@@ -80,6 +80,27 @@ describe("compactPytestMap", () => {
 
     const compact = compactPytestMap(data);
     expect(compact.failedTests).toEqual([]);
+    expect(compact).not.toHaveProperty("exitCode");
+    expect(compact).not.toHaveProperty("errorOutput");
+  });
+
+  it("keeps exitCode and errorOutput diagnostics on failed empty runs", () => {
+    const data: PytestResult = {
+      success: false,
+      passed: 0,
+      failed: 0,
+      errors: 0,
+      skipped: 0,
+      warnings: 0,
+      failures: [],
+      exitCode: 2,
+      errorOutput: "ModuleNotFoundError: No module named 'mypkg'",
+    };
+
+    const compact = compactPytestMap(data);
+
+    expect(compact.exitCode).toBe(2);
+    expect(compact.errorOutput).toBe("ModuleNotFoundError: No module named 'mypkg'");
   });
 });
 
@@ -112,6 +133,24 @@ describe("formatPytestCompact", () => {
       failedTests: [],
     };
     expect(formatPytestCompact(compact)).toBe("pytest: no tests collected.");
+  });
+
+  it("formats failed empty run with exit code and diagnostics", () => {
+    const compact = {
+      success: false,
+      passed: 0,
+      failed: 0,
+      errors: 0,
+      skipped: 0,
+      warnings: 0,
+      failedTests: [],
+      exitCode: 2,
+      errorOutput: "ModuleNotFoundError: No module named 'mypkg'",
+    };
+    const output = formatPytestCompact(compact);
+
+    expect(output).toContain("run failed with no test results (exit code 2)");
+    expect(output).toContain("ModuleNotFoundError: No module named 'mypkg'");
   });
 });
 

--- a/packages/server-python/__tests__/integration.test.ts
+++ b/packages/server-python/__tests__/integration.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const SERVER_PATH = resolve(__dirname, "../dist/index.js");
@@ -165,6 +167,122 @@ describe("@paretools/python integration", () => {
         expect(typeof sc.skipped).toBe("number");
         expect(Array.isArray(sc.failures)).toBe(true);
       }
+    });
+
+    describe("src-layout project (issue #984)", () => {
+      let projectDir: string;
+
+      beforeAll(() => {
+        // src-layout project: tests import `mypkg`, which is only importable
+        // with PYTHONPATH=src.
+        projectDir = mkdtempSync(join(tmpdir(), "pare-pytest-984-"));
+        mkdirSync(join(projectDir, "src", "mypkg"), { recursive: true });
+        mkdirSync(join(projectDir, "tests"), { recursive: true });
+        writeFileSync(
+          join(projectDir, "src", "mypkg", "__init__.py"),
+          "def add(a, b):\n    return a + b\n",
+        );
+        writeFileSync(
+          join(projectDir, "tests", "test_add.py"),
+          "from mypkg import add\n\n\ndef test_add():\n    assert add(1, 2) == 3\n",
+        );
+      });
+
+      afterAll(() => {
+        rmSync(projectDir, { recursive: true, force: true });
+      });
+
+      it("surfaces diagnostics when the run fails with no test results", async () => {
+        const result = await client.callTool(
+          { name: "pytest", arguments: { path: projectDir, compact: false } },
+          undefined,
+          CALL_TIMEOUT,
+        );
+
+        if (result.isError) {
+          // pytest not installed on this machine
+          const content = result.content as Array<{ type: string; text: string }>;
+          expect(content[0].text).toMatch(/pytest|command|not found/i);
+          return;
+        }
+
+        const sc = result.structuredContent as Record<string, unknown>;
+        // Without PYTHONPATH the run must fail (collection error or plugin
+        // crash) — and the agent must be able to see why.
+        expect(sc.success).toBe(false);
+        expect(sc.passed).toBe(0);
+        expect(typeof sc.exitCode).toBe("number");
+        expect(typeof sc.errorOutput).toBe("string");
+        expect((sc.errorOutput as string).length).toBeGreaterThan(0);
+      });
+
+      it("passes with env PYTHONPATH and extraArgs plugin disable", async () => {
+        const result = await client.callTool(
+          {
+            name: "pytest",
+            arguments: {
+              path: projectDir,
+              env: { PYTHONPATH: "src" },
+              // `-p no:logfire` mirrors the issue's broken-plugin workaround;
+              // disabling a plugin that is not installed is a no-op, so this is
+              // safe on any machine while still exercising the passthrough.
+              extraArgs: ["-p", "no:logfire", "-p", "no:cacheprovider"],
+              compact: false,
+            },
+          },
+          undefined,
+          CALL_TIMEOUT,
+        );
+
+        if (result.isError) {
+          const content = result.content as Array<{ type: string; text: string }>;
+          expect(content[0].text).toMatch(/pytest|command|not found/i);
+          return;
+        }
+
+        const sc = result.structuredContent as Record<string, unknown>;
+        expect(sc.success).toBe(true);
+        expect(sc.passed).toBe(1);
+        expect(sc.errorOutput).toBeUndefined();
+      });
+
+      it("rejects invalid env variable names", async () => {
+        const result = await client.callTool(
+          {
+            name: "pytest",
+            arguments: {
+              path: projectDir,
+              env: { "BAD-NAME; rm -rf /": "x" },
+              compact: false,
+            },
+          },
+          undefined,
+          CALL_TIMEOUT,
+        );
+
+        expect(result.isError).toBe(true);
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/Invalid env/i);
+      });
+
+      it("rejects extraArgs containing control characters", async () => {
+        const result = await client.callTool(
+          {
+            name: "pytest",
+            arguments: {
+              path: projectDir,
+              extraArgs: ["-p\nno:evil"],
+              compact: false,
+            },
+          },
+          undefined,
+          CALL_TIMEOUT,
+        );
+
+        expect(result.isError).toBe(true);
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0].text).toMatch(/must not contain NUL or newline/i);
+      });
     });
   });
 

--- a/packages/server-python/__tests__/p2-gaps.test.ts
+++ b/packages/server-python/__tests__/p2-gaps.test.ts
@@ -195,6 +195,82 @@ describe("Python P2 gaps", () => {
     expect(vi.mocked(pytest).mock.calls[0][2]).toBe(".venv/bin/python");
   });
 
+  it("#984 passes env through to the pytest runner", async () => {
+    const server = new FakeServer();
+    registerPytestTool(server as never);
+    const handler = server.tools.get("pytest")!.handler;
+    vi.mocked(pytest).mockResolvedValueOnce({
+      stdout: "1 passed in 0.1s",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    await handler({ env: { PYTHONPATH: "src" }, compact: false });
+
+    expect(vi.mocked(pytest).mock.calls[0][3]).toEqual({ PYTHONPATH: "src" });
+  });
+
+  it("#984 appends extraArgs before targets", async () => {
+    const server = new FakeServer();
+    registerPytestTool(server as never);
+    const handler = server.tools.get("pytest")!.handler;
+    vi.mocked(pytest).mockResolvedValueOnce({
+      stdout: "1 passed in 0.1s",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    await handler({ extraArgs: ["-p", "no:logfire"], targets: ["tests/"], compact: false });
+
+    const args = vi.mocked(pytest).mock.calls[0][0] as string[];
+    expect(args.slice(-3)).toEqual(["-p", "no:logfire", "tests/"]);
+  });
+
+  it("#984 rejects env keys that are not valid variable names", async () => {
+    const server = new FakeServer();
+    registerPytestTool(server as never);
+    const handler = server.tools.get("pytest")!.handler;
+
+    await expect(handler({ env: { "BAD-NAME": "x" }, compact: false })).rejects.toThrow(
+      /Invalid env/,
+    );
+    await expect(handler({ env: { "1LEADING": "x" }, compact: false })).rejects.toThrow(
+      /Invalid env/,
+    );
+    expect(vi.mocked(pytest)).not.toHaveBeenCalled();
+  });
+
+  it("#984 rejects env values and extraArgs with control characters", async () => {
+    const server = new FakeServer();
+    registerPytestTool(server as never);
+    const handler = server.tools.get("pytest")!.handler;
+
+    await expect(handler({ env: { GOOD_NAME: "bad\nvalue" }, compact: false })).rejects.toThrow(
+      /must not contain NUL or newline/,
+    );
+    await expect(handler({ extraArgs: ["-p\nno:evil"], compact: false })).rejects.toThrow(
+      /must not contain NUL or newline/,
+    );
+    expect(vi.mocked(pytest)).not.toHaveBeenCalled();
+  });
+
+  it("#984 surfaces errorOutput when a run fails with no test results", async () => {
+    const server = new FakeServer();
+    registerPytestTool(server as never);
+    const handler = server.tools.get("pytest")!.handler;
+    vi.mocked(pytest).mockResolvedValueOnce({
+      stdout: "",
+      stderr: "ImportError: broken plugin",
+      exitCode: 1,
+    });
+
+    const out = await handler({ compact: false });
+
+    expect(out.structuredContent.success).toBe(false);
+    expect(out.structuredContent.exitCode).toBe(1);
+    expect(out.structuredContent.errorOutput).toContain("ImportError: broken plugin");
+  });
+
   it("#365 includes pip-audit skipped dependencies", () => {
     const out = parsePipAuditJson(
       JSON.stringify({

--- a/packages/server-python/__tests__/pytest.test.ts
+++ b/packages/server-python/__tests__/pytest.test.ts
@@ -107,6 +107,104 @@ describe("parsePytestOutput", () => {
     expect(result.success).toBe(true);
     expect(result.passed).toBe(5);
   });
+
+  // Real pytest output captured from a src-layout project missing PYTHONPATH=src
+  // (pytest 8.x, --tb=short -q). See issue #984.
+  const COLLECTION_ERROR_STDOUT = [
+    "=================================== ERRORS ====================================",
+    "_____________________ ERROR collecting tests/test_core.py _____________________",
+    "ImportError while importing test module 'C:\\proj\\tests\\test_core.py'.",
+    "Hint: make sure your test modules/packages have valid Python names.",
+    "Traceback:",
+    "C:\\Python313\\Lib\\importlib\\__init__.py:88: in import_module",
+    "    return _bootstrap._gcd_import(name[level:], package, level)",
+    "tests\\test_core.py:1: in <module>",
+    "    from mypkg.core import add",
+    "E   ModuleNotFoundError: No module named 'mypkg'",
+    "=========================== short test summary info ===========================",
+    "ERROR tests/test_core.py",
+    "!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!",
+    "1 error in 0.89s",
+  ].join("\n");
+
+  it("surfaces collection error diagnostics when no tests ran (issue #984)", () => {
+    const result = parsePytestOutput(COLLECTION_ERROR_STDOUT, "", 2);
+
+    expect(result.success).toBe(false);
+    expect(result.passed).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.exitCode).toBe(2);
+    expect(result.errorOutput).toContain("ModuleNotFoundError: No module named 'mypkg'");
+    expect(result.errorOutput).toContain("ERROR collecting tests/test_core.py");
+  });
+
+  it("surfaces startup crash diagnostics from stderr (broken plugin)", () => {
+    // Real shape of a pytest startup crash: broken plugin import kills pytest
+    // before any output reaches stdout; the traceback lands on stderr.
+    const stderr = [
+      "Traceback (most recent call last):",
+      '  File "site-packages/pluggy/_manager.py", line 416, in load_setuptools_entrypoints',
+      "    plugin = ep.load()",
+      "ImportError: cannot import name 'ReadableLogRecord' from 'opentelemetry.sdk._logs'",
+    ].join("\n");
+
+    const result = parsePytestOutput("", stderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.passed).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(result.exitCode).toBe(1);
+    expect(result.errorOutput).toContain("ImportError: cannot import name 'ReadableLogRecord'");
+  });
+
+  it("prefers the stream carrying the error signal", () => {
+    // Collection errors land on stdout even when stderr has unrelated warnings.
+    const stderr = "UserWarning: some plugin warning\n  plugins = get_plugins()";
+
+    const result = parsePytestOutput(COLLECTION_ERROR_STDOUT, stderr, 2);
+
+    expect(result.errorOutput).toContain("ModuleNotFoundError");
+    expect(result.errorOutput).not.toContain("UserWarning");
+  });
+
+  it("truncates long diagnostics keeping the tail", () => {
+    const stdout = "x".repeat(10_000) + "\nModuleNotFoundError: No module named 'foo'";
+
+    const result = parsePytestOutput(stdout, "", 2);
+
+    expect(result.errorOutput).toMatch(/^… \(output truncated\)\n/);
+    expect(result.errorOutput).toContain("ModuleNotFoundError: No module named 'foo'");
+    expect(result.errorOutput!.length).toBeLessThanOrEqual(4_100);
+  });
+
+  it("does not attach diagnostics to successful runs", () => {
+    const result = parsePytestOutput("....\n4 passed in 0.52s", "", 0);
+
+    expect(result.errorOutput).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("does not attach diagnostics when no tests ran cleanly (exit 5)", () => {
+    const result = parsePytestOutput("no tests ran in 0.01s", "", 5);
+
+    expect(result.success).toBe(true);
+    expect(result.errorOutput).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("does not attach diagnostics when tests actually failed", () => {
+    const stdout = [
+      "_____________________________ test_addition _____________________________",
+      "E       assert 2 == 3",
+      "==================== 2 passed, 1 failed in 1.23s ====================",
+    ].join("\n");
+
+    const result = parsePytestOutput(stdout, "", 1);
+
+    expect(result.failed).toBe(1);
+    expect(result.errorOutput).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
 });
 
 describe("formatPytest", () => {
@@ -150,5 +248,41 @@ describe("formatPytest", () => {
 
     expect(output).toContain("3 passed, 1 failed, 2 skipped");
     expect(output).toContain("FAILED test_thing: assert 1 == 2");
+  });
+
+  it("formats failed run with no test results using exit code and diagnostics", () => {
+    const data: PytestResult = {
+      success: false,
+      passed: 0,
+      failed: 0,
+      errors: 0,
+      skipped: 0,
+      warnings: 0,
+      failures: [],
+      exitCode: 2,
+      errorOutput: "ModuleNotFoundError: No module named 'mypkg'",
+    };
+    const output = formatPytest(data);
+
+    expect(output).toContain("run failed with no test results (exit code 2)");
+    expect(output).toContain("ModuleNotFoundError: No module named 'mypkg'");
+  });
+
+  it("appends diagnostics after counts when collection errors were counted", () => {
+    const data: PytestResult = {
+      success: false,
+      passed: 0,
+      failed: 0,
+      errors: 1,
+      skipped: 0,
+      warnings: 0,
+      failures: [{ test: "ERROR collecting tests/test_core.py", message: "ModuleNotFoundError" }],
+      exitCode: 2,
+      errorOutput: "E   ModuleNotFoundError: No module named 'mypkg'",
+    };
+    const output = formatPytest(data);
+
+    expect(output).toContain("1 errors");
+    expect(output).toContain("ModuleNotFoundError: No module named 'mypkg'");
   });
 });

--- a/packages/server-python/src/lib/formatters.ts
+++ b/packages/server-python/src/lib/formatters.ts
@@ -88,7 +88,12 @@ export function formatPipAudit(data: PipAuditResult): string {
 /** Formats structured pytest results into a human-readable test summary. */
 export function formatPytest(data: PytestResult): string {
   const total = data.passed + data.failed + data.errors + data.skipped;
-  if (total === 0) return "pytest: no tests collected.";
+  if (total === 0) {
+    if (data.success) return "pytest: no tests collected.";
+    const lines = [`pytest: run failed with no test results (exit code ${data.exitCode ?? "?"}).`];
+    if (data.errorOutput) lines.push(data.errorOutput);
+    return lines.join("\n");
+  }
 
   const parts: string[] = [];
   if (data.passed > 0) parts.push(`${data.passed} passed`);
@@ -101,6 +106,9 @@ export function formatPytest(data: PytestResult): string {
 
   for (const f of data.failures ?? []) {
     lines.push(`  FAILED ${f.test}: ${f.message}`);
+  }
+  if (data.errorOutput) {
+    lines.push(data.errorOutput);
   }
 
   return lines.join("\n");
@@ -192,7 +200,9 @@ export function formatBlack(data: BlackResult): string {
 
 // ── Compact types, mappers, and formatters ───────────────────────────
 
-/** Compact pytest: counts + failure test names only (no stack traces). */
+/** Compact pytest: counts + failure test names only (no stack traces).
+ *  Diagnostics (exitCode/errorOutput) are kept: they only appear on failed runs
+ *  with no test results, where they are the sole actionable signal. */
 export interface PytestResultCompact {
   [key: string]: unknown;
   success: boolean;
@@ -202,10 +212,12 @@ export interface PytestResultCompact {
   skipped: number;
   warnings: number;
   failedTests: string[];
+  exitCode?: number;
+  errorOutput?: string;
 }
 
 export function compactPytestMap(data: PytestResult): PytestResultCompact {
-  return {
+  const compact: PytestResultCompact = {
     success: data.success,
     passed: data.passed,
     failed: data.failed,
@@ -214,11 +226,19 @@ export function compactPytestMap(data: PytestResult): PytestResultCompact {
     warnings: data.warnings,
     failedTests: (data.failures ?? []).map((f) => f.test),
   };
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
+  if (data.errorOutput !== undefined) compact.errorOutput = data.errorOutput;
+  return compact;
 }
 
 export function formatPytestCompact(data: PytestResultCompact): string {
   const total = data.passed + data.failed + data.errors + data.skipped;
-  if (total === 0) return "pytest: no tests collected.";
+  if (total === 0) {
+    if (data.success) return "pytest: no tests collected.";
+    const lines = [`pytest: run failed with no test results (exit code ${data.exitCode ?? "?"}).`];
+    if (data.errorOutput) lines.push(data.errorOutput);
+    return lines.join("\n");
+  }
 
   const parts: string[] = [];
   if (data.passed > 0) parts.push(`${data.passed} passed`);
@@ -230,6 +250,9 @@ export function formatPytestCompact(data: PytestResultCompact): string {
   const lines = [`pytest: ${parts.join(", ")}`];
   for (const t of data.failedTests) {
     lines.push(`  FAILED ${t}`);
+  }
+  if (data.errorOutput) {
+    lines.push(data.errorOutput);
   }
   return lines.join("\n");
 }

--- a/packages/server-python/src/lib/parsers.ts
+++ b/packages/server-python/src/lib/parsers.ts
@@ -283,6 +283,52 @@ function extractCount(line: string, label: RegExp): number {
   return m ? parseInt(m[1], 10) : 0;
 }
 
+/** Maximum size of the errorOutput diagnostic attached to failed empty pytest runs. */
+const PYTEST_ERROR_OUTPUT_MAX = 4_000;
+
+/** Picks the stream most likely to explain a failed pytest run.
+ *  Collection errors ("ERRORS" section, ModuleNotFoundError) land on stdout;
+ *  plugin/startup crashes (tracebacks) land on stderr. Prefers whichever stream
+ *  carries an error signal, falling back to stdout. */
+function pickPytestErrorStream(stdout: string, stderr: string): string {
+  const out = stdout.trim();
+  const err = stderr.trim();
+  if (!out) return err;
+  if (!err) return out;
+  const signal = /\b(?:ERRORS?|[A-Za-z]*Error|Traceback|error)\b/;
+  if (signal.test(out)) return out;
+  if (signal.test(err)) return err;
+  return out;
+}
+
+/** When a pytest run failed but produced no parseable test results (e.g. collection
+ *  error from a missing PYTHONPATH, or a broken plugin crashing at startup), attaches
+ *  the exit code and a capped tail of the raw output so agents can see WHY instead of
+ *  a silent all-zero result. See issue #984. */
+function attachEmptyRunDiagnostics(
+  result: PytestResult,
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): PytestResult {
+  // Zero executed tests + failure means the run never got past collection/startup.
+  // Any parsed `failures` in this state are collection-error blocks (e.g.
+  // "ERROR collecting tests/test_x.py"), not test failures, so the raw tail is
+  // still the only place the agent can see the underlying cause.
+  const noTestsExecuted = result.passed === 0 && result.failed === 0 && result.skipped === 0;
+  if (result.success || !noTestsExecuted) return result;
+
+  result.exitCode = exitCode;
+  const detail = pickPytestErrorStream(stdout, stderr);
+  if (detail) {
+    result.errorOutput =
+      detail.length > PYTEST_ERROR_OUTPUT_MAX
+        ? `… (output truncated)\n${detail.slice(-PYTEST_ERROR_OUTPUT_MAX)}`
+        : detail;
+  }
+  return result;
+}
+
 /** Parses pytest output into structured test results with pass/fail/error/skip/warning counts and failure details. */
 export function parsePytestOutput(stdout: string, stderr: string, exitCode: number): PytestResult {
   const output = stdout + "\n" + stderr;
@@ -309,15 +355,20 @@ export function parsePytestOutput(stdout: string, stderr: string, exitCode: numb
   // Check for "no tests ran" case
   const noTests = output.includes("no tests ran");
   if (noTests && passed === 0 && failed === 0 && errors === 0) {
-    return {
-      success: exitCode === 0 || exitCode === 5,
-      passed: 0,
-      failed: 0,
-      errors: 0,
-      skipped: 0,
-      warnings,
-      failures: [],
-    };
+    return attachEmptyRunDiagnostics(
+      {
+        success: exitCode === 0 || exitCode === 5,
+        passed: 0,
+        failed: 0,
+        errors: 0,
+        skipped: 0,
+        warnings,
+        failures: [],
+      },
+      stdout,
+      stderr,
+      exitCode,
+    );
   }
 
   // Parse failure blocks from short traceback
@@ -353,15 +404,20 @@ export function parsePytestOutput(stdout: string, stderr: string, exitCode: numb
     failures.push({ test: testName, message });
   }
 
-  return {
-    success: exitCode === 0,
-    passed,
-    failed,
-    errors,
-    skipped,
-    warnings,
-    failures,
-  };
+  return attachEmptyRunDiagnostics(
+    {
+      success: exitCode === 0,
+      passed,
+      failed,
+      errors,
+      skipped,
+      warnings,
+      failures,
+    },
+    stdout,
+    stderr,
+    exitCode,
+  );
 }
 
 // Matches uv install output lines like: " + package==version" or "Installed N packages in Ns"

--- a/packages/server-python/src/lib/python-runner.ts
+++ b/packages/server-python/src/lib/python-runner.ts
@@ -16,8 +16,9 @@ export async function pytest(
   args: string[],
   cwd?: string,
   pythonPath?: string,
+  env?: Record<string, string>,
 ): Promise<RunResult> {
-  return runPythonTool("pytest", "pytest", args, { cwd, pythonPath, timeout: 300_000 });
+  return runPythonTool("pytest", "pytest", args, { cwd, pythonPath, env, timeout: 300_000 });
 }
 
 export async function uv(args: string[], cwd?: string): Promise<RunResult> {

--- a/packages/server-python/src/schemas/index.ts
+++ b/packages/server-python/src/schemas/index.ts
@@ -113,6 +113,18 @@ export const PytestResultSchema = z.object({
   skipped: z.number(),
   warnings: z.number().describe("Count of warnings from pytest warnings summary"),
   failures: z.array(PytestFailureSchema).optional(),
+  exitCode: z
+    .number()
+    .optional()
+    .describe("pytest exit code; only present when the run failed with no parseable test results"),
+  errorOutput: z
+    .string()
+    .optional()
+    .describe(
+      "Tail of the raw pytest output explaining why the run produced no test results " +
+        "(e.g. collection error, ModuleNotFoundError, broken plugin); " +
+        "only present when the run failed with no parseable test results",
+    ),
 });
 
 export type PytestResult = z.infer<typeof PytestResultSchema>;

--- a/packages/server-python/src/tools/pytest.ts
+++ b/packages/server-python/src/tools/pytest.ts
@@ -8,6 +8,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   compactDualOutput,
   assertNoFlagInjection,
+  assertSafePassthroughArg,
+  coerceJsonArray,
   INPUT_LIMITS,
   compactInput,
   projectPathInput,
@@ -93,6 +95,24 @@ export function registerPytestTool(server: McpServer) {
           .optional()
           .describe("Number of parallel workers for pytest-xdist (-n NUM, 0=auto)"),
         configFile: configInput("Path to pytest config file (-c FILE)"),
+        env: z
+          .record(z.string(), z.string().max(INPUT_LIMITS.STRING_MAX))
+          .optional()
+          .describe(
+            "Additional environment variables for the pytest process, merged over the " +
+              'parent environment (e.g. {"PYTHONPATH": "src"} for src-layout projects)',
+          ),
+        extraArgs: z.preprocess(
+          coerceJsonArray,
+          z
+            .array(z.string().max(INPUT_LIMITS.STRING_MAX))
+            .max(INPUT_LIMITS.ARRAY_MAX)
+            .optional()
+            .describe(
+              'Additional pytest CLI arguments passed through verbatim (e.g. ["-p", "no:logfire"] ' +
+                "to disable a broken plugin). Each element is validated for control characters.",
+            ),
+        ),
         compact: compactInput,
       },
       outputSchema: PytestResultSchema,
@@ -113,6 +133,8 @@ export function registerPytestTool(server: McpServer) {
       coverage,
       parallel,
       configFile,
+      env,
+      extraArgs,
       compact,
     }) => {
       const cwd = path || process.cwd();
@@ -124,6 +146,26 @@ export function registerPytestTool(server: McpServer) {
       if (coverage) assertNoFlagInjection(coverage, "coverage");
       if (configFile) assertNoFlagInjection(configFile, "configFile");
       if (pythonPath) assertNoFlagInjection(pythonPath, "pythonPath");
+      if (env) {
+        for (const [key, value] of Object.entries(env)) {
+          if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+            throw new Error(
+              `Invalid env: key "${key}" must match /^[A-Za-z_][A-Za-z0-9_]*$/ ` +
+                "(letters, digits, and underscores, not starting with a digit).",
+            );
+          }
+          assertSafePassthroughArg(value, `env.${key}`);
+        }
+      }
+      if (extraArgs) {
+        // `extraArgs` is an explicit passthrough field: the caller intends these to
+        // reach pytest verbatim, so leading `-`/`--` flags (e.g. `-p no:logfire`)
+        // are allowed. Only NUL/newline control chars are rejected.
+        // See assertSafePassthroughArg and the same pattern in server-test.
+        for (const arg of extraArgs) {
+          assertSafePassthroughArg(arg, "extraArgs");
+        }
+      }
 
       const tbStyle = tracebackStyle || "short";
       const args = [`--tb=${tbStyle}`, "-q"];
@@ -139,9 +181,10 @@ export function registerPytestTool(server: McpServer) {
       if (coverage) args.push(`--cov=${coverage}`);
       if (parallel != null) args.push("-n", String(parallel));
       if (configFile) args.push("-c", configFile);
+      if (extraArgs && extraArgs.length > 0) args.push(...extraArgs);
       if (targets && targets.length > 0) args.push(...targets);
 
-      const result = await pytest(args, cwd, pythonPath);
+      const result = await pytest(args, cwd, pythonPath, env);
       const data = parsePytestOutput(result.stdout, result.stderr, result.exitCode);
       return compactDualOutput(
         data,


### PR DESCRIPTION
## Summary

Fixes the pytest tool's silent empty result when a run fails before executing any test (collection error, broken plugin, usage error). Closes #984.

### Part 1 — diagnostics on failed empty runs

When the run fails and zero tests executed (`passed + failed + skipped == 0`), the structured output now includes:

- `exitCode` — the pytest exit code
- `errorOutput` — a capped tail (4 KB) of the output stream carrying the error signal. Pytest collection errors (`ERRORS` section, `ModuleNotFoundError`) land on stdout; plugin/startup crashes (tracebacks) land on stderr — the parser picks whichever stream has the signal.

Both fields are optional and only present in this failure state, per the "only fields an agent would act on" rule. The human formatter and compact mapping/formatter surface them too. Mirrors the `surfaceLoadFailure` precedent in server-test (#928/#931).

**Before**

```json
{"success":false,"passed":0,"failed":0,"errors":0,"skipped":0,"warnings":0,"failedTests":[]}
```

**After**

```json
{"success":false,"passed":0,"failed":0,"errors":1,"skipped":0,"warnings":0,"failedTests":["ERROR collecting tests/test_core.py"],"exitCode":2,"errorOutput":"=== ERRORS ===\n... E   ModuleNotFoundError: No module named 'mypkg' ..."}
```

### Part 2 — `env` and `extraArgs` inputs

- `env`: record of extra environment variables merged over the parent env when spawning pytest (e.g. `{"PYTHONPATH": "src"}` for src-layout projects). Keys validated against `/^[A-Za-z_][A-Za-z0-9_]*$/`; values guarded with `assertSafePassthroughArg` (no NUL/newline). Merge semantics mirror server-process's `env` input.
- `extraArgs`: additional pytest CLI args passed through verbatim (e.g. `["-p", "no:logfire"]`), appended after built flags and before targets. Guarded per element with `assertSafePassthroughArg`, following the same pattern as server-test's `args` passthrough field (leading `-` is intentional here, so `assertNoFlagInjection` does not apply).

### Tests

- Parser fixtures captured from a real pytest 8.x run on a src-layout project (ModuleNotFoundError collection error) plus a real broken-plugin startup crash: diagnostics attached, stream selection, tail truncation, and no-diagnostics on success / exit-5 / genuine test failures.
- Formatter + compact map/format coverage for the new fields.
- Mock-based tool-handler tests for env/extraArgs plumbing, argument ordering, and validation rejections.
- Integration tests: end-to-end src-layout temp project — fails with diagnostics without `env`, passes with `env: {PYTHONPATH: "src"}` + `extraArgs: ["-p","no:logfire","-p","no:cacheprovider"]`; validation errors surface as tool errors.

`@paretools/python`: 444 tests passing; lint, format:check clean. Changeset included (minor — new input options).