### PR TITLE
fix(go): surface toolchain failures and restore compact payloads

### DIFF
--- a/.changeset/fix-go-silent-and-compact.md
+++ b/.changeset/fix-go-silent-and-compact.md
@@ -1,0 +1,12 @@
+---
+"@paretools/go": patch
+---
+
+Surface toolchain failures and restore compact payloads (#1022, #1024).
+
+- `go test`: toolchain failures (e.g. "go: cannot find main module", bad -tags) that previously read as a zeroed clean result now surface the raw stderr tail via a new `error` field plus `exitCode`. Normal test failures are unaffected.
+- `golangci-lint`: the parser now uses the exit code and stderr; linter crashes/config errors that previously read as a clean `{diagnostics: [], errors: 0}` result now surface `error` and `exitCode`. Exit code 1 with issues found remains a normal result.
+- Compact `run`: stdout/stderr content is now kept (truncated to the shared compact budget with `stdoutTruncated`/`stderrTruncated` flags and total line counts) instead of being dropped entirely.
+- Compact `get`: failing packages are kept with their `error`/`errorType` instead of being dropped.
+- Compact `fmt`: parse errors are kept in full instead of being reduced to a count.
+- Compact `golangci-lint`: the first 20 diagnostics are now included (fix data stripped, `diagnosticsOmitted` count when capped) instead of counts only; `error` is passed through.

--- a/packages/server-go/__tests__/compact.test.ts
+++ b/packages/server-go/__tests__/compact.test.ts
@@ -20,6 +20,9 @@ import {
   formatListCompact,
   compactGetMap,
   formatGetCompact,
+  compactGolangciLintMap,
+  formatGolangciLintCompact,
+  GOLANGCI_LINT_COMPACT_MAX_DIAGNOSTICS,
 } from "../src/lib/formatters.js";
 import type {
   GoBuildResult,
@@ -32,6 +35,7 @@ import type {
   GoEnvResult,
   GoListResult,
   GoGetResult,
+  GolangciLintResult,
 } from "../src/schemas/index.js";
 
 // ---------------------------------------------------------------------------
@@ -231,7 +235,7 @@ describe("formatFmtCompact", () => {
 // run
 // ---------------------------------------------------------------------------
 describe("compactRunMap", () => {
-  it("keeps exitCode and success, drops stdout/stderr", () => {
+  it("keeps exitCode, success, and short stdout/stderr content (#1022)", () => {
     const data: GoRunResult = {
       exitCode: 0,
       stdout: "Hello, World!\nLine 2",
@@ -243,11 +247,12 @@ describe("compactRunMap", () => {
 
     expect(compact.exitCode).toBe(0);
     expect(compact.success).toBe(true);
-    expect(compact).not.toHaveProperty("stdout");
+    expect(compact.stdout).toBe("Hello, World!\nLine 2");
     expect(compact).not.toHaveProperty("stderr");
+    expect(compact).not.toHaveProperty("stdoutTruncated");
   });
 
-  it("preserves non-zero exit code", () => {
+  it("preserves non-zero exit code and stderr content", () => {
     const data: GoRunResult = {
       exitCode: 2,
       stdout: "",
@@ -259,6 +264,41 @@ describe("compactRunMap", () => {
 
     expect(compact.exitCode).toBe(2);
     expect(compact.success).toBe(false);
+    expect(compact.stderr).toBe("panic: runtime error");
+  });
+
+  it("truncates long streams to the compact budget with flags and total lines", () => {
+    const stdout = Array.from({ length: 200 }, (_, i) => `line ${i}`).join("\n");
+    const data: GoRunResult = {
+      exitCode: 0,
+      stdout,
+      stderr: "",
+      success: true,
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.stdoutTruncated).toBe(true);
+    expect(compact.stdoutTotalLines).toBe(200);
+    expect(compact.stdout).toContain("line 0");
+    expect(compact.stdout).toContain("line 199");
+    expect(compact.stdout).toContain("lines omitted");
+    expect(compact.stdout!.length).toBeLessThan(stdout.length);
+  });
+
+  it("preserves upstream maxOutput truncation flags", () => {
+    const data: GoRunResult = {
+      exitCode: 0,
+      stdout: "partial output\n... (truncated)",
+      stderr: "",
+      stdoutTruncated: true,
+      success: true,
+    };
+
+    const compact = compactRunMap(data);
+
+    expect(compact.stdoutTruncated).toBe(true);
+    expect(compact.stdout).toContain("partial output");
   });
 });
 
@@ -269,6 +309,21 @@ describe("formatRunCompact", () => {
 
   it("formats failed run with exit code", () => {
     expect(formatRunCompact({ exitCode: 2, success: false })).toBe("go run: exit code 2.");
+  });
+
+  it("includes stream content and truncation notes (#1022)", () => {
+    const text = formatRunCompact({
+      exitCode: 1,
+      success: false,
+      stdout: "some output",
+      stderr: "boom",
+      stderrTruncated: true,
+      stderrTotalLines: 500,
+    });
+    expect(text).toContain("go run: exit code 1.");
+    expect(text).toContain("some output");
+    expect(text).toContain("boom");
+    expect(text).toContain("[stderr truncated: 500 total lines");
   });
 });
 
@@ -629,10 +684,10 @@ describe("compactEnvMap — queried vars (Gap #150)", () => {
   });
 });
 
-// ─── Gap #151: fmt compact with parse error count ───────────────────
+// ─── Gap #151 / #1022: fmt compact keeps parse errors ───────────────
 
-describe("compactFmtMap — parseErrorCount (Gap #151)", () => {
-  it("includes parseErrorCount when parse errors present", () => {
+describe("compactFmtMap — parseErrors (#1022)", () => {
+  it("keeps the full parseErrors array (real errors, not noise)", () => {
     const data: GoFmtResult = {
       success: false,
       filesChanged: 1,
@@ -642,10 +697,11 @@ describe("compactFmtMap — parseErrorCount (Gap #151)", () => {
 
     const compact = compactFmtMap(data);
 
-    expect(compact.parseErrorCount).toBe(1);
+    expect(compact.parseErrors).toEqual(data.parseErrors);
+    expect(compact).not.toHaveProperty("files");
   });
 
-  it("does not include parseErrorCount when no parse errors", () => {
+  it("does not include parseErrors when no parse errors", () => {
     const data: GoFmtResult = {
       success: true,
       filesChanged: 0,
@@ -654,15 +710,21 @@ describe("compactFmtMap — parseErrorCount (Gap #151)", () => {
 
     const compact = compactFmtMap(data);
 
-    expect(compact).not.toHaveProperty("parseErrorCount");
+    expect(compact).not.toHaveProperty("parseErrors");
   });
 });
 
-describe("formatFmtCompact — parseErrorCount (Gap #151)", () => {
-  it("includes parse error count in compact format", () => {
-    expect(formatFmtCompact({ success: false, filesChanged: 2, parseErrorCount: 3 })).toBe(
-      "gofmt: 2 files, 3 parse errors",
-    );
+describe("formatFmtCompact — parseErrors (#1022)", () => {
+  it("lists parse errors in compact format", () => {
+    const text = formatFmtCompact({
+      success: false,
+      filesChanged: 2,
+      parseErrors: [
+        { file: "broken.go", line: 5, column: 1, message: "expected declaration, found foo" },
+      ],
+    });
+    expect(text).toContain("gofmt: 2 files, 1 parse errors");
+    expect(text).toContain("broken.go:5:1: expected declaration, found foo");
   });
 });
 
@@ -735,5 +797,192 @@ describe("formatModTidyCompact — madeChanges (Gap #156)", () => {
 
   it("formats without madeChanges", () => {
     expect(formatModTidyCompact({ success: true })).toBe("go mod tidy: success.");
+  });
+});
+
+// ─── #1022: get compact keeps failing packages ──────────────────────
+
+describe("compactGetMap — failing packages (#1022)", () => {
+  it("keeps packages with error/errorType on failure", () => {
+    const data: GoGetResult = {
+      success: false,
+      packages: [
+        { path: "github.com/ok/pkg", version: "v1.0.0" },
+        {
+          path: "github.com/nonexistent/pkg",
+          error: 'no matching versions for query "latest"',
+          errorType: "unknown",
+        },
+      ],
+    };
+
+    const compact = compactGetMap(data);
+
+    expect(compact.success).toBe(false);
+    expect(compact.packages).toHaveLength(1);
+    expect(compact.packages![0].path).toBe("github.com/nonexistent/pkg");
+    expect(compact.packages![0].error).toBe('no matching versions for query "latest"');
+    expect(compact.packages![0].errorType).toBe("unknown");
+  });
+
+  it("omits packages when none failed", () => {
+    const data: GoGetResult = {
+      success: true,
+      packages: [{ path: "github.com/ok/pkg", version: "v1.0.0" }],
+    };
+
+    const compact = compactGetMap(data);
+
+    expect(compact).not.toHaveProperty("packages");
+  });
+});
+
+describe("formatGetCompact — failing packages (#1022)", () => {
+  it("lists per-package errors", () => {
+    const text = formatGetCompact({
+      success: false,
+      resolvedCount: 0,
+      packages: [
+        {
+          path: "github.com/nonexistent/pkg",
+          error: "no matching versions",
+          errorType: "unknown",
+        },
+      ],
+    });
+    expect(text).toContain("go get: FAIL");
+    expect(text).toContain("github.com/nonexistent/pkg [unknown]: no matching versions");
+  });
+});
+
+// ─── #1024: test compact passes through toolchain error ─────────────
+
+describe("compactTestMap — error passthrough (#1024)", () => {
+  it("keeps error and exitCode from a surfaced toolchain failure", () => {
+    const data: GoTestResult = {
+      success: false,
+      tests: [],
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      error: "go: cannot find main module, but found .git/config",
+      exitCode: 1,
+    };
+
+    const compact = compactTestMap(data);
+
+    expect(compact.error).toBe("go: cannot find main module, but found .git/config");
+    expect(compact.exitCode).toBe(1);
+  });
+
+  it("omits error when not set", () => {
+    const data: GoTestResult = { success: true, tests: [], passed: 3, failed: 0, skipped: 0 };
+
+    const compact = compactTestMap(data);
+
+    expect(compact).not.toHaveProperty("error");
+    expect(compact).not.toHaveProperty("exitCode");
+  });
+});
+
+describe("formatTestCompact — error (#1024)", () => {
+  it("shows the toolchain error", () => {
+    const text = formatTestCompact({
+      success: false,
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      error: "go: cannot find main module",
+    });
+    expect(text).toContain("FAIL: 0 passed, 0 failed, 0 skipped");
+    expect(text).toContain("go: cannot find main module");
+  });
+});
+
+// ─── #1022/#1024: golangci-lint compact diagnostics + error ─────────
+
+describe("compactGolangciLintMap (#1022)", () => {
+  const diag = (i: number): NonNullable<GolangciLintResult["diagnostics"]>[number] => ({
+    file: `file${i}.go`,
+    line: i,
+    column: 2,
+    linter: "govet",
+    severity: "warning" as const,
+    message: `issue ${i}`,
+  });
+
+  it("keeps the first N diagnostics with fix data stripped", () => {
+    const diagnostics = Array.from({ length: 5 }, (_, i) => ({
+      ...diag(i),
+      fix: { text: "replacement" },
+    }));
+    const data: GolangciLintResult = { diagnostics, errors: 0, warnings: 5 };
+
+    const compact = compactGolangciLintMap(data);
+
+    expect(compact.diagnostics).toHaveLength(5);
+    expect(compact.diagnostics![0]).not.toHaveProperty("fix");
+    expect(compact.diagnostics![0].message).toBe("issue 0");
+    expect(compact).not.toHaveProperty("diagnosticsOmitted");
+  });
+
+  it("caps diagnostics and reports omitted count", () => {
+    const count = GOLANGCI_LINT_COMPACT_MAX_DIAGNOSTICS + 7;
+    const diagnostics = Array.from({ length: count }, (_, i) => diag(i));
+    const data: GolangciLintResult = { diagnostics, errors: 0, warnings: count };
+
+    const compact = compactGolangciLintMap(data);
+
+    expect(compact.diagnostics).toHaveLength(GOLANGCI_LINT_COMPACT_MAX_DIAGNOSTICS);
+    expect(compact.diagnosticsOmitted).toBe(7);
+  });
+
+  it("passes through error and exitCode from a surfaced linter failure (#1024)", () => {
+    const data: GolangciLintResult = {
+      diagnostics: [],
+      errors: 0,
+      warnings: 0,
+      error: "Can't read config: unknown linter 'bogus'",
+      exitCode: 3,
+    };
+
+    const compact = compactGolangciLintMap(data);
+
+    expect(compact.error).toBe("Can't read config: unknown linter 'bogus'");
+    expect(compact.exitCode).toBe(3);
+  });
+});
+
+describe("formatGolangciLintCompact (#1022)", () => {
+  it("lists kept diagnostics and omitted count", () => {
+    const text = formatGolangciLintCompact({
+      errors: 1,
+      warnings: 21,
+      diagnostics: [
+        {
+          file: "main.go",
+          line: 10,
+          column: 5,
+          linter: "govet",
+          severity: "warning",
+          message: "unreachable code",
+        },
+      ],
+      diagnosticsOmitted: 2,
+    });
+    expect(text).toContain("golangci-lint: 22 issues (1 errors, 21 warnings)");
+    expect(text).toContain("main.go:10:5: unreachable code (govet)");
+    expect(text).toContain("... 2 more");
+  });
+
+  it("shows the linter failure error", () => {
+    const text = formatGolangciLintCompact({
+      errors: 0,
+      warnings: 0,
+      error: "Can't read config",
+      exitCode: 3,
+    });
+    expect(text).toContain("golangci-lint: FAIL (exit code 3)");
+    expect(text).toContain("Can't read config");
   });
 });

--- a/packages/server-go/__tests__/parsers.test.ts
+++ b/packages/server-go/__tests__/parsers.test.ts
@@ -302,6 +302,77 @@ describe("parseGoTestJson", () => {
   });
 });
 
+// ─── #1024: go test silent-failure surfacing ────────────────────────
+
+describe("parseGoTestJson — silent failure surfacing (#1024)", () => {
+  it("surfaces a toolchain error from stderr when no tests parsed", () => {
+    const stderr = "go: cannot find main module, but found .git/config in /repo\n";
+    const result = parseGoTestJson("", 1, stderr);
+
+    expect(result.success).toBe(false);
+    expect(result.passed).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.error).toBe("go: cannot find main module, but found .git/config in /repo");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("surfaces a bad build tag error", () => {
+    const stderr = 'go: -tags= flag: malformed tag "bad tag"';
+    const result = parseGoTestJson("", 2, stderr);
+
+    expect(result.error).toContain("malformed tag");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("does NOT set error when test failures were parsed (normal non-zero exit)", () => {
+    const stdout = [
+      JSON.stringify({ Action: "run", Package: "myapp", Test: "TestFail" }),
+      JSON.stringify({ Action: "fail", Package: "myapp", Test: "TestFail", Elapsed: 0.01 }),
+    ].join("\n");
+    const result = parseGoTestJson(stdout, 1, "some stderr noise");
+
+    expect(result.failed).toBe(1);
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("does NOT set error when package failures were parsed", () => {
+    const stdout = [
+      JSON.stringify({
+        Action: "output",
+        Package: "myapp/broken",
+        Output: "./main.go:5:2: undefined: missingFunc\n",
+      }),
+      JSON.stringify({ Action: "fail", Package: "myapp/broken", Elapsed: 0.1 }),
+    ].join("\n");
+    const result = parseGoTestJson(stdout, 1, "");
+
+    expect(result.packageFailures).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("does NOT set error on clean empty run (exit 0)", () => {
+    const result = parseGoTestJson("", 0, "");
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("falls back to stdout when stderr is empty", () => {
+    const result = parseGoTestJson("malformed non-JSON output", 1, "");
+
+    expect(result.error).toBe("malformed non-JSON output");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("uses a fallback message when both streams are empty on failure", () => {
+    const result = parseGoTestJson("", 1, "");
+
+    expect(result.error).toContain("exited with code 1");
+    expect(result.exitCode).toBe(1);
+  });
+});
+
 describe("parseGoVetOutput", () => {
   it("parses vet diagnostics from text output (fallback)", () => {
     const stderr = [
@@ -829,10 +900,12 @@ describe("parseGolangciLintJson", () => {
     expect(result.warnings).toBe(0);
   });
 
-  it("handles malformed JSON", () => {
+  it("handles malformed JSON by surfacing the failure (#1024)", () => {
     const result = parseGolangciLintJson("not valid json", 1);
 
     expect(result.diagnostics).toHaveLength(0);
+    expect(result.error).toBe("not valid json");
+    expect(result.exitCode).toBe(1);
   });
 
   it("groups diagnostics by linter", () => {
@@ -869,6 +942,53 @@ describe("parseGolangciLintJson", () => {
     const result = parseGolangciLintJson(stdout, 0);
 
     expect(result.diagnostics).toHaveLength(0);
+  });
+});
+
+// ─── #1024: golangci-lint silent-failure surfacing ──────────────────
+
+describe("parseGolangciLintJson — silent failure surfacing (#1024)", () => {
+  it("surfaces a config error from stderr on empty stdout", () => {
+    const stderr =
+      "level=error msg=\"Can't read config: can't read viper config: While parsing config: yaml: line 3: mapping values are not allowed in this context\"";
+    const result = parseGolangciLintJson("", 3, stderr);
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.errors).toBe(0);
+    expect(result.error).toContain("Can't read config");
+    expect(result.exitCode).toBe(3);
+  });
+
+  it("prefers stderr over unparseable stdout for the error detail", () => {
+    const result = parseGolangciLintJson("garbage output", 2, 'level=error msg="linter panic"');
+
+    expect(result.error).toContain("linter panic");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("does NOT set error when issues were found (normal exit 1)", () => {
+    const stdout = JSON.stringify({
+      Issues: [{ FromLinter: "govet", Text: "issue", Pos: { Filename: "a.go", Line: 1 } }],
+    });
+    const result = parseGolangciLintJson(stdout, 1, "some stderr noise");
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("does NOT set error on a clean run (exit 0, empty output)", () => {
+    const result = parseGolangciLintJson("", 0, "");
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("uses a fallback message when both streams are empty on failure", () => {
+    const result = parseGolangciLintJson("", 4, "");
+
+    expect(result.error).toContain("exited with code 4");
+    expect(result.exitCode).toBe(4);
   });
 });
 

--- a/packages/server-go/src/lib/formatters.ts
+++ b/packages/server-go/src/lib/formatters.ts
@@ -1,3 +1,4 @@
+import { compactStreamFields } from "@paretools/shared";
 import type {
   GoBuildResult,
   GoTestResult,
@@ -44,6 +45,12 @@ export function formatGoTest(data: GoTestResult): string {
   const lines = [
     `${status}: ${data.passed} passed, ${data.failed} failed, ${data.skipped} skipped`,
   ];
+  if (data.error) {
+    lines.push("Toolchain error:");
+    for (const errorLine of data.error.split("\n")) {
+      lines.push(`  ${errorLine}`);
+    }
+  }
   for (const t of data.tests ?? []) {
     const elapsed = t.elapsed !== undefined ? ` (${t.elapsed}s)` : "";
     lines.push(`  ${t.status.padEnd(4)} ${t.package}/${t.name}${elapsed}`);
@@ -233,7 +240,7 @@ export function formatBuildCompact(data: GoBuildCompact): string {
   return `go build: ${total} errors`;
 }
 
-/** Compact test: passed, failed, skipped. Drop individual test details but keep package failures. */
+/** Compact test: passed, failed, skipped. Drop individual test details but keep package failures and toolchain errors. */
 export interface GoTestCompact {
   [key: string]: unknown;
   success: boolean;
@@ -241,6 +248,8 @@ export interface GoTestCompact {
   failed: number;
   skipped: number;
   packageFailures?: GoTestResult["packageFailures"];
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactTestMap(data: GoTestResult): GoTestCompact {
@@ -251,12 +260,23 @@ export function compactTestMap(data: GoTestResult): GoTestCompact {
     skipped: data.skipped,
   };
   if (data.packageFailures?.length) compact.packageFailures = data.packageFailures;
+  if (data.error) compact.error = data.error;
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
   return compact;
 }
 
 export function formatTestCompact(data: GoTestCompact): string {
   const status = data.success ? "ok" : "FAIL";
-  return `${status}: ${data.passed} passed, ${data.failed} failed, ${data.skipped} skipped`;
+  const lines = [
+    `${status}: ${data.passed} passed, ${data.failed} failed, ${data.skipped} skipped`,
+  ];
+  if (data.error) {
+    lines.push("Toolchain error:");
+    for (const errorLine of data.error.split("\n")) {
+      lines.push(`  ${errorLine}`);
+    }
+  }
+  return lines.join("\n");
 }
 
 /** Compact vet: success + diagnostics preserved when non-empty (total derived from diagnostics). */
@@ -280,12 +300,12 @@ export function formatVetCompact(data: GoVetCompact): string {
   return `go vet: ${total} issues`;
 }
 
-/** Compact fmt: success, file count. Drop individual file list and parse errors. */
+/** Compact fmt: success, file count. Drop the file list but keep parse errors — they are real errors, not noise (#1022). */
 export interface GoFmtCompact {
   [key: string]: unknown;
   success: boolean;
   filesChanged: number;
-  parseErrorCount?: number;
+  parseErrors?: GoFmtResult["parseErrors"];
 }
 
 export function compactFmtMap(data: GoFmtResult): GoFmtCompact {
@@ -293,42 +313,77 @@ export function compactFmtMap(data: GoFmtResult): GoFmtCompact {
     success: data.success,
     filesChanged: data.filesChanged,
   };
-  if (data.parseErrors?.length) compact.parseErrorCount = data.parseErrors.length;
+  if (data.parseErrors?.length) compact.parseErrors = data.parseErrors;
   return compact;
 }
 
 export function formatFmtCompact(data: GoFmtCompact): string {
-  if (data.success && data.filesChanged === 0) return "gofmt: all files formatted.";
-  const parts = [`gofmt: ${data.filesChanged} files`];
-  if (data.parseErrorCount) parts.push(`${data.parseErrorCount} parse errors`);
-  return parts.join(", ");
+  const parseErrors = data.parseErrors ?? [];
+  if (data.success && data.filesChanged === 0 && parseErrors.length === 0) {
+    return "gofmt: all files formatted.";
+  }
+  const lines = [
+    `gofmt: ${data.filesChanged} files` +
+      (parseErrors.length > 0 ? `, ${parseErrors.length} parse errors` : ""),
+  ];
+  for (const pe of parseErrors) {
+    const col = pe.column ? `:${pe.column}` : "";
+    lines.push(`  ${pe.file}:${pe.line}${col}: ${pe.message}`);
+  }
+  return lines.join("\n");
 }
 
-/** Compact run: exitCode, success, truncation flags. Drop stdout/stderr (signal removed from schema). */
+/** Compact run: exitCode, success, and stdout/stderr truncated to the shared compact budget (#1022, the #983/#1020 pattern). */
 export interface GoRunCompact {
   [key: string]: unknown;
   exitCode: number;
   success: boolean;
   timedOut?: boolean;
+  stdout?: string;
+  stderr?: string;
   stdoutTruncated?: boolean;
   stderrTruncated?: boolean;
+  stdoutTotalLines?: number;
+  stderrTotalLines?: number;
 }
 
 export function compactRunMap(data: GoRunResult): GoRunCompact {
   const compact: GoRunCompact = {
     exitCode: data.exitCode,
     success: data.success,
+    ...compactStreamFields(data.stdout, data.stderr),
   };
   if (data.timedOut) compact.timedOut = true;
+  // Preserve pre-existing truncation flags (maxOutput limit applied upstream)
   if (data.stdoutTruncated) compact.stdoutTruncated = true;
   if (data.stderrTruncated) compact.stderrTruncated = true;
   return compact;
 }
 
 export function formatRunCompact(data: GoRunCompact): string {
-  if (data.timedOut) return "go run: timed out.";
-  if (data.success) return "go run: success.";
-  return `go run: exit code ${data.exitCode}.`;
+  const lines: string[] = [];
+  if (data.timedOut) {
+    lines.push("go run: timed out.");
+  } else if (data.success) {
+    lines.push("go run: success.");
+  } else {
+    lines.push(`go run: exit code ${data.exitCode}.`);
+  }
+  if (data.stdout) {
+    lines.push(data.stdout);
+    if (data.stdoutTruncated) {
+      const total = data.stdoutTotalLines ? `: ${data.stdoutTotalLines} total lines` : "";
+      lines.push(`  [stdout truncated${total}; re-run with compact:false for full output]`);
+    }
+  }
+  if (data.stderr) {
+    lines.push(data.stderr);
+    if (data.stderrTruncated) {
+      const total = data.stderrTotalLines ? `: ${data.stderrTotalLines} total lines` : "";
+      lines.push(`  [stderr truncated${total}; re-run with compact:false for full output]`);
+    }
+  }
+  return lines.join("\n");
 }
 
 /** Compact generate: success. Output included when non-empty. */
@@ -569,26 +624,42 @@ export function formatGoGet(data: GoGetResult): string {
   return lines.join("\n");
 }
 
-/** Compact get: success + resolved package count. Drop individual details (output removed from schema). */
+/** Compact get: success + resolved package count. Keep failing packages with error/errorType so failures stay actionable (#1022). */
 export interface GoGetCompact {
   [key: string]: unknown;
   success: boolean;
   resolvedCount: number;
+  packages?: GoGetResult["packages"];
 }
 
 export function compactGetMap(data: GoGetResult): GoGetCompact {
-  return {
+  const compact: GoGetCompact = {
     success: data.success,
     resolvedCount: data.resolvedPackages?.length ?? 0,
   };
+  const failing = data.packages?.filter((p) => p.error);
+  if (failing?.length) compact.packages = failing;
+  return compact;
 }
 
 export function formatGetCompact(data: GoGetCompact): string {
+  const lines: string[] = [];
   if (data.success) {
-    if (data.resolvedCount > 0) return `go get: success, ${data.resolvedCount} packages resolved.`;
-    return "go get: success.";
+    if (data.resolvedCount > 0) {
+      lines.push(`go get: success, ${data.resolvedCount} packages resolved.`);
+    } else {
+      lines.push("go get: success.");
+    }
+  } else {
+    lines.push("go get: FAIL");
   }
-  return "go get: FAIL";
+  for (const pkg of data.packages ?? []) {
+    if (pkg.error) {
+      const type = pkg.errorType ? ` [${pkg.errorType}]` : "";
+      lines.push(`  ${pkg.path}${type}: ${pkg.error}`);
+    }
+  }
+  return lines.join("\n");
 }
 
 // ── golangci-lint ────────────────────────────────────────────────────
@@ -597,6 +668,12 @@ export function formatGetCompact(data: GoGetCompact): string {
 export function formatGolangciLint(data: GolangciLintResult): string {
   const diagnostics = data.diagnostics ?? [];
   const total = diagnostics.length;
+  if (data.error) {
+    const exitNote = data.exitCode !== undefined ? ` (exit code ${data.exitCode})` : "";
+    return [`golangci-lint: FAIL${exitNote}`, ...data.error.split("\n").map((l) => `  ${l}`)].join(
+      "\n",
+    );
+  }
   if (total === 0) return "golangci-lint: no issues found.";
 
   const lines = [
@@ -616,12 +693,19 @@ export function formatGolangciLint(data: GolangciLintResult): string {
   return lines.join("\n");
 }
 
-/** Compact golangci-lint: errors, warnings counts. Drop individual diagnostics (total derived from errors+warnings). */
+/** Maximum diagnostics kept in compact golangci-lint output (#1022). */
+export const GOLANGCI_LINT_COMPACT_MAX_DIAGNOSTICS = 20;
+
+/** Compact golangci-lint: errors/warnings counts plus the first N diagnostics (fix data stripped) and any linter failure (#1022). */
 export interface GolangciLintCompact {
   [key: string]: unknown;
   errors: number;
   warnings: number;
   resultsTruncated?: boolean;
+  diagnostics?: GolangciLintResult["diagnostics"];
+  diagnosticsOmitted?: number;
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactGolangciLintMap(data: GolangciLintResult): GolangciLintCompact {
@@ -630,12 +714,46 @@ export function compactGolangciLintMap(data: GolangciLintResult): GolangciLintCo
     warnings: data.warnings,
   };
   if (data.resultsTruncated) compact.resultsTruncated = true;
+  const diagnostics = data.diagnostics ?? [];
+  if (diagnostics.length > 0) {
+    compact.diagnostics = diagnostics
+      .slice(0, GOLANGCI_LINT_COMPACT_MAX_DIAGNOSTICS)
+      .map(({ file, line, column, linter, severity, message }) => ({
+        file,
+        line,
+        ...(column !== undefined ? { column } : {}),
+        linter,
+        severity,
+        message,
+      }));
+    if (diagnostics.length > GOLANGCI_LINT_COMPACT_MAX_DIAGNOSTICS) {
+      compact.diagnosticsOmitted = diagnostics.length - GOLANGCI_LINT_COMPACT_MAX_DIAGNOSTICS;
+    }
+  }
+  if (data.error) compact.error = data.error;
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
   return compact;
 }
 
 export function formatGolangciLintCompact(data: GolangciLintCompact): string {
+  if (data.error) {
+    const exitNote = data.exitCode !== undefined ? ` (exit code ${data.exitCode})` : "";
+    return [`golangci-lint: FAIL${exitNote}`, ...data.error.split("\n").map((l) => `  ${l}`)].join(
+      "\n",
+    );
+  }
   const total = data.errors + data.warnings;
   if (total === 0) return "golangci-lint: no issues found.";
   const truncated = data.resultsTruncated ? " (truncated)" : "";
-  return `golangci-lint: ${total} issues (${data.errors} errors, ${data.warnings} warnings)${truncated}`;
+  const lines = [
+    `golangci-lint: ${total} issues (${data.errors} errors, ${data.warnings} warnings)${truncated}`,
+  ];
+  for (const d of data.diagnostics ?? []) {
+    const col = d.column ? `:${d.column}` : "";
+    lines.push(`  ${d.file}:${d.line}${col}: ${d.message} (${d.linter})`);
+  }
+  if (data.diagnosticsOmitted) {
+    lines.push(`  ... ${data.diagnosticsOmitted} more (re-run with compact:false for all)`);
+  }
+  return lines.join("\n");
 }

--- a/packages/server-go/src/lib/parsers.ts
+++ b/packages/server-go/src/lib/parsers.ts
@@ -1,3 +1,4 @@
+import { surfaceEmptyFailure } from "@paretools/shared";
 import type {
   GoBuildResult,
   GoTestResult,
@@ -84,8 +85,18 @@ export function parseGoBuildOutput(
  * Parses `go test -json` output.
  * Each line is a JSON object: { Time, Action, Package, Test, Elapsed, Output }
  * Actions: "run", "pause", "cont", "pass", "fail", "skip", "output"
+ *
+ * Toolchain failures (e.g. "go: cannot find main module", bad -tags, invalid
+ * flags) go to stderr and produce no parseable JSON on stdout. When the run
+ * exits non-zero with zero parsed tests and no package failures, the raw
+ * stderr/stdout tail is surfaced via the `error` field (#1024). Normal test
+ * failures (non-zero exit with parsed failures) do NOT set `error`.
  */
-export function parseGoTestJson(stdout: string, exitCode: number): GoTestResult {
+export function parseGoTestJson(
+  stdout: string,
+  exitCode: number,
+  stderr: string = "",
+): GoTestResult {
   const lines = stdout.trim().split("\n").filter(Boolean);
 
   // Collect output lines per test (keyed by package/test)
@@ -187,7 +198,7 @@ export function parseGoTestJson(stdout: string, exitCode: number): GoTestResult 
   const failed = tests.filter((t) => t.status === "fail").length;
   const skipped = tests.filter((t) => t.status === "skip").length;
 
-  return {
+  const data: GoTestResult = {
     success: exitCode === 0,
     tests,
     packageFailures: packageFailures.length > 0 ? packageFailures : undefined,
@@ -195,6 +206,15 @@ export function parseGoTestJson(stdout: string, exitCode: number): GoTestResult 
     failed,
     skipped,
   };
+
+  // Surface toolchain failures that produced no parseable test output (#1024)
+  return surfaceEmptyFailure(
+    data,
+    { exitCode, stdout, stderr },
+    {
+      isEmpty: (d) => (d.tests?.length ?? 0) === 0 && (d.packageFailures?.length ?? 0) === 0,
+    },
+  );
 }
 
 interface GoTestEvent {
@@ -832,20 +852,37 @@ function splitJsonObjects(text: string): string[] {
 /**
  * Parses `golangci-lint run --out-format json` output into structured diagnostics.
  * The JSON output has the shape: { Issues: [...], Report: { Linters: [...] } }
+ *
+ * golangci-lint exits 1 when issues are found — that is normal and does NOT
+ * set `error`. But when the linter fails outright (config error, crash,
+ * timeout) it exits non-zero with no parseable JSON on stdout; that state
+ * previously read as a clean `{diagnostics: [], errors: 0}` result. The raw
+ * stderr/stdout tail is now surfaced via the `error` field (#1024).
  */
-export function parseGolangciLintJson(stdout: string, _exitCode: number): GolangciLintResult {
+export function parseGolangciLintJson(
+  stdout: string,
+  exitCode: number,
+  stderr: string = "",
+): GolangciLintResult {
   const diagnostics: GolangciLintDiagnostic[] = [];
+  // Surface linter failures that produced no parseable diagnostics (#1024)
+  const withFailure = (data: GolangciLintResult): GolangciLintResult =>
+    surfaceEmptyFailure(
+      data,
+      { exitCode, stdout, stderr },
+      { isEmpty: (d) => (d.diagnostics?.length ?? 0) === 0 },
+    );
 
   if (!stdout.trim()) {
-    return { diagnostics, errors: 0, warnings: 0 };
+    return withFailure({ diagnostics, errors: 0, warnings: 0 });
   }
 
   let parsed: GolangciLintJsonOutput;
   try {
     parsed = JSON.parse(stdout);
   } catch {
-    // If JSON parsing fails, return empty result
-    return { diagnostics, errors: 0, warnings: 0 };
+    // JSON parsing failed: surface the failure instead of a clean-looking result
+    return withFailure({ diagnostics, errors: 0, warnings: 0 });
   }
 
   const issues = parsed.Issues ?? [];
@@ -895,11 +932,11 @@ export function parseGolangciLintJson(stdout: string, _exitCode: number): Golang
   const errors = diagnostics.filter((d) => d.severity === "error").length;
   const warnings = diagnostics.filter((d) => d.severity === "warning").length;
 
-  return {
+  return withFailure({
     diagnostics,
     errors,
     warnings,
-  };
+  });
 }
 
 function mapSeverity(severity?: string): "error" | "warning" | "info" {

--- a/packages/server-go/src/schemas/index.ts
+++ b/packages/server-go/src/schemas/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CompactStreamSchemaFields, EmptyFailureSchemaFields } from "@paretools/shared";
 
 /** Zod schema for a single go build error with file location and message. */
 export const GoBuildErrorSchema = z.object({
@@ -54,6 +55,8 @@ export const GoTestResultSchema = z.object({
   passed: z.number(),
   failed: z.number(),
   skipped: z.number(),
+  /** Toolchain failure output (e.g. "go: cannot find main module") surfaced when the run failed with zero parsed tests (#1024). */
+  ...EmptyFailureSchemaFields,
 });
 
 export type GoTestResult = z.infer<typeof GoTestResultSchema>;
@@ -84,10 +87,8 @@ export const GoRunResultSchema = z.object({
   stdout: z.string().optional(),
   stderr: z.string().optional(),
   timedOut: z.boolean().optional(),
-  /** Whether stdout was truncated due to maxOutput limit. */
-  stdoutTruncated: z.boolean().optional(),
-  /** Whether stderr was truncated due to maxOutput limit. */
-  stderrTruncated: z.boolean().optional(),
+  /** Truncation flags cover both the maxOutput limit and compact-mode stream budgets (#1022). */
+  ...CompactStreamSchemaFields,
   success: z.boolean(),
 });
 
@@ -283,6 +284,8 @@ export const GolangciLintResultSchema = z.object({
   errors: z.number(),
   warnings: z.number(),
   resultsTruncated: z.boolean().optional(),
+  /** Linter failure output (config error, crash) surfaced when the run failed with no parseable diagnostics (#1024). */
+  ...EmptyFailureSchemaFields,
 });
 
 export type GolangciLintResult = z.infer<typeof GolangciLintResultSchema>;

--- a/packages/server-go/src/tools/golangci-lint.ts
+++ b/packages/server-go/src/tools/golangci-lint.ts
@@ -198,8 +198,9 @@ export function registerGolangciLintTool(server: McpServer) {
       args.push(...(patterns || ["./..."]));
 
       const result = await golangciLintCmd(args, cwd);
-      // golangci-lint outputs JSON to stdout even on exit code 1 (issues found)
-      const data = parseGolangciLintJson(result.stdout, result.exitCode);
+      // golangci-lint outputs JSON to stdout even on exit code 1 (issues found).
+      // stderr is passed so outright linter failures are surfaced as `error` (#1024).
+      const data = parseGolangciLintJson(result.stdout, result.exitCode, result.stderr);
 
       // Set resultsTruncated if limits were set (indicates potential truncation)
       const totalIssues = data.diagnostics?.length ?? 0;

--- a/packages/server-go/src/tools/test.ts
+++ b/packages/server-go/src/tools/test.ts
@@ -175,10 +175,11 @@ export function registerTestTool(server: McpServer) {
       if (runFilter) args.push("-run", runFilter);
 
       const result = await goCmd(args, cwd);
-      const data = parseGoTestJson(result.stdout, result.exitCode);
+      // Pass stderr so toolchain failures (no parseable JSON) are surfaced (#1024)
+      const data = parseGoTestJson(result.stdout, result.exitCode, result.stderr);
       return compactDualOutput(
         data,
-        result.stdout,
+        (result.stdout + "\n" + result.stderr).trim(),
         formatGoTest,
         compactTestMap,
         formatTestCompact,


### PR DESCRIPTION
## Summary

Implements the `server-go` slice of the silent-empty-failure audit (#1024) and the compact-mode audit (#1022), using the shared helpers from #1026 (`surfaceEmptyFailure`, `compactStreamFields`, and the matching schema fragments).

### Silent failures (#1024)

- **`go test`** — `parseGoTestJson` now receives stderr and the exit code is used to surface failures. Toolchain errors ("go: cannot find main module", bad `-tags`, malformed flags) go to stderr with no parseable JSON on stdout and previously read as a clean zeroed result. When the run exits non-zero with zero parsed tests and no package failures, the stderr/stdout tail is attached as `error` plus `exitCode` (new optional schema fields via `EmptyFailureSchemaFields`). Normal test failures (non-zero exit with parsed failures) do NOT set `error`.
- **`golangci-lint`** — the parser's exit-code parameter was literally `_exitCode` (ignored) and stderr never reached it, so config errors/crashes read as a clean `{diagnostics: [], errors: 0, warnings: 0}`. It now surfaces `error`/`exitCode` when a non-zero exit produced no parseable diagnostics. Exit code 1 with issues found remains a normal result.

### Compact-mode payload restoration (#1022)

- **`run`** (`compactRunMap`) — previously kept `stdoutTruncated`/`stderrTruncated` flags but dropped the stream content. Now keeps stdout/stderr truncated to the shared compact budget via `compactStreamFields` (head 40 / tail 10 lines, 8 KiB cap), with total-line counts (`CompactStreamSchemaFields` added to the run schema). Upstream `maxOutput` truncation flags are preserved.
- **`get`** (`compactGetMap`) — previously dropped per-package `error`/`errorType` on failure; failing packages are now included, and the compact text lists them.
- **`fmt`** (`compactFmtMap`) — parse errors (real syntax errors) are now kept in full instead of being reduced to `parseErrorCount`.
- **`golangci-lint`** (`compactGolangciLintMap`) — now includes the first 20 diagnostics (fix data stripped) with a `diagnosticsOmitted` count when capped, and passes through the new `error`/`exitCode` fields.

Compact and full text formatters updated to render the new fields.

## Testing

- 378 tests pass (12 files) in `@paretools/go`, including new unit tests for: toolchain-error surfacing (empty/garbage stdout, stderr detail, fallback message, no-false-positive on normal failures), compact stream truncation and flag preservation, failing-package retention, parse-error retention, and diagnostic capping.
- `@paretools/shared` + `@paretools/go` build clean; ESLint and Prettier clean.

Part of #1022 and #1024.