### PR TITLE
fix(security): surface scanner failures and restore compact findings payload

### DIFF
--- a/.changeset/fix-security-silent-and-compact.md
+++ b/.changeset/fix-security-silent-and-compact.md
@@ -1,0 +1,9 @@
+---
+"@paretools/security": patch
+---
+
+Surface scanner failures and restore compact findings payload for trivy, semgrep, and gitleaks.
+
+- A crashed scan (non-zero exit with no parseable report) no longer reads as a clean scan: the result now carries `error` (stderr/stdout tail) and `exitCode`, in both structured and text output.
+- Exit-code semantics are respected per tool: gitleaks exit 1 with a findings report, trivy `--exit-code`, and semgrep findings exits are still treated as successful scans.
+- Compact mode no longer drops the actionable payload: gitleaks compact (previously `{}`) now returns `totalFindings` plus the top findings (rule/file/line); trivy compact includes the top critical/high vulnerabilities (id, package, severity, fixed version); semgrep compact includes the top findings and always passes through `errors[]`. All compact projections carry `error`/`exitCode` and set a truncation flag when the list is cut.

--- a/packages/server-security/__tests__/compact.test.ts
+++ b/packages/server-security/__tests__/compact.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  COMPACT_MAX_FINDINGS,
   compactTrivyScanMap,
   formatTrivyScanCompact,
   compactSemgrepScanMap,
@@ -7,53 +8,121 @@ import {
   compactGitleaksScanMap,
   formatGitleaksScanCompact,
 } from "../src/lib/formatters.js";
+import {
+  TrivyScanResultSchema,
+  SemgrepScanResultSchema,
+  GitleaksScanResultSchema,
+} from "../src/schemas/index.js";
 import type {
   TrivyScanResultInternal,
+  TrivyVulnerabilityInternal,
   SemgrepScanResultInternal,
+  SemgrepFindingInternal,
   GitleaksScanResultInternal,
+  GitleaksFindingInternal,
 } from "../src/schemas/index.js";
+
+function makeTrivyVuln(i: number, severity: string): TrivyVulnerabilityInternal {
+  return {
+    id: `CVE-2023-${1000 + i}`,
+    severity,
+    package: `pkg${i}`,
+    installedVersion: "1.0.0",
+    fixedVersion: "1.0.1",
+    title: `Vuln ${i}`,
+  };
+}
+
+function makeSemgrepFinding(i: number, severity: string): SemgrepFindingInternal {
+  return {
+    ruleId: `rule.${i}`,
+    path: `src/file${i}.py`,
+    startLine: i,
+    endLine: i,
+    message: `Finding ${i}`,
+    severity,
+  };
+}
+
+function makeGitleaksFinding(i: number): GitleaksFindingInternal {
+  return {
+    ruleID: `rule-${i}`,
+    description: `Rule ${i}`,
+    match: `MATCH_${i}=secretvalue`,
+    secret: "abc***xyz",
+    file: `src/file${i}.env`,
+    startLine: i,
+    endLine: i,
+    commit: "abc123def456789012345678901234567890abcd",
+    author: "dev@example.com",
+    date: "2024-01-15",
+  };
+}
 
 // ---------------------------------------------------------------------------
 // compactTrivyScanMap
 // ---------------------------------------------------------------------------
 
 describe("compactTrivyScanMap", () => {
-  it("keeps target, scanType, summary; drops vulnerabilities and totalVulnerabilities", () => {
+  it("keeps target, scanType, summary and the critical/high vulnerabilities", () => {
     const data: TrivyScanResultInternal = {
       target: "alpine:3.18",
       scanType: "image",
       vulnerabilities: [
-        {
-          id: "CVE-2023-1234",
-          severity: "CRITICAL",
-          package: "openssl",
-          installedVersion: "1.1.1t-r0",
-          fixedVersion: "1.1.1u-r0",
-          title: "Buffer overflow in OpenSSL",
-        },
-        {
-          id: "CVE-2023-5678",
-          severity: "HIGH",
-          package: "curl",
-          installedVersion: "8.0.0-r0",
-          fixedVersion: "8.1.0-r0",
-        },
+        makeTrivyVuln(1, "CRITICAL"),
+        makeTrivyVuln(2, "HIGH"),
+        makeTrivyVuln(3, "MEDIUM"),
+        makeTrivyVuln(4, "LOW"),
       ],
-      summary: { critical: 1, high: 1, medium: 0, low: 0, unknown: 0 },
-      totalVulnerabilities: 2,
+      summary: { critical: 1, high: 1, medium: 1, low: 1, unknown: 0 },
+      totalVulnerabilities: 4,
     };
 
     const compact = compactTrivyScanMap(data);
 
     expect(compact.target).toBe("alpine:3.18");
     expect(compact.scanType).toBe("image");
-    expect(compact.summary).toEqual({ critical: 1, high: 1, medium: 0, low: 0, unknown: 0 });
-    // Verify dropped fields
-    expect(compact).not.toHaveProperty("vulnerabilities");
+    expect(compact.summary).toEqual({ critical: 1, high: 1, medium: 1, low: 1, unknown: 0 });
+    // Critical/high kept with actionable fields
+    expect(compact.vulnerabilities).toEqual([
+      {
+        id: "CVE-2023-1001",
+        severity: "CRITICAL",
+        package: "pkg1",
+        installedVersion: "1.0.0",
+        fixedVersion: "1.0.1",
+      },
+      {
+        id: "CVE-2023-1002",
+        severity: "HIGH",
+        package: "pkg2",
+        installedVersion: "1.0.0",
+        fixedVersion: "1.0.1",
+      },
+    ]);
+    // Medium/low dropped -> truncation flag set
+    expect(compact.vulnerabilitiesTruncated).toBe(true);
+    // Display-only fields stripped
+    expect(compact.vulnerabilities?.[0]).not.toHaveProperty("title");
     expect(compact).not.toHaveProperty("totalVulnerabilities");
   });
 
-  it("handles zero vulnerabilities", () => {
+  it("caps critical/high vulnerabilities at COMPACT_MAX_FINDINGS", () => {
+    const vulns = Array.from({ length: 30 }, (_, i) => makeTrivyVuln(i, "CRITICAL"));
+    const data: TrivyScanResultInternal = {
+      target: "img",
+      scanType: "image",
+      vulnerabilities: vulns,
+      summary: { critical: 30, high: 0, medium: 0, low: 0, unknown: 0 },
+      totalVulnerabilities: 30,
+    };
+
+    const compact = compactTrivyScanMap(data);
+    expect(compact.vulnerabilities).toHaveLength(COMPACT_MAX_FINDINGS);
+    expect(compact.vulnerabilitiesTruncated).toBe(true);
+  });
+
+  it("handles zero vulnerabilities without truncation flag", () => {
     const data: TrivyScanResultInternal = {
       target: "./",
       scanType: "fs",
@@ -66,21 +135,54 @@ describe("compactTrivyScanMap", () => {
 
     expect(compact.summary.critical).toBe(0);
     expect(compact).not.toHaveProperty("vulnerabilities");
-    expect(compact).not.toHaveProperty("totalVulnerabilities");
+    expect(compact).not.toHaveProperty("vulnerabilitiesTruncated");
+  });
+
+  it("passes through error and exitCode", () => {
+    const data: TrivyScanResultInternal = {
+      target: "img",
+      scanType: "image",
+      vulnerabilities: [],
+      summary: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
+      totalVulnerabilities: 0,
+      error: "FATAL: image not found",
+      exitCode: 1,
+    };
+
+    const compact = compactTrivyScanMap(data);
+    expect(compact.error).toBe("FATAL: image not found");
+    expect(compact.exitCode).toBe(1);
+  });
+
+  it("produces schema-valid output", () => {
+    const data: TrivyScanResultInternal = {
+      target: "img",
+      scanType: "image",
+      vulnerabilities: [makeTrivyVuln(1, "CRITICAL"), makeTrivyVuln(2, "MEDIUM")],
+      summary: { critical: 1, high: 0, medium: 1, low: 0, unknown: 0 },
+      totalVulnerabilities: 2,
+      error: "boom",
+      exitCode: 1,
+    };
+    expect(() => TrivyScanResultSchema.parse(compactTrivyScanMap(data))).not.toThrow();
   });
 });
 
 describe("formatTrivyScanCompact", () => {
-  it("formats compact trivy scan output", () => {
-    const compact = {
+  it("formats summary line and kept vulnerabilities", () => {
+    const compact = compactTrivyScanMap({
       target: "nginx:latest",
-      scanType: "image" as const,
-      summary: { critical: 1, high: 2, medium: 1, low: 1, unknown: 0 },
-    };
+      scanType: "image",
+      vulnerabilities: [makeTrivyVuln(1, "CRITICAL"), makeTrivyVuln(2, "MEDIUM")],
+      summary: { critical: 1, high: 0, medium: 1, low: 0, unknown: 0 },
+      totalVulnerabilities: 2,
+    });
     const output = formatTrivyScanCompact(compact);
     expect(output).toContain("Trivy image scan: nginx:latest");
-    expect(output).toContain("5 vulnerabilities");
-    expect(output).toContain("1C/2H/1M/1L");
+    expect(output).toContain("2 vulnerabilities");
+    expect(output).toContain("1C/0H/1M/0L");
+    expect(output).toContain("[CRITICAL] CVE-2023-1001: pkg1@1.0.0 -> 1.0.1");
+    expect(output).toContain("truncated");
   });
 
   it("formats zero-vulnerability scan", () => {
@@ -92,6 +194,19 @@ describe("formatTrivyScanCompact", () => {
     const output = formatTrivyScanCompact(compact);
     expect(output).toContain("0 vulnerabilities");
   });
+
+  it("surfaces error in text output", () => {
+    const output = formatTrivyScanCompact({
+      target: "img",
+      scanType: "image",
+      summary: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
+      error: "FATAL: image not found",
+      exitCode: 1,
+    });
+    expect(output).toContain("Scan failed");
+    expect(output).toContain("exit code 1");
+    expect(output).toContain("FATAL: image not found");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -99,73 +214,123 @@ describe("formatTrivyScanCompact", () => {
 // ---------------------------------------------------------------------------
 
 describe("compactSemgrepScanMap", () => {
-  it("keeps summary; drops findings, totalFindings, config", () => {
+  it("keeps summary and the top findings; drops totalFindings and config", () => {
     const data: SemgrepScanResultInternal = {
-      totalFindings: 3,
+      totalFindings: 2,
       findings: [
-        {
-          ruleId: "python.lang.security.audit.dangerous-system-call",
-          path: "src/app.py",
-          startLine: 10,
-          endLine: 10,
-          message: "Avoid dangerous system calls",
-          severity: "ERROR",
-          category: "security",
-        },
-        {
-          ruleId: "python.lang.best-practice.open-never-closed",
-          path: "src/utils.py",
-          startLine: 25,
-          endLine: 25,
-          message: "File handle never closed",
-          severity: "WARNING",
-        },
-        {
-          ruleId: "python.lang.style.useless-pass",
-          path: "src/models.py",
-          startLine: 42,
-          endLine: 42,
-          message: "Useless pass statement",
-          severity: "INFO",
-        },
+        { ...makeSemgrepFinding(1, "ERROR"), category: "security" },
+        makeSemgrepFinding(2, "WARNING"),
       ],
-      summary: { error: 1, warning: 1, info: 1 },
+      summary: { error: 1, warning: 1, info: 0 },
       config: "auto",
     };
 
     const compact = compactSemgrepScanMap(data);
 
-    expect(compact.summary).toEqual({ error: 1, warning: 1, info: 1 });
-    // Verify dropped fields
-    expect(compact).not.toHaveProperty("findings");
+    expect(compact.summary).toEqual({ error: 1, warning: 1, info: 0 });
+    expect(compact.findings).toEqual([
+      {
+        ruleId: "rule.1",
+        path: "src/file1.py",
+        startLine: 1,
+        endLine: 1,
+        message: "Finding 1",
+        severity: "ERROR",
+      },
+      {
+        ruleId: "rule.2",
+        path: "src/file2.py",
+        startLine: 2,
+        endLine: 2,
+        message: "Finding 2",
+        severity: "WARNING",
+      },
+    ]);
+    expect(compact).not.toHaveProperty("findingsTruncated");
     expect(compact).not.toHaveProperty("totalFindings");
     expect(compact).not.toHaveProperty("config");
   });
 
-  it("handles zero findings", () => {
+  it("caps findings at COMPACT_MAX_FINDINGS with truncation flag", () => {
+    const data: SemgrepScanResultInternal = {
+      totalFindings: 30,
+      findings: Array.from({ length: 30 }, (_, i) => makeSemgrepFinding(i, "ERROR")),
+      summary: { error: 30, warning: 0, info: 0 },
+      config: "auto",
+    };
+
+    const compact = compactSemgrepScanMap(data);
+    expect(compact.findings).toHaveLength(COMPACT_MAX_FINDINGS);
+    expect(compact.findingsTruncated).toBe(true);
+  });
+
+  it("always passes through errors[]", () => {
+    const data: SemgrepScanResultInternal = {
+      totalFindings: 0,
+      findings: [],
+      errors: [{ type: "ParseError", message: "invalid syntax", path: "bad.py" }],
+      summary: { error: 0, warning: 0, info: 0 },
+      config: "auto",
+    };
+
+    const compact = compactSemgrepScanMap(data);
+    expect(compact.errors).toEqual([
+      { type: "ParseError", message: "invalid syntax", path: "bad.py" },
+    ]);
+  });
+
+  it("passes through error and exitCode", () => {
     const data: SemgrepScanResultInternal = {
       totalFindings: 0,
       findings: [],
       summary: { error: 0, warning: 0, info: 0 },
-      config: "p/security-audit",
+      config: "auto",
+      error: "semgrep: command crashed",
+      exitCode: 2,
     };
 
     const compact = compactSemgrepScanMap(data);
+    expect(compact.error).toBe("semgrep: command crashed");
+    expect(compact.exitCode).toBe(2);
+  });
 
-    expect(compact.summary.error).toBe(0);
-    expect(compact).not.toHaveProperty("findings");
-    expect(compact).not.toHaveProperty("totalFindings");
-    expect(compact).not.toHaveProperty("config");
+  it("produces schema-valid output", () => {
+    const data: SemgrepScanResultInternal = {
+      totalFindings: 1,
+      findings: [makeSemgrepFinding(1, "ERROR")],
+      errors: [{ message: "warn" }],
+      summary: { error: 1, warning: 0, info: 0 },
+      config: "auto",
+      error: "boom",
+      exitCode: 2,
+    };
+    expect(() => SemgrepScanResultSchema.parse(compactSemgrepScanMap(data))).not.toThrow();
   });
 });
 
 describe("formatSemgrepScanCompact", () => {
-  it("formats compact semgrep scan output", () => {
-    const compact = {
-      summary: { error: 2, warning: 2, info: 1 },
-    };
+  it("formats summary, findings, errors, and surfaced failure", () => {
+    const compact = compactSemgrepScanMap({
+      totalFindings: 1,
+      findings: [makeSemgrepFinding(1, "ERROR")],
+      errors: [{ type: "ParseError", message: "invalid syntax", path: "bad.py" }],
+      summary: { error: 1, warning: 0, info: 0 },
+      config: "auto",
+      error: "semgrep crashed",
+      exitCode: 2,
+    });
     const output = formatSemgrepScanCompact(compact);
     expect(output).toContain("Semgrep scan");
+    expect(output).toContain("1 findings");
+    expect(output).toContain("[ERROR] rule.1: src/file1.py:1-1");
+    expect(output).toContain("Finding 1");
+    expect(output).toContain("[ParseError] invalid syntax (bad.py)");
+    expect(output).toContain("Scan failed");
+    expect(output).toContain("semgrep crashed");
+  });
+
+  it("formats plain summary when nothing else is present", () => {
+    const output = formatSemgrepScanCompact({ summary: { error: 2, warning: 2, info: 1 } });
     expect(output).toContain("5 findings");
     expect(output).toContain("2E/2W/1I");
   });
@@ -176,44 +341,37 @@ describe("formatSemgrepScanCompact", () => {
 // ---------------------------------------------------------------------------
 
 describe("compactGitleaksScanMap", () => {
-  it("returns empty object; drops findings and totalFindings", () => {
+  it("keeps totalFindings and rule/file/line per finding; drops match/secret/commit", () => {
     const data: GitleaksScanResultInternal = {
       totalFindings: 2,
-      findings: [
-        {
-          ruleID: "generic-api-key",
-          description: "Generic API Key",
-          match: "API_KEY=abc123secret",
-          secret: "abc123secret",
-          file: ".env",
-          startLine: 3,
-          endLine: 3,
-          commit: "abc123def456789012345678901234567890abcd",
-          author: "dev@example.com",
-          date: "2024-01-15",
-        },
-        {
-          ruleID: "aws-access-key-id",
-          description: "AWS Access Key ID",
-          match: "AKIAIOSFODNN7EXAMPLE",
-          secret: "AKIAIOSFODNN7EXAMPLE",
-          file: "config/aws.yml",
-          startLine: 10,
-          endLine: 10,
-          commit: "def456ghi789012345678901234567890abcdef12",
-          author: "admin@example.com",
-          date: "2024-02-20",
-        },
-      ],
+      findings: [makeGitleaksFinding(1), makeGitleaksFinding(2)],
       summary: { totalFindings: 2 },
     };
 
     const compact = compactGitleaksScanMap(data);
 
-    // Schema only has `findings`, compact mode drops it; result is empty
-    expect(compact).not.toHaveProperty("findings");
-    expect(compact).not.toHaveProperty("totalFindings");
-    expect(compact).not.toHaveProperty("summary");
+    expect(compact.totalFindings).toBe(2);
+    expect(compact.findings).toEqual([
+      { ruleID: "rule-1", file: "src/file1.env", startLine: 1, endLine: 1 },
+      { ruleID: "rule-2", file: "src/file2.env", startLine: 2, endLine: 2 },
+    ]);
+    expect(compact.findings?.[0]).not.toHaveProperty("match");
+    expect(compact.findings?.[0]).not.toHaveProperty("secret");
+    expect(compact.findings?.[0]).not.toHaveProperty("commit");
+    expect(compact).not.toHaveProperty("findingsTruncated");
+  });
+
+  it("caps findings at COMPACT_MAX_FINDINGS with truncation flag", () => {
+    const data: GitleaksScanResultInternal = {
+      totalFindings: 25,
+      findings: Array.from({ length: 25 }, (_, i) => makeGitleaksFinding(i)),
+      summary: { totalFindings: 25 },
+    };
+
+    const compact = compactGitleaksScanMap(data);
+    expect(compact.totalFindings).toBe(25);
+    expect(compact.findings).toHaveLength(COMPACT_MAX_FINDINGS);
+    expect(compact.findingsTruncated).toBe(true);
   });
 
   it("handles zero findings", () => {
@@ -225,15 +383,57 @@ describe("compactGitleaksScanMap", () => {
 
     const compact = compactGitleaksScanMap(data);
 
+    expect(compact.totalFindings).toBe(0);
     expect(compact).not.toHaveProperty("findings");
-    expect(compact).not.toHaveProperty("totalFindings");
+  });
+
+  it("passes through error and exitCode", () => {
+    const data: GitleaksScanResultInternal = {
+      totalFindings: 0,
+      findings: [],
+      summary: { totalFindings: 0 },
+      error: "gitleaks: bad config",
+      exitCode: 1,
+    };
+
+    const compact = compactGitleaksScanMap(data);
+    expect(compact.error).toBe("gitleaks: bad config");
+    expect(compact.exitCode).toBe(1);
+  });
+
+  it("produces schema-valid output", () => {
+    const data: GitleaksScanResultInternal = {
+      totalFindings: 2,
+      findings: [makeGitleaksFinding(1), makeGitleaksFinding(2)],
+      summary: { totalFindings: 2 },
+      error: "boom",
+      exitCode: 1,
+    };
+    expect(() => GitleaksScanResultSchema.parse(compactGitleaksScanMap(data))).not.toThrow();
   });
 });
 
 describe("formatGitleaksScanCompact", () => {
-  it("formats compact gitleaks scan output", () => {
-    const compact = {};
+  it("formats finding count and per-finding lines", () => {
+    const compact = compactGitleaksScanMap({
+      totalFindings: 2,
+      findings: [makeGitleaksFinding(1), makeGitleaksFinding(2)],
+      summary: { totalFindings: 2 },
+    });
     const output = formatGitleaksScanCompact(compact);
-    expect(output).toContain("Gitleaks scan");
+    expect(output).toContain("Gitleaks scan -- 2 secret(s) found");
+    expect(output).toContain("[rule-1] src/file1.env:1-1");
+    expect(output).toContain("[rule-2] src/file2.env:2-2");
+  });
+
+  it("surfaces error in text output", () => {
+    const output = formatGitleaksScanCompact({
+      totalFindings: 0,
+      error: "gitleaks: bad config",
+      exitCode: 1,
+    });
+    expect(output).toContain("0 secret(s)");
+    expect(output).toContain("Scan failed");
+    expect(output).toContain("gitleaks: bad config");
   });
 });

--- a/packages/server-security/__tests__/empty-failure.test.ts
+++ b/packages/server-security/__tests__/empty-failure.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import { surfaceEmptyFailure } from "@paretools/shared";
+import { parseTrivyJson, parseSemgrepJson, parseGitleaksJson } from "../src/lib/parsers.js";
+import {
+  schemaTrivyScanMap,
+  schemaSemgrepScanMap,
+  schemaGitleaksScanMap,
+  formatTrivyScan,
+  formatSemgrepScan,
+  formatGitleaksScan,
+} from "../src/lib/formatters.js";
+import {
+  TrivyScanResultSchema,
+  SemgrepScanResultSchema,
+  GitleaksScanResultSchema,
+} from "../src/schemas/index.js";
+
+// These tests replicate the exact composition used in each tool handler:
+// surfaceEmptyFailure(parseX(result.stdout), result, { isEmpty: parseFailed && no findings })
+// covering the two critical cases per tool (epic #1024):
+//   1. findings-found: non-zero exit with a parseable report -> NO error attached
+//   2. crash: non-zero exit with unparseable output -> error + exitCode attached
+
+// ---------------------------------------------------------------------------
+// Trivy
+// ---------------------------------------------------------------------------
+
+describe("trivy silent-failure surfacing", () => {
+  const trivyReportWithVulns = JSON.stringify({
+    Results: [
+      {
+        Target: "alpine:3.18",
+        Vulnerabilities: [
+          {
+            VulnerabilityID: "CVE-2023-1234",
+            Severity: "CRITICAL",
+            PkgName: "openssl",
+            InstalledVersion: "1.1.1t-r0",
+            FixedVersion: "1.1.1u-r0",
+          },
+        ],
+      },
+    ],
+  });
+
+  it("does not attach error when vulnerabilities are found with --exit-code (successful scan)", () => {
+    // trivy --exit-code 1 exits 1 when vulnerabilities are found
+    const result = { exitCode: 1, stdout: trivyReportWithVulns, stderr: "" };
+    const data = surfaceEmptyFailure(
+      parseTrivyJson(result.stdout, "alpine:3.18", "image"),
+      result,
+      {
+        isEmpty: (d) => d.parseFailed === true && d.totalVulnerabilities === 0,
+      },
+    );
+
+    expect(data.totalVulnerabilities).toBe(1);
+    expect(data.error).toBeUndefined();
+  });
+
+  it("attaches stderr tail when trivy crashes without a report", () => {
+    const result = {
+      exitCode: 1,
+      stdout: "",
+      stderr: "FATAL image scan error: unable to find the specified image",
+    };
+    const data = surfaceEmptyFailure(parseTrivyJson(result.stdout, "nosuch:img", "image"), result, {
+      isEmpty: (d) => d.parseFailed === true && d.totalVulnerabilities === 0,
+    });
+
+    expect(data.error).toContain("unable to find the specified image");
+    expect(data.exitCode).toBe(1);
+    // Full-mode structured output carries the error and stays schema-valid
+    const structured = schemaTrivyScanMap(data);
+    expect(structured.error).toContain("unable to find the specified image");
+    expect(() => TrivyScanResultSchema.parse(structured)).not.toThrow();
+    expect(structured).not.toHaveProperty("parseFailed");
+    // Text channel surfaces the failure
+    expect(formatTrivyScan(data)).toContain("Scan failed");
+  });
+
+  it("does not attach error on a clean scan (exit 0, empty report)", () => {
+    const result = { exitCode: 0, stdout: JSON.stringify({ Results: [] }), stderr: "" };
+    const data = surfaceEmptyFailure(parseTrivyJson(result.stdout, "img", "image"), result, {
+      isEmpty: (d) => d.parseFailed === true && d.totalVulnerabilities === 0,
+    });
+    expect(data.error).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Semgrep
+// ---------------------------------------------------------------------------
+
+describe("semgrep silent-failure surfacing", () => {
+  const semgrepReportWithFindings = JSON.stringify({
+    results: [
+      {
+        check_id: "python.lang.security.audit.dangerous-system-call",
+        path: "src/app.py",
+        start: { line: 10 },
+        end: { line: 10 },
+        extra: { message: "Avoid dangerous system calls", severity: "ERROR" },
+      },
+    ],
+  });
+
+  it("does not attach error when findings are found with non-zero exit (--error semantics)", () => {
+    // semgrep --error exits 1 when findings are present
+    const result = { exitCode: 1, stdout: semgrepReportWithFindings, stderr: "" };
+    const data = surfaceEmptyFailure(parseSemgrepJson(result.stdout, "auto"), result, {
+      isEmpty: (d) => d.parseFailed === true && d.totalFindings === 0,
+    });
+
+    expect(data.totalFindings).toBe(1);
+    expect(data.error).toBeUndefined();
+  });
+
+  it("does not attach error when a valid report carries its own errors[]", () => {
+    const report = JSON.stringify({
+      results: [],
+      errors: [{ type: "ParseError", message: "invalid syntax", path: "bad.py" }],
+    });
+    const result = { exitCode: 2, stdout: report, stderr: "" };
+    const data = surfaceEmptyFailure(parseSemgrepJson(result.stdout, "auto"), result, {
+      isEmpty: (d) => d.parseFailed === true && d.totalFindings === 0,
+    });
+
+    // Report parsed fine; failure detail is already in errors[]
+    expect(data.error).toBeUndefined();
+    expect(data.errors).toHaveLength(1);
+  });
+
+  it("attaches stderr tail when semgrep crashes without a report", () => {
+    const result = {
+      exitCode: 2,
+      stdout: "",
+      stderr: "[ERROR] Invalid rule schema in config 'broken.yml'",
+    };
+    const data = surfaceEmptyFailure(parseSemgrepJson(result.stdout, "broken.yml"), result, {
+      isEmpty: (d) => d.parseFailed === true && d.totalFindings === 0,
+    });
+
+    expect(data.error).toContain("Invalid rule schema");
+    expect(data.exitCode).toBe(2);
+    const structured = schemaSemgrepScanMap(data);
+    expect(structured.error).toContain("Invalid rule schema");
+    expect(() => SemgrepScanResultSchema.parse(structured)).not.toThrow();
+    expect(formatSemgrepScan(data)).toContain("Scan failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gitleaks
+// ---------------------------------------------------------------------------
+
+describe("gitleaks silent-failure surfacing", () => {
+  const gitleaksReportWithLeaks = JSON.stringify([
+    {
+      RuleID: "aws-access-key-id",
+      Description: "AWS Access Key ID",
+      Match: "AKIAIOSFODNN7EXAMPLE",
+      Secret: "AKIAIOSFODNN7EXAMPLE",
+      File: "config/aws.yml",
+      StartLine: 10,
+      EndLine: 10,
+      Commit: "def456",
+      Author: "admin@example.com",
+      Date: "2024-02-20",
+    },
+  ]);
+
+  it("does not attach error when leaks are found (exit 1 is a successful scan)", () => {
+    // gitleaks exits 1 when leaks ARE found — that is a successful scan
+    const result = { exitCode: 1, stdout: gitleaksReportWithLeaks, stderr: "" };
+    const data = surfaceEmptyFailure(parseGitleaksJson(result.stdout), result, {
+      isEmpty: (d) => d.parseFailed === true && d.totalFindings === 0,
+    });
+
+    expect(data.totalFindings).toBe(1);
+    expect(data.error).toBeUndefined();
+  });
+
+  it("attaches stderr tail when gitleaks crashes without a report", () => {
+    const result = {
+      exitCode: 1,
+      stdout: "",
+      stderr: "ERR failed to load config: yaml: unmarshal errors",
+    };
+    const data = surfaceEmptyFailure(parseGitleaksJson(result.stdout), result, {
+      isEmpty: (d) => d.parseFailed === true && d.totalFindings === 0,
+    });
+
+    expect(data.error).toContain("failed to load config");
+    expect(data.exitCode).toBe(1);
+    const structured = schemaGitleaksScanMap(data);
+    expect(structured.error).toContain("failed to load config");
+    expect(() => GitleaksScanResultSchema.parse(structured)).not.toThrow();
+    expect(structured).not.toHaveProperty("parseFailed");
+    expect(formatGitleaksScan(data)).toContain("Scan failed");
+  });
+
+  it("does not attach error on a clean scan (exit 0, empty array)", () => {
+    const result = { exitCode: 0, stdout: "[]", stderr: "" };
+    const data = surfaceEmptyFailure(parseGitleaksJson(result.stdout), result, {
+      isEmpty: (d) => d.parseFailed === true && d.totalFindings === 0,
+    });
+    expect(data.error).toBeUndefined();
+  });
+
+  it("uses a fallback message when both streams are empty", () => {
+    const result = { exitCode: 126, stdout: "", stderr: "" };
+    const data = surfaceEmptyFailure(parseGitleaksJson(result.stdout), result, {
+      isEmpty: (d) => d.parseFailed === true && d.totalFindings === 0,
+    });
+
+    expect(data.error).toContain("exited with code 126");
+    expect(data.exitCode).toBe(126);
+  });
+});

--- a/packages/server-security/__tests__/formatters.test.ts
+++ b/packages/server-security/__tests__/formatters.test.ts
@@ -250,7 +250,7 @@ describe("schemaGitleaksScanMap", () => {
 // -- Compact mappers and formatters -------------------------------------------
 
 describe("compactTrivyScanMap", () => {
-  it("keeps target, scanType, summary; drops vulnerabilities and totalVulnerabilities", () => {
+  it("keeps target, scanType, summary and critical/high vulns; drops totalVulnerabilities", () => {
     const data: TrivyScanResultInternal = {
       target: "alpine:3.18",
       scanType: "image",
@@ -273,7 +273,16 @@ describe("compactTrivyScanMap", () => {
     expect(compact.target).toBe("alpine:3.18");
     expect(compact.scanType).toBe("image");
     expect(compact.summary.critical).toBe(1);
-    expect(compact).not.toHaveProperty("vulnerabilities");
+    expect(compact.vulnerabilities).toEqual([
+      {
+        id: "CVE-2024-0001",
+        severity: "CRITICAL",
+        package: "libcrypto3",
+        installedVersion: "3.1.4-r1",
+        fixedVersion: "3.1.4-r5",
+      },
+    ]);
+    expect(compact).not.toHaveProperty("vulnerabilitiesTruncated");
     expect(compact).not.toHaveProperty("totalVulnerabilities");
   });
 });
@@ -392,7 +401,25 @@ describe("compactSemgrepScanMap", () => {
 
     expect(compact.summary.error).toBe(1);
     expect(compact.summary.warning).toBe(1);
-    expect(compact).not.toHaveProperty("findings");
+    expect(compact.findings).toEqual([
+      {
+        ruleId: "rule1",
+        path: "test.py",
+        startLine: 1,
+        endLine: 1,
+        message: "msg",
+        severity: "ERROR",
+      },
+      {
+        ruleId: "rule2",
+        path: "test.py",
+        startLine: 2,
+        endLine: 2,
+        message: "msg",
+        severity: "WARNING",
+      },
+    ]);
+    expect(compact).not.toHaveProperty("findingsTruncated");
     expect(compact).not.toHaveProperty("totalFindings");
     expect(compact).not.toHaveProperty("config");
   });
@@ -476,7 +503,7 @@ describe("formatGitleaksScan", () => {
 });
 
 describe("compactGitleaksScanMap", () => {
-  it("returns empty object; drops findings and totalFindings", () => {
+  it("keeps totalFindings and rule/file/line; drops match, secret, commit, summary", () => {
     const data: GitleaksScanResultInternal = {
       totalFindings: 2,
       findings: [
@@ -498,15 +525,18 @@ describe("compactGitleaksScanMap", () => {
 
     const compact = compactGitleaksScanMap(data);
 
-    expect(compact).not.toHaveProperty("findings");
-    expect(compact).not.toHaveProperty("totalFindings");
+    expect(compact.totalFindings).toBe(2);
+    expect(compact.findings).toEqual([
+      { ruleID: "rule1", file: "test.py", startLine: 1, endLine: 1 },
+    ]);
     expect(compact).not.toHaveProperty("summary");
   });
 });
 
 describe("formatGitleaksScanCompact", () => {
   it("formats compact summary", () => {
-    const output = formatGitleaksScanCompact({});
+    const output = formatGitleaksScanCompact({ totalFindings: 0 });
     expect(output).toContain("Gitleaks scan");
+    expect(output).toContain("0 secret(s)");
   });
 });

--- a/packages/server-security/__tests__/parsers.test.ts
+++ b/packages/server-security/__tests__/parsers.test.ts
@@ -96,13 +96,19 @@ describe("parseTrivyJson", () => {
     expect(result.vulnerabilities).toEqual([]);
   });
 
-  it("handles invalid JSON gracefully", () => {
+  it("flags invalid JSON as parseFailed", () => {
     const result = parseTrivyJson("not valid json", "target", "fs");
 
     expect(result.target).toBe("target");
     expect(result.scanType).toBe("fs");
     expect(result.totalVulnerabilities).toBe(0);
     expect(result.vulnerabilities).toEqual([]);
+    expect(result.parseFailed).toBe(true);
+  });
+
+  it("does not set parseFailed on a valid empty report", () => {
+    const result = parseTrivyJson(JSON.stringify({ Results: [] }), "target", "fs");
+    expect(result.parseFailed).toBeUndefined();
   });
 
   it("handles null Results", () => {
@@ -341,13 +347,19 @@ describe("parseSemgrepJson", () => {
     expect(result.findings).toEqual([]);
   });
 
-  it("handles invalid JSON gracefully", () => {
+  it("flags invalid JSON as parseFailed", () => {
     const result = parseSemgrepJson("not valid json", "auto");
 
     expect(result.config).toBe("auto");
     expect(result.totalFindings).toBe(0);
     expect(result.findings).toEqual([]);
     expect(result.summary).toEqual({ error: 0, warning: 0, info: 0 });
+    expect(result.parseFailed).toBe(true);
+  });
+
+  it("does not set parseFailed on a valid empty report", () => {
+    const result = parseSemgrepJson(JSON.stringify({ results: [] }), "auto");
+    expect(result.parseFailed).toBeUndefined();
   });
 
   it("normalizes severity strings to uppercase", () => {
@@ -485,20 +497,27 @@ describe("parseGitleaksJson", () => {
     expect(result.summary).toEqual({ totalFindings: 0 });
   });
 
-  it("handles invalid JSON gracefully", () => {
+  it("flags invalid JSON as parseFailed", () => {
     const result = parseGitleaksJson("not valid json");
 
     expect(result.totalFindings).toBe(0);
     expect(result.findings).toEqual([]);
     expect(result.summary).toEqual({ totalFindings: 0 });
+    expect(result.parseFailed).toBe(true);
   });
 
-  it("handles non-array JSON gracefully", () => {
+  it("flags non-array JSON as parseFailed", () => {
     const json = JSON.stringify({ notAnArray: true });
     const result = parseGitleaksJson(json);
 
     expect(result.totalFindings).toBe(0);
     expect(result.findings).toEqual([]);
+    expect(result.parseFailed).toBe(true);
+  });
+
+  it("does not set parseFailed on a valid empty report", () => {
+    const result = parseGitleaksJson(JSON.stringify([]));
+    expect(result.parseFailed).toBeUndefined();
   });
 
   it("handles missing fields with defaults", () => {

--- a/packages/server-security/src/lib/formatters.ts
+++ b/packages/server-security/src/lib/formatters.ts
@@ -7,6 +7,30 @@ import type {
   GitleaksScanResultInternal,
 } from "../schemas/index.js";
 
+/** Maximum number of findings/vulnerabilities kept in compact projections. */
+export const COMPACT_MAX_FINDINGS = 20;
+
+/** Builds the optional error/exitCode passthrough fields (set by surfaceEmptyFailure). */
+function errorFields(data: { error?: string; exitCode?: number }): {
+  error?: string;
+  exitCode?: number;
+} {
+  return {
+    ...(data.error !== undefined ? { error: data.error } : {}),
+    ...(data.exitCode !== undefined ? { exitCode: data.exitCode } : {}),
+  };
+}
+
+/** Appends the surfaced scan-failure error (if any) to formatter output lines. */
+function pushErrorLines(lines: string[], data: { error?: string; exitCode?: number }): void {
+  if (!data.error) return;
+  lines.push("");
+  lines.push(
+    `Scan failed${data.exitCode !== undefined ? ` (exit code ${data.exitCode})` : ""} — results are NOT a clean scan:`,
+  );
+  lines.push(data.error);
+}
+
 // -- Schema maps (strip Internal-only fields for structuredContent) -----------
 
 /** Strips Internal-only fields from Trivy scan result for structuredContent. */
@@ -23,6 +47,7 @@ export function schemaTrivyScanMap(data: TrivyScanResultInternal): TrivyScanResu
       cvssScore: v.cvssScore,
     })),
     summary: data.summary,
+    ...errorFields(data),
   };
 }
 
@@ -40,6 +65,7 @@ export function schemaSemgrepScanMap(data: SemgrepScanResultInternal): SemgrepSc
     })),
     errors: data.errors,
     summary: data.summary,
+    ...errorFields(data),
   };
 }
 
@@ -55,6 +81,7 @@ export function schemaGitleaksScanMap(data: GitleaksScanResultInternal): Gitleak
       endLine: f.endLine,
       commit: f.commit,
     })),
+    ...errorFields(data),
   };
 }
 
@@ -84,16 +111,27 @@ export function formatTrivyScan(data: TrivyScanResultInternal): string {
     }
   }
 
+  pushErrorLines(lines, data);
+
   return lines.join("\n");
 }
 
 // -- Compact types, mappers, and formatters -----------------------------------
 
-/** Compact scan result: summary only, no individual vulnerabilities (schema-compatible). */
+/** Compact scan result: severity summary plus the top critical/high
+ * vulnerabilities (schema-compatible). */
 export interface TrivyScanCompact {
   [key: string]: unknown;
   target: string;
   scanType: "image" | "fs" | "config";
+  vulnerabilities?: Array<{
+    id: string;
+    severity: string;
+    package: string;
+    installedVersion: string;
+    fixedVersion?: string;
+  }>;
+  vulnerabilitiesTruncated?: true;
   summary: {
     critical: number;
     high: number;
@@ -101,13 +139,28 @@ export interface TrivyScanCompact {
     low: number;
     unknown: number;
   };
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactTrivyScanMap(data: TrivyScanResultInternal): TrivyScanCompact {
+  const all = data.vulnerabilities ?? [];
+  const topSeverity = all.filter((v) => v.severity === "CRITICAL" || v.severity === "HIGH");
+  const kept = topSeverity.slice(0, COMPACT_MAX_FINDINGS).map((v) => ({
+    id: v.id,
+    severity: v.severity,
+    package: v.package,
+    installedVersion: v.installedVersion,
+    ...(v.fixedVersion !== undefined ? { fixedVersion: v.fixedVersion } : {}),
+  }));
+  const truncated = kept.length < all.length;
   return {
     target: data.target,
     scanType: data.scanType,
+    ...(kept.length > 0 ? { vulnerabilities: kept } : {}),
+    ...(truncated ? { vulnerabilitiesTruncated: true as const } : {}),
     summary: data.summary,
+    ...errorFields(data),
   };
 }
 
@@ -118,11 +171,20 @@ export function formatTrivyScanCompact(data: TrivyScanCompact): string {
     data.summary.medium +
     data.summary.low +
     data.summary.unknown;
-  return (
+  const lines: string[] = [
     `Trivy ${data.scanType} scan: ${data.target} -- ` +
-    `${total} vulnerabilities ` +
-    `(${data.summary.critical}C/${data.summary.high}H/${data.summary.medium}M/${data.summary.low}L)`
-  );
+      `${total} vulnerabilities ` +
+      `(${data.summary.critical}C/${data.summary.high}H/${data.summary.medium}M/${data.summary.low}L)`,
+  ];
+  for (const v of data.vulnerabilities ?? []) {
+    const fixed = v.fixedVersion ? ` -> ${v.fixedVersion}` : "";
+    lines.push(`  [${v.severity}] ${v.id}: ${v.package}@${v.installedVersion}${fixed}`);
+  }
+  if (data.vulnerabilitiesTruncated) {
+    lines.push(`  ... (list truncated; totals per severity above)`);
+  }
+  pushErrorLines(lines, data);
+  return lines.join("\n");
 }
 
 // -- Semgrep formatters -------------------------------------------------------
@@ -158,34 +220,79 @@ export function formatSemgrepScan(data: SemgrepScanResultInternal): string {
     }
   }
 
+  pushErrorLines(lines, data);
+
   return lines.join("\n");
 }
 
 // -- Semgrep compact types, mappers, and formatters ---------------------------
 
-/** Compact scan result: summary only, no individual findings (schema-compatible). */
+/** Compact scan result: severity summary plus the top findings and any scan
+ * errors (schema-compatible). */
 export interface SemgrepScanCompact {
   [key: string]: unknown;
+  findings?: Array<{
+    ruleId: string;
+    path: string;
+    startLine: number;
+    endLine: number;
+    message: string;
+    severity: string;
+  }>;
+  findingsTruncated?: true;
+  errors?: Array<{ type?: string; message: string; path?: string }>;
   summary: {
     error: number;
     warning: number;
     info: number;
   };
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactSemgrepScanMap(data: SemgrepScanResultInternal): SemgrepScanCompact {
+  const all = data.findings ?? [];
+  const kept = all.slice(0, COMPACT_MAX_FINDINGS).map((f) => ({
+    ruleId: f.ruleId,
+    path: f.path,
+    startLine: f.startLine,
+    endLine: f.endLine,
+    message: f.message,
+    severity: f.severity,
+  }));
   return {
+    ...(kept.length > 0 ? { findings: kept } : {}),
+    ...(kept.length < all.length ? { findingsTruncated: true as const } : {}),
+    ...(data.errors && data.errors.length > 0 ? { errors: data.errors } : {}),
     summary: data.summary,
+    ...errorFields(data),
   };
 }
 
 export function formatSemgrepScanCompact(data: SemgrepScanCompact): string {
   const total = data.summary.error + data.summary.warning + data.summary.info;
-  return (
+  const lines: string[] = [
     `Semgrep scan -- ` +
-    `${total} findings ` +
-    `(${data.summary.error}E/${data.summary.warning}W/${data.summary.info}I)`
-  );
+      `${total} findings ` +
+      `(${data.summary.error}E/${data.summary.warning}W/${data.summary.info}I)`,
+  ];
+  for (const f of data.findings ?? []) {
+    lines.push(`  [${f.severity}] ${f.ruleId}: ${f.path}:${f.startLine}-${f.endLine}`);
+    lines.push(`    ${f.message}`);
+  }
+  if (data.findingsTruncated) {
+    lines.push(`  ... (list truncated; totals per severity above)`);
+  }
+  if ((data.errors ?? []).length > 0) {
+    lines.push(`Errors: ${data.errors?.length ?? 0}`);
+    for (const err of data.errors ?? []) {
+      const type = err.type ? `[${err.type}] ` : "";
+      const path = err.path ? ` (${err.path})` : "";
+      lines.push(`  ${type}${err.message}${path}`);
+    }
+  }
+  pushErrorLines(lines, data);
+  return lines.join("\n");
 }
 
 // -- Gitleaks formatters ------------------------------------------------------
@@ -213,21 +320,53 @@ export function formatGitleaksScan(data: GitleaksScanResultInternal): string {
     }
   }
 
+  pushErrorLines(lines, data);
+
   return lines.join("\n");
 }
 
 // -- Gitleaks compact types, mappers, and formatters --------------------------
 
-/** Compact scan result: empty projection, no findings (schema-compatible).
- * GitleaksScanResultSchema only has `findings`, which compact mode drops. */
+/** Compact scan result: finding count plus the top findings by rule/file/line
+ * (schema-compatible). Drops match/secret/commit details. */
 export interface GitleaksScanCompact {
   [key: string]: unknown;
+  totalFindings: number;
+  findings?: Array<{
+    ruleID: string;
+    file: string;
+    startLine: number;
+    endLine: number;
+  }>;
+  findingsTruncated?: true;
+  error?: string;
+  exitCode?: number;
 }
 
-export function compactGitleaksScanMap(_data: GitleaksScanResultInternal): GitleaksScanCompact {
-  return {};
+export function compactGitleaksScanMap(data: GitleaksScanResultInternal): GitleaksScanCompact {
+  const all = data.findings ?? [];
+  const kept = all.slice(0, COMPACT_MAX_FINDINGS).map((f) => ({
+    ruleID: f.ruleID,
+    file: f.file,
+    startLine: f.startLine,
+    endLine: f.endLine,
+  }));
+  return {
+    totalFindings: data.totalFindings,
+    ...(kept.length > 0 ? { findings: kept } : {}),
+    ...(kept.length < all.length ? { findingsTruncated: true as const } : {}),
+    ...errorFields(data),
+  };
 }
 
-export function formatGitleaksScanCompact(_data: GitleaksScanCompact): string {
-  return `Gitleaks scan: compact summary`;
+export function formatGitleaksScanCompact(data: GitleaksScanCompact): string {
+  const lines: string[] = [`Gitleaks scan -- ${data.totalFindings} secret(s) found`];
+  for (const f of data.findings ?? []) {
+    lines.push(`  [${f.ruleID}] ${f.file}:${f.startLine}-${f.endLine}`);
+  }
+  if (data.findingsTruncated) {
+    lines.push(`  ... (list truncated; ${data.totalFindings} total)`);
+  }
+  pushErrorLines(lines, data);
+  return lines.join("\n");
 }

--- a/packages/server-security/src/lib/parsers.ts
+++ b/packages/server-security/src/lib/parsers.ts
@@ -57,12 +57,15 @@ export function parseTrivyJson(
   try {
     parsed = JSON.parse(jsonStr) as TrivyJsonOutput;
   } catch {
+    // Not a Trivy JSON report (crash, empty output, error text). Flag it so
+    // the tool layer can surface the failure instead of reporting a clean scan.
     return {
       target,
       scanType,
       vulnerabilities: [],
       summary: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
       totalVulnerabilities: 0,
+      parseFailed: true,
     };
   }
 
@@ -203,11 +206,14 @@ export function parseSemgrepJson(jsonStr: string, config: string): SemgrepScanRe
   try {
     parsed = JSON.parse(jsonStr) as SemgrepJsonOutput;
   } catch {
+    // Not a Semgrep JSON report (crash, empty output, error text). Flag it so
+    // the tool layer can surface the failure instead of reporting a clean scan.
     return {
       totalFindings: 0,
       findings: [],
       summary: { error: 0, warning: 0, info: 0 },
       config,
+      parseFailed: true,
     };
   }
 
@@ -333,11 +339,14 @@ export function parseGitleaksJson(jsonStr: string): GitleaksScanResultInternal {
   try {
     const raw = JSON.parse(jsonStr) as unknown;
     if (!Array.isArray(raw)) {
-      return { totalFindings: 0, findings: [], summary: { totalFindings: 0 } };
+      // Valid JSON but not a findings array — not a Gitleaks report. Flag it
+      // so the tool layer can surface the failure instead of a clean scan.
+      return { totalFindings: 0, findings: [], summary: { totalFindings: 0 }, parseFailed: true };
     }
     parsed = raw as GitleaksJsonFinding[];
   } catch {
-    return { totalFindings: 0, findings: [], summary: { totalFindings: 0 } };
+    // Not a Gitleaks JSON report (crash, empty output, error text).
+    return { totalFindings: 0, findings: [], summary: { totalFindings: 0 }, parseFailed: true };
   }
 
   const findings: GitleaksFindingInternal[] = [];

--- a/packages/server-security/src/schemas/index.ts
+++ b/packages/server-security/src/schemas/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { EmptyFailureSchemaFields } from "@paretools/shared";
 
 /** Zod schema for a single vulnerability entry from Trivy output.
  * Moved to formatter: title (display-only). */
@@ -30,7 +31,10 @@ export const TrivyScanResultSchema = z.object({
   target: z.string(),
   scanType: z.enum(["image", "fs", "config"]),
   vulnerabilities: z.array(TrivyVulnerabilitySchema).optional(),
+  /** Set (true) in compact mode when the vulnerability list was cut to the top entries. */
+  vulnerabilitiesTruncated: z.boolean().optional(),
   summary: TrivySeveritySummarySchema,
+  ...EmptyFailureSchemaFields,
 });
 
 export type TrivyScanResult = z.infer<typeof TrivyScanResultSchema>;
@@ -44,6 +48,8 @@ export type TrivyVulnerabilityInternal = TrivyVulnerability & {
 export type TrivyScanResultInternal = Omit<TrivyScanResult, "vulnerabilities"> & {
   vulnerabilities?: TrivyVulnerabilityInternal[];
   totalVulnerabilities: number;
+  /** Internal-only: set when the CLI output could not be parsed as a Trivy report. */
+  parseFailed?: true;
 };
 
 // -- Semgrep schemas ----------------------------------------------------------
@@ -76,6 +82,8 @@ export type SemgrepSeveritySummary = z.infer<typeof SemgrepSeveritySummarySchema
  * Moved to formatter: config (echo-back / display-only). */
 export const SemgrepScanResultSchema = z.object({
   findings: z.array(SemgrepFindingSchema).optional(),
+  /** Set (true) in compact mode when the findings list was cut to the top entries. */
+  findingsTruncated: z.boolean().optional(),
   errors: z
     .array(
       z.object({
@@ -86,6 +94,7 @@ export const SemgrepScanResultSchema = z.object({
     )
     .optional(),
   summary: SemgrepSeveritySummarySchema,
+  ...EmptyFailureSchemaFields,
 });
 
 export type SemgrepScanResult = z.infer<typeof SemgrepScanResultSchema>;
@@ -100,20 +109,23 @@ export type SemgrepScanResultInternal = Omit<SemgrepScanResult, "findings"> & {
   findings?: SemgrepFindingInternal[];
   totalFindings: number;
   config: string;
+  /** Internal-only: set when the CLI output could not be parsed as a Semgrep report. */
+  parseFailed?: true;
 };
 
 // -- Gitleaks schemas ---------------------------------------------------------
 
 /** Zod schema for a single Gitleaks finding.
- * Moved to formatter: description, author, date (display-only). */
+ * Moved to formatter: description, author, date (display-only).
+ * `match`, `secret`, and `commit` are omitted in compact mode. */
 export const GitleaksFindingSchema = z.object({
   ruleID: z.string(),
-  match: z.string(),
-  secret: z.string(),
+  match: z.string().optional(),
+  secret: z.string().optional(),
   file: z.string(),
   startLine: z.number(),
   endLine: z.number(),
-  commit: z.string(),
+  commit: z.string().optional(),
 });
 
 export type GitleaksFinding = z.infer<typeof GitleaksFindingSchema>;
@@ -128,6 +140,11 @@ export type GitleaksSummary = z.infer<typeof GitleaksSummarySchema>;
  * Removed derivable: totalFindings (= findings.length). */
 export const GitleaksScanResultSchema = z.object({
   findings: z.array(GitleaksFindingSchema).optional(),
+  /** Total findings detected; set in compact mode where `findings` may be cut. */
+  totalFindings: z.number().optional(),
+  /** Set (true) in compact mode when the findings list was cut to the top entries. */
+  findingsTruncated: z.boolean().optional(),
+  ...EmptyFailureSchemaFields,
 });
 
 export type GitleaksScanResult = z.infer<typeof GitleaksScanResultSchema>;
@@ -150,4 +167,6 @@ export type GitleaksScanResultInternal = Omit<GitleaksScanResult, "findings"> & 
   findings?: GitleaksFindingInternal[];
   totalFindings: number;
   summary?: GitleaksSummaryInternal;
+  /** Internal-only: set when the CLI output could not be parsed as a Gitleaks report. */
+  parseFailed?: true;
 };

--- a/packages/server-security/src/tools/gitleaks.ts
+++ b/packages/server-security/src/tools/gitleaks.ts
@@ -10,6 +10,7 @@ import {
   repoPathInput,
   compactInput,
   configInput,
+  surfaceEmptyFailure,
 } from "@paretools/shared";
 import { parseGitleaksJson } from "../lib/parsers.js";
 import {
@@ -170,7 +171,13 @@ export function registerGitleaksTool(server: McpServer) {
       // gitleaks exits with code 1 when findings are detected, which is not an error
       const result = await run("gitleaks", args, { cwd, timeout: 300_000 });
 
-      const data = parseGitleaksJson(result.stdout);
+      // Gitleaks exits 1 both when leaks are found (a successful scan that
+      // emits a JSON findings array) and on execution errors (no report).
+      // Only surface a failure when the output was not a findings array, so a
+      // crashed scan can never read as "0 secrets found".
+      const data = surfaceEmptyFailure(parseGitleaksJson(result.stdout), result, {
+        isEmpty: (d) => d.parseFailed === true && d.totalFindings === 0,
+      });
       const rawOutput = (result.stdout + "\n" + result.stderr).trim();
 
       return strippedCompactDualOutput(

--- a/packages/server-security/src/tools/semgrep.ts
+++ b/packages/server-security/src/tools/semgrep.ts
@@ -9,6 +9,7 @@ import {
   cwdPathInput,
   compactInput,
   coerceJsonArray,
+  surfaceEmptyFailure,
 } from "@paretools/shared";
 import { parseSemgrepJson } from "../lib/parsers.js";
 import {
@@ -199,7 +200,14 @@ export function registerSemgrepTool(server: McpServer) {
 
       // Use first config for display; join all for the structured output
       const configDisplay = configs.join(",");
-      const data = parseSemgrepJson(result.stdout, configDisplay);
+      // Semgrep exits non-zero on findings (with --error) and on execution
+      // errors. A non-zero exit with a parseable report (findings and/or its
+      // own errors[] array) is a completed scan. Only surface a failure when
+      // the output was not a Semgrep JSON report at all, so a crashed scan
+      // can never read as "0 findings".
+      const data = surfaceEmptyFailure(parseSemgrepJson(result.stdout, configDisplay), result, {
+        isEmpty: (d) => d.parseFailed === true && d.totalFindings === 0,
+      });
       const rawOutput = (result.stdout + "\n" + result.stderr).trim();
 
       return strippedCompactDualOutput(

--- a/packages/server-security/src/tools/trivy.ts
+++ b/packages/server-security/src/tools/trivy.ts
@@ -8,6 +8,7 @@ import {
   assertNoFlagInjection,
   cwdPathInput,
   compactInput,
+  surfaceEmptyFailure,
 } from "@paretools/shared";
 import { parseTrivyJson } from "../lib/parsers.js";
 import {
@@ -179,7 +180,14 @@ export function registerTrivyTool(server: McpServer) {
 
       const result = await run("trivy", args, { cwd, timeout: 300_000 });
 
-      const data = parseTrivyJson(result.stdout, target, scanType);
+      // Trivy exits non-zero on execution errors, and also (per --exit-code)
+      // when vulnerabilities are found — a non-zero exit with a parseable
+      // report is still a successful scan. Only surface a failure when the
+      // output was not a Trivy report at all (crash, bad target, etc.), so a
+      // crashed scan can never read as "0 vulnerabilities".
+      const data = surfaceEmptyFailure(parseTrivyJson(result.stdout, target, scanType), result, {
+        isEmpty: (d) => d.parseFailed === true && d.totalVulnerabilities === 0,
+      });
       const rawOutput = (result.stdout + "\n" + result.stderr).trim();
 
       return strippedCompactDualOutput(


### PR DESCRIPTION
## What was broken

**Silent false-clean on crash (#1024 — critical for security tools).** `parseTrivyJson`, `parseSemgrepJson`, and `parseGitleaksJson` all swallowed unparseable CLI output (`JSON.parse` catch, plus gitleaks' non-array guard) and returned an all-zero summary; the tool handlers never inspected `result.exitCode`/`stderr`. A trivy crash (bad image, DB error), a semgrep config failure, or a gitleaks config error was reported to the agent as a clean scan with 0 findings.

**Compact-mode payload loss (#1022).** `compactGitleaksScanMap` returned `{}` — literally nothing. `compactTrivyScanMap` kept only the severity summary and dropped every CVE. `compactSemgrepScanMap` dropped all findings AND semgrep's own `errors[]` array. Since compact engages exactly when there are many findings, the payload the agent called the tool for was gone from both channels.

## What changed

- Parsers flag unparseable output with an internal `parseFailed` marker instead of silently zeroing.
- Each tool handler applies the shared `surfaceEmptyFailure` helper (PR #1026): a non-zero exit with no parseable report now attaches `error` (stderr/stdout tail) and `exitCode` to the result, in both `structuredContent` and the text channel ("Scan failed ... — results are NOT a clean scan").
- Exit-code semantics respected per tool — findings-found is NOT an error: gitleaks exit 1 with a findings array, trivy `--exit-code` with a report, and semgrep findings/`errors[]` reports parse fine and get no `error` attached. Tests cover both the findings-found and crash cases per tool.
- `compactGitleaksScanMap` now returns `totalFindings` + top 20 findings (ruleID/file/startLine/endLine) with a `findingsTruncated` flag.
- `compactTrivyScanMap` now includes the top 20 critical/high vulnerabilities (id, package, severity, installed/fixed version) with a `vulnerabilitiesTruncated` flag.
- `compactSemgrepScanMap` now includes the top 20 findings and always passes through `errors[]`.
- All compact projections and compact text formatters pass through `error`/`exitCode`; schemas extended with `EmptyFailureSchemaFields` and truncation flags so compact output stays schema-valid (asserted in tests via `Schema.parse(compactMap(...))`).

## Testing

- 102 tests pass in `@paretools/security` (new `empty-failure.test.ts` + extended parser/compact/formatter tests)
- eslint and prettier clean

Part of #1022 and #1024
