### PR TITLE
fix(cargo): surface toolchain failures and restore compact payloads

### DIFF
--- a/.changeset/fix-cargo-silent-and-compact.md
+++ b/.changeset/fix-cargo-silent-and-compact.md
@@ -1,0 +1,11 @@
+---
+"@paretools/cargo": patch
+---
+
+Surface silent toolchain failures and restore compact payloads (part of #1022 and #1024).
+
+- `cargo build`/`check`/`clippy`/`test`: a non-zero exit with no parseable diagnostics/tests (missing Cargo.toml, toolchain error, clippy not installed) now attaches the raw stderr as `error` plus `exitCode` instead of returning a zeroed result that reads as clean. Failing tests and denied lints still parse normally with no `error`.
+- `cargo audit`: unparseable output (cargo-audit missing, advisory DB fetch failure) now surfaces `error`/`exitCode` instead of a false-clean "0 vulnerabilities" result. Exit 1 with vulnerabilities found remains a successful scan.
+- `cargo run` compact mode: keeps the executed binary's stdout/stderr, truncated to the shared compact budget with truncation metadata, instead of dropping them.
+- `cargo audit` compact mode: keeps the first 10 advisory identities (id, package, version, severity, title, patched) plus an omitted count, instead of an empty vulnerabilities list.
+- Compact mappers and text formatters pass through the new `error`/`exitCode` fields.

--- a/packages/server-cargo/__tests__/formatters.test.ts
+++ b/packages/server-cargo/__tests__/formatters.test.ts
@@ -352,7 +352,8 @@ describe("compactClippyMap", () => {
 });
 
 describe("compactRunMap", () => {
-  it("strips stdout/stderr and keeps exit code", () => {
+  // Epic #1022: compact mode must keep the executed binary's stdout/stderr.
+  it("keeps stdout/stderr and exit code", () => {
     const data: CargoRunResult = {
       exitCode: 0,
       stdout: "Hello, world!\nLine 2\nLine 3",
@@ -360,9 +361,48 @@ describe("compactRunMap", () => {
       success: true,
     };
     const compact = compactRunMap(data);
+    expect(compact).toEqual({
+      exitCode: 0,
+      success: true,
+      stdout: "Hello, world!\nLine 2\nLine 3",
+      stderr: "some warnings here",
+    });
+    expect(compact.stdoutTruncated).toBeUndefined();
+    expect(compact.stderrTruncated).toBeUndefined();
+  });
+
+  it("omits empty streams entirely", () => {
+    const compact = compactRunMap({ exitCode: 0, stdout: "", stderr: "", success: true });
     expect(compact).toEqual({ exitCode: 0, success: true });
     expect(compact).not.toHaveProperty("stdout");
     expect(compact).not.toHaveProperty("stderr");
+  });
+
+  it("truncates long streams to the compact budget with metadata", () => {
+    const longStdout = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`).join("\n");
+    const compact = compactRunMap({
+      exitCode: 0,
+      stdout: longStdout,
+      stderr: "",
+      success: true,
+    });
+    expect(compact.stdout).toContain("line 1");
+    expect(compact.stdout).toContain("line 200");
+    expect(compact.stdout).toContain("lines omitted");
+    expect(compact.stdoutTruncated).toBe(true);
+    expect(compact.stdoutTotalLines).toBe(200);
+  });
+
+  it("preserves upstream maxOutputSize truncation flags", () => {
+    const compact = compactRunMap({
+      exitCode: 0,
+      stdout: "partial output",
+      stderr: "",
+      success: true,
+      stdoutTruncated: true,
+    });
+    expect(compact.stdout).toBe("partial output");
+    expect(compact.stdoutTruncated).toBe(true);
   });
 
   it("formats compact run output", () => {
@@ -372,6 +412,21 @@ describe("compactRunMap", () => {
     expect(formatRunCompact({ exitCode: 1, success: false })).toBe(
       "cargo run: failed (exit code 1)",
     );
+  });
+
+  it("formats compact run output with streams and truncation notes", () => {
+    const output = formatRunCompact({
+      exitCode: 1,
+      success: false,
+      stdout: "some output",
+      stderr: "boom",
+      stderrTruncated: true,
+      stderrTotalLines: 99,
+    });
+    expect(output).toContain("cargo run: failed (exit code 1)");
+    expect(output).toContain("stdout:\nsome output");
+    expect(output).toContain("stderr:\nboom");
+    expect(output).toContain("[stderr truncated: 99 total lines; re-run with compact:false");
   });
 });
 
@@ -523,7 +578,8 @@ describe("formatCargoAudit", () => {
 });
 
 describe("compactAuditMap", () => {
-  it("strips vulnerability details and keeps summary counts", () => {
+  // Epic #1022: compact mode keeps advisory identities instead of bare counts.
+  it("keeps advisory identities and summary counts", () => {
     const data: CargoAuditResult = {
       success: false,
       vulnerabilities: [
@@ -541,7 +597,16 @@ describe("compactAuditMap", () => {
     const compact = compactAuditMap(data);
     expect(compact).toEqual({
       success: false,
-      vulnerabilities: [],
+      vulnerabilities: [
+        {
+          id: "RUSTSEC-2022-0090",
+          package: "libsqlite3-sys",
+          version: "0.24.2",
+          severity: "critical",
+          title: "Use-after-free",
+          patched: [">=0.25.1"],
+        },
+      ],
       total: 1,
       critical: 1,
       high: 0,
@@ -552,12 +617,129 @@ describe("compactAuditMap", () => {
     });
   });
 
+  it("strips optional per-vuln fields (cvssScore, unaffected) in compact entries", () => {
+    const data: CargoAuditResult = {
+      success: false,
+      vulnerabilities: [
+        {
+          id: "RUSTSEC-2022-0090",
+          package: "libsqlite3-sys",
+          version: "0.24.2",
+          severity: "critical",
+          title: "Use-after-free",
+          patched: [">=0.25.1"],
+          unaffected: ["<0.9.0"],
+          cvssScore: 9.8,
+        },
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, informational: 0, unknown: 0 },
+    };
+    const compact = compactAuditMap(data);
+    expect(compact.vulnerabilities[0]).not.toHaveProperty("cvssScore");
+    expect(compact.vulnerabilities[0]).not.toHaveProperty("unaffected");
+  });
+
+  it("caps the compact list at 10 entries and reports omitted count", () => {
+    const vulns = Array.from({ length: 14 }, (_, i) => ({
+      id: `RUSTSEC-2024-${String(i).padStart(4, "0")}`,
+      package: `crate-${i}`,
+      version: "1.0.0",
+      severity: "high" as const,
+      title: `Vuln ${i}`,
+      patched: [],
+    }));
+    const data: CargoAuditResult = {
+      success: false,
+      vulnerabilities: vulns,
+      summary: {
+        total: 14,
+        critical: 0,
+        high: 14,
+        medium: 0,
+        low: 0,
+        informational: 0,
+        unknown: 0,
+      },
+    };
+    const compact = compactAuditMap(data);
+    expect(compact.vulnerabilities).toHaveLength(10);
+    expect(compact.vulnerabilities[0].id).toBe("RUSTSEC-2024-0000");
+    expect(compact.omittedVulnerabilities).toBe(4);
+  });
+
+  it("passes through error and exitCode from a failed scan", () => {
+    const data: CargoAuditResult = {
+      success: false,
+      vulnerabilities: [],
+      summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, informational: 0, unknown: 0 },
+      error: "error: couldn't fetch advisory database",
+      exitCode: 2,
+    };
+    const compact = compactAuditMap(data);
+    expect(compact.error).toBe("error: couldn't fetch advisory database");
+    expect(compact.exitCode).toBe(2);
+  });
+
   it("formats compact audit output", () => {
-    expect(formatAuditCompact({ total: 0, critical: 0, high: 0, medium: 0, low: 0 })).toBe(
-      "cargo audit: no vulnerabilities found.",
-    );
-    expect(formatAuditCompact({ total: 3, critical: 1, high: 1, medium: 1, low: 0 })).toBe(
+    expect(
+      formatAuditCompact({
+        success: true,
+        vulnerabilities: [],
+        total: 0,
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        informational: 0,
+        unknown: 0,
+      }),
+    ).toBe("cargo audit: no vulnerabilities found.");
+    const output = formatAuditCompact({
+      success: false,
+      vulnerabilities: [
+        {
+          id: "RUSTSEC-2022-0090",
+          package: "libsqlite3-sys",
+          version: "0.24.2",
+          severity: "critical",
+          title: "Use-after-free",
+          patched: [">=0.25.1"],
+        },
+      ],
+      total: 3,
+      critical: 1,
+      high: 1,
+      medium: 1,
+      low: 0,
+      informational: 0,
+      unknown: 0,
+      omittedVulnerabilities: 2,
+    });
+    expect(output).toContain(
       "cargo audit: 3 vulnerabilities (1 critical, 1 high, 1 medium, 0 low)",
     );
+    expect(output).toContain(
+      "[critical] RUSTSEC-2022-0090 libsqlite3-sys@0.24.2 (patched: >=0.25.1)",
+    );
+    expect(output).toContain("... 2 more omitted; re-run with compact:false");
+  });
+
+  it("formats a failed scan as NOT clean instead of 'no vulnerabilities'", () => {
+    const output = formatAuditCompact({
+      success: false,
+      vulnerabilities: [],
+      total: 0,
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      informational: 0,
+      unknown: 0,
+      error: "error: not found: cargo-audit",
+      exitCode: 101,
+    });
+    expect(output).not.toContain("no vulnerabilities found");
+    expect(output).toContain("scan failed");
+    expect(output).toContain("error: not found: cargo-audit");
   });
 });

--- a/packages/server-cargo/__tests__/silent-failures.test.ts
+++ b/packages/server-cargo/__tests__/silent-failures.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCargoBuildJson,
+  parseCargoCheckJson,
+  parseCargoTestOutput,
+  parseCargoClippyJson,
+  parseCargoAuditJson,
+} from "../src/lib/parsers.js";
+import {
+  formatCargoBuild,
+  formatCargoTest,
+  formatCargoClippy,
+  formatCargoAudit,
+  compactBuildMap,
+  compactTestMap,
+  compactClippyMap,
+  formatBuildCompact,
+  formatTestCompact,
+  formatClippyCompact,
+} from "../src/lib/formatters.js";
+import {
+  CargoBuildResultSchema,
+  CargoTestResultSchema,
+  CargoClippyResultSchema,
+  CargoAuditResultSchema,
+} from "../src/schemas/index.js";
+
+// Real cargo error output captured from cargo 1.79 on a directory without a project.
+const MISSING_MANIFEST_STDERR =
+  "error: could not find `Cargo.toml` in `/tmp/not-a-project` or any parent directory";
+
+// Real rustup error when no toolchain is configured.
+const NO_TOOLCHAIN_STDERR =
+  "error: rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and no default is configured.\n" +
+  "help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.";
+
+// ── Epic #1024: cargo build/check silent failures ────────────────────
+
+describe("Epic #1024: parseCargoBuildJson silent failures", () => {
+  it("surfaces stderr when build fails with no parseable diagnostics", () => {
+    const result = parseCargoBuildJson("", 101, MISSING_MANIFEST_STDERR);
+    expect(result.success).toBe(false);
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.error).toContain("could not find `Cargo.toml`");
+    expect(result.exitCode).toBe(101);
+  });
+
+  it("uses a fallback message when both streams are empty", () => {
+    const result = parseCargoBuildJson("", 101, "");
+    expect(result.error).toBeTruthy();
+    expect(result.error).toContain("101");
+  });
+
+  it("does not attach error when the build fails WITH diagnostics", () => {
+    const stdout = JSON.stringify({
+      reason: "compiler-message",
+      message: {
+        code: { code: "E0308" },
+        level: "error",
+        message: "mismatched types",
+        spans: [{ file_name: "src/main.rs", line_start: 5, column_start: 9 }],
+      },
+    });
+    const result = parseCargoBuildJson(stdout, 101, "error: could not compile `myapp`");
+    expect(result.success).toBe(false);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("does not attach error on a clean successful build", () => {
+    const stdout = JSON.stringify({ reason: "build-finished", success: true });
+    const result = parseCargoBuildJson(stdout, 0, "    Finished dev profile");
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("check parser mirrors the build guard", () => {
+    const result = parseCargoCheckJson("", 101, MISSING_MANIFEST_STDERR);
+    expect(result.error).toContain("could not find `Cargo.toml`");
+    expect(result.exitCode).toBe(101);
+  });
+
+  it("augmented result validates against the schema", () => {
+    const result = parseCargoBuildJson("", 101, MISSING_MANIFEST_STDERR);
+    expect(() => CargoBuildResultSchema.parse(result)).not.toThrow();
+  });
+
+  it("full and compact formatters surface the error instead of '0 errors'", () => {
+    const result = parseCargoBuildJson("", 101, MISSING_MANIFEST_STDERR);
+    expect(formatCargoBuild(result)).toContain("could not find `Cargo.toml`");
+    const compact = compactBuildMap(result);
+    expect(compact.error).toContain("could not find `Cargo.toml`");
+    expect(compact.exitCode).toBe(101);
+    expect(formatBuildCompact(compact)).toContain("could not find `Cargo.toml`");
+  });
+});
+
+// ── Epic #1024: cargo test silent failures ───────────────────────────
+
+describe("Epic #1024: parseCargoTestOutput silent failures", () => {
+  it("surfaces stderr when cargo test fails before running any test", () => {
+    const result = parseCargoTestOutput("", 101, undefined, MISSING_MANIFEST_STDERR);
+    expect(result.success).toBe(false);
+    expect(result.passed).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.error).toContain("could not find `Cargo.toml`");
+    expect(result.exitCode).toBe(101);
+  });
+
+  it("surfaces toolchain errors", () => {
+    const result = parseCargoTestOutput("", 1, undefined, NO_TOOLCHAIN_STDERR);
+    expect(result.error).toContain("rustup");
+  });
+
+  it("does NOT attach error when tests failed (non-zero exit is expected)", () => {
+    const stdout = [
+      "running 2 tests",
+      "test tests::test_add ... ok",
+      "test tests::test_div ... FAILED",
+      "",
+      "failures:",
+      "",
+      "---- tests::test_div stdout ----",
+      "thread 'tests::test_div' panicked at 'attempt to divide by zero'",
+      "",
+      "failures:",
+      "    tests::test_div",
+      "",
+      "test result: FAILED. 1 passed; 1 failed; 0 ignored",
+    ].join("\n");
+    const result = parseCargoTestOutput(stdout, 101, undefined, "error: test failed");
+    expect(result.failed).toBe(1);
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("does NOT attach error when compilation diagnostics were parsed", () => {
+    const jsonOutput = JSON.stringify({
+      reason: "compiler-message",
+      message: {
+        code: { code: "E0308" },
+        level: "error",
+        message: "mismatched types",
+        spans: [{ file_name: "src/lib.rs", line_start: 3, column_start: 1 }],
+      },
+    });
+    const result = parseCargoTestOutput("", 101, jsonOutput, "error: could not compile");
+    expect(result.compilationDiagnostics).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("does NOT attach error for zero tests with exit 0 (e.g. --no-run)", () => {
+    const result = parseCargoTestOutput("", 0, undefined, "");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("augmented result validates against the schema", () => {
+    const result = parseCargoTestOutput("", 101, undefined, MISSING_MANIFEST_STDERR);
+    expect(() => CargoTestResultSchema.parse(result)).not.toThrow();
+  });
+
+  it("full and compact formatters surface the error instead of '0 passed; 0 failed'", () => {
+    const result = parseCargoTestOutput("", 101, undefined, MISSING_MANIFEST_STDERR);
+    expect(formatCargoTest(result)).toContain("could not find `Cargo.toml`");
+    const compact = compactTestMap(result);
+    expect(compact.error).toContain("could not find `Cargo.toml`");
+    expect(compact.exitCode).toBe(101);
+    expect(formatTestCompact(compact)).toContain("could not find `Cargo.toml`");
+  });
+});
+
+// ── Epic #1024: cargo clippy silent failures ─────────────────────────
+
+describe("Epic #1024: parseCargoClippyJson silent failures", () => {
+  it("surfaces stderr when clippy fails with no diagnostics", () => {
+    const stderr = "error: no such command: `clippy`\n\n\tDid you mean `flip`?";
+    const result = parseCargoClippyJson("", 101, stderr);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("no such command");
+    expect(result.exitCode).toBe(101);
+  });
+
+  it("does NOT attach error when denied lints produce diagnostics", () => {
+    const stdout = JSON.stringify({
+      reason: "compiler-message",
+      message: {
+        code: { code: "clippy::unwrap_used" },
+        level: "error",
+        message: "used `unwrap()` on a `Result` value",
+        spans: [{ file_name: "src/main.rs", line_start: 10, column_start: 5 }],
+      },
+    });
+    const result = parseCargoClippyJson(stdout, 101, "error: could not compile `myapp`");
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("does NOT attach error on a clean run", () => {
+    const result = parseCargoClippyJson("", 0, "    Finished dev profile");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("augmented result validates against the schema", () => {
+    const result = parseCargoClippyJson("", 101, MISSING_MANIFEST_STDERR);
+    expect(() => CargoClippyResultSchema.parse(result)).not.toThrow();
+  });
+
+  it("full and compact formatters surface the error instead of 'no warnings'", () => {
+    const result = parseCargoClippyJson("", 101, MISSING_MANIFEST_STDERR);
+    expect(formatCargoClippy(result)).not.toBe("clippy: no warnings.");
+    expect(formatCargoClippy(result)).toContain("could not find `Cargo.toml`");
+    const compact = compactClippyMap(result);
+    expect(compact.error).toContain("could not find `Cargo.toml`");
+    expect(formatClippyCompact(compact)).toContain("could not find `Cargo.toml`");
+  });
+});
+
+// ── Epic #1024: cargo audit false-clean on unparseable output ────────
+
+describe("Epic #1024: parseCargoAuditJson silent failures", () => {
+  it("surfaces raw output when the report is unparseable (NOT a clean scan)", () => {
+    const raw = "error: couldn't fetch advisory database: git operation failed";
+    const result = parseCargoAuditJson(raw, 2);
+    expect(result.success).toBe(false);
+    expect(result.vulnerabilities).toHaveLength(0);
+    expect(result.summary?.total).toBe(0);
+    expect(result.error).toContain("couldn't fetch advisory database");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("uses a fallback message when output is empty", () => {
+    const result = parseCargoAuditJson("", 101);
+    expect(result.error).toBeTruthy();
+    expect(result.error).toContain("101");
+    expect(result.error).toContain("not a clean scan");
+  });
+
+  it("truncates very long unparseable output, keeping the tail", () => {
+    const raw = "x".repeat(10000) + "\nfinal error line";
+    const result = parseCargoAuditJson(raw, 2);
+    expect(result.error).toContain("(output truncated)");
+    expect(result.error).toContain("final error line");
+    expect(result.error!.length).toBeLessThan(5000);
+  });
+
+  it("does NOT attach error when vulnerabilities are found (exit 1 is a successful scan)", () => {
+    const json = JSON.stringify({
+      vulnerabilities: {
+        found: true,
+        count: 1,
+        list: [
+          {
+            advisory: { id: "RUSTSEC-2022-0090", title: "Use-after-free", cvss: "9.8" },
+            package: { name: "libsqlite3-sys", version: "0.24.2" },
+            versions: { patched: [">=0.25.1"] },
+          },
+        ],
+      },
+    });
+    const result = parseCargoAuditJson(json, 1);
+    expect(result.vulnerabilities).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("augmented result validates against the schema", () => {
+    const result = parseCargoAuditJson("garbage output", 2);
+    expect(() => CargoAuditResultSchema.parse(result)).not.toThrow();
+  });
+
+  it("full formatter reports a failed scan instead of 'no vulnerabilities found'", () => {
+    const result = parseCargoAuditJson("error: not found: cargo-audit", 101);
+    const output = formatCargoAudit(result);
+    expect(output).not.toContain("no vulnerabilities found");
+    expect(output).toContain("scan failed");
+    expect(output).toContain("not found: cargo-audit");
+  });
+});

--- a/packages/server-cargo/src/lib/formatters.ts
+++ b/packages/server-cargo/src/lib/formatters.ts
@@ -1,3 +1,4 @@
+import { compactStreamFields, type CompactStreamFields } from "@paretools/shared";
 import type {
   CargoBuildResult,
   CargoTestResult,
@@ -42,6 +43,8 @@ export interface CargoBuildCompact {
   success: boolean;
   diagnostics?: CargoBuildResult["diagnostics"];
   timings?: CargoBuildResult["timings"];
+  error?: string;
+  exitCode?: number;
 }
 
 /** Compact test: summary counts with failed test entries preserved for diagnostics. */
@@ -53,6 +56,8 @@ export interface CargoTestCompact {
   failed: number;
   ignored: number;
   compilationDiagnostics?: CargoTestResult["compilationDiagnostics"];
+  error?: string;
+  exitCode?: number;
 }
 
 /** Compact clippy: success + diagnostics preserved when non-empty (counts derived from diagnostics). */
@@ -60,10 +65,16 @@ export interface CargoClippyCompact {
   [key: string]: unknown;
   success: boolean;
   diagnostics?: CargoClippyResult["diagnostics"];
+  error?: string;
+  exitCode?: number;
 }
 
-/** Compact run: exit code + success only, no stdout/stderr (signal derived from exit code). */
-export interface CargoRunCompact {
+/**
+ * Compact run: exit code + success with stdout/stderr truncated to the shared
+ * compact budget (epic #1022, the #983/#1020 pattern). The executed binary's
+ * output is the payload the agent called the tool for — never drop it.
+ */
+export interface CargoRunCompact extends CompactStreamFields {
   [key: string]: unknown;
   exitCode: number;
   success: boolean;
@@ -113,6 +124,11 @@ export function formatCargoBuild(data: CargoBuildResult): string {
   const errors = diagnostics.filter((d) => d.severity === "error").length;
   const warnings = diagnostics.filter((d) => d.severity === "warning").length;
   const total = diagnostics.length;
+  // Epic #1024: failed with no parsed diagnostics — show the raw error instead
+  // of an empty "0 errors" summary that reads as success.
+  if (!data.success && total === 0 && data.error) {
+    return `cargo build: failed (no diagnostics parsed):\n${data.error}`;
+  }
   if (data.success && total === 0) return "cargo build: success, no diagnostics.";
 
   const status = data.success ? "success" : "failed";
@@ -135,6 +151,11 @@ export function formatCargoBuild(data: CargoBuildResult): string {
 
 /** Formats structured cargo test results into a human-readable test summary with pass/fail status. */
 export function formatCargoTest(data: CargoTestResult): string {
+  // Epic #1024: failed before any test ran — show the raw error instead of a
+  // zeroed "0 passed; 0 failed" summary.
+  if (!data.success && (data.tests ?? []).length === 0 && data.error) {
+    return `cargo test: failed (no tests ran):\n${data.error}`;
+  }
   const status = data.success ? "ok" : "FAILED";
   const lines = [
     `test result: ${status}. ${data.passed} passed; ${data.failed} failed; ${data.ignored} ignored`,
@@ -166,6 +187,11 @@ export function formatCargoClippy(data: CargoClippyResult): string {
   const errors = diagnostics.filter((d) => d.severity === "error").length;
   const warnings = diagnostics.filter((d) => d.severity === "warning").length;
   const total = diagnostics.length;
+  // Epic #1024: failed with no parsed diagnostics — show the raw error instead
+  // of "no warnings" which reads as a clean lint run.
+  if (!data.success && total === 0 && data.error) {
+    return `clippy: failed (no diagnostics parsed):\n${data.error}`;
+  }
   if (total === 0) return "clippy: no warnings.";
 
   const lines = [`clippy: ${errors} errors, ${warnings} warnings`];
@@ -282,6 +308,8 @@ export function compactBuildMap(data: CargoBuildResult): CargoBuildCompact {
   };
   if (data.diagnostics?.length) compact.diagnostics = data.diagnostics;
   if (data.timings) compact.timings = data.timings;
+  if (data.error) compact.error = data.error;
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
   return compact;
 }
 
@@ -299,6 +327,8 @@ export function compactTestMap(data: CargoTestResult): CargoTestCompact {
   if (data.compilationDiagnostics?.length) {
     compact.compilationDiagnostics = data.compilationDiagnostics;
   }
+  if (data.error) compact.error = data.error;
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
   return compact;
 }
 
@@ -307,15 +337,23 @@ export function compactClippyMap(data: CargoClippyResult): CargoClippyCompact {
     success: data.success,
   };
   if (data.diagnostics?.length) compact.diagnostics = data.diagnostics;
+  if (data.error) compact.error = data.error;
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
   return compact;
 }
 
 export function compactRunMap(data: CargoRunResult): CargoRunCompact {
+  // Epic #1022: keep the executed binary's stdout/stderr (truncated to the
+  // shared compact budget) — dropping them was the #983 class of bug.
   const compact: CargoRunCompact = {
     exitCode: data.exitCode,
     success: data.success,
+    ...compactStreamFields(data.stdout, data.stderr),
   };
   if (data.failureType) compact.failureType = data.failureType;
+  // Preserve upstream maxOutputSize truncation flags from the full result.
+  if (data.stdoutTruncated) compact.stdoutTruncated = true;
+  if (data.stderrTruncated) compact.stderrTruncated = true;
   return compact;
 }
 
@@ -362,8 +400,11 @@ export function compactDocMap(data: CargoDocResult): CargoDocCompact {
 // ── Compact formatters ───────────────────────────────────────────────
 
 export function formatBuildCompact(data: CargoBuildCompact): string {
-  const status = data.success ? "success" : "failed";
   const diagnostics = data.diagnostics ?? [];
+  if (!data.success && diagnostics.length === 0 && data.error) {
+    return `cargo build: failed (no diagnostics parsed):\n${data.error}`;
+  }
+  const status = data.success ? "success" : "failed";
   const errors = diagnostics.filter((d) => d.severity === "error").length;
   const warnings = diagnostics.filter((d) => d.severity === "warning").length;
   const timingSuffix = data.timings?.generated ? " [timings]" : "";
@@ -371,6 +412,9 @@ export function formatBuildCompact(data: CargoBuildCompact): string {
 }
 
 export function formatTestCompact(data: CargoTestCompact): string {
+  if (!data.success && data.passed === 0 && data.failed === 0 && data.error) {
+    return `cargo test: failed (no tests ran):\n${data.error}`;
+  }
   const status = data.success ? "ok" : "FAILED";
   return `test result: ${status}. ${data.passed} passed; ${data.failed} failed; ${data.ignored} ignored`;
 }
@@ -380,6 +424,9 @@ export function formatClippyCompact(data: CargoClippyCompact): string {
   const errors = diagnostics.filter((d) => d.severity === "error").length;
   const warnings = diagnostics.filter((d) => d.severity === "warning").length;
   const total = diagnostics.length;
+  if (!data.success && total === 0 && data.error) {
+    return `clippy: failed (no diagnostics parsed):\n${data.error}`;
+  }
   if (total === 0) return "clippy: no warnings.";
   return `clippy: ${errors} errors, ${warnings} warnings`;
 }
@@ -387,7 +434,24 @@ export function formatClippyCompact(data: CargoClippyCompact): string {
 export function formatRunCompact(data: CargoRunCompact): string {
   const status = data.success ? "success" : "failed";
   const failType = data.failureType ? ` [${data.failureType}]` : "";
-  return `cargo run: ${status}${failType} (exit code ${data.exitCode})`;
+  const lines = [`cargo run: ${status}${failType} (exit code ${data.exitCode})`];
+  if (data.stdout) {
+    lines.push(`stdout:\n${data.stdout}`);
+    if (data.stdoutTruncated) {
+      const total =
+        data.stdoutTotalLines !== undefined ? `: ${data.stdoutTotalLines} total lines` : "";
+      lines.push(`  [stdout truncated${total}; re-run with compact:false for full output]`);
+    }
+  }
+  if (data.stderr) {
+    lines.push(`stderr:\n${data.stderr}`);
+    if (data.stderrTruncated) {
+      const total =
+        data.stderrTotalLines !== undefined ? `: ${data.stderrTotalLines} total lines` : "";
+      lines.push(`  [stderr truncated${total}; re-run with compact:false for full output]`);
+    }
+  }
+  return lines.join("\n");
 }
 
 export function formatAddCompact(data: CargoAddCompact): string {
@@ -506,6 +570,11 @@ export function formatCargoAudit(data: CargoAuditResult): string {
     unknown: 0,
   };
 
+  // Epic #1024: an unparseable/failed scan must not read as "no vulnerabilities".
+  if (data.error && summary.total === 0) {
+    return `cargo audit: scan failed (no report parsed) — NOT a clean scan:\n${data.error}`;
+  }
+
   const fixesSuffix =
     data.fixesApplied !== undefined ? ` (${data.fixesApplied} fix(es) applied)` : "";
 
@@ -522,7 +591,15 @@ export function formatCargoAudit(data: CargoAuditResult): string {
   return lines.join("\n");
 }
 
-/** Compact audit: success + summary counts only, no individual vulnerabilities. */
+/** Maximum vulnerability entries kept in compact audit output (epic #1022). */
+export const AUDIT_COMPACT_MAX_VULNS = 10;
+
+/**
+ * Compact audit: severity counts plus the first {@link AUDIT_COMPACT_MAX_VULNS}
+ * vulnerability identities (advisory id, package, version, severity, title,
+ * patched versions). Epic #1022: the advisory identities are the payload the
+ * agent called the tool for — never reduce them to bare counts.
+ */
 export interface CargoAuditCompact {
   [key: string]: unknown;
   success: boolean;
@@ -533,7 +610,18 @@ export interface CargoAuditCompact {
   low: number;
   informational: number;
   unknown: number;
+  vulnerabilities: {
+    id: string;
+    package: string;
+    version: string;
+    severity: "critical" | "high" | "medium" | "low" | "informational" | "unknown";
+    title: string;
+    patched: string[];
+  }[];
+  omittedVulnerabilities?: number;
   fixesApplied?: number;
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactAuditMap(data: CargoAuditResult): CargoAuditCompact {
@@ -546,9 +634,18 @@ export function compactAuditMap(data: CargoAuditResult): CargoAuditCompact {
     informational: 0,
     unknown: 0,
   };
+  const allVulns = data.vulnerabilities ?? [];
   const compact: CargoAuditCompact = {
     success: data.success,
-    vulnerabilities: [],
+    // Epic #1022: keep advisory identities (first N) instead of dropping the list.
+    vulnerabilities: allVulns.slice(0, AUDIT_COMPACT_MAX_VULNS).map((v) => ({
+      id: v.id,
+      package: v.package,
+      version: v.version,
+      severity: v.severity,
+      title: v.title,
+      patched: v.patched,
+    })),
     total: summary.total,
     critical: summary.critical,
     high: summary.high,
@@ -557,15 +654,37 @@ export function compactAuditMap(data: CargoAuditResult): CargoAuditCompact {
     informational: summary.informational,
     unknown: summary.unknown,
   };
+  if (allVulns.length > AUDIT_COMPACT_MAX_VULNS) {
+    compact.omittedVulnerabilities = allVulns.length - AUDIT_COMPACT_MAX_VULNS;
+  }
   if (data.fixesApplied !== undefined) {
     compact.fixesApplied = data.fixesApplied;
   }
+  // Epic #1024: pass through silent-failure evidence.
+  if (data.error) compact.error = data.error;
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
   return compact;
 }
 
 export function formatAuditCompact(data: CargoAuditCompact): string {
+  // Epic #1024: an unparseable/failed scan must not read as "no vulnerabilities".
+  if (data.error && data.total === 0) {
+    return `cargo audit: scan failed (no report parsed) — NOT a clean scan:\n${data.error}`;
+  }
   const fixesSuffix =
     data.fixesApplied !== undefined ? ` (${data.fixesApplied} fix(es) applied)` : "";
   if (data.total === 0) return `cargo audit: no vulnerabilities found.${fixesSuffix}`;
-  return `cargo audit: ${data.total} vulnerabilities (${data.critical} critical, ${data.high} high, ${data.medium} medium, ${data.low} low)${fixesSuffix}`;
+  const lines = [
+    `cargo audit: ${data.total} vulnerabilities (${data.critical} critical, ${data.high} high, ${data.medium} medium, ${data.low} low)${fixesSuffix}`,
+  ];
+  for (const v of data.vulnerabilities ?? []) {
+    const patched = v.patched.length > 0 ? ` (patched: ${v.patched.join(", ")})` : "";
+    lines.push(`  [${v.severity}] ${v.id} ${v.package}@${v.version}${patched}`);
+  }
+  if (data.omittedVulnerabilities) {
+    lines.push(
+      `  ... ${data.omittedVulnerabilities} more omitted; re-run with compact:false for the full list`,
+    );
+  }
+  return lines.join("\n");
 }

--- a/packages/server-cargo/src/lib/parsers.ts
+++ b/packages/server-cargo/src/lib/parsers.ts
@@ -1,3 +1,4 @@
+import { surfaceEmptyFailure, SURFACE_EMPTY_FAILURE_MAX_BYTES } from "@paretools/shared";
 import type {
   CargoBuildResult,
   CargoCheckResult,
@@ -51,7 +52,17 @@ export function parseCargoBuildJson(
   if (timings) {
     result.timings = timings;
   }
-  return result;
+
+  // Epic #1024: a failed build with zero parsed diagnostics (missing Cargo.toml,
+  // toolchain error, manifest parse failure) would otherwise read as a clean
+  // "0 errors" result. Surface the raw stderr so the failure is actionable.
+  return surfaceEmptyFailure(
+    result,
+    { exitCode, stdout, stderr: stderr ?? "" },
+    {
+      isEmpty: (d) => !d.success && (d.diagnostics ?? []).length === 0,
+    },
+  );
 }
 
 /** Parses cargo check output using the build parser. */
@@ -72,11 +83,14 @@ export function parseCargoCheckJson(
  * and the "failures:" name list or "test result:" line.
  *
  * Gap #95: Also parses JSON message format output for compilation diagnostics.
+ * Epic #1024: accepts stderr so pre-run failures (missing Cargo.toml, toolchain
+ * errors) surface an `error` instead of a silent zeroed result.
  */
 export function parseCargoTestOutput(
   stdout: string,
   exitCode: number,
   jsonOutput?: string,
+  stderr?: string,
 ): CargoTestResult {
   const lines = stdout.split("\n");
   const tests: {
@@ -145,7 +159,17 @@ export function parseCargoTestOutput(
     }
   }
 
-  return result;
+  // Epic #1024: cargo test exits non-zero when tests FAIL — parsed failures are a
+  // successful run, no error. But a non-zero exit with zero parsed tests and no
+  // compilation diagnostics (missing Cargo.toml, toolchain error) is a silent
+  // failure that would read as "0 passed; 0 failed" — surface the raw output.
+  return surfaceEmptyFailure(
+    result,
+    { exitCode, stdout, stderr: stderr ?? "" },
+    {
+      isEmpty: (d) => (d.tests ?? []).length === 0 && !d.compilationDiagnostics?.length,
+    },
+  );
 }
 
 /**
@@ -208,14 +232,30 @@ function parseFailureOutputSections(stdout: string): Map<string, string> {
  * Parses `cargo clippy --message-format=json` output.
  * Same JSON format as cargo build. Now includes success field.
  * Gap #90: Captures suggestion text from JSON children.
+ * Epic #1024: accepts stderr so pre-lint failures (missing Cargo.toml, clippy not
+ * installed) surface an `error` instead of a silent "no warnings" result.
  */
-export function parseCargoClippyJson(stdout: string, exitCode: number): CargoClippyResult {
+export function parseCargoClippyJson(
+  stdout: string,
+  exitCode: number,
+  stderr?: string,
+): CargoClippyResult {
   const { diagnostics } = parseCompilerMessages(stdout);
 
-  return {
+  const result: CargoClippyResult = {
     success: exitCode === 0,
     diagnostics,
   };
+
+  // Epic #1024: clippy exits non-zero when lints are denied — parsed diagnostics
+  // are fine. A non-zero exit with zero diagnostics is a silent failure.
+  return surfaceEmptyFailure(
+    result,
+    { exitCode, stdout, stderr: stderr ?? "" },
+    {
+      isEmpty: (d) => (d.diagnostics ?? []).length === 0,
+    },
+  );
 }
 
 /**
@@ -984,6 +1024,18 @@ export function parseCargoAuditJson(
   try {
     data = JSON.parse(jsonStr);
   } catch {
+    // Epic #1024: an unparseable report (cargo-audit not installed, advisory DB
+    // fetch failure, crash) must never read as a clean "0 vulnerabilities" scan.
+    // Surface the raw output and exit code so the failure is visible.
+    // NOTE: cargo audit exits 1 when vulnerabilities ARE found — that path still
+    // produces valid JSON and never reaches this catch.
+    const detail = jsonStr.trim();
+    const error = detail
+      ? detail.length > SURFACE_EMPTY_FAILURE_MAX_BYTES
+        ? `… (output truncated)\n${detail.slice(-SURFACE_EMPTY_FAILURE_MAX_BYTES)}`
+        : detail
+      : `cargo audit exited with code ${exitCode} but produced no parseable JSON output. ` +
+        `This is not a clean scan.`;
     return {
       success: false,
       vulnerabilities: [],
@@ -996,6 +1048,8 @@ export function parseCargoAuditJson(
         informational: 0,
         unknown: 0,
       },
+      error,
+      exitCode,
     };
   }
 

--- a/packages/server-cargo/src/schemas/index.ts
+++ b/packages/server-cargo/src/schemas/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CompactStreamSchemaFields, EmptyFailureSchemaFields } from "@paretools/shared";
 
 /** Zod schema for a single Rust compiler diagnostic with file location, severity, and optional lint code. */
 export const CargoDiagnosticSchema = z.object({
@@ -23,6 +24,7 @@ export const CargoBuildResultSchema = z.object({
     })
     .optional()
     .describe("Structured cargo --timings metadata when timing report generation is enabled"),
+  ...EmptyFailureSchemaFields,
 });
 
 export type CargoBuildResult = z.infer<typeof CargoBuildResultSchema>;
@@ -51,6 +53,7 @@ export const CargoTestResultSchema = z.object({
     .array(CargoDiagnosticSchema)
     .optional()
     .describe("Compiler diagnostics from --message-format=json when tests fail to compile"),
+  ...EmptyFailureSchemaFields,
 });
 
 export type CargoTestResult = z.infer<typeof CargoTestResultSchema>;
@@ -59,6 +62,7 @@ export type CargoTestResult = z.infer<typeof CargoTestResultSchema>;
 export const CargoClippyResultSchema = z.object({
   success: z.boolean(),
   diagnostics: z.array(CargoDiagnosticSchema).optional(),
+  ...EmptyFailureSchemaFields,
 });
 
 export type CargoClippyResult = z.infer<typeof CargoClippyResultSchema>;
@@ -73,14 +77,9 @@ export const CargoRunResultSchema = z.object({
     .enum(["compilation", "runtime", "timeout"])
     .optional()
     .describe("Type of failure: compilation (rustc error), runtime (program error), or timeout"),
-  stdoutTruncated: z
-    .boolean()
-    .optional()
-    .describe("True when stdout exceeded maxOutputSize and was truncated"),
-  stderrTruncated: z
-    .boolean()
-    .optional()
-    .describe("True when stderr exceeded maxOutputSize and was truncated"),
+  // stdoutTruncated/stderrTruncated cover both maxOutputSize truncation (full mode)
+  // and the compact stream budget (compact mode, epic #1022).
+  ...CompactStreamSchemaFields,
 });
 
 export type CargoRunResult = z.infer<typeof CargoRunResultSchema>;
@@ -247,6 +246,11 @@ export const CargoAuditResultSchema = z.object({
     .number()
     .optional()
     .describe("Number of fixes applied when using cargo audit fix"),
+  omittedVulnerabilities: z
+    .number()
+    .optional()
+    .describe("Number of vulnerabilities omitted from the compact vulnerability list"),
+  ...EmptyFailureSchemaFields,
 });
 
 export type CargoAuditResult = z.infer<typeof CargoAuditResultSchema>;

--- a/packages/server-cargo/src/tools/clippy.ts
+++ b/packages/server-cargo/src/tools/clippy.ts
@@ -186,7 +186,9 @@ export function registerClippyTool(server: McpServer) {
       }
 
       const result = await cargo(args, cwd);
-      const data = parseCargoClippyJson(result.stdout, result.exitCode);
+      // Epic #1024: pass stderr so pre-lint failures surface an error instead of
+      // a silent "no warnings" result.
+      const data = parseCargoClippyJson(result.stdout, result.exitCode, result.stderr);
       return compactDualOutput(
         data,
         result.stdout,

--- a/packages/server-cargo/src/tools/test.ts
+++ b/packages/server-cargo/src/tools/test.ts
@@ -158,7 +158,9 @@ export function registerTestTool(server: McpServer) {
       const humanOutput = humanLines.join("\n");
       const jsonOutput = jsonLines.length > 0 ? jsonLines.join("\n") : undefined;
 
-      const data = parseCargoTestOutput(humanOutput, result.exitCode, jsonOutput);
+      // Epic #1024: pass stderr so pre-run failures (missing Cargo.toml, toolchain
+      // errors) surface an error instead of a silent zeroed result.
+      const data = parseCargoTestOutput(humanOutput, result.exitCode, jsonOutput, result.stderr);
       return compactDualOutput(
         data,
         result.stdout,


### PR DESCRIPTION
## Summary

Implements the `server-cargo` slice of the two systemic-bug epics.

Part of #1022 and #1024.

### Silent failures (#1024)

- **`cargo build` / `cargo check`** (`parseCargoBuildJson`/`parseCargoCheckJson`): a failed build with zero parsed diagnostics (missing Cargo.toml, toolchain error, manifest parse failure) now attaches `error` (raw stderr tail) and `exitCode` via the shared `surfaceEmptyFailure` helper, mirroring the `parseTscOutput` #965 guard.
- **`cargo clippy`** (`parseCargoClippyJson`): now receives stderr (previously no stderr param at all) and applies the same guard. Denied lints with parsed diagnostics still produce no `error`.
- **`cargo test`** (`parseCargoTestOutput`): now receives stderr; a non-zero exit with zero parsed tests and no compilation diagnostics surfaces `error`/`exitCode` instead of a silent `0 passed; 0 failed`. Failing tests (non-zero exit with parsed failures) remain a successful run with no `error`.
- **`cargo audit`** (`parseCargoAuditJson`): the JSON.parse catch no longer returns a false-clean zeroed result — it attaches `error` (raw output, tail-truncated at 4 KiB) and `exitCode`. Exit 1 with vulnerabilities found still parses as a successful scan.
- Affected schemas gain the shared `EmptyFailureSchemaFields` (`error`/`exitCode`, both optional); full and compact text formatters render the error instead of "0 errors" / "no warnings" / "no vulnerabilities found".

### Compact-mode payload loss (#1022)

- **`cargo run` compact** (`compactRunMap`): keeps the executed binary's stdout/stderr using the shared `compactStreamFields` budget from PR #1026 (the #983/#1020 pattern), with `*Truncated`/`*TotalLines` metadata; upstream `maxOutputSize` truncation flags are preserved. `CargoRunResultSchema` now spreads `CompactStreamSchemaFields`.
- **`cargo audit` compact** (`compactAuditMap`): previously set `vulnerabilities: []` explicitly. Now keeps the first 10 advisory identities (id, package, version, severity, title, patched) plus severity counts and an `omittedVulnerabilities` count; compact text lists each advisory and the omitted count.
- All compact mappers/formatters for build/test/clippy/audit pass through the new `error`/`exitCode` fields.

## Testing

- New `__tests__/silent-failures.test.ts` (24 tests) with realistic cargo error fixtures (missing Cargo.toml, rustup toolchain error, `no such command: clippy`, advisory DB fetch failure), including no-false-positive cases (failing tests, denied lints, compile-error diagnostics, `--no-run`) and schema validation of augmented results.
- Updated `__tests__/formatters.test.ts` assertions that pinned the old dropping behavior; added truncation-budget and passthrough cases.
- `pnpm --filter @paretools/cargo test`: **373/373 passing**. ESLint clean, Prettier clean.