### PR TITLE
fix(lint): surface linter config failures and keep diagnostics in compact output

### DIFF
--- a/.changeset/fix-lint-silent-and-compact.md
+++ b/.changeset/fix-lint-silent-and-compact.md
@@ -1,0 +1,11 @@
+---
+"@paretools/lint": patch
+---
+
+Surface linter config failures and keep the actionable payload in compact output.
+
+- All six linters (eslint, biome-check, stylelint, shellcheck, hadolint, oxlint) now attach `error` and `exitCode` when the CLI exits non-zero with zero parsed diagnostics, instead of reporting a false "clean" result on config errors or crashes (#1024). Exits caused by found violations are unaffected.
+- `format-check` surfaces prettier failures (exit > 1) as `error` instead of a silent `{formatted: false, files: []}` (#1024).
+- Compact lint output now keeps the first 25 diagnostics plus `diagnosticsTruncated`/`omittedCount` and the fixable counts, instead of dropping every diagnostic (#1022).
+- Compact `format-check` output now includes the failing file list (capped at 50 with `filesTruncated`) and `total` (#1021).
+- Compact `prettier-format`/`biome-format` output now includes the list of reformatted files (capped at 50 with `filesTruncated`) (#1022).

--- a/packages/server-lint/__tests__/compact.test.ts
+++ b/packages/server-lint/__tests__/compact.test.ts
@@ -6,15 +6,34 @@ import {
   formatFormatCheckCompact,
   compactFormatWriteMap,
   formatFormatWriteCompact,
+  COMPACT_DIAGNOSTIC_LIMIT,
+  COMPACT_FILE_LIMIT,
 } from "../src/lib/formatters.js";
-import type { LintResult, FormatCheckResult, FormatWriteResult } from "../src/schemas/index.js";
+import {
+  LintResultSchema,
+  FormatCheckResultSchema,
+  type LintResult,
+  type LintDiagnostic,
+  type FormatCheckResult,
+  type FormatWriteResult,
+} from "../src/schemas/index.js";
+
+function makeDiagnostics(count: number): LintDiagnostic[] {
+  return Array.from({ length: count }, (_, i) => ({
+    file: `src/file${i}.ts`,
+    line: i + 1,
+    severity: (i % 2 === 0 ? "error" : "warning") as "error" | "warning",
+    rule: "no-unused-vars",
+    message: `'foo${i}' is defined but never used.`,
+  }));
+}
 
 // ---------------------------------------------------------------------------
 // compactLintMap
 // ---------------------------------------------------------------------------
 
 describe("compactLintMap", () => {
-  it("keeps only counts, drops diagnostics", () => {
+  it("keeps counts AND diagnostics (#1022)", () => {
     const data: LintResult = {
       diagnostics: [
         {
@@ -43,8 +62,49 @@ describe("compactLintMap", () => {
     expect(compact.errors).toBe(1);
     expect(compact.warnings).toBe(1);
     expect(compact.filesChecked).toBe(10);
-    // Verify diagnostics are dropped
-    expect(compact).not.toHaveProperty("diagnostics");
+    // Diagnostics are kept in compact mode (the actionable payload)
+    expect(compact.diagnostics).toHaveLength(2);
+    expect(compact.diagnostics?.[0]).toMatchObject({
+      file: "src/index.ts",
+      line: 5,
+      rule: "no-unused-vars",
+      message: "'foo' is defined but never used.",
+    });
+    // No truncation flags when under the cap
+    expect(compact).not.toHaveProperty("diagnosticsTruncated");
+    expect(compact).not.toHaveProperty("omittedCount");
+  });
+
+  it("caps diagnostics at COMPACT_DIAGNOSTIC_LIMIT with truncation metadata", () => {
+    const data: LintResult = {
+      diagnostics: makeDiagnostics(COMPACT_DIAGNOSTIC_LIMIT + 15),
+      errors: 20,
+      warnings: 20,
+      filesChecked: 40,
+    };
+
+    const compact = compactLintMap(data);
+
+    expect(compact.diagnostics).toHaveLength(COMPACT_DIAGNOSTIC_LIMIT);
+    expect(compact.diagnosticsTruncated).toBe(true);
+    expect(compact.omittedCount).toBe(15);
+    // First-N kept in order
+    expect(compact.diagnostics?.[0].file).toBe("src/file0.ts");
+  });
+
+  it("keeps fixable counts (#1022)", () => {
+    const data: LintResult = {
+      diagnostics: makeDiagnostics(2),
+      errors: 1,
+      warnings: 1,
+      fixableErrorCount: 1,
+      fixableWarningCount: 1,
+      filesChecked: 5,
+    };
+
+    const compact = compactLintMap(data);
+    expect(compact.fixableErrorCount).toBe(1);
+    expect(compact.fixableWarningCount).toBe(1);
   });
 
   it("handles clean lint result", () => {
@@ -76,6 +136,35 @@ describe("compactLintMap", () => {
     const compact = compactLintMap(data);
     expect(compact.deprecationCount).toBe(1);
   });
+
+  it("passes through error and exitCode (#1024)", () => {
+    const data: LintResult = {
+      diagnostics: [],
+      errors: 0,
+      warnings: 0,
+      filesChecked: 0,
+      error: "Oops! Something went wrong! Cannot find module 'eslint-plugin-foo'",
+      exitCode: 2,
+    };
+
+    const compact = compactLintMap(data);
+    expect(compact.error).toBe(data.error);
+    expect(compact.exitCode).toBe(2);
+  });
+
+  it("produces output that validates against LintResultSchema", () => {
+    const data: LintResult = {
+      diagnostics: makeDiagnostics(COMPACT_DIAGNOSTIC_LIMIT + 5),
+      errors: 15,
+      warnings: 15,
+      fixableErrorCount: 3,
+      fixableWarningCount: 2,
+      filesChecked: 30,
+    };
+
+    const compact = compactLintMap(data);
+    expect(LintResultSchema.safeParse(compact).success).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -99,6 +188,32 @@ describe("formatLintCompact", () => {
       "Lint: 0 errors, 1 warnings across 2 files (3 deprecations).",
     );
   });
+
+  it("lists diagnostics and the omitted count", () => {
+    const compact = compactLintMap({
+      diagnostics: makeDiagnostics(COMPACT_DIAGNOSTIC_LIMIT + 3),
+      errors: 14,
+      warnings: 14,
+      filesChecked: 28,
+    });
+
+    const text = formatLintCompact(compact);
+    expect(text).toContain("src/file0.ts:1 error no-unused-vars");
+    expect(text).toContain("... (3 more diagnostics omitted)");
+  });
+
+  it("formats surfaced failures", () => {
+    const compact = {
+      errors: 0,
+      warnings: 0,
+      filesChecked: 0,
+      error: "Cannot find module 'eslint-plugin-foo'",
+      exitCode: 2,
+    };
+    expect(formatLintCompact(compact)).toBe(
+      "Lint failed (exit 2): Cannot find module 'eslint-plugin-foo'",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -106,7 +221,7 @@ describe("formatLintCompact", () => {
 // ---------------------------------------------------------------------------
 
 describe("compactLintMap with shellcheck-shaped data", () => {
-  it("keeps only counts, drops SC-code diagnostics", () => {
+  it("keeps counts and SC-code diagnostics", () => {
     const data: LintResult = {
       diagnostics: [
         {
@@ -135,7 +250,8 @@ describe("compactLintMap with shellcheck-shaped data", () => {
     expect(compact.errors).toBe(1);
     expect(compact.warnings).toBe(0);
     expect(compact.filesChecked).toBe(2);
-    expect(compact).not.toHaveProperty("diagnostics");
+    expect(compact.diagnostics).toHaveLength(2);
+    expect(compact.diagnostics?.[0].rule).toBe("SC2086");
   });
 });
 
@@ -144,7 +260,7 @@ describe("compactLintMap with shellcheck-shaped data", () => {
 // ---------------------------------------------------------------------------
 
 describe("compactLintMap with hadolint-shaped data", () => {
-  it("keeps only counts, drops DL-code diagnostics", () => {
+  it("keeps counts and DL-code diagnostics", () => {
     const data: LintResult = {
       diagnostics: [
         {
@@ -173,7 +289,8 @@ describe("compactLintMap with hadolint-shaped data", () => {
     expect(compact.errors).toBe(1);
     expect(compact.warnings).toBe(1);
     expect(compact.filesChecked).toBe(1);
-    expect(compact).not.toHaveProperty("diagnostics");
+    expect(compact.diagnostics).toHaveLength(2);
+    expect(compact.diagnostics?.[1].rule).toBe("DL3008");
   });
 });
 
@@ -182,7 +299,7 @@ describe("compactLintMap with hadolint-shaped data", () => {
 // ---------------------------------------------------------------------------
 
 describe("compactFormatCheckMap", () => {
-  it("keeps only formatted status, drops file list", () => {
+  it("keeps the file list and total (#1021)", () => {
     const data: FormatCheckResult = {
       formatted: false,
       files: ["src/index.ts", "src/utils.ts", "src/config.ts"],
@@ -191,8 +308,20 @@ describe("compactFormatCheckMap", () => {
     const compact = compactFormatCheckMap(data);
 
     expect(compact.formatted).toBe(false);
-    // Verify files are dropped
-    expect(compact).not.toHaveProperty("files");
+    expect(compact.files).toEqual(["src/index.ts", "src/utils.ts", "src/config.ts"]);
+    expect(compact.total).toBe(3);
+    expect(compact).not.toHaveProperty("filesTruncated");
+  });
+
+  it("caps the file list at COMPACT_FILE_LIMIT with truncation metadata", () => {
+    const files = Array.from({ length: COMPACT_FILE_LIMIT + 20 }, (_, i) => `src/file${i}.ts`);
+    const data: FormatCheckResult = { formatted: false, files };
+
+    const compact = compactFormatCheckMap(data);
+
+    expect(compact.files).toHaveLength(COMPACT_FILE_LIMIT);
+    expect(compact.total).toBe(COMPACT_FILE_LIMIT + 20);
+    expect(compact.filesTruncated).toBe(true);
   });
 
   it("handles all-formatted result", () => {
@@ -206,6 +335,25 @@ describe("compactFormatCheckMap", () => {
     expect(compact.formatted).toBe(true);
     expect(compact).not.toHaveProperty("files");
   });
+
+  it("passes through error and exitCode (#1024)", () => {
+    const data: FormatCheckResult = {
+      formatted: false,
+      files: [],
+      error: "[error] Invalid configuration file `.prettierrc`",
+      exitCode: 2,
+    };
+
+    const compact = compactFormatCheckMap(data);
+    expect(compact.error).toBe(data.error);
+    expect(compact.exitCode).toBe(2);
+  });
+
+  it("produces output that validates against FormatCheckResultSchema", () => {
+    const files = Array.from({ length: COMPACT_FILE_LIMIT + 1 }, (_, i) => `src/file${i}.ts`);
+    const compact = compactFormatCheckMap({ formatted: false, files });
+    expect(FormatCheckResultSchema.safeParse(compact).success).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -218,9 +366,38 @@ describe("formatFormatCheckCompact", () => {
     expect(formatFormatCheckCompact(compact)).toBe("All files are formatted.");
   });
 
-  it("formats when files need formatting", () => {
+  it("formats when files need formatting but no list is available", () => {
     const compact = { formatted: false };
     expect(formatFormatCheckCompact(compact)).toBe("Some files need formatting.");
+  });
+
+  it("lists the failing files", () => {
+    const compact = compactFormatCheckMap({
+      formatted: false,
+      files: ["src/index.ts", "src/utils.ts"],
+    });
+    expect(formatFormatCheckCompact(compact)).toBe(
+      "2 files need formatting:\n  src/index.ts\n  src/utils.ts",
+    );
+  });
+
+  it("notes omitted files when truncated", () => {
+    const files = Array.from({ length: COMPACT_FILE_LIMIT + 5 }, (_, i) => `src/file${i}.ts`);
+    const compact = compactFormatCheckMap({ formatted: false, files });
+    const text = formatFormatCheckCompact(compact);
+    expect(text).toContain(`${COMPACT_FILE_LIMIT + 5} files need formatting:`);
+    expect(text).toContain("... (5 more files omitted)");
+  });
+
+  it("formats surfaced failures", () => {
+    const compact = {
+      formatted: false,
+      error: "[error] Invalid configuration file",
+      exitCode: 2,
+    };
+    expect(formatFormatCheckCompact(compact)).toBe(
+      "Format check failed (exit 2): [error] Invalid configuration file",
+    );
   });
 });
 
@@ -229,7 +406,7 @@ describe("formatFormatCheckCompact", () => {
 // ---------------------------------------------------------------------------
 
 describe("compactFormatWriteMap", () => {
-  it("keeps only success and filesChanged, drops file list", () => {
+  it("keeps counts and the reformatted file list (#1022)", () => {
     const data: FormatWriteResult = {
       filesChanged: 3,
       files: ["src/index.ts", "src/utils.ts", "src/config.ts"],
@@ -240,8 +417,21 @@ describe("compactFormatWriteMap", () => {
 
     expect(compact.success).toBe(true);
     expect(compact.filesChanged).toBe(3);
-    // Verify files are dropped
-    expect(compact).not.toHaveProperty("files");
+    expect(compact.files).toEqual(["src/index.ts", "src/utils.ts", "src/config.ts"]);
+  });
+
+  it("caps the file list at COMPACT_FILE_LIMIT with truncation metadata", () => {
+    const files = Array.from({ length: COMPACT_FILE_LIMIT + 10 }, (_, i) => `src/file${i}.ts`);
+    const data: FormatWriteResult = {
+      filesChanged: files.length,
+      files,
+      success: true,
+    };
+
+    const compact = compactFormatWriteMap(data);
+
+    expect(compact.files).toHaveLength(COMPACT_FILE_LIMIT);
+    expect(compact.filesTruncated).toBe(true);
   });
 
   it("handles failed format result", () => {
@@ -309,8 +499,24 @@ describe("formatFormatWriteCompact", () => {
     expect(formatFormatWriteCompact(compact)).toBe("All files already formatted.");
   });
 
-  it("formats files changed", () => {
-    const compact = { success: true, filesChanged: 7 };
-    expect(formatFormatWriteCompact(compact)).toBe("Formatted 7 files.");
+  it("lists formatted files", () => {
+    const compact = compactFormatWriteMap({
+      filesChanged: 2,
+      files: ["src/a.ts", "src/b.ts"],
+      success: true,
+    });
+    expect(formatFormatWriteCompact(compact)).toBe("Formatted 2 files:\n  src/a.ts\n  src/b.ts");
+  });
+
+  it("notes omitted files when truncated", () => {
+    const files = Array.from({ length: COMPACT_FILE_LIMIT + 7 }, (_, i) => `src/file${i}.ts`);
+    const compact = compactFormatWriteMap({
+      filesChanged: files.length,
+      files,
+      success: true,
+    });
+    const text = formatFormatWriteCompact(compact);
+    expect(text).toContain(`Formatted ${COMPACT_FILE_LIMIT + 7} files:`);
+    expect(text).toContain("... (7 more files omitted)");
   });
 });

--- a/packages/server-lint/__tests__/silent-failures.test.ts
+++ b/packages/server-lint/__tests__/silent-failures.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect } from "vitest";
+import { surfaceEmptyFailure } from "@paretools/shared";
+import {
+  parseEslintJson,
+  parseBiomeJson,
+  parseStylelintJson,
+  parseShellcheckJson,
+  parseHadolintJson,
+  parseOxlintJson,
+  parsePrettierListDifferent,
+} from "../src/lib/parsers.js";
+import type { LintResult, FormatCheckResult } from "../src/schemas/index.js";
+
+/**
+ * Mirrors the composition used by every linter tool handler (#1024): the
+ * parser sees only stdout, then surfaceEmptyFailure attaches the failure
+ * evidence when the CLI exited non-zero with zero parsed diagnostics.
+ */
+function surfaceLint(
+  data: LintResult,
+  result: { exitCode: number; stdout: string; stderr: string },
+) {
+  return surfaceEmptyFailure(data, result, {
+    isEmpty: (d) => (d.diagnostics ?? []).length === 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// ESLint
+// ---------------------------------------------------------------------------
+
+describe("eslint silent-failure surfacing", () => {
+  const violationsJson = JSON.stringify([
+    {
+      filePath: "/proj/src/index.ts",
+      messages: [
+        {
+          ruleId: "no-unused-vars",
+          severity: 2,
+          message: "'foo' is defined but never used.",
+          line: 5,
+          column: 7,
+        },
+      ],
+      errorCount: 1,
+      warningCount: 0,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0,
+    },
+  ]);
+
+  it("does NOT attach error when violations were found (exit 1 is normal)", () => {
+    const result = { exitCode: 1, stdout: violationsJson, stderr: "" };
+    const data = surfaceLint(parseEslintJson(result.stdout), result);
+
+    expect(data.errors).toBe(1);
+    expect(data.error).toBeUndefined();
+  });
+
+  it("surfaces a config crash (exit 2, stderr, no JSON) instead of a false clean", () => {
+    const stderr =
+      "Oops! Something went wrong! :(\n\n" +
+      "ESLint: 9.0.0\n\n" +
+      "Error: Cannot find module 'eslint-plugin-foo'\n" +
+      "Require stack:\n- /proj/eslint.config.js";
+    const result = { exitCode: 2, stdout: "", stderr };
+    const data = surfaceLint(parseEslintJson(result.stdout), result);
+
+    expect(data.errors).toBe(0);
+    expect(data.diagnostics).toEqual([]);
+    expect(data.error).toContain("Cannot find module 'eslint-plugin-foo'");
+    expect(data.exitCode).toBe(2);
+  });
+
+  it("provides a fallback message when both streams are empty", () => {
+    const result = { exitCode: 2, stdout: "", stderr: "" };
+    const data = surfaceLint(parseEslintJson(result.stdout), result);
+
+    expect(data.error).toContain("exited with code 2");
+    expect(data.exitCode).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Biome
+// ---------------------------------------------------------------------------
+
+describe("biome silent-failure surfacing", () => {
+  it("does NOT attach error when diagnostics were found", () => {
+    const stdout = JSON.stringify({
+      summary: { errors: 1, warnings: 0 },
+      diagnostics: [
+        {
+          category: "lint/suspicious/noExplicitAny",
+          severity: "error",
+          description: "Unexpected any.",
+          location: { path: "src/index.ts", start: { line: 3, column: 12 } },
+        },
+      ],
+    });
+    const result = { exitCode: 1, stdout, stderr: "" };
+    const data = surfaceLint(parseBiomeJson(result.stdout), result);
+
+    expect(data.errors).toBe(1);
+    expect(data.error).toBeUndefined();
+  });
+
+  it("surfaces a config error instead of a false clean", () => {
+    const stderr =
+      "biome.json:5:3 deserialize ━━━━━━━━━━━━━━━━━━━\n" + "  ✖ Found an unknown key `linterr`.\n";
+    const result = { exitCode: 1, stdout: "", stderr };
+    const data = surfaceLint(parseBiomeJson(result.stdout), result);
+
+    expect(data.filesChecked).toBe(0);
+    expect(data.error).toContain("unknown key");
+    expect(data.exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stylelint
+// ---------------------------------------------------------------------------
+
+describe("stylelint silent-failure surfacing", () => {
+  it("does NOT attach error when violations were found (exit 2 is normal)", () => {
+    const stdout = JSON.stringify([
+      {
+        source: "/proj/src/styles.css",
+        warnings: [
+          {
+            line: 4,
+            column: 3,
+            rule: "block-no-empty",
+            severity: "error",
+            text: "Unexpected empty block (block-no-empty)",
+          },
+        ],
+      },
+    ]);
+    const result = { exitCode: 2, stdout, stderr: "" };
+    const data = surfaceLint(parseStylelintJson(result.stdout), result);
+
+    expect(data.errors).toBe(1);
+    expect(data.error).toBeUndefined();
+  });
+
+  it("surfaces a missing-config crash instead of a false clean", () => {
+    const stderr =
+      "Error: No configuration provided for /proj/src/styles.css\n" +
+      "    at getConfigForFile (/proj/node_modules/stylelint/lib/getConfigForFile.cjs:47:11)";
+    const result = { exitCode: 78, stdout: "", stderr };
+    const data = surfaceLint(parseStylelintJson(result.stdout), result);
+
+    expect(data.diagnostics).toEqual([]);
+    expect(data.error).toContain("No configuration provided");
+    expect(data.exitCode).toBe(78);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ShellCheck
+// ---------------------------------------------------------------------------
+
+describe("shellcheck silent-failure surfacing", () => {
+  it("does NOT attach error when issues were found (exit 1 is normal)", () => {
+    const stdout = JSON.stringify([
+      {
+        file: "deploy.sh",
+        line: 5,
+        column: 8,
+        level: "error",
+        code: 2086,
+        message: "Double quote to prevent globbing and word splitting.",
+      },
+    ]);
+    const result = { exitCode: 1, stdout, stderr: "" };
+    const data = surfaceLint(parseShellcheckJson(result.stdout), result);
+
+    expect(data.errors).toBe(1);
+    expect(data.error).toBeUndefined();
+  });
+
+  it("surfaces an unprocessable-file failure instead of a false clean", () => {
+    const result = {
+      exitCode: 2,
+      stdout: "[]",
+      stderr: "missing.sh: missing.sh: openBinaryFile: does not exist (No such file or directory)",
+    };
+    const data = surfaceLint(parseShellcheckJson(result.stdout), result);
+
+    expect(data.diagnostics).toEqual([]);
+    expect(data.error).toContain("does not exist");
+    expect(data.exitCode).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hadolint
+// ---------------------------------------------------------------------------
+
+describe("hadolint silent-failure surfacing", () => {
+  it("does NOT attach error when violations were found (exit 1 is normal)", () => {
+    const stdout = JSON.stringify([
+      {
+        file: "Dockerfile",
+        line: 3,
+        column: 1,
+        level: "warning",
+        code: "DL3008",
+        message: "Pin versions in apt get install.",
+      },
+    ]);
+    const result = { exitCode: 1, stdout, stderr: "" };
+    const data = surfaceLint(parseHadolintJson(result.stdout), result);
+
+    expect(data.warnings).toBe(1);
+    expect(data.error).toBeUndefined();
+  });
+
+  it("surfaces a missing-file failure instead of a false clean", () => {
+    const result = {
+      exitCode: 1,
+      stdout: "",
+      stderr: "hadolint: Dockerfile: openBinaryFile: does not exist (No such file or directory)",
+    };
+    const data = surfaceLint(parseHadolintJson(result.stdout), result);
+
+    expect(data.diagnostics).toEqual([]);
+    expect(data.error).toContain("does not exist");
+    expect(data.exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Oxlint
+// ---------------------------------------------------------------------------
+
+describe("oxlint silent-failure surfacing", () => {
+  it("does NOT attach error when issues were found (exit 1 is normal)", () => {
+    const stdout =
+      JSON.stringify({
+        file: "src/index.ts",
+        line: 5,
+        column: 7,
+        message: "'foo' is declared but never used.",
+        severity: "warning",
+        ruleId: "no-unused-vars",
+      }) + "\n";
+    const result = { exitCode: 1, stdout, stderr: "" };
+    const data = surfaceLint(parseOxlintJson(result.stdout), result);
+
+    expect(data.warnings).toBe(1);
+    expect(data.error).toBeUndefined();
+  });
+
+  it("surfaces a bad-config crash instead of a false clean", () => {
+    const result = {
+      exitCode: 1,
+      stdout: "",
+      stderr: 'Failed to parse configuration file "oxlintrc.json": expected value at line 1',
+    };
+    const data = surfaceLint(parseOxlintJson(result.stdout), result);
+
+    expect(data.diagnostics).toEqual([]);
+    expect(data.error).toContain("Failed to parse configuration file");
+    expect(data.exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// format-check (prettier --list-different)
+// ---------------------------------------------------------------------------
+
+describe("format-check silent-failure surfacing", () => {
+  /** Mirrors the composition used by the format-check tool handler. */
+  function surfaceFormatCheck(result: { exitCode: number; stdout: string; stderr: string }) {
+    const files = parsePrettierListDifferent(result.stdout);
+    const data: FormatCheckResult = { formatted: result.exitCode === 0, files };
+    return surfaceEmptyFailure(data, result, {
+      // Prettier exits 1 when files differ (normal); >1 means the run failed.
+      isEmpty: () => result.exitCode > 1,
+    });
+  }
+
+  it("does NOT attach error when files need formatting (exit 1 is normal)", () => {
+    const result = { exitCode: 1, stdout: "src/index.ts\nsrc/utils.ts\n", stderr: "" };
+    const data = surfaceFormatCheck(result);
+
+    expect(data.formatted).toBe(false);
+    expect(data.files).toEqual(["src/index.ts", "src/utils.ts"]);
+    expect(data.error).toBeUndefined();
+  });
+
+  it("does NOT attach error on a clean check (exit 0)", () => {
+    const result = { exitCode: 0, stdout: "", stderr: "" };
+    const data = surfaceFormatCheck(result);
+
+    expect(data.formatted).toBe(true);
+    expect(data.error).toBeUndefined();
+  });
+
+  it("surfaces a config error (exit 2) instead of a silent empty result (#1024)", () => {
+    const result = {
+      exitCode: 2,
+      stdout: "",
+      stderr:
+        "[error] Invalid configuration file `.prettierrc.json`: JSON Error in .prettierrc.json:\n" +
+        "[error] Unexpected token } in JSON at position 42",
+    };
+    const data = surfaceFormatCheck(result);
+
+    expect(data.formatted).toBe(false);
+    expect(data.files).toEqual([]);
+    expect(data.error).toContain("Invalid configuration file");
+    expect(data.exitCode).toBe(2);
+  });
+});

--- a/packages/server-lint/src/lib/formatters.ts
+++ b/packages/server-lint/src/lib/formatters.ts
@@ -1,7 +1,15 @@
-import type { LintResult, FormatCheckResult, FormatWriteResult } from "../schemas/index.js";
+import type {
+  LintResult,
+  LintDiagnostic,
+  FormatCheckResult,
+  FormatWriteResult,
+} from "../schemas/index.js";
 
 /** Formats structured ESLint results into a human-readable diagnostic summary with file locations. */
 export function formatLint(data: LintResult): string {
+  if (data.error) {
+    return `Lint failed (exit ${data.exitCode ?? "unknown"}): ${data.error}`;
+  }
   const total = data.errors + data.warnings;
   if (total === 0) return `Lint: no issues found (${data.filesChecked} files checked).`;
 
@@ -24,6 +32,9 @@ export function formatLint(data: LintResult): string {
 
 /** Formats structured Prettier check results into a human-readable list of unformatted files. */
 export function formatFormatCheck(data: FormatCheckResult): string {
+  if (data.error) {
+    return `Format check failed (exit ${data.exitCode ?? "unknown"}): ${data.error}`;
+  }
   if (data.formatted) return "All files are formatted.";
 
   const fileCount = (data.files ?? []).length;
@@ -58,13 +69,26 @@ export function formatFormatWrite(data: FormatWriteResult): string {
 
 // ── Compact types, mappers, and formatters ───────────────────────────
 
-/** Compact lint: counts only, no individual diagnostics. */
+/** Maximum diagnostics kept in compact lint output (#1022). */
+export const COMPACT_DIAGNOSTIC_LIMIT = 25;
+
+/** Maximum file paths kept in compact format-check/format-write output (#1021). */
+export const COMPACT_FILE_LIMIT = 50;
+
+/** Compact lint: counts plus the first {@link COMPACT_DIAGNOSTIC_LIMIT} diagnostics. */
 export interface LintResultCompact {
   [key: string]: unknown;
   errors: number;
   warnings: number;
   filesChecked: number;
+  diagnostics?: LintDiagnostic[];
+  diagnosticsTruncated?: boolean;
+  omittedCount?: number;
+  fixableErrorCount?: number;
+  fixableWarningCount?: number;
   deprecationCount?: number;
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactLintMap(data: LintResult): LintResultCompact {
@@ -73,45 +97,118 @@ export function compactLintMap(data: LintResult): LintResultCompact {
     warnings: data.warnings,
     filesChecked: data.filesChecked,
   };
+  const diagnostics = data.diagnostics ?? [];
+  if (diagnostics.length > 0) {
+    result.diagnostics = diagnostics.slice(0, COMPACT_DIAGNOSTIC_LIMIT);
+    if (diagnostics.length > COMPACT_DIAGNOSTIC_LIMIT) {
+      result.diagnosticsTruncated = true;
+      result.omittedCount = diagnostics.length - COMPACT_DIAGNOSTIC_LIMIT;
+    }
+  }
+  if (data.fixableErrorCount !== undefined) {
+    result.fixableErrorCount = data.fixableErrorCount;
+  }
+  if (data.fixableWarningCount !== undefined) {
+    result.fixableWarningCount = data.fixableWarningCount;
+  }
   if (data.deprecations && data.deprecations.length > 0) {
     result.deprecationCount = data.deprecations.length;
+  }
+  if (data.error) {
+    result.error = data.error;
+  }
+  if (data.exitCode !== undefined) {
+    result.exitCode = data.exitCode;
   }
   return result;
 }
 
 export function formatLintCompact(data: LintResultCompact): string {
+  if (data.error) {
+    return `Lint failed (exit ${data.exitCode ?? "unknown"}): ${data.error}`;
+  }
   const total = data.errors + data.warnings;
   if (total === 0) return `Lint: no issues found (${data.filesChecked} files checked).`;
   const suffix =
     data.deprecationCount && data.deprecationCount > 0
       ? ` (${data.deprecationCount} deprecations)`
       : "";
-  return `Lint: ${data.errors} errors, ${data.warnings} warnings across ${data.filesChecked} files${suffix}.`;
+  const lines = [
+    `Lint: ${data.errors} errors, ${data.warnings} warnings across ${data.filesChecked} files${suffix}.`,
+  ];
+  if (data.fixableErrorCount || data.fixableWarningCount) {
+    lines[0] +=
+      ` (${data.fixableErrorCount ?? 0} fixable errors,` +
+      ` ${data.fixableWarningCount ?? 0} fixable warnings)`;
+  }
+  for (const d of data.diagnostics ?? []) {
+    const loc = d.column ? `${d.file}:${d.line}:${d.column}` : `${d.file}:${d.line}`;
+    lines.push(`  ${loc} ${d.severity} ${d.rule}: ${d.message}`);
+  }
+  if (data.diagnosticsTruncated && data.omittedCount) {
+    lines.push(`  ... (${data.omittedCount} more diagnostics omitted)`);
+  }
+  return lines.join("\n");
 }
 
-/** Compact format check: formatted status only. */
+/** Compact format check: formatted status plus the first {@link COMPACT_FILE_LIMIT} files. */
 export interface FormatCheckResultCompact {
   [key: string]: unknown;
   formatted: boolean;
+  files?: string[];
+  total?: number;
+  filesTruncated?: boolean;
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactFormatCheckMap(data: FormatCheckResult): FormatCheckResultCompact {
-  return {
+  const result: FormatCheckResultCompact = {
     formatted: data.formatted,
   };
+  const files = data.files ?? [];
+  if (files.length > 0) {
+    result.files = files.slice(0, COMPACT_FILE_LIMIT);
+    result.total = files.length;
+    if (files.length > COMPACT_FILE_LIMIT) {
+      result.filesTruncated = true;
+    }
+  }
+  if (data.error) {
+    result.error = data.error;
+  }
+  if (data.exitCode !== undefined) {
+    result.exitCode = data.exitCode;
+  }
+  return result;
 }
 
 export function formatFormatCheckCompact(data: FormatCheckResultCompact): string {
+  if (data.error) {
+    return `Format check failed (exit ${data.exitCode ?? "unknown"}): ${data.error}`;
+  }
   if (data.formatted) return "All files are formatted.";
-  return "Some files need formatting.";
+  const files = data.files ?? [];
+  if (files.length === 0) return "Some files need formatting.";
+  const total = data.total ?? files.length;
+  const lines = [`${total} files need formatting:`];
+  for (const f of files) {
+    lines.push(`  ${f}`);
+  }
+  if (data.filesTruncated) {
+    lines.push(`  ... (${total - files.length} more files omitted)`);
+  }
+  return lines.join("\n");
 }
 
-/** Compact format write: counts only, no individual file paths. */
+/** Compact format write: counts plus the first {@link COMPACT_FILE_LIMIT} reformatted files. */
 export interface FormatWriteResultCompact {
   [key: string]: unknown;
   success: boolean;
   filesChanged: number;
   filesUnchanged?: number;
+  files?: string[];
+  filesTruncated?: boolean;
   errorMessage?: string;
 }
 
@@ -122,6 +219,13 @@ export function compactFormatWriteMap(data: FormatWriteResult): FormatWriteResul
   };
   if (data.filesUnchanged !== undefined) {
     result.filesUnchanged = data.filesUnchanged;
+  }
+  const files = data.files ?? [];
+  if (files.length > 0) {
+    result.files = files.slice(0, COMPACT_FILE_LIMIT);
+    if (files.length > COMPACT_FILE_LIMIT) {
+      result.filesTruncated = true;
+    }
   }
   if (data.errorMessage) {
     result.errorMessage = data.errorMessage;
@@ -134,8 +238,15 @@ export function formatFormatWriteCompact(data: FormatWriteResultCompact): string
     return data.errorMessage ? `Format failed: ${data.errorMessage}` : "Format failed.";
   }
   if (data.filesChanged === 0) return "All files already formatted.";
+  const lines = [`Formatted ${data.filesChanged} files:`];
   if (data.filesUnchanged !== undefined && data.filesUnchanged > 0) {
-    return `Formatted ${data.filesChanged} files (${data.filesUnchanged} already formatted).`;
+    lines[0] = `Formatted ${data.filesChanged} files (${data.filesUnchanged} already formatted):`;
   }
-  return `Formatted ${data.filesChanged} files.`;
+  for (const f of data.files ?? []) {
+    lines.push(`  ${f}`);
+  }
+  if (data.filesTruncated) {
+    lines.push(`  ... (${data.filesChanged - (data.files ?? []).length} more files omitted)`);
+  }
+  return lines.join("\n");
 }

--- a/packages/server-lint/src/schemas/index.ts
+++ b/packages/server-lint/src/schemas/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { EmptyFailureSchemaFields } from "@paretools/shared";
 
 /** Zod schema for a single ESLint diagnostic with file location, severity, rule name, and message. */
 export const LintDiagnosticSchema = z.object({
@@ -26,6 +27,11 @@ export const LintResultSchema = z.object({
       }),
     )
     .optional(),
+  /** Whether the compact diagnostics list was capped (only set when true). */
+  diagnosticsTruncated: z.boolean().optional(),
+  /** Number of diagnostics omitted from the compact list (set alongside diagnosticsTruncated). */
+  omittedCount: z.number().optional(),
+  ...EmptyFailureSchemaFields,
 });
 
 export type LintResult = z.infer<typeof LintResultSchema>;
@@ -35,6 +41,11 @@ export type LintDiagnostic = z.infer<typeof LintDiagnosticSchema>;
 export const FormatCheckResultSchema = z.object({
   formatted: z.boolean(),
   files: z.array(z.string()).optional(),
+  /** Total number of files needing formatting (may exceed files.length in compact mode). */
+  total: z.number().optional(),
+  /** Whether the compact file list was capped (only set when true). */
+  filesTruncated: z.boolean().optional(),
+  ...EmptyFailureSchemaFields,
 });
 
 export type FormatCheckResult = z.infer<typeof FormatCheckResultSchema>;
@@ -44,6 +55,8 @@ export const FormatWriteResultSchema = z.object({
   filesChanged: z.number(),
   filesUnchanged: z.number().optional(),
   files: z.array(z.string()).optional(),
+  /** Whether the compact file list was capped (only set when true). */
+  filesTruncated: z.boolean().optional(),
   success: z.boolean(),
   errorMessage: z.string().optional(),
 });

--- a/packages/server-lint/src/tools/biome-check.ts
+++ b/packages/server-lint/src/tools/biome-check.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   compactDualOutput,
   assertNoFlagInjection,
+  surfaceEmptyFailure,
   INPUT_LIMITS,
   compactInput,
   projectPathInput,
@@ -131,7 +132,12 @@ export function registerBiomeCheckTool(server: McpServer) {
       args.push(...(patterns || ["."]));
 
       const result = await biome(args, cwd);
-      const data = parseBiomeJson(result.stdout);
+      // Biome exits 1 when diagnostics are found (normal). A non-zero exit with
+      // zero parsed diagnostics means the run itself failed (bad config,
+      // internal error) — surface it instead of reporting a false clean (#1024).
+      const data = surfaceEmptyFailure(parseBiomeJson(result.stdout), result, {
+        isEmpty: (d) => (d.diagnostics ?? []).length === 0,
+      });
       return compactDualOutput(
         data,
         result.stdout,

--- a/packages/server-lint/src/tools/format-check.ts
+++ b/packages/server-lint/src/tools/format-check.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   compactDualOutput,
   assertNoFlagInjection,
+  surfaceEmptyFailure,
   INPUT_LIMITS,
   compactInput,
   projectPathInput,
@@ -126,10 +127,12 @@ export function registerFormatCheckTool(server: McpServer) {
 
       const result = await prettier(args, cwd);
       const files = parsePrettierListDifferent(result.stdout);
-      const data = {
-        formatted: result.exitCode === 0,
-        files,
-      };
+      // Prettier exits 1 when files need formatting (normal for
+      // --list-different); exit >1 means the run itself failed (config error,
+      // parse error) — surface stderr instead of a silent empty result (#1024).
+      const data = surfaceEmptyFailure({ formatted: result.exitCode === 0, files }, result, {
+        isEmpty: () => result.exitCode > 1,
+      });
       return compactDualOutput(
         data,
         result.stdout,

--- a/packages/server-lint/src/tools/hadolint.ts
+++ b/packages/server-lint/src/tools/hadolint.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   compactDualOutput,
   assertNoFlagInjection,
+  surfaceEmptyFailure,
   INPUT_LIMITS,
   compactInput,
   projectPathInput,
@@ -173,7 +174,12 @@ export function registerHadolintTool(server: McpServer) {
       args.push(...(patterns || ["Dockerfile"]));
 
       const result = await hadolintCmd(args, cwd);
-      const data = parseHadolintJson(result.stdout);
+      // Hadolint exits 1 when violations are found (normal). A non-zero exit
+      // with zero parsed diagnostics means the run itself failed (missing
+      // file, bad config) — surface it instead of a false clean (#1024).
+      const data = surfaceEmptyFailure(parseHadolintJson(result.stdout), result, {
+        isEmpty: (d) => (d.diagnostics ?? []).length === 0,
+      });
       return compactDualOutput(
         data,
         result.stdout,

--- a/packages/server-lint/src/tools/lint.ts
+++ b/packages/server-lint/src/tools/lint.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   compactDualOutput,
   assertNoFlagInjection,
+  surfaceEmptyFailure,
   INPUT_LIMITS,
   compactInput,
   projectPathInput,
@@ -113,7 +114,12 @@ export function registerLintTool(server: McpServer) {
       }
 
       const result = await eslint(args, cwd);
-      const data = parseEslintJson(result.stdout);
+      // ESLint exits 1 when violations are found (normal) and 2 on config/fatal
+      // errors. A non-zero exit with zero parsed diagnostics means the run
+      // itself failed — surface it instead of reporting a false clean (#1024).
+      const data = surfaceEmptyFailure(parseEslintJson(result.stdout), result, {
+        isEmpty: (d) => (d.diagnostics ?? []).length === 0,
+      });
       return compactDualOutput(
         data,
         result.stdout,

--- a/packages/server-lint/src/tools/oxlint.ts
+++ b/packages/server-lint/src/tools/oxlint.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   compactDualOutput,
   assertNoFlagInjection,
+  surfaceEmptyFailure,
   INPUT_LIMITS,
   compactInput,
   projectPathInput,
@@ -154,7 +155,12 @@ export function registerOxlintTool(server: McpServer) {
       }
 
       const result = await oxlintCmd(args, cwd);
-      const data = parseOxlintJson(result.stdout);
+      // Oxlint exits 1 when lint issues are found (normal). A non-zero exit
+      // with zero parsed diagnostics means the run itself failed (bad config,
+      // crash) — surface it instead of reporting a false clean (#1024).
+      const data = surfaceEmptyFailure(parseOxlintJson(result.stdout), result, {
+        isEmpty: (d) => (d.diagnostics ?? []).length === 0,
+      });
       return compactDualOutput(
         data,
         result.stdout,

--- a/packages/server-lint/src/tools/shellcheck.ts
+++ b/packages/server-lint/src/tools/shellcheck.ts
@@ -4,6 +4,7 @@ import {
   compactDualOutput,
   dualOutput,
   assertNoFlagInjection,
+  surfaceEmptyFailure,
   INPUT_LIMITS,
   compactInput,
   projectPathInput,
@@ -158,7 +159,13 @@ export function registerShellcheckTool(server: McpServer) {
       args.push(...resolvedFiles);
 
       const result = await shellcheckCmd(args, cwd);
-      const data = parseShellcheckJson(result.stdout);
+      // ShellCheck exits 1 when issues are found (normal); exit 2+ signals it
+      // could not process the files. A non-zero exit with zero parsed
+      // diagnostics means the run itself failed — surface it instead of
+      // reporting a false clean (#1024).
+      const data = surfaceEmptyFailure(parseShellcheckJson(result.stdout), result, {
+        isEmpty: (d) => (d.diagnostics ?? []).length === 0,
+      });
       return compactDualOutput(
         data,
         result.stdout,

--- a/packages/server-lint/src/tools/stylelint.ts
+++ b/packages/server-lint/src/tools/stylelint.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   compactDualOutput,
   assertNoFlagInjection,
+  surfaceEmptyFailure,
   INPUT_LIMITS,
   compactInput,
   projectPathInput,
@@ -104,7 +105,13 @@ export function registerStylelintTool(server: McpServer) {
       }
 
       const result = await stylelintCmd(args, cwd);
-      const data = parseStylelintJson(result.stdout);
+      // Stylelint exits 2 when violations are found (normal); exit 1 signals a
+      // fatal error and 78 a config problem. A non-zero exit with zero parsed
+      // diagnostics means the run itself failed — surface it instead of
+      // reporting a false clean (#1024).
+      const data = surfaceEmptyFailure(parseStylelintJson(result.stdout), result, {
+        isEmpty: (d) => (d.diagnostics ?? []).length === 0,
+      });
       return compactDualOutput(
         data,
         result.stdout,


### PR DESCRIPTION
## Summary

Implements the `server-lint` slice of the silent-empty-failure epic (#1024) and the compact-payload-loss epic (#1022), using the shared helpers from #1026.

### Silent false-clean fixes (#1024)

- All six linter tools (`lint`/eslint, `biome-check`, `stylelint`, `shellcheck`, `hadolint`, `oxlint`) now apply `surfaceEmptyFailure` in the tool handler: when the CLI exits non-zero AND zero diagnostics were parsed, the result carries `error` (tail of stderr/stdout) and `exitCode` instead of looking like a clean run. Exit codes that merely signal "violations found" (eslint 1, stylelint 2, shellcheck 1, etc.) never attach an error because diagnostics are non-empty.
- `format-check`: prettier exit > 1 (config/parse error) now surfaces `error` + `exitCode` instead of a silent `{formatted: false, files: []}`. Exit 1 (files differ) stays a normal result.
- `LintResultSchema` and `FormatCheckResultSchema` gained the shared `EmptyFailureSchemaFields` (`error`, `exitCode`).

### Compact-mode fixes (#1022, closes #1021)

- `compactLintMap` (shared by all 6 linters) keeps the first 25 diagnostics (full shape: file/line/column/severity/rule/message) with `diagnosticsTruncated` + `omittedCount`, and keeps `fixableErrorCount`/`fixableWarningCount`.
- `compactFormatCheckMap` includes the failing `files` list (capped at 50 with `filesTruncated`) and `total` — fixes #1021's `{formatted:false}`-only payload.
- `compactFormatWriteMap` includes the `files[]` list of reformatted files (capped at 50 with `filesTruncated`).
- `error`/`exitCode` always pass through compact projections, and all compact text formatters render the new fields.
- Compact projections still validate against the registered output schemas (covered by tests).

## Tests

- New `__tests__/silent-failures.test.ts`: per-linter fixture pairs — "violations found" (non-zero exit, no error attached) and "config crash" (error + exitCode attached) — using real CLI output shapes, plus format-check exit-semantics coverage.
- `__tests__/compact.test.ts` updated for the new compact shapes (caps, truncation metadata, error passthrough, schema validation).
- `@paretools/lint`: 294/294 tests pass; package builds clean; ESLint and Prettier clean.

Closes #1021
Part of #1022 and #1024