### PR TITLE
fix(npm): surface npm failures and restore compact list payload

### DIFF
--- a/.changeset/fix-npm-silent-and-compact.md
+++ b/.changeset/fix-npm-silent-and-compact.md
@@ -1,0 +1,10 @@
+---
+"@paretools/npm": patch
+---
+
+Surface npm failures and restore the compact list payload.
+
+- `outdated`: a non-zero exit with no output, or npm's `{"error": ...}` JSON payload, now returns an error instead of reading as "everything up to date" (#1024)
+- `audit`: unparseable output or a failed run (e.g. ENOLOCK) now returns a structured Pare error via the shared `errorOutput`/`classifyError` helpers instead of a raw SyntaxError or a false "no vulnerabilities" (#1024)
+- compact `list` output now includes `dependencyCount`, `problems`, `packageManager`, and the first 20 top-level dependencies with an omitted-count marker (#1022)
+- compact `info` output now includes `dependencyCount` and `versionCount` (#1022)

--- a/packages/server-npm/__tests__/compact.test.ts
+++ b/packages/server-npm/__tests__/compact.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { compactListMap, formatListCompact } from "../src/lib/formatters.js";
-import type { NpmList } from "../src/schemas/index.js";
+import { compactListMap, formatListCompact, COMPACT_LIST_MAX_DEPS } from "../src/lib/formatters.js";
+import { NpmListSchema, type NpmList } from "../src/schemas/index.js";
 
 describe("compactListMap", () => {
-  it("keeps name and version; drops dependencies tree", () => {
+  it("keeps name, version, dependencyCount, and flattened top-level deps (#1022)", () => {
     const list: NpmList = {
       name: "my-app",
       version: "1.0.0",
@@ -21,8 +21,12 @@ describe("compactListMap", () => {
 
     expect(compact.name).toBe("my-app");
     expect(compact.version).toBe("1.0.0");
-    // dependencies tree is dropped in compact mode (shape incompatible with schema)
-    expect(compact).not.toHaveProperty("dependencies");
+    expect(compact.dependencyCount).toBe(2);
+    expect(compact.dependencies).toEqual({
+      express: { version: "4.18.2" },
+      lodash: { version: "4.17.21" },
+    });
+    expect(compact.omittedDependencyCount).toBeUndefined();
   });
 
   it("handles empty dependencies", () => {
@@ -34,6 +38,7 @@ describe("compactListMap", () => {
 
     const compact = compactListMap(list);
 
+    expect(compact.dependencyCount).toBe(0);
     expect(compact).not.toHaveProperty("dependencies");
   });
 
@@ -47,10 +52,11 @@ describe("compactListMap", () => {
 
     expect(compact.name).toBe("my-app");
     expect(compact.version).toBe("1.0.0");
+    expect(compact.dependencyCount).toBe(0);
     expect(compact).not.toHaveProperty("dependencies");
   });
 
-  it("handles nested dependencies without leaking tree into compact", () => {
+  it("counts nested dependencies but flattens them out of the compact tree", () => {
     const list: NpmList = {
       name: "my-app",
       version: "1.0.0",
@@ -73,31 +79,115 @@ describe("compactListMap", () => {
 
     const compact = compactListMap(list);
 
-    expect(compact.name).toBe("my-app");
-    expect(compact).not.toHaveProperty("dependencies");
+    // total count includes nested deps
+    expect(compact.dependencyCount).toBe(5);
+    // only top-level deps are kept, without their nested trees
+    expect(Object.keys(compact.dependencies ?? {})).toEqual(["express", "lodash"]);
+    expect(compact.dependencies?.express).toEqual({ version: "4.18.2" });
+  });
+
+  it("caps top-level deps at COMPACT_LIST_MAX_DEPS and reports the omitted count", () => {
+    const deps: NpmList["dependencies"] = {};
+    for (let i = 0; i < COMPACT_LIST_MAX_DEPS + 5; i++) {
+      deps[`pkg-${String(i).padStart(2, "0")}`] = { version: `1.0.${i}` };
+    }
+    const list: NpmList = { name: "big-app", version: "1.0.0", dependencies: deps };
+
+    const compact = compactListMap(list);
+
+    expect(compact.dependencyCount).toBe(COMPACT_LIST_MAX_DEPS + 5);
+    expect(Object.keys(compact.dependencies ?? {})).toHaveLength(COMPACT_LIST_MAX_DEPS);
+    expect(compact.omittedDependencyCount).toBe(5);
+  });
+
+  it("always keeps problems (#1022)", () => {
+    const list: NpmList = {
+      name: "my-app",
+      version: "1.0.0",
+      dependencies: { express: { version: "4.18.2" } },
+      problems: ["missing: lodash@^4.0.0, required by my-app@1.0.0"],
+    };
+
+    const compact = compactListMap(list);
+
+    expect(compact.problems).toEqual(["missing: lodash@^4.0.0, required by my-app@1.0.0"]);
+  });
+
+  it("preserves packageManager and dependency types", () => {
+    const list: NpmList = {
+      name: "my-app",
+      version: "1.0.0",
+      packageManager: "pnpm",
+      dependencies: {
+        vitest: { version: "3.0.0", type: "devDependency" },
+      },
+    };
+
+    const compact = compactListMap(list);
+
+    expect(compact.packageManager).toBe("pnpm");
+    expect(compact.dependencies?.vitest).toEqual({ version: "3.0.0", type: "devDependency" });
+  });
+
+  it("produces output that validates against NpmListSchema", () => {
+    const deps: NpmList["dependencies"] = {};
+    for (let i = 0; i < COMPACT_LIST_MAX_DEPS + 3; i++) {
+      deps[`pkg-${i}`] = { version: "1.0.0", type: "dependency" };
+    }
+    const list: NpmList = {
+      name: "my-app",
+      version: "1.0.0",
+      packageManager: "npm",
+      dependencies: deps,
+      problems: ["extraneous: foo@1.0.0"],
+    };
+
+    const compact = compactListMap(list);
+
+    const parsed = NpmListSchema.safeParse(compact);
+    expect(parsed.success).toBe(true);
   });
 });
 
 describe("formatListCompact", () => {
-  it("formats compact list output as name@version", () => {
-    const compact = {
+  it("formats compact list output with dependency count and top-level deps", () => {
+    const output = formatListCompact({
       name: "my-app",
       version: "1.0.0",
-    };
+      dependencyCount: 2,
+      dependencies: {
+        express: { version: "4.18.2" },
+        lodash: { version: "4.17.21" },
+      },
+    });
 
-    const output = formatListCompact(compact);
-
-    expect(output).toBe("my-app@1.0.0");
+    expect(output).toContain("my-app@1.0.0 (2 dependencies)");
+    expect(output).toContain("express@4.18.2");
+    expect(output).toContain("lodash@4.17.21");
   });
 
   it("formats empty compact list", () => {
-    const compact = {
+    const output = formatListCompact({
       name: "empty-app",
       version: "0.0.1",
-    };
+      dependencyCount: 0,
+    });
 
-    const output = formatListCompact(compact);
+    expect(output).toBe("empty-app@0.0.1 (0 dependencies)");
+  });
 
-    expect(output).toBe("empty-app@0.0.1");
+  it("shows problems and the omitted-dependency marker", () => {
+    const output = formatListCompact({
+      name: "my-app",
+      version: "1.0.0",
+      dependencyCount: 30,
+      dependencies: { express: { version: "4.18.2" } },
+      omittedDependencyCount: 9,
+      problems: ["missing: lodash@^4.0.0"],
+    });
+
+    expect(output).toContain("Problems (1):");
+    expect(output).toContain("missing: lodash@^4.0.0");
+    expect(output).toContain("... and 9 more top-level dependencies");
   });
 });

--- a/packages/server-npm/__tests__/info-search.test.ts
+++ b/packages/server-npm/__tests__/info-search.test.ts
@@ -268,6 +268,8 @@ describe("compactInfoMap", () => {
     expect(compact.homepage).toBe("http://expressjs.com/");
     expect(compact).not.toHaveProperty("dependencies");
     expect(compact).not.toHaveProperty("dist");
+    // #1022: counts are kept even though the details are dropped
+    expect(compact.dependencyCount).toBe(1);
   });
 
   it("omits license and homepage when not present", () => {
@@ -279,6 +281,20 @@ describe("compactInfoMap", () => {
     const compact = compactInfoMap(data);
     expect(compact.license).toBeUndefined();
     expect(compact.homepage).toBeUndefined();
+    expect(compact.dependencyCount).toBeUndefined();
+    expect(compact.versionCount).toBeUndefined();
+  });
+
+  it("keeps versionCount when versions are present (#1022)", () => {
+    const data: NpmInfo = {
+      name: "pkg",
+      version: "3.0.0",
+      description: "test",
+      versions: ["1.0.0", "2.0.0", "3.0.0"],
+    };
+    const compact = compactInfoMap(data);
+    expect(compact).not.toHaveProperty("versions");
+    expect(compact.versionCount).toBe(3);
   });
 });
 
@@ -297,6 +313,18 @@ describe("formatInfoCompact", () => {
     expect(output).toContain("Fast web framework");
     expect(output).toContain("License: MIT");
     expect(output).toContain("Homepage: http://expressjs.com/");
+  });
+
+  it("includes dependency and version counts when present (#1022)", () => {
+    const output = formatInfoCompact({
+      name: "express",
+      version: "4.18.2",
+      description: "Fast web framework",
+      dependencyCount: 31,
+      versionCount: 279,
+    });
+    expect(output).toContain("Dependencies: 31");
+    expect(output).toContain("Published Versions: 279");
   });
 
   it("formats minimal compact info", () => {

--- a/packages/server-npm/__tests__/integration.test.ts
+++ b/packages/server-npm/__tests__/integration.test.ts
@@ -147,6 +147,71 @@ describe("@paretools/npm integration", () => {
     });
   });
 
+  describe("silent-failure surfacing (#1024)", () => {
+    let fixtureDir: string;
+
+    beforeAll(async () => {
+      const { mkdtemp, writeFile } = await import("node:fs/promises");
+      const { tmpdir } = await import("node:os");
+      fixtureDir = await mkdtemp(join(tmpdir(), "pare-npm-fail-"));
+      // package.json with a dependency but NO lockfile and NO workspaces
+      await writeFile(
+        join(fixtureDir, "package.json"),
+        JSON.stringify({
+          name: "pare-npm-failure-fixture",
+          version: "1.0.0",
+          dependencies: { lodash: "^4.0.0" },
+        }),
+      );
+    });
+
+    afterAll(async () => {
+      const { rm } = await import("node:fs/promises");
+      await rm(fixtureDir, { recursive: true, force: true });
+    });
+
+    it("outdated surfaces npm failures instead of reporting 'up to date'", async () => {
+      const result = await client.callTool(
+        {
+          name: "outdated",
+          arguments: { path: fixtureDir, workspace: "nope", packageManager: "npm" },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      // npm exits 1 with an {"error": ...} payload — must NOT parse as
+      // "all packages up to date"
+      expect(result.isError).toBe(true);
+      const text = (result.content as { type: string; text: string }[])
+        .map((c) => c.text)
+        .join("\n");
+      expect(text).toContain("outdated failed");
+      expect(text.toLowerCase()).toContain("workspace");
+    });
+
+    it("audit returns a structured PareError when npm audit cannot run", async () => {
+      const result = await client.callTool(
+        {
+          name: "audit",
+          arguments: { path: fixtureDir, packageManager: "npm" },
+        },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      // No lockfile → npm audit fails with ENOLOCK; previously this parsed
+      // npm's {"error": ...} stdout as zero vulnerabilities (false clean)
+      expect(result.isError).toBe(true);
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toBeDefined();
+      expect(sc.isError).toBe(true);
+      expect(typeof sc.category).toBe("string");
+      expect(typeof sc.message).toBe("string");
+      expect((sc.message as string).toLowerCase()).toContain("lockfile");
+    });
+  });
+
   describe("run", () => {
     it("returns structured run data for a valid script", async () => {
       const pkgPath = resolve(__dirname, "..");

--- a/packages/server-npm/__tests__/parsers.test.ts
+++ b/packages/server-npm/__tests__/parsers.test.ts
@@ -154,6 +154,43 @@ describe("parseOutdatedJson", () => {
     const result = parseOutdatedJson(json);
     expect(result.packages[0].homepage).toBe("https://www.typescriptlang.org/");
   });
+
+  // #1024: npm CLI failures with --json print {"error": {...}} to stdout —
+  // captured from `npm outdated --json --workspace=nope` (npm 11).
+  it("throws on npm's {error: ...} failure payload instead of parsing a package named 'error'", () => {
+    const json = JSON.stringify({
+      error: {
+        summary: "No workspaces found:\n  --workspace=nope",
+        detail: "",
+      },
+    });
+
+    expect(() => parseOutdatedJson(json)).toThrow(/No workspaces found/);
+  });
+
+  it("includes the error code in the thrown message when present", () => {
+    const json = JSON.stringify({
+      error: {
+        code: "ENOLOCK",
+        summary: "This command requires an existing lockfile.",
+        detail: "Try creating one first with: npm i --package-lock-only",
+      },
+    });
+
+    expect(() => parseOutdatedJson(json)).toThrow(/ENOLOCK.*existing lockfile/s);
+  });
+
+  it("still parses a real dependency literally named 'error'", () => {
+    // A package entry has version-shaped fields, not summary/code — must not
+    // be misclassified as a failure payload.
+    const json = JSON.stringify({
+      error: { current: "1.0.0", wanted: "1.1.0", latest: "2.0.0" },
+    });
+
+    const result = parseOutdatedJson(json);
+    expect(result.packages).toHaveLength(1);
+    expect(result.packages[0].name).toBe("error");
+  });
 });
 
 describe("parseListJson", () => {

--- a/packages/server-npm/src/lib/formatters.ts
+++ b/packages/server-npm/src/lib/formatters.ts
@@ -180,22 +180,85 @@ export function formatInit(data: NpmInit): string {
 
 // ── Compact types, mappers, and formatters ───────────────────────────
 
-/** Compact list: counts only, no dependency tree (tree shape can't validate against schema). */
+/** Maximum number of top-level dependencies kept in compact list output. */
+export const COMPACT_LIST_MAX_DEPS = 20;
+
+/**
+ * Compact list: total dependency count, problems, and the first
+ * {@link COMPACT_LIST_MAX_DEPS} top-level dependencies flattened (nested
+ * dependency trees are dropped). Epic #1022: the previous compact shape
+ * dropped the entire payload (no count, no deps, no problems).
+ */
 export interface NpmListCompact {
   [key: string]: unknown;
   name: string;
   version: string;
+  packageManager?: string;
+  dependencyCount: number;
+  dependencies?: Record<string, NpmListDep>;
+  omittedDependencyCount?: number;
+  problems?: string[];
 }
 
 export function compactListMap(data: NpmList): NpmListCompact {
-  return {
+  function countDeps(deps: Record<string, NpmListDep>): number {
+    let count = 0;
+    for (const dep of Object.values(deps)) {
+      count++;
+      if (dep.dependencies) count += countDeps(dep.dependencies);
+    }
+    return count;
+  }
+
+  const allDeps = data.dependencies ?? {};
+  const topLevel = Object.entries(allDeps);
+
+  const result: NpmListCompact = {
     name: data.name,
     version: data.version,
+    dependencyCount: countDeps(allDeps),
   };
+  if (data.packageManager) result.packageManager = data.packageManager;
+
+  if (topLevel.length > 0) {
+    const kept = topLevel.slice(0, COMPACT_LIST_MAX_DEPS);
+    result.dependencies = Object.fromEntries(
+      kept.map(([name, dep]) => [
+        name,
+        { version: dep.version, ...(dep.type ? { type: dep.type } : {}) },
+      ]),
+    );
+    if (topLevel.length > kept.length) {
+      result.omittedDependencyCount = topLevel.length - kept.length;
+    }
+  }
+
+  // Problems (missing/extraneous/invalid deps) are always actionable — never drop them.
+  if (data.problems && data.problems.length > 0) {
+    result.problems = data.problems;
+  }
+
+  return result;
 }
 
 export function formatListCompact(data: NpmListCompact): string {
-  return `${data.name}@${data.version}`;
+  const lines = [`${data.name}@${data.version} (${data.dependencyCount} dependencies)`];
+  if (data.problems && data.problems.length > 0) {
+    lines.push(`Problems (${data.problems.length}):`);
+    for (const problem of data.problems) {
+      lines.push(`  - ${problem}`);
+    }
+  }
+  for (const [name, dep] of Object.entries(data.dependencies ?? {})) {
+    const typeTag = dep.type ? ` [${dep.type}]` : "";
+    lines.push(`  ${name}@${dep.version}${typeTag}`);
+  }
+  if (data.omittedDependencyCount) {
+    lines.push(
+      `  ... and ${data.omittedDependencyCount} more top-level dependencies (compact: false for full tree)`,
+    );
+  }
+  return lines.join("\n");
 }
 
 // ── Info formatters ──────────────────────────────────────────────────
@@ -241,7 +304,7 @@ export function formatInfo(data: NpmInfo, deprecationMessage?: string): string {
   return lines.join("\n");
 }
 
-/** Compact info: drop dependencies, dist details, versions. */
+/** Compact info: drop dependency/version details but keep their counts (#1022). */
 export interface NpmInfoCompact {
   [key: string]: unknown;
   name: string;
@@ -250,6 +313,8 @@ export interface NpmInfoCompact {
   license?: string;
   homepage?: string;
   isDeprecated?: boolean;
+  dependencyCount?: number;
+  versionCount?: number;
 }
 
 export function compactInfoMap(data: NpmInfo): NpmInfoCompact {
@@ -261,6 +326,8 @@ export function compactInfoMap(data: NpmInfo): NpmInfoCompact {
   if (data.license) result.license = data.license;
   if (data.homepage) result.homepage = data.homepage;
   if (data.isDeprecated) result.isDeprecated = data.isDeprecated;
+  if (data.dependencies) result.dependencyCount = Object.keys(data.dependencies).length;
+  if (data.versions && data.versions.length > 0) result.versionCount = data.versions.length;
   return result;
 }
 
@@ -270,6 +337,8 @@ export function formatInfoCompact(data: NpmInfoCompact): string {
   if (data.isDeprecated) lines.push(`DEPRECATED`);
   if (data.license) lines.push(`License: ${data.license}`);
   if (data.homepage) lines.push(`Homepage: ${data.homepage}`);
+  if (data.dependencyCount !== undefined) lines.push(`Dependencies: ${data.dependencyCount}`);
+  if (data.versionCount !== undefined) lines.push(`Published Versions: ${data.versionCount}`);
   return lines.join("\n");
 }
 

--- a/packages/server-npm/src/lib/parsers.ts
+++ b/packages/server-npm/src/lib/parsers.ts
@@ -363,9 +363,30 @@ export function parsePnpmAuditJson(jsonStr: string): NpmAudit {
   return { vulnerabilities };
 }
 
-/** Parses `npm outdated --json` or `pnpm outdated --json` output into structured data with current, wanted, and latest versions. */
+/**
+ * Parses `npm outdated --json` or `pnpm outdated --json` output into structured data with current, wanted, and latest versions.
+ *
+ * Throws when the payload is npm's `{"error": {...}}` failure shape (emitted on
+ * stdout with a non-zero exit, e.g. `--workspace` pointing at a missing
+ * workspace) so a crashed run is never misread as "everything up to date" (#1024).
+ */
 export function parseOutdatedJson(jsonStr: string, _pm: PackageManager = "npm"): NpmOutdated {
   const data = JSON.parse(jsonStr);
+
+  // npm CLI failures with --json print {"error": {code?, summary, detail}} to
+  // stdout — surface that as a failure instead of a package named "error".
+  if (
+    data !== null &&
+    typeof data === "object" &&
+    !Array.isArray(data) &&
+    typeof data.error === "object" &&
+    data.error !== null &&
+    ("summary" in data.error || "code" in data.error)
+  ) {
+    const err = data.error as { code?: string; summary?: string; detail?: string };
+    const parts = [err.code, err.summary, err.detail].filter(Boolean);
+    throw new Error(parts.join(": ") || "npm reported an unknown error");
+  }
 
   // pnpm outdated --json returns an object keyed by package name, same as npm
   // but may also return an array in some versions

--- a/packages/server-npm/src/schemas/index.ts
+++ b/packages/server-npm/src/schemas/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { PareErrorSchema } from "@paretools/shared";
 
 /** Reusable schema field indicating which package manager was used. */
 const packageManagerField = z
@@ -62,6 +63,19 @@ export const NpmAuditSchema = z.object({
 
 export type NpmAudit = z.infer<typeof NpmAuditSchema>;
 
+/**
+ * Output schema for the audit tool: either structured audit results or a
+ * structured Pare error (#1024 — audit is the pilot for `errorOutput`).
+ *
+ * Declared as a single object with optional fields from both shapes because
+ * the MCP SDK does not support union output schemas, while MCP clients
+ * validate `structuredContent` even on `isError` results: successful audits
+ * always carry `vulnerabilities`; failures carry `isError`/`category`/`message`.
+ */
+export const NpmAuditOutputSchema = NpmAuditSchema.partial({ vulnerabilities: true }).extend(
+  PareErrorSchema.partial().shape,
+);
+
 /** Zod schema for a single outdated package entry with current, wanted, and latest versions. */
 export const NpmOutdatedEntrySchema = z.object({
   name: z.string(),
@@ -116,6 +130,16 @@ export const NpmListSchema = z.object({
     .array(z.string())
     .optional()
     .describe("Problems reported by npm ls (e.g., missing/extraneous/invalid deps)"),
+  dependencyCount: z
+    .number()
+    .optional()
+    .describe("Total number of dependencies including nested ones (set in compact output)"),
+  omittedDependencyCount: z
+    .number()
+    .optional()
+    .describe(
+      "Number of top-level dependencies omitted from compact output (use compact: false for the full tree)",
+    ),
 });
 
 export type NpmList = z.infer<typeof NpmListSchema>;
@@ -202,6 +226,14 @@ export const NpmInfoSchema = z.object({
   repository: NpmRepositorySchema.optional().describe("Source code repository info"),
   keywords: z.array(z.string()).optional().describe("Package keywords for discovery"),
   versions: z.array(z.string()).optional().describe("All published versions"),
+  dependencyCount: z
+    .number()
+    .optional()
+    .describe("Number of runtime dependencies (set in compact output)"),
+  versionCount: z
+    .number()
+    .optional()
+    .describe("Number of published versions (set in compact output)"),
 });
 
 export type NpmInfo = z.infer<typeof NpmInfoSchema>;

--- a/packages/server-npm/src/tools/audit.ts
+++ b/packages/server-npm/src/tools/audit.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   dualOutput,
+  errorOutput,
+  classifyError,
   assertNoFlagInjection,
   INPUT_LIMITS,
   projectPathInput,
@@ -10,7 +12,7 @@ import { runPm } from "../lib/npm-runner.js";
 import { detectPackageManager } from "../lib/detect-pm.js";
 import { parseAuditJson, parsePnpmAuditJson, parseYarnAuditJson } from "../lib/parsers.js";
 import { formatAudit } from "../lib/formatters.js";
-import { NpmAuditSchema } from "../schemas/index.js";
+import { NpmAuditOutputSchema } from "../schemas/index.js";
 import { packageManagerInput } from "../lib/pm-input.js";
 
 /** Registers the `audit` tool on the given MCP server. */
@@ -66,7 +68,7 @@ export function registerAuditTool(server: McpServer) {
           ),
         packageManager: packageManagerInput,
       },
-      outputSchema: NpmAuditSchema,
+      outputSchema: NpmAuditOutputSchema,
     },
     async ({
       path,
@@ -114,12 +116,27 @@ export function registerAuditTool(server: McpServer) {
 
       // audit returns exit code 1 when vulnerabilities are found, which is expected
       const output = result.stdout || result.stderr;
-      const audit =
-        pm === "pnpm"
-          ? parsePnpmAuditJson(output)
-          : pm === "yarn"
-            ? parseYarnAuditJson(output)
-            : parseAuditJson(output);
+      let audit;
+      try {
+        audit =
+          pm === "pnpm"
+            ? parsePnpmAuditJson(output)
+            : pm === "yarn"
+              ? parseYarnAuditJson(output)
+              : parseAuditJson(output);
+      } catch {
+        // Unparseable output (crash, garbage, empty) — return a structured
+        // error instead of leaking a raw SyntaxError (#1024).
+        return errorOutput(classifyError(result, `${pm} audit`));
+      }
+
+      // npm prints {"error": {...}} JSON to stdout on failure (e.g. ENOLOCK),
+      // which parses "successfully" as zero vulnerabilities. A non-zero exit
+      // with nothing parsed is a failed audit, not a clean one (#1024).
+      if (result.exitCode !== 0 && audit.vulnerabilities.length === 0) {
+        return errorOutput(classifyError(result, `${pm} audit`));
+      }
+
       return dualOutput({ ...audit, packageManager: pm }, formatAudit);
     },
   );

--- a/packages/server-npm/src/tools/outdated.ts
+++ b/packages/server-npm/src/tools/outdated.ts
@@ -109,10 +109,25 @@ export function registerOutdatedTool(server: McpServer) {
 
       const result = await runPm(pm, pmArgs, cwd);
 
-      // outdated returns exit code 1 when outdated packages exist, which is expected
+      // outdated returns exit code 1 when outdated packages exist, which is
+      // expected — but a non-zero exit with NO output is a crash, and must not
+      // be misread as "everything up to date" (#1024). Mirrors list.ts.
+      if (result.exitCode !== 0 && !result.stdout.trim()) {
+        throw new Error(
+          `${pm} outdated failed: ${result.stderr.trim() || `exit code ${result.exitCode}`}`,
+        );
+      }
+
       const output = result.stdout || "{}";
-      const outdated =
-        pm === "yarn" ? parseYarnOutdatedJson(output) : parseOutdatedJson(output, pm);
+      let outdated;
+      try {
+        outdated = pm === "yarn" ? parseYarnOutdatedJson(output) : parseOutdatedJson(output, pm);
+      } catch (err) {
+        // Unparseable stdout or npm's {"error": {...}} failure payload.
+        throw new Error(
+          `${pm} outdated failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       return dualOutput({ ...outdated, packageManager: pm }, formatOutdated);
     },
   );

--- a/tests/smoke/mocked/npm-tools.smoke.test.ts
+++ b/tests/smoke/mocked/npm-tools.smoke.test.ts
@@ -1153,10 +1153,12 @@ describe("Smoke: npm.outdated", () => {
   });
 
   it("S3 [P0] no package.json", async () => {
-    // outdated parses result.stdout || "{}" so it won't throw, just returns empty
+    // A non-zero exit with no stdout is a crash, not "all deps up to date".
+    // The previous expectation (silently returning empty packages) was the
+    // exact false-clean bug fixed in #1024 — outdated now throws, mirroring
+    // the list S3 contract for the same ELSPROBLEMS failure.
     mockRunPm("", "npm ERR! code ELSPROBLEMS", 1);
-    const { parsed } = await callAndValidate({ path: "/tmp/empty" });
-    expect(parsed.packages).toEqual([]);
+    await expect(callAndValidate({ path: "/tmp/empty" })).rejects.toThrow(/outdated failed/);
   });
 
   it("S4 [P0] flag injection via filter", async () => {


### PR DESCRIPTION
Part of #1022 and #1024.

## Silent/partial failures (#1024)

**outdated** — previously `result.stdout || "{}"` meant an npm crash parsed as "everything up to date" (false clean). Now:
- non-zero exit with empty stdout throws `<pm> outdated failed: <stderr>` (mirrors `list.ts`)
- npm's `{"error": {...}}` JSON payload — which npm prints to **stdout** with exit 1 (verified live: `npm outdated --json --workspace=nope`) — is detected in `parseOutdatedJson` and surfaced as a failure instead of being parsed as a package literally named `error`. A real dependency named `error` (version-shaped fields, no `summary`/`code`) still parses normally.
- npm outdated's normal exit-1-when-outdated-packages-exist behavior is unchanged.

**audit** — previously a bare `JSON.parse(result.stdout || result.stderr)` threw a raw `SyntaxError` on garbage output, and worse: npm prints `{"error": {code: "ENOLOCK", ...}}` as **valid JSON on stdout** with exit 1 (verified live), which parsed "successfully" as zero vulnerabilities — a false clean from a security tool. Now both cases return a structured error via the shared `errorOutput(classifyError(result, "<pm> audit"))` helpers — the pilot usage of `@paretools/shared/errors`.

Two SDK realities shaped the schema change:
- MCP clients validate `structuredContent` against the tool's outputSchema **even on `isError` results**
- the MCP SDK does not support union output schemas (`normalizeObjectSchema` returns undefined and `validateToolOutput` crashes — verified against a live server)

So `NpmAuditOutputSchema` is a single flattened object: `NpmAuditSchema.partial({ vulnerabilities: true })` extended with the optional `PareErrorSchema` fields. Successful audits always carry `vulnerabilities`; failures carry `isError`/`category`/`message`/`suggestion`.

## Compact-mode payload loss (#1022)

**compact list** previously returned only `{name, version}` — no count, no deps, no problems. Now it keeps:
- `dependencyCount` (total, including nested)
- the first 20 top-level dependencies (flattened, nested trees dropped) + `omittedDependencyCount`
- `problems[]` always (missing/extraneous/invalid deps are actionable)
- `packageManager`

**compact info** now keeps `dependencyCount` and `versionCount` alongside the existing core fields. `compactSearchMap` left as-is (already keeps the actionable payload).

New fields are declared in `NpmListSchema`/`NpmInfoSchema` so compact `structuredContent` stays schema-valid for validating clients, and a test asserts `compactListMap` output parses against `NpmListSchema`.

## Tests

- `parsers.test.ts`: npm error-payload detection (summary, code, and the dependency-actually-named-`error` edge)
- `compact.test.ts`: rewritten for the new compact list shape (count, flatten, cap+omitted marker, problems, packageManager/type passthrough, schema validation)
- `info-search.test.ts`: dependencyCount/versionCount coverage
- `integration.test.ts`: two end-to-end failure-path tests against real npm (missing workspace → outdated error; no lockfile → audit `ENOLOCK` structured PareError)

`pnpm --filter @paretools/npm test`: 20 files, 395 tests, all passing. Lint and format:check clean.