### PR TITLE
feat(shared): add compact stream truncation and surfaceEmptyFailure helpers

### DIFF
--- a/.changeset/shared-compact-diagnostics-helpers.md
+++ b/.changeset/shared-compact-diagnostics-helpers.md
@@ -1,0 +1,5 @@
+---
+"@paretools/shared": minor
+---
+
+Add shared compact-output and diagnostics helpers: `truncateStream`/`compactStreamFields` (head/tail + byte-cap stream truncation with `CompactStreamSchemaFields`, generalizing the server-process compact budget from #1020) and `surfaceEmptyFailure` (attaches `error`/`exitCode` when a CLI exits non-zero with nothing parseable, with `EmptyFailureSchemaFields`, generalizing server-test's `surfaceLoadFailure`). Foundation for epics #1022 and #1024.

--- a/packages/shared/__tests__/compact.test.ts
+++ b/packages/shared/__tests__/compact.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { z } from "zod";
 import { estimateTokens, compactDualOutput, strippedCompactDualOutput } from "../src/output.js";
+import {
+  truncateStream,
+  compactStreamFields,
+  CompactStreamSchemaFields,
+  COMPACT_HEAD_LINES,
+  COMPACT_TAIL_LINES,
+  COMPACT_BYTE_CAP,
+} from "../src/compact.js";
 
 describe("estimateTokens", () => {
   it("returns 1 for a 4-char string", () => {
@@ -272,5 +280,193 @@ describe("strippedCompactDualOutput dev-mode validation", () => {
         schema,
       ),
     ).not.toThrow();
+  });
+});
+
+// ── truncateStream / compactStreamFields (extracted from server-process #1020) ──
+
+/** Builds a string of `count` numbered lines joined with the given separator. */
+function makeLines(count: number, sep = "\n"): string {
+  return Array.from({ length: count }, (_, i) => `line ${i + 1}`).join(sep);
+}
+
+describe("truncateStream", () => {
+  it("exports the #1020 default budget constants", () => {
+    expect(COMPACT_HEAD_LINES).toBe(40);
+    expect(COMPACT_TAIL_LINES).toBe(10);
+    expect(COMPACT_BYTE_CAP).toBe(8192);
+  });
+
+  it("returns empty text unchanged (one line per String.split semantics)", () => {
+    expect(truncateStream("")).toEqual({ text: "", truncated: false, totalLines: 1 });
+  });
+
+  it("returns short text unchanged", () => {
+    const text = makeLines(5);
+    expect(truncateStream(text)).toEqual({ text, truncated: false, totalLines: 5 });
+  });
+
+  it("does not truncate at exactly head + tail lines", () => {
+    const text = makeLines(COMPACT_HEAD_LINES + COMPACT_TAIL_LINES);
+    const result = truncateStream(text);
+    expect(result.truncated).toBe(false);
+    expect(result.text).toBe(text);
+    expect(result.totalLines).toBe(50);
+  });
+
+  it("truncates at one line over the budget with an omission marker", () => {
+    const text = makeLines(51);
+    const result = truncateStream(text);
+    expect(result.truncated).toBe(true);
+    expect(result.totalLines).toBe(51);
+    const lines = result.text.split("\n");
+    expect(lines).toHaveLength(51); // 40 head + 1 marker + 10 tail
+    expect(lines[0]).toBe("line 1");
+    expect(lines[39]).toBe("line 40");
+    expect(lines[40]).toBe("... (1 lines omitted) ...");
+    expect(lines[41]).toBe("line 42");
+    expect(lines[50]).toBe("line 51");
+  });
+
+  it("reports the omitted line count in the marker", () => {
+    const result = truncateStream(makeLines(150));
+    expect(result.text).toContain("... (100 lines omitted) ...");
+    expect(result.totalLines).toBe(150);
+  });
+
+  it("counts a trailing newline as an extra (empty) line", () => {
+    const result = truncateStream("a\nb\n");
+    expect(result.totalLines).toBe(3);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("does not apply the byte cap at exactly the cap", () => {
+    const text = "x".repeat(COMPACT_BYTE_CAP);
+    const result = truncateStream(text);
+    expect(result.truncated).toBe(false);
+    expect(result.text).toBe(text);
+  });
+
+  it("applies the byte cap at one character over", () => {
+    const text = "x".repeat(COMPACT_BYTE_CAP + 1);
+    const result = truncateStream(text);
+    expect(result.truncated).toBe(true);
+    expect(result.text).toBe("x".repeat(COMPACT_BYTE_CAP) + "\n... (truncated)");
+    expect(result.totalLines).toBe(1);
+  });
+
+  it("applies the byte cap after line trimming when trimmed text is still too large", () => {
+    // 60 lines of 190 chars: line-trimmed to 40 head + marker + 10 tail (~9.6KB),
+    // so the marker lands inside the 8KB cap but the trimmed text still exceeds it.
+    const text = Array.from({ length: 60 }, () => "y".repeat(190)).join("\n");
+    const result = truncateStream(text);
+    expect(result.truncated).toBe(true);
+    expect(result.text.endsWith("\n... (truncated)")).toBe(true);
+    expect(result.text).toContain("... (10 lines omitted) ...");
+    expect(result.text.length).toBe(COMPACT_BYTE_CAP + "\n... (truncated)".length);
+    expect(result.totalLines).toBe(60);
+  });
+
+  it("honors custom headLines/tailLines", () => {
+    const result = truncateStream(makeLines(10), { headLines: 2, tailLines: 1 });
+    expect(result.truncated).toBe(true);
+    expect(result.text).toBe("line 1\nline 2\n... (7 lines omitted) ...\nline 10");
+    expect(result.totalLines).toBe(10);
+  });
+
+  it("honors a custom byteCap", () => {
+    const result = truncateStream("abcdef", { byteCap: 4 });
+    expect(result.truncated).toBe(true);
+    expect(result.text).toBe("abcd\n... (truncated)");
+  });
+
+  it("splits CRLF input on \\n, preserving carriage returns", () => {
+    const text = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\r\n");
+    const result = truncateStream(text, { headLines: 2, tailLines: 1 });
+    expect(result.totalLines).toBe(10);
+    expect(result.truncated).toBe(true);
+    expect(result.text).toBe("line 1\r\nline 2\r\n... (7 lines omitted) ...\nline 10");
+  });
+});
+
+describe("compactStreamFields", () => {
+  it("returns an empty object for undefined streams", () => {
+    expect(compactStreamFields(undefined, undefined)).toEqual({});
+  });
+
+  it("omits empty-string streams entirely", () => {
+    const fields = compactStreamFields("", "");
+    expect(Object.keys(fields)).toEqual([]);
+  });
+
+  it("keeps a short stdout without truncation metadata", () => {
+    const fields = compactStreamFields("hello\nworld", undefined);
+    expect(fields).toEqual({ stdout: "hello\nworld" });
+    expect("stdoutTruncated" in fields).toBe(false);
+    expect("stdoutTotalLines" in fields).toBe(false);
+  });
+
+  it("sets stdoutTruncated and stdoutTotalLines only when stdout is truncated", () => {
+    const fields = compactStreamFields(makeLines(60), "err");
+    expect(fields.stdoutTruncated).toBe(true);
+    expect(fields.stdoutTotalLines).toBe(60);
+    expect(fields.stderr).toBe("err");
+    expect("stderrTruncated" in fields).toBe(false);
+    expect("stderrTotalLines" in fields).toBe(false);
+  });
+
+  it("sets stderrTruncated and stderrTotalLines only when stderr is truncated", () => {
+    const fields = compactStreamFields("out", makeLines(60));
+    expect(fields.stdout).toBe("out");
+    expect(fields.stderrTruncated).toBe(true);
+    expect(fields.stderrTotalLines).toBe(60);
+    expect("stdoutTruncated" in fields).toBe(false);
+  });
+
+  it("handles both streams truncated independently", () => {
+    const fields = compactStreamFields(makeLines(70), makeLines(90));
+    expect(fields.stdoutTruncated).toBe(true);
+    expect(fields.stdoutTotalLines).toBe(70);
+    expect(fields.stderrTruncated).toBe(true);
+    expect(fields.stderrTotalLines).toBe(90);
+  });
+
+  it("passes budget overrides through to truncateStream", () => {
+    const fields = compactStreamFields("a\nb\nc\nd", undefined, { headLines: 1, tailLines: 1 });
+    expect(fields.stdoutTruncated).toBe(true);
+    expect(fields.stdoutTotalLines).toBe(4);
+    expect(fields.stdout).toBe("a\n... (2 lines omitted) ...\nd");
+  });
+});
+
+describe("CompactStreamSchemaFields", () => {
+  const schema = z.object({
+    stdout: z.string().optional(),
+    stderr: z.string().optional(),
+    ...CompactStreamSchemaFields,
+  });
+
+  it("validates compactStreamFields output with truncation metadata", () => {
+    const fields = compactStreamFields(makeLines(60), makeLines(60));
+    expect(schema.parse(fields)).toEqual(fields);
+  });
+
+  it("validates compactStreamFields output without truncation metadata", () => {
+    const fields = compactStreamFields("short", undefined);
+    expect(schema.parse(fields)).toEqual(fields);
+  });
+
+  it("matches the server-process #1020 field shape", () => {
+    // Same field names and types declared by ProcessRunResultSchema.
+    expect(
+      schema.safeParse({
+        stdoutTruncated: true,
+        stderrTruncated: true,
+        stdoutTotalLines: 123,
+        stderrTotalLines: 456,
+      }).success,
+    ).toBe(true);
+    expect(schema.safeParse({ stdoutTotalLines: "123" }).success).toBe(false);
+    expect(schema.safeParse({ stdoutTruncated: "yes" }).success).toBe(false);
   });
 });

--- a/packages/shared/__tests__/diagnostics.test.ts
+++ b/packages/shared/__tests__/diagnostics.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import {
+  surfaceEmptyFailure,
+  EmptyFailureSchemaFields,
+  SURFACE_EMPTY_FAILURE_MAX_BYTES,
+} from "../src/diagnostics.js";
+
+interface FakeRun {
+  summary: { total: number; failed: number };
+  error?: string;
+}
+
+const emptyData: FakeRun = { summary: { total: 0, failed: 0 } };
+const isEmpty = (d: FakeRun) => d.summary.total === 0 && d.summary.failed === 0;
+
+describe("surfaceEmptyFailure", () => {
+  it("attaches error and exitCode when the CLI failed and nothing was parsed", () => {
+    const result = surfaceEmptyFailure(
+      emptyData,
+      { exitCode: 2, stdout: "", stderr: "SyntaxError: unexpected token" },
+      { isEmpty },
+    );
+    expect(result.error).toBe("SyntaxError: unexpected token");
+    expect(result.exitCode).toBe(2);
+    expect(result.summary).toEqual({ total: 0, failed: 0 });
+  });
+
+  it("does not fire on exit code 0", () => {
+    const result = surfaceEmptyFailure(
+      emptyData,
+      { exitCode: 0, stdout: "", stderr: "some warning" },
+      { isEmpty },
+    );
+    expect(result).toBe(emptyData);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("does not fire when results were parsed", () => {
+    const data: FakeRun = { summary: { total: 3, failed: 1 } };
+    const result = surfaceEmptyFailure(
+      data,
+      { exitCode: 1, stdout: "", stderr: "2 tests failed" },
+      { isEmpty },
+    );
+    expect(result).toBe(data);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("does not overwrite an existing error field", () => {
+    const data: FakeRun = { summary: { total: 0, failed: 0 }, error: "parser exploded" };
+    const result = surfaceEmptyFailure(
+      data,
+      { exitCode: 1, stdout: "", stderr: "other detail" },
+      { isEmpty },
+    );
+    expect(result).toBe(data);
+    expect(result.error).toBe("parser exploded");
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("prefers stderr over stdout when both have content", () => {
+    const result = surfaceEmptyFailure(
+      emptyData,
+      { exitCode: 1, stdout: "stdout detail", stderr: "stderr detail" },
+      { isEmpty },
+    );
+    expect(result.error).toBe("stderr detail");
+  });
+
+  it("falls back to stdout when stderr is whitespace-only", () => {
+    const result = surfaceEmptyFailure(
+      emptyData,
+      { exitCode: 1, stdout: "  stdout detail  ", stderr: "   \n  " },
+      { isEmpty },
+    );
+    expect(result.error).toBe("stdout detail");
+  });
+
+  it("uses a fallback message when both streams are empty", () => {
+    const result = surfaceEmptyFailure(
+      emptyData,
+      { exitCode: 7, stdout: "", stderr: "" },
+      { isEmpty },
+    );
+    expect(result.error).toBeTruthy();
+    expect(result.error).toContain("exited with code 7");
+    expect(result.exitCode).toBe(7);
+  });
+
+  it("keeps the tail (not the head) when the detail exceeds maxBytes", () => {
+    const detail = `${"x".repeat(100)}END-OF-OUTPUT`;
+    const result = surfaceEmptyFailure(
+      emptyData,
+      { exitCode: 1, stdout: "", stderr: detail },
+      { isEmpty, maxBytes: 20 },
+    );
+    expect(result.error).toBe(`… (output truncated)\n${detail.slice(-20)}`);
+    expect(result.error).toContain("END-OF-OUTPUT");
+    expect(result.error).not.toContain("x".repeat(30));
+  });
+
+  it("does not truncate a detail exactly at maxBytes", () => {
+    const detail = "y".repeat(30);
+    const result = surfaceEmptyFailure(
+      emptyData,
+      { exitCode: 1, stdout: "", stderr: detail },
+      { isEmpty, maxBytes: 30 },
+    );
+    expect(result.error).toBe(detail);
+  });
+
+  it("defaults maxBytes to 4096", () => {
+    expect(SURFACE_EMPTY_FAILURE_MAX_BYTES).toBe(4096);
+    const detail = "z".repeat(5000);
+    const result = surfaceEmptyFailure(
+      emptyData,
+      { exitCode: 1, stdout: "", stderr: detail },
+      { isEmpty },
+    );
+    expect(result.error).toBe(`… (output truncated)\n${"z".repeat(4096)}`);
+  });
+
+  it("returns a new object (does not mutate the input) when it fires", () => {
+    const data: FakeRun = { summary: { total: 0, failed: 0 } };
+    const result = surfaceEmptyFailure(
+      data,
+      { exitCode: 1, stdout: "", stderr: "boom" },
+      { isEmpty },
+    );
+    expect(result).not.toBe(data);
+    expect(data.error).toBeUndefined();
+    expect("exitCode" in data).toBe(false);
+  });
+});
+
+describe("EmptyFailureSchemaFields", () => {
+  const schema = z.object({
+    summary: z.object({ total: z.number(), failed: z.number() }),
+    ...EmptyFailureSchemaFields,
+  });
+
+  it("validates an augmented result", () => {
+    const augmented = surfaceEmptyFailure(
+      emptyData,
+      { exitCode: 1, stdout: "", stderr: "boom" },
+      { isEmpty },
+    );
+    expect(schema.parse(augmented)).toEqual(augmented);
+  });
+
+  it("validates a result without the optional fields", () => {
+    expect(schema.safeParse({ summary: { total: 5, failed: 0 } }).success).toBe(true);
+  });
+
+  it("rejects wrong types", () => {
+    expect(
+      schema.safeParse({ summary: { total: 0, failed: 0 }, error: 42, exitCode: "1" }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/compact.ts
+++ b/packages/shared/src/compact.ts
@@ -1,0 +1,190 @@
+import { z } from "zod";
+
+/**
+ * Default number of leading lines kept when truncating a stream for compact
+ * output. Matches the budget introduced for `server-process` in PR #1020.
+ */
+export const COMPACT_HEAD_LINES = 40;
+
+/**
+ * Default number of trailing lines kept when truncating a stream for compact
+ * output. Matches the budget introduced for `server-process` in PR #1020.
+ */
+export const COMPACT_TAIL_LINES = 10;
+
+/**
+ * Default hard byte cap applied to each stream after line trimming.
+ * Matches the budget introduced for `server-process` in PR #1020.
+ */
+export const COMPACT_BYTE_CAP = 8192;
+
+/** Options for {@link truncateStream} and {@link compactStreamFields}. */
+export interface TruncateStreamOptions {
+  /** Number of leading lines to keep (default {@link COMPACT_HEAD_LINES}). */
+  headLines?: number;
+  /** Number of trailing lines to keep (default {@link COMPACT_TAIL_LINES}). */
+  tailLines?: number;
+  /** Hard byte cap applied after line trimming (default {@link COMPACT_BYTE_CAP}). */
+  byteCap?: number;
+}
+
+/** Result of {@link truncateStream}. */
+export interface TruncateStreamResult {
+  /** The (possibly truncated) text. */
+  text: string;
+  /** Whether any truncation (line trimming or byte cap) occurred. */
+  truncated: boolean;
+  /** Total number of lines in the original text (before truncation). */
+  totalLines: number;
+}
+
+/**
+ * Truncates a stream (stdout/stderr) to a compact budget: the first
+ * `headLines` lines and the last `tailLines` lines with a
+ * `... (N lines omitted) ...` marker in between, followed by a hard byte cap
+ * that appends `... (truncated)` when exceeded.
+ *
+ * Behaviorally identical to the compact truncation shipped for
+ * `server-process` in PR #1020, extracted so every server can share it
+ * (epic #1022).
+ *
+ * Notes:
+ * - Lines are split on `"\n"`; CRLF input keeps its `"\r"` characters and a
+ *   trailing newline counts as one extra (empty) line, mirroring the
+ *   reference implementation.
+ * - The byte cap is applied to the JavaScript string length (UTF-16 code
+ *   units), matching the original implementation.
+ *
+ * @param text - The raw stream text to truncate.
+ * @param opts - Optional budget overrides (see {@link TruncateStreamOptions}).
+ * @returns The truncated text, whether truncation occurred, and the total
+ *   line count of the original text.
+ */
+export function truncateStream(
+  text: string,
+  opts: TruncateStreamOptions = {},
+): TruncateStreamResult {
+  const headLines = opts.headLines ?? COMPACT_HEAD_LINES;
+  const tailLines = opts.tailLines ?? COMPACT_TAIL_LINES;
+  const byteCap = opts.byteCap ?? COMPACT_BYTE_CAP;
+
+  const lines = text.split("\n");
+  const totalLines = lines.length;
+  let out = text;
+  let truncated = false;
+
+  if (totalLines > headLines + tailLines) {
+    const omitted = totalLines - headLines - tailLines;
+    out = [
+      ...lines.slice(0, headLines),
+      `... (${omitted} lines omitted) ...`,
+      ...lines.slice(totalLines - tailLines),
+    ].join("\n");
+    truncated = true;
+  }
+
+  if (out.length > byteCap) {
+    out = out.slice(0, byteCap) + "\n... (truncated)";
+    truncated = true;
+  }
+
+  return { text: out, truncated, totalLines };
+}
+
+/**
+ * The optional stdout/stderr fields produced by {@link compactStreamFields}.
+ *
+ * Truncation flags are only present (and always `true`) when the
+ * corresponding stream was truncated; total line counts are only present
+ * alongside their flag. Empty streams are omitted entirely.
+ */
+export interface CompactStreamFields {
+  /** Truncated stdout (omitted when the stream is empty). */
+  stdout?: string;
+  /** Truncated stderr (omitted when the stream is empty). */
+  stderr?: string;
+  /** Present (and `true`) only when stdout was truncated. */
+  stdoutTruncated?: true;
+  /** Present (and `true`) only when stderr was truncated. */
+  stderrTruncated?: true;
+  /** Total stdout lines before truncation; present only when stdoutTruncated. */
+  stdoutTotalLines?: number;
+  /** Total stderr lines before truncation; present only when stderrTruncated. */
+  stderrTotalLines?: number;
+}
+
+/**
+ * Builds the compact stdout/stderr field set used by compact tool results.
+ *
+ * Convenience wrapper around {@link truncateStream} producing the exact
+ * optional-field shape shipped for `server-process` in PR #1020:
+ *
+ * - Empty or `undefined` streams are omitted entirely (no `stdout: ""`).
+ * - `stdoutTruncated`/`stderrTruncated` are set (to `true`) only when the
+ *   corresponding stream was actually truncated — never `false`.
+ * - `stdoutTotalLines`/`stderrTotalLines` are set only when the
+ *   corresponding truncated flag is set.
+ *
+ * Spread the result into a compact result object:
+ * ```ts
+ * const compact = { exitCode, success, ...compactStreamFields(stdout, stderr) };
+ * ```
+ *
+ * @param stdout - Raw stdout text (empty/undefined streams are omitted).
+ * @param stderr - Raw stderr text (empty/undefined streams are omitted).
+ * @param opts - Optional budget overrides (see {@link TruncateStreamOptions}).
+ * @returns An object containing only the fields that apply.
+ */
+export function compactStreamFields(
+  stdout: string | undefined,
+  stderr: string | undefined,
+  opts: TruncateStreamOptions = {},
+): CompactStreamFields {
+  const fields: CompactStreamFields = {};
+
+  if (stdout) {
+    const t = truncateStream(stdout, opts);
+    fields.stdout = t.text;
+    if (t.truncated) {
+      fields.stdoutTruncated = true;
+      fields.stdoutTotalLines = t.totalLines;
+    }
+  }
+  if (stderr) {
+    const t = truncateStream(stderr, opts);
+    fields.stderr = t.text;
+    if (t.truncated) {
+      fields.stderrTruncated = true;
+      fields.stderrTotalLines = t.totalLines;
+    }
+  }
+
+  return fields;
+}
+
+/**
+ * Zod fragment for the compact stream truncation metadata fields.
+ *
+ * Spread into a tool's result schema so `structuredContent` produced with
+ * {@link compactStreamFields} validates:
+ * ```ts
+ * const MyResultSchema = z.object({
+ *   exitCode: z.number(),
+ *   stdout: z.string().optional(),
+ *   stderr: z.string().optional(),
+ *   ...CompactStreamSchemaFields,
+ * });
+ * ```
+ *
+ * Field-compatible with the `server-process` run schema from PR #1020.
+ */
+export const CompactStreamSchemaFields = {
+  /** Whether stdout was truncated to the compact output budget (only set when true). */
+  stdoutTruncated: z.boolean().optional(),
+  /** Whether stderr was truncated to the compact output budget (only set when true). */
+  stderrTruncated: z.boolean().optional(),
+  /** Total stdout lines before compact truncation (only set when stdoutTruncated). */
+  stdoutTotalLines: z.number().optional(),
+  /** Total stderr lines before compact truncation (only set when stderrTruncated). */
+  stderrTotalLines: z.number().optional(),
+};

--- a/packages/shared/src/diagnostics.ts
+++ b/packages/shared/src/diagnostics.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+/** Options for {@link surfaceEmptyFailure}. */
+export interface SurfaceEmptyFailureOptions<T extends object> {
+  /**
+   * Predicate deciding whether the parsed data is "empty" — i.e. the parser
+   * found nothing actionable (zero tests, zero diagnostics, zero results).
+   */
+  isEmpty: (data: T) => boolean;
+  /**
+   * Maximum number of characters of raw output to attach as the `error`
+   * detail (the tail of the stream is kept). Default 4096.
+   */
+  maxBytes?: number;
+}
+
+/** Default maximum error detail length for {@link surfaceEmptyFailure}. */
+export const SURFACE_EMPTY_FAILURE_MAX_BYTES = 4096;
+
+/**
+ * Surfaces a "silent green" failure: the CLI exited non-zero but the parser
+ * produced no results, which would otherwise read as a clean/passing run.
+ *
+ * When `result.exitCode !== 0`, `opts.isEmpty(data)` is true, and no `error`
+ * field is already set on `data`, this returns a copy of `data` with:
+ *
+ * - `error` — the trimmed tail (last `maxBytes` characters) of whichever
+ *   stream has content, preferring stderr when non-empty, else stdout. When
+ *   the detail exceeds `maxBytes` a `… (output truncated)` marker is
+ *   prepended to the kept tail. When both streams are empty a fallback
+ *   message is used so the `error` field is never an empty string.
+ * - `exitCode` — the CLI's exit code.
+ *
+ * Otherwise `data` is returned unchanged (same reference).
+ *
+ * Generalizes `server-test`'s `surfaceLoadFailure` (issues #928/#931) for
+ * every server (epic #1024): a test suite that fails at import/collection
+ * time, a linter that crashes before emitting JSON, etc., all exit non-zero
+ * with nothing parseable — this makes that state visible to agents.
+ *
+ * Layering note: this is NOT a replacement for `classifyError`/`errorOutput`
+ * (see `errors.ts`). Those handle "the command itself failed and the tool
+ * returns an error response". `surfaceEmptyFailure` covers the layer above:
+ * the CLI ran, the tool still returns a structured (non-error) result, but
+ * the output contained nothing parseable — so the result must carry evidence
+ * of the failure instead of looking like a clean pass.
+ *
+ * @param data - The parsed result object (returned as-is when no failure is surfaced).
+ * @param result - The raw CLI outcome (exit code plus captured streams).
+ * @param opts - Emptiness predicate and optional detail size cap.
+ * @returns `data`, possibly augmented with `error` and `exitCode`.
+ */
+export function surfaceEmptyFailure<T extends object>(
+  data: T,
+  result: { exitCode: number; stdout: string; stderr: string },
+  opts: SurfaceEmptyFailureOptions<T>,
+): T & { error?: string; exitCode?: number } {
+  if (result.exitCode === 0 || !opts.isEmpty(data)) {
+    return data;
+  }
+  if ((data as { error?: unknown }).error) {
+    return data;
+  }
+
+  const maxBytes = opts.maxBytes ?? SURFACE_EMPTY_FAILURE_MAX_BYTES;
+  const detail = (result.stderr.trim() || result.stdout.trim()).trim();
+  const error =
+    detail.length > maxBytes
+      ? `… (output truncated)\n${detail.slice(-maxBytes)}`
+      : detail ||
+        `Command exited with code ${result.exitCode} but produced no parseable output. ` +
+          `This is not a passing run.`;
+
+  return { ...data, error, exitCode: result.exitCode };
+}
+
+/**
+ * Zod fragment for the fields {@link surfaceEmptyFailure} may attach.
+ *
+ * Spread into a tool's result schema so augmented results validate:
+ * ```ts
+ * const MyResultSchema = z.object({
+ *   summary: SummarySchema,
+ *   ...EmptyFailureSchemaFields,
+ * });
+ * ```
+ */
+export const EmptyFailureSchemaFields = {
+  /** Raw CLI output surfaced when the run failed but nothing was parseable. */
+  error: z.string().optional(),
+  /** CLI exit code, set alongside `error` when a silent failure was surfaced. */
+  exitCode: z.number().optional(),
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -39,6 +39,25 @@ export {
   filePatternsInput,
 } from "./input-schemas.js";
 export { sanitizeErrorOutput } from "./sanitize.js";
+export {
+  COMPACT_HEAD_LINES,
+  COMPACT_TAIL_LINES,
+  COMPACT_BYTE_CAP,
+  truncateStream,
+  compactStreamFields,
+  CompactStreamSchemaFields,
+} from "./compact.js";
+export type {
+  TruncateStreamOptions,
+  TruncateStreamResult,
+  CompactStreamFields,
+} from "./compact.js";
+export {
+  surfaceEmptyFailure,
+  SURFACE_EMPTY_FAILURE_MAX_BYTES,
+  EmptyFailureSchemaFields,
+} from "./diagnostics.js";
+export type { SurfaceEmptyFailureOptions } from "./diagnostics.js";
 export { shouldRegisterTool, isLazyEnabled, _resetProfileCache } from "./tool-filter.js";
 export { PROFILES, CORE_TOOLS, resolveProfile, isCoreToolForServer } from "./profiles.js";
 export type { ProfileName } from "./profiles.js";


### PR DESCRIPTION
## Summary

Adds two shared helpers to `@paretools/shared` that the upcoming batch fixes for #1022 and #1024 will build on. **No server packages are modified in this PR** — it is foundation only.

### 1. Compact stream truncation (`src/compact.ts`) — for epic #1022

Extracts the compact-mode stdout/stderr truncation shipped for server-process in #1020 so every server can reuse it:

- `truncateStream(text, opts?)` — pure head/tail truncation (default first 40 + last 10 lines with a `... (N lines omitted) ...` marker) followed by a hard byte cap (default 8KB, appends `... (truncated)`). Returns `{ text, truncated, totalLines }`.
- `compactStreamFields(stdout, stderr, opts?)` — produces the exact optional-field shape from #1020: empty streams omitted entirely, `stdoutTruncated`/`stderrTruncated` set only when `true`, `stdoutTotalLines`/`stderrTotalLines` set only when truncated.
- `COMPACT_HEAD_LINES` / `COMPACT_TAIL_LINES` / `COMPACT_BYTE_CAP` default constants.
- `CompactStreamSchemaFields` — Zod fragment to spread into result schemas; field-compatible with `ProcessRunResultSchema` from #1020.

Behavioral parity with `server-process/src/lib/formatters.ts` (`truncateForCompact` + `compactRunMap`) is verified by tests, including the head-budget-exceeds-byte-cap interaction and CRLF handling.

### 2. `surfaceEmptyFailure` (`src/diagnostics.ts`) — for epic #1024

Generalizes server-test's `surfaceLoadFailure` (#928/#931): when a CLI exits non-zero but the parser produced no results (import/collection error, crash before output), the structured result would otherwise read as a clean pass.

- `surfaceEmptyFailure(data, result, { isEmpty, maxBytes? })` — attaches `error` (tail of stderr, else stdout, capped at 4096 chars with a truncation marker; fallback message when both streams are empty) and `exitCode`, only when `exitCode !== 0`, `isEmpty(data)` is true, and no `error` is already set. Returns `data` unchanged (same reference) otherwise.
- `EmptyFailureSchemaFields` — Zod fragment (`error`/`exitCode`, both optional).

This is deliberately a different layer from `classifyError`/`errorOutput` (documented in TSDoc): those return an error response when the command itself fails; `surfaceEmptyFailure` keeps a structured result but makes a "ran, produced nothing parseable" state visible.

## Testing

- 29 new unit tests (`__tests__/compact.test.ts`, `__tests__/diagnostics.test.ts`); shared suite: 472 passed, 0 failed.
- Coverage on both new files: 100% lines / functions / branches / statements (thresholds: 80/80/70).
- `pnpm lint` and `pnpm format:check` clean.

## Notes

- Full TSDoc on all exports for the TypeDoc API docs.
- Changeset included: `@paretools/shared` minor.