### PR TITLE
fix(python): surface tool failures and restore compact payloads

### DIFF
--- a/.changeset/fix-python-silent-and-compact.md
+++ b/.changeset/fix-python-silent-and-compact.md
@@ -1,0 +1,8 @@
+---
+"@paretools/python": patch
+---
+
+Surface silent tool failures and restore compact-mode payloads (part of #1022 and #1024).
+
+- pip-audit, mypy, ruff-check, ruff-format, pip-install, and poetry now attach `error` and `exitCode` when a run fails without producing parseable output, instead of returning a silent zeroed result — a crashed pip-audit no longer reads as "0 vulnerabilities", and pip's `ERROR:` lines are captured.
+- Compact mode now keeps the actionable payload: mypy/ruff diagnostics (first 20 + severity/fixable counts), pip-audit severity counts + vulnerability identities, pip-list name/version pairs, poetry package/artifact/message entries, pyenv version lists, and uv-run truncated stdout/stderr via the shared compact-stream budget.

--- a/packages/server-python/__tests__/compact.test.ts
+++ b/packages/server-python/__tests__/compact.test.ts
@@ -157,7 +157,7 @@ describe("formatPytestCompact", () => {
 // ── Mypy compact ──────────────────────────────────────────────────────
 
 describe("compactMypyMap", () => {
-  it("keeps success, drops individual diagnostics", () => {
+  it("keeps severity counts and first-N diagnostics", () => {
     const data: MypyResult = {
       success: false,
       diagnostics: [
@@ -181,26 +181,103 @@ describe("compactMypyMap", () => {
     const compact = compactMypyMap(data);
 
     expect(compact.success).toBe(false);
-    expect(compact).not.toHaveProperty("diagnostics");
+    expect(compact.errorCount).toBe(1);
+    expect(compact.warningCount).toBe(0);
+    expect(compact.diagnostics).toEqual([
+      {
+        file: "src/main.py",
+        line: 10,
+        severity: "error",
+        message: "Incompatible return value type",
+        code: "return-value",
+      },
+      {
+        file: "src/utils.py",
+        line: 3,
+        severity: "note",
+        message: "Revealed type is 'builtins.str'",
+      },
+    ]);
+    expect(compact).not.toHaveProperty("truncated");
+  });
+
+  it("caps diagnostics at 20 and sets truncated", () => {
+    const data: MypyResult = {
+      success: false,
+      diagnostics: Array.from({ length: 25 }, (_, i) => ({
+        file: `src/m${i}.py`,
+        line: i + 1,
+        severity: "error" as const,
+        message: `error ${i}`,
+      })),
+    };
+
+    const compact = compactMypyMap(data);
+
+    expect(compact.errorCount).toBe(25);
+    expect(compact.diagnostics).toHaveLength(20);
+    expect(compact.truncated).toBe(true);
+  });
+
+  it("passes through error and exitCode from failed runs", () => {
+    const data: MypyResult = {
+      success: false,
+      diagnostics: [],
+      error: "mypy: error: Cannot find config file 'missing.ini'",
+      exitCode: 2,
+    };
+
+    const compact = compactMypyMap(data);
+
+    expect(compact.error).toBe("mypy: error: Cannot find config file 'missing.ini'");
+    expect(compact.exitCode).toBe(2);
   });
 });
 
 describe("formatMypyCompact", () => {
   it("formats clean result", () => {
-    const compact = { success: true };
+    const compact = { success: true, errorCount: 0, warningCount: 0 };
     expect(formatMypyCompact(compact)).toBe("mypy: no errors found.");
   });
 
-  it("formats result with errors", () => {
-    const compact = { success: false };
-    expect(formatMypyCompact(compact)).toBe("mypy: errors found.");
+  it("formats result with errors including diagnostics", () => {
+    const compact = {
+      success: false,
+      errorCount: 1,
+      warningCount: 0,
+      diagnostics: [
+        {
+          file: "src/main.py",
+          line: 10,
+          severity: "error" as const,
+          message: "Incompatible return value type",
+          code: "return-value",
+        },
+      ],
+    };
+    const output = formatMypyCompact(compact);
+    expect(output).toContain("mypy: 1 errors, 0 warnings");
+    expect(output).toContain("src/main.py:10 error: Incompatible return value type [return-value]");
+  });
+
+  it("formats failed run with error detail", () => {
+    const compact = {
+      success: false,
+      errorCount: 0,
+      warningCount: 0,
+      error: "mypy: error: Cannot find config file 'missing.ini'",
+      exitCode: 2,
+    };
+    const output = formatMypyCompact(compact);
+    expect(output).toContain("mypy: run failed (exit code 2)");
+    expect(output).toContain("Cannot find config file");
   });
 });
 
 // ── Ruff compact ──────────────────────────────────────────────────────
 
 describe("compactRuffMap", () => {
-  it("keeps success and fixedCount, drops diagnostics", () => {
+  it("keeps totals, fixedCount, and first-N diagnostics", () => {
     const data: RuffResult = {
       success: false,
       diagnostics: [
@@ -211,6 +288,8 @@ describe("compactRuffMap", () => {
           code: "F401",
           message: "'os' imported but unused",
           fixable: true,
+          fixApplicability: "safe",
+          url: "https://docs.astral.sh/ruff/rules/unused-import",
         },
         {
           file: "src/main.py",
@@ -227,20 +306,104 @@ describe("compactRuffMap", () => {
     const compact = compactRuffMap(data);
 
     expect(compact.success).toBe(false);
+    expect(compact.total).toBe(2);
+    expect(compact.fixableCount).toBe(1);
     expect(compact.fixedCount).toBe(1);
-    expect(compact).not.toHaveProperty("diagnostics");
+    expect(compact.diagnostics).toEqual([
+      {
+        file: "src/main.py",
+        line: 1,
+        column: 1,
+        code: "F401",
+        message: "'os' imported but unused",
+        fixable: true,
+      },
+      {
+        file: "src/main.py",
+        line: 5,
+        column: 10,
+        code: "E501",
+        message: "Line too long",
+        fixable: false,
+      },
+    ]);
+    expect(compact).not.toHaveProperty("truncated");
+  });
+
+  it("caps diagnostics at 20 and sets truncated", () => {
+    const data: RuffResult = {
+      success: false,
+      diagnostics: Array.from({ length: 30 }, (_, i) => ({
+        file: `src/m${i}.py`,
+        line: i + 1,
+        column: 1,
+        code: "F401",
+        message: `unused import ${i}`,
+        fixable: true,
+      })),
+    };
+
+    const compact = compactRuffMap(data);
+
+    expect(compact.total).toBe(30);
+    expect(compact.diagnostics).toHaveLength(20);
+    expect(compact.truncated).toBe(true);
+  });
+
+  it("passes through error and exitCode from failed runs", () => {
+    const data: RuffResult = {
+      success: false,
+      diagnostics: [],
+      error: "ruff failed\n  Cause: Failed to parse ruff.toml",
+      exitCode: 2,
+    };
+
+    const compact = compactRuffMap(data);
+
+    expect(compact.error).toContain("Failed to parse ruff.toml");
+    expect(compact.exitCode).toBe(2);
   });
 });
 
 describe("formatRuffCompact", () => {
   it("formats clean result", () => {
-    const compact = { success: true };
+    const compact = { success: true, total: 0, fixableCount: 0 };
     expect(formatRuffCompact(compact)).toBe("ruff: no issues found.");
   });
 
   it("formats result with issues", () => {
-    const compact = { success: false, fixedCount: 3 };
-    expect(formatRuffCompact(compact)).toBe("ruff: issues found, 3 fixed");
+    const compact = {
+      success: false,
+      total: 2,
+      fixableCount: 1,
+      fixedCount: 3,
+      diagnostics: [
+        {
+          file: "src/main.py",
+          line: 1,
+          column: 1,
+          code: "F401",
+          message: "'os' imported but unused",
+          fixable: true,
+        },
+      ],
+    };
+    const output = formatRuffCompact(compact);
+    expect(output).toContain("ruff: 2 issues (1 fixable, 3 fixed)");
+    expect(output).toContain("src/main.py:1:1 F401: 'os' imported but unused");
+  });
+
+  it("formats failed run with error detail", () => {
+    const compact = {
+      success: false,
+      total: 0,
+      fixableCount: 0,
+      error: "ruff failed\n  Cause: Failed to parse ruff.toml",
+      exitCode: 2,
+    };
+    const output = formatRuffCompact(compact);
+    expect(output).toContain("ruff: run failed (exit code 2)");
+    expect(output).toContain("Failed to parse ruff.toml");
   });
 });
 
@@ -322,7 +485,7 @@ describe("formatPipInstallCompact", () => {
 // ── Pip Audit compact ─────────────────────────────────────────────────
 
 describe("compactPipAuditMap", () => {
-  it("keeps success, drops vulnerability details", () => {
+  it("keeps total, severity counts, and vulnerability identities", () => {
     const data: PipAuditResult = {
       success: false,
       vulnerabilities: [
@@ -332,6 +495,7 @@ describe("compactPipAuditMap", () => {
           id: "PYSEC-2023-001",
           description: "Session fixation vulnerability",
           fixVersions: ["2.31.0"],
+          severity: "HIGH",
         },
         {
           name: "flask",
@@ -346,19 +510,92 @@ describe("compactPipAuditMap", () => {
     const compact = compactPipAuditMap(data);
 
     expect(compact.success).toBe(false);
-    expect(compact).not.toHaveProperty("vulnerabilities");
+    expect(compact.total).toBe(2);
+    expect(compact.severityCounts).toEqual({ HIGH: 1, unknown: 1 });
+    expect(compact.vulnerabilities).toHaveLength(2);
+    expect(compact.vulnerabilities?.[0]).toMatchObject({
+      name: "requests",
+      version: "2.25.0",
+      id: "PYSEC-2023-001",
+      fixVersions: ["2.31.0"],
+      severity: "HIGH",
+    });
+  });
+
+  it("truncates long descriptions and caps entries at 10", () => {
+    const data: PipAuditResult = {
+      success: false,
+      vulnerabilities: Array.from({ length: 12 }, (_, i) => ({
+        name: `pkg${i}`,
+        version: "1.0.0",
+        id: `PYSEC-2024-${i}`,
+        description: "x".repeat(500),
+        fixVersions: [],
+      })),
+    };
+
+    const compact = compactPipAuditMap(data);
+
+    expect(compact.total).toBe(12);
+    expect(compact.vulnerabilities).toHaveLength(10);
+    expect(compact.truncated).toBe(true);
+    expect(compact.vulnerabilities?.[0].description.length).toBeLessThanOrEqual(141);
+  });
+
+  it("passes through error and exitCode from crashed audits", () => {
+    const data: PipAuditResult = {
+      success: false,
+      vulnerabilities: [],
+      error: "ERROR:pip_audit._cli:Vulnerability service returned an error",
+      exitCode: 1,
+    };
+
+    const compact = compactPipAuditMap(data);
+
+    expect(compact.total).toBe(0);
+    expect(compact.error).toContain("Vulnerability service returned an error");
+    expect(compact.exitCode).toBe(1);
   });
 });
 
 describe("formatPipAuditCompact", () => {
   it("formats clean audit", () => {
-    const compact = { success: true };
+    const compact = { success: true, total: 0 };
     expect(formatPipAuditCompact(compact)).toBe("No vulnerabilities found.");
   });
 
   it("formats audit with vulnerabilities", () => {
-    const compact = { success: false };
-    expect(formatPipAuditCompact(compact)).toBe("Vulnerabilities found.");
+    const compact = {
+      success: false,
+      total: 2,
+      severityCounts: { HIGH: 1, unknown: 1 },
+      vulnerabilities: [
+        {
+          name: "requests",
+          version: "2.25.0",
+          id: "PYSEC-2023-001",
+          description: "Session fixation",
+          fixVersions: ["2.31.0"],
+          severity: "HIGH",
+        },
+      ],
+    };
+    const output = formatPipAuditCompact(compact);
+    expect(output).toContain("2 vulnerabilities (1 HIGH, 1 unknown):");
+    expect(output).toContain("requests==2.25.0 PYSEC-2023-001 [HIGH] (fix: 2.31.0)");
+  });
+
+  it("formats crashed audit as NOT a clean scan", () => {
+    const compact = {
+      success: false,
+      total: 0,
+      error: "ERROR:pip_audit._cli:Vulnerability service returned an error",
+      exitCode: 1,
+    };
+    const output = formatPipAuditCompact(compact);
+    expect(output).toContain("audit failed (exit code 1)");
+    expect(output).toContain("NOT a clean scan");
+    expect(output).not.toContain("No vulnerabilities found");
   });
 });
 
@@ -401,7 +638,7 @@ describe("formatUvInstallCompact", () => {
 // ── Uv Run compact ───────────────────────────────────────────────────
 
 describe("compactUvRunMap", () => {
-  it("keeps exitCode and success; drops stdout/stderr", () => {
+  it("keeps exitCode, success, and truncated streams (the #983/#1020 pattern)", () => {
     const data: UvRun = {
       exitCode: 0,
       stdout: "Hello, world!\nLine 2\nLine 3",
@@ -413,8 +650,43 @@ describe("compactUvRunMap", () => {
 
     expect(compact.exitCode).toBe(0);
     expect(compact.success).toBe(true);
+    expect(compact.stdout).toBe("Hello, world!\nLine 2\nLine 3");
+    expect(compact.stderr).toBe("some warnings here");
+    expect(compact).not.toHaveProperty("stdoutTruncated");
+    expect(compact).not.toHaveProperty("stderrTruncated");
+  });
+
+  it("prefers commandStderr and omits empty streams", () => {
+    const data: UvRun = {
+      exitCode: 1,
+      stdout: "",
+      stderr: "Resolved 3 packages\nTraceback (most recent call last):\n  ValueError: boom",
+      commandStderr: "Traceback (most recent call last):\n  ValueError: boom",
+      success: false,
+    };
+
+    const compact = compactUvRunMap(data);
+
     expect(compact).not.toHaveProperty("stdout");
-    expect(compact).not.toHaveProperty("stderr");
+    expect(compact.stderr).toBe("Traceback (most recent call last):\n  ValueError: boom");
+  });
+
+  it("truncates long streams and sets truncation metadata", () => {
+    const longStdout = Array.from({ length: 200 }, (_, i) => `line ${i}`).join("\n");
+    const data: UvRun = {
+      exitCode: 0,
+      stdout: longStdout,
+      stderr: "",
+      success: true,
+    };
+
+    const compact = compactUvRunMap(data);
+
+    expect(compact.stdoutTruncated).toBe(true);
+    expect(compact.stdoutTotalLines).toBe(200);
+    expect(compact.stdout).toContain("line 0");
+    expect(compact.stdout).toContain("lines omitted");
+    expect(compact.stdout).toContain("line 199");
   });
 });
 
@@ -424,20 +696,27 @@ describe("formatUvRunCompact", () => {
     expect(formatUvRunCompact(compact)).toBe("uv run completed");
   });
 
-  it("formats failed run", () => {
-    const compact = { exitCode: 1, success: false };
-    expect(formatUvRunCompact(compact)).toBe("uv run failed (exit 1)");
+  it("formats failed run with streams", () => {
+    const compact = {
+      exitCode: 1,
+      success: false,
+      stderr: "ValueError: boom",
+    };
+    const output = formatUvRunCompact(compact);
+    expect(output).toContain("uv run failed (exit 1)");
+    expect(output).toContain("stderr:");
+    expect(output).toContain("ValueError: boom");
   });
 });
 
 // ── Pip List compact ──────────────────────────────────────────────────
 
 describe("compactPipListMap", () => {
-  it("keeps success and error, drops package details", () => {
+  it("keeps total and name/version pairs", () => {
     const data: PipList = {
       success: true,
       packages: [
-        { name: "flask", version: "3.0.0" },
+        { name: "flask", version: "3.0.0", location: "/usr/lib/site-packages" },
         { name: "requests", version: "2.31.0" },
       ],
     };
@@ -445,18 +724,50 @@ describe("compactPipListMap", () => {
     const compact = compactPipListMap(data);
 
     expect(compact.success).toBe(true);
-    expect(compact).not.toHaveProperty("packages");
+    expect(compact.total).toBe(2);
+    expect(compact.packages).toEqual([
+      { name: "flask", version: "3.0.0" },
+      { name: "requests", version: "2.31.0" },
+    ]);
+  });
+
+  it("keeps latestVersion for outdated mode and caps at 50", () => {
+    const data: PipList = {
+      success: true,
+      packages: Array.from({ length: 60 }, (_, i) => ({
+        name: `pkg${i}`,
+        version: "1.0.0",
+        latestVersion: "2.0.0",
+      })),
+    };
+
+    const compact = compactPipListMap(data);
+
+    expect(compact.total).toBe(60);
+    expect(compact.packages).toHaveLength(50);
+    expect(compact.truncated).toBe(true);
+    expect(compact.packages?.[0].latestVersion).toBe("2.0.0");
   });
 });
 
 describe("formatPipListCompact", () => {
-  it("formats successful list", () => {
-    const compact = { success: true };
-    expect(formatPipListCompact(compact)).toBe("Packages listed.");
+  it("formats successful list with packages", () => {
+    const compact = {
+      success: true,
+      total: 2,
+      packages: [
+        { name: "flask", version: "3.0.0" },
+        { name: "requests", version: "2.31.0" },
+      ],
+    };
+    const output = formatPipListCompact(compact);
+    expect(output).toContain("2 packages installed:");
+    expect(output).toContain("flask==3.0.0");
+    expect(output).toContain("requests==2.31.0");
   });
 
   it("formats error", () => {
-    const compact = { success: false, error: "parse error" };
+    const compact = { success: false, total: 0, error: "parse error" };
     expect(formatPipListCompact(compact)).toBe("pip list error: parse error");
   });
 });

--- a/packages/server-python/__tests__/formatters.test.ts
+++ b/packages/server-python/__tests__/formatters.test.ts
@@ -824,22 +824,24 @@ describe("formatPyenv", () => {
 });
 
 describe("formatPyenvCompact", () => {
-  it("formats failed action", () => {
+  it("formats failed action with error detail", () => {
     const data = compactPyenvMap({
       action: "install",
       success: false,
       error: "not found",
     } as PyenvResult);
-    expect(formatPyenvCompact(data)).toBe("pyenv install failed.");
+    expect(formatPyenvCompact(data)).toBe("pyenv install failed: not found");
   });
 
-  it("formats successful action", () => {
+  it("formats successful versions action with the version list", () => {
     const data = compactPyenvMap({
       action: "versions",
       success: true,
       versions: ["3.11.7"],
     } as PyenvResult);
-    expect(formatPyenvCompact(data)).toBe("pyenv versions: success.");
+    const output = formatPyenvCompact(data);
+    expect(output).toContain("1 versions installed:");
+    expect(output).toContain("3.11.7");
   });
 });
 
@@ -946,7 +948,7 @@ describe("formatPoetryCompact", () => {
     expect(formatPoetryCompact(data)).toBe("poetry: failed.");
   });
 
-  it("formats successful action", () => {
+  it("formats successful action with package entries", () => {
     const data = compactPoetryMap({
       success: true,
       packages: [
@@ -954,7 +956,22 @@ describe("formatPoetryCompact", () => {
         { name: "flask", version: "3.0.0" },
       ],
     } as PoetryResult);
-    expect(formatPoetryCompact(data)).toBe("poetry: success.");
+    const output = formatPoetryCompact(data);
+    expect(output).toContain("poetry: success.");
+    expect(output).toContain("2 packages:");
+    expect(output).toContain("requests==2.31.0");
+    expect(output).toContain("flask==3.0.0");
+  });
+
+  it("keeps messages and error on failed runs", () => {
+    const data = compactPoetryMap({
+      success: false,
+      messages: ["Poetry could not find a pyproject.toml file in C:\\proj or its parents"],
+      exitCode: 1,
+    } as PoetryResult);
+    const output = formatPoetryCompact(data);
+    expect(output).toContain("poetry: failed.");
+    expect(output).toContain("could not find a pyproject.toml");
   });
 });
 

--- a/packages/server-python/__tests__/pyenv.test.ts
+++ b/packages/server-python/__tests__/pyenv.test.ts
@@ -259,7 +259,7 @@ describe("formatPyenv", () => {
 // ── Compact formatter tests ──────────────────────────────────────────
 
 describe("compactPyenvMap", () => {
-  it("maps full result to compact form", () => {
+  it("keeps versions and current for the versions action", () => {
     const data: PyenvResult = {
       action: "versions",
       success: true,
@@ -270,8 +270,33 @@ describe("compactPyenvMap", () => {
 
     expect(compact.action).toBe("versions");
     expect(compact.success).toBe(true);
-    // Compact drops versions/current/etc.
-    expect((compact as Record<string, unknown>).versions).toBeUndefined();
+    // Compact keeps the version list — it is the whole point of the call (#1022)
+    expect(compact.versions).toEqual(["3.10.13", "3.11.7", "3.12.0"]);
+    expect(compact.current).toBe("3.12.0");
+  });
+
+  it("caps installList availableVersions at 50 with a count", () => {
+    const data: PyenvResult = {
+      action: "installList",
+      success: true,
+      availableVersions: Array.from({ length: 120 }, (_, i) => `3.${i}.0`),
+    };
+    const compact = compactPyenvMap(data);
+
+    expect(compact.availableVersionCount).toBe(120);
+    expect(compact.availableVersions).toHaveLength(50);
+    expect(compact.truncated).toBe(true);
+  });
+
+  it("passes through error on failure", () => {
+    const data: PyenvResult = {
+      action: "install",
+      success: false,
+      error: "python-build: definition not found: 9.9.9",
+    };
+    const compact = compactPyenvMap(data);
+
+    expect(compact.error).toBe("python-build: definition not found: 9.9.9");
   });
 });
 

--- a/packages/server-python/__tests__/silent-failures.test.ts
+++ b/packages/server-python/__tests__/silent-failures.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from "vitest";
+import {
+  parsePipInstall,
+  parseMypyJsonOutput,
+  parseMypyTextOutput,
+  parseRuffJson,
+  parseRuffFormatOutput,
+  parsePipAuditJson,
+  parsePoetryOutput,
+} from "../src/lib/parsers.js";
+
+// Epic #1024: parsers must never return a zeroed/empty result on a failed run
+// without surfacing WHY (error + exitCode). Fixtures below are real CLI output.
+
+// ── pip-audit ────────────────────────────────────────────────────────
+
+describe("parsePipAuditJson — silent failures (#1024)", () => {
+  // Real pip-audit stderr when the vulnerability service is unreachable
+  const auditCrashStderr =
+    "ERROR:pip_audit._cli:Vulnerability service PyPI returned an error: " +
+    "HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded";
+
+  it("surfaces a crashed audit instead of reporting 0 vulnerabilities", () => {
+    const result = parsePipAuditJson("", 1, auditCrashStderr);
+
+    expect(result.success).toBe(false);
+    expect(result.vulnerabilities).toEqual([]);
+    expect(result.error).toContain("Vulnerability service PyPI returned an error");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("does NOT attach error when exit 1 comes from found vulnerabilities", () => {
+    const stdout = JSON.stringify({
+      dependencies: [
+        {
+          name: "requests",
+          version: "2.25.0",
+          vulns: [{ id: "PYSEC-2023-001", description: "bad", fix_versions: ["2.31.0"] }],
+        },
+      ],
+    });
+    const result = parsePipAuditJson(stdout, 1, "");
+
+    expect(result.vulnerabilities).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("attaches error on non-zero exit with valid JSON but no vulnerabilities (e.g. --strict skip)", () => {
+    const stdout = JSON.stringify({ dependencies: [] });
+    const result = parsePipAuditJson(
+      stdout,
+      1,
+      "ERROR: dependency 'local-pkg' could not be audited",
+    );
+
+    expect(result.vulnerabilities).toEqual([]);
+    expect(result.error).toContain("could not be audited");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("leaves clean successful audits unchanged", () => {
+    const result = parsePipAuditJson(JSON.stringify({ dependencies: [] }), 0, "");
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("attaches a fallback message when the crash produced no output at all", () => {
+    const result = parsePipAuditJson("", 1, "");
+
+    expect(result.error).toContain("exited with code 1");
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+// ── mypy ─────────────────────────────────────────────────────────────
+
+describe("parseMypyJsonOutput — silent failures (#1024)", () => {
+  it("surfaces usage/config errors (exit 2) with empty output", () => {
+    // mypy writes usage errors to stderr and produces no JSON on stdout
+    const stderr = "mypy: error: Cannot find config file 'missing.ini'";
+    const result = parseMypyJsonOutput("", 2, stderr);
+
+    expect(result.success).toBe(false);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.error).toBe(stderr);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("does NOT attach error for exit 1 with parsed diagnostics (normal type errors)", () => {
+    const stdout = JSON.stringify([
+      {
+        file: "src/main.py",
+        line: 10,
+        column: 5,
+        message: "Incompatible return value type",
+        hint: null,
+        code: "return-value",
+        severity: "error",
+      },
+    ]);
+    const result = parseMypyJsonOutput(stdout, 1, "");
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("attaches stderr alongside diagnostics when exit > 1", () => {
+    // mypy exits 2 on blocking errors but may still emit diagnostics
+    const stdout = JSON.stringify([
+      {
+        file: "src/broken.py",
+        line: 3,
+        column: 1,
+        message: "invalid syntax",
+        hint: null,
+        code: "syntax",
+        severity: "error",
+      },
+    ]);
+    const stderr = "Found 1 error in 1 file (errors prevented further checking)";
+    const result = parseMypyJsonOutput(stdout, 2, stderr);
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.error).toBe(stderr);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("surfaces failures through the text-parsing fallback too", () => {
+    const stderr = "mypy: error: Invalid value for --python-version: 'not-a-version'";
+    const result = parseMypyTextOutput("", 2, stderr);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.error).toBe(stderr);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("leaves clean runs unchanged", () => {
+    const result = parseMypyJsonOutput("[]", 0, "");
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+});
+
+// ── ruff check ───────────────────────────────────────────────────────
+
+describe("parseRuffJson — silent failures (#1024)", () => {
+  it("surfaces unparseable output on non-zero exit (config error)", () => {
+    // Real ruff stderr shape for a broken config file (exit 2, no JSON on stdout)
+    const stderr =
+      "ruff failed\n  Cause: Failed to parse C:\\proj\\ruff.toml\n" +
+      "  Cause: TOML parse error at line 1, column 1";
+    const result = parseRuffJson("", 2, stderr);
+
+    expect(result.success).toBe(false);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.error).toContain("Failed to parse");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("does NOT attach error when JSON parses (violations found, exit 1)", () => {
+    const stdout = JSON.stringify([
+      {
+        code: "F401",
+        message: "'os' imported but unused",
+        filename: "main.py",
+        location: { row: 1, column: 1 },
+      },
+    ]);
+    const result = parseRuffJson(stdout, 1, "");
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("keeps the old empty result for unparseable output at exit 0", () => {
+    const result = parseRuffJson("not json", 0, "");
+
+    expect(result.success).toBe(true);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.error).toBeUndefined();
+  });
+});
+
+// ── ruff format ──────────────────────────────────────────────────────
+
+describe("parseRuffFormatOutput — silent failures (#1024)", () => {
+  it("surfaces stderr on non-zero exit with no file matches", () => {
+    const stderr =
+      "ruff failed\n  Cause: Failed to parse C:\\proj\\pyproject.toml\n" +
+      "  Cause: TOML parse error at line 12, column 3";
+    const result = parseRuffFormatOutput("", stderr, 2);
+
+    expect(result.success).toBe(false);
+    expect(result.filesChanged).toBe(0);
+    expect(result.error).toContain("Failed to parse");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("does NOT attach error for check-mode exit 1 with matched files", () => {
+    const stderr = "Would reformat: src/main.py\n1 file would be reformatted";
+    const result = parseRuffFormatOutput("", stderr, 1);
+
+    expect(result.filesChanged).toBe(1);
+    expect(result.checkMode).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+});
+
+// ── pip install ──────────────────────────────────────────────────────
+
+describe("parsePipInstall — ERROR line capture (#1024)", () => {
+  // Real pip 25.2 stderr for a nonexistent package (exit 1), captured on Windows
+  const pipErrorStderr =
+    "ERROR: Could not find a version that satisfies the requirement " +
+    "nonexistent-package-xyz-12345 (from versions: none)\n" +
+    "ERROR: No matching distribution found for nonexistent-package-xyz-12345";
+
+  it("captures pip ERROR: lines into error on failure", () => {
+    const result = parsePipInstall("", pipErrorStderr, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Could not find a version that satisfies");
+    expect(result.error).toContain("No matching distribution found");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("falls back to raw stderr when the failure has no ERROR: lines", () => {
+    const stderr = "Traceback (most recent call last):\n  MemoryError";
+    const result = parsePipInstall("", stderr, 2);
+
+    expect(result.error).toContain("MemoryError");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("does not attach error on successful installs with warnings", () => {
+    const stdout = "Successfully installed requests-2.31.0";
+    const stderr = "WARNING: You are using pip version 25.2";
+    const result = parsePipInstall(stdout, stderr, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.installed).toEqual([{ name: "requests", version: "2.31.0" }]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBeUndefined();
+  });
+});
+
+// ── poetry ───────────────────────────────────────────────────────────
+
+describe("parsePoetryOutput — messages fallback (#1024)", () => {
+  // Real poetry error when run outside a project
+  const noPyprojectStderr =
+    "Poetry could not find a pyproject.toml file in C:\\proj or its parents";
+
+  it("keeps raw output lines as messages when install parses nothing", () => {
+    const result = parsePoetryOutput("", noPyprojectStderr, 1, "install");
+
+    expect(result.success).toBe(false);
+    expect(result.packages).toEqual([]);
+    expect(result.messages).toEqual([noPyprojectStderr]);
+  });
+
+  it("keeps raw output lines as messages when show parses nothing", () => {
+    const result = parsePoetryOutput("", noPyprojectStderr, 1, "show");
+
+    expect(result.packages).toEqual([]);
+    expect(result.messages).toEqual([noPyprojectStderr]);
+  });
+
+  it("keeps raw output lines as messages when build parses nothing", () => {
+    const stderr = "No file/folder found for package broken-project";
+    const result = parsePoetryOutput("", stderr, 1, "build");
+
+    expect(result.artifacts).toEqual([]);
+    expect(result.messages).toEqual([stderr]);
+  });
+
+  it("attaches a fallback error when a failed run produced no output at all", () => {
+    const result = parsePoetryOutput("", "", 1, "add");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("exited with code 1");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("does not add messages when packages were parsed", () => {
+    const stdout = "  - Installing requests (2.31.0)\n  - Installing flask (3.0.0)";
+    const result = parsePoetryOutput(stdout, "", 0, "install");
+
+    expect(result.packages).toEqual([
+      { name: "requests", version: "2.31.0" },
+      { name: "flask", version: "3.0.0" },
+    ]);
+    expect(result.messages).toBeUndefined();
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/packages/server-python/src/lib/formatters.ts
+++ b/packages/server-python/src/lib/formatters.ts
@@ -20,12 +20,32 @@ import type {
   PyenvResult,
   PoetryResult,
 } from "../schemas/index.js";
+import { compactStreamFields, type CompactStreamFields } from "@paretools/shared";
+
+/** Maximum diagnostic entries kept in compact mode (mypy/ruff). */
+const COMPACT_MAX_DIAGNOSTICS = 20;
+/** Maximum vulnerability entries kept in compact mode (pip-audit). */
+const COMPACT_MAX_VULNS = 10;
+/** Maximum characters of a vulnerability description kept in compact mode. */
+const COMPACT_VULN_DESCRIPTION_MAX = 140;
+/** Maximum package/artifact/version entries kept in compact mode (pip-list/poetry/pyenv). */
+const COMPACT_MAX_ENTRIES = 50;
+/** Maximum message lines kept in compact mode (poetry). */
+const COMPACT_MAX_MESSAGES = 20;
 
 /** Formats structured pip install results into a human-readable summary of installed packages. */
 export function formatPipInstall(data: PipInstall): string {
   const total = (data.installed ?? []).length;
-  if (data.alreadySatisfied && total === 0) return "All requirements already satisfied.";
-  if (!data.success) return "pip install failed.";
+  if (data.alreadySatisfied && total === 0 && data.success) {
+    return "All requirements already satisfied.";
+  }
+  if (!data.success) {
+    const lines = [
+      `pip install failed${data.exitCode !== undefined ? ` (exit code ${data.exitCode})` : ""}.`,
+    ];
+    if (data.error) lines.push(data.error);
+    return lines.join("\n");
+  }
 
   const verb = data.dryRun ? "Would install" : "Installed";
   const lines = [`${verb} ${total} packages:`];
@@ -38,6 +58,9 @@ export function formatPipInstall(data: PipInstall): string {
 /** Formats structured mypy type-check results into a human-readable diagnostic summary. */
 export function formatMypy(data: MypyResult): string {
   const diagnostics = data.diagnostics ?? [];
+  if (data.error && diagnostics.length === 0) {
+    return [`mypy: run failed (exit code ${data.exitCode ?? "?"}).`, data.error].join("\n");
+  }
   if (data.success && diagnostics.length === 0) return "mypy: no errors found.";
 
   const errors = diagnostics.filter((d) => d.severity === "error").length;
@@ -50,6 +73,7 @@ export function formatMypy(data: MypyResult): string {
     const code = d.code ? ` [${d.code}]` : "";
     lines.push(`  ${d.file}:${d.line}${col} ${d.severity}: ${d.message}${code}`);
   }
+  if (data.error) lines.push(data.error);
   return lines.join("\n");
 }
 
@@ -57,6 +81,9 @@ export function formatMypy(data: MypyResult): string {
 export function formatRuff(data: RuffResult): string {
   const diagnostics = data.diagnostics ?? [];
   const total = diagnostics.length;
+  if (data.error && total === 0) {
+    return [`ruff: run failed (exit code ${data.exitCode ?? "?"}).`, data.error].join("\n");
+  }
   if (total === 0) return "ruff: no issues found.";
 
   const fixable = diagnostics.filter((d) => d.fixable).length;
@@ -73,6 +100,12 @@ export function formatRuff(data: RuffResult): string {
 export function formatPipAudit(data: PipAuditResult): string {
   const vulns = data.vulnerabilities ?? [];
   const total = vulns.length;
+  if (data.error && total === 0) {
+    return [
+      `pip-audit: audit failed (exit code ${data.exitCode ?? "?"}) — result is NOT a clean scan.`,
+      data.error,
+    ].join("\n");
+  }
   if (total === 0) return "No vulnerabilities found.";
 
   const lines = [`${total} vulnerabilities:`];
@@ -257,41 +290,132 @@ export function formatPytestCompact(data: PytestResultCompact): string {
   return lines.join("\n");
 }
 
-/** Compact mypy: success only. Drop individual diagnostics. */
+/** Compact mypy diagnostic entry: full location + message, minus column/url extras. */
+export interface MypyDiagnosticCompact {
+  file: string;
+  line: number;
+  severity: "error" | "warning" | "note";
+  message: string;
+  code?: string;
+}
+
+/** Compact mypy: severity counts + first-N diagnostics. Notes beyond the cap are dropped. */
 export interface MypyResultCompact {
   [key: string]: unknown;
   success: boolean;
+  errorCount: number;
+  warningCount: number;
+  diagnostics?: MypyDiagnosticCompact[];
+  truncated?: boolean;
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactMypyMap(data: MypyResult): MypyResultCompact {
-  return {
+  const diagnostics = data.diagnostics ?? [];
+  const compact: MypyResultCompact = {
     success: data.success,
+    errorCount: diagnostics.filter((d) => d.severity === "error").length,
+    warningCount: diagnostics.filter((d) => d.severity === "warning").length,
   };
+  if (diagnostics.length > 0) {
+    compact.diagnostics = diagnostics.slice(0, COMPACT_MAX_DIAGNOSTICS).map((d) => ({
+      file: d.file,
+      line: d.line,
+      severity: d.severity,
+      message: d.message,
+      ...(d.code ? { code: d.code } : {}),
+    }));
+    if (diagnostics.length > COMPACT_MAX_DIAGNOSTICS) compact.truncated = true;
+  }
+  if (data.error !== undefined) compact.error = data.error;
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
+  return compact;
 }
 
 export function formatMypyCompact(data: MypyResultCompact): string {
-  if (data.success) return "mypy: no errors found.";
-  return "mypy: errors found.";
+  const diagnostics = data.diagnostics ?? [];
+  if (data.error && diagnostics.length === 0) {
+    return [`mypy: run failed (exit code ${data.exitCode ?? "?"}).`, data.error].join("\n");
+  }
+  if (data.success && diagnostics.length === 0) return "mypy: no errors found.";
+
+  const lines = [`mypy: ${data.errorCount} errors, ${data.warningCount} warnings`];
+  for (const d of diagnostics) {
+    const code = d.code ? ` [${d.code}]` : "";
+    lines.push(`  ${d.file}:${d.line} ${d.severity}: ${d.message}${code}`);
+  }
+  if (data.truncated) {
+    lines.push("  … more diagnostics omitted (run with compact:false for the full list)");
+  }
+  if (data.error) lines.push(data.error);
+  return lines.join("\n");
 }
 
-/** Compact ruff: success + fixedCount. Drop individual entries. */
+/** Compact ruff diagnostic entry: location + rule + message + fixability. */
+export interface RuffDiagnosticCompact {
+  file: string;
+  line: number;
+  column: number;
+  code: string;
+  message: string;
+  fixable: boolean;
+}
+
+/** Compact ruff: totals + first-N diagnostics. Drop fix metadata/urls. */
 export interface RuffResultCompact {
   [key: string]: unknown;
   success: boolean;
+  total: number;
+  fixableCount: number;
   fixedCount?: number;
+  diagnostics?: RuffDiagnosticCompact[];
+  truncated?: boolean;
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactRuffMap(data: RuffResult): RuffResultCompact {
-  return {
+  const diagnostics = data.diagnostics ?? [];
+  const compact: RuffResultCompact = {
     success: data.success,
+    total: diagnostics.length,
+    fixableCount: diagnostics.filter((d) => d.fixable).length,
     fixedCount: data.fixedCount,
   };
+  if (diagnostics.length > 0) {
+    compact.diagnostics = diagnostics.slice(0, COMPACT_MAX_DIAGNOSTICS).map((d) => ({
+      file: d.file,
+      line: d.line,
+      column: d.column,
+      code: d.code,
+      message: d.message,
+      fixable: d.fixable,
+    }));
+    if (diagnostics.length > COMPACT_MAX_DIAGNOSTICS) compact.truncated = true;
+  }
+  if (data.error !== undefined) compact.error = data.error;
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
+  return compact;
 }
 
 export function formatRuffCompact(data: RuffResultCompact): string {
-  if (data.success && !data.fixedCount) return "ruff: no issues found.";
+  if (data.error && data.total === 0) {
+    return [`ruff: run failed (exit code ${data.exitCode ?? "?"}).`, data.error].join("\n");
+  }
+  if (data.total === 0 && !data.fixedCount) return "ruff: no issues found.";
   const fixedPart = data.fixedCount !== undefined ? `, ${data.fixedCount} fixed` : "";
-  return `ruff: issues found${fixedPart}`;
+  const lines = [`ruff: ${data.total} issues (${data.fixableCount} fixable${fixedPart})`];
+  for (const d of data.diagnostics ?? []) {
+    lines.push(`  ${d.file}:${d.line}:${d.column} ${d.code}: ${d.message}`);
+  }
+  if (data.truncated) {
+    lines.push(
+      `  … ${data.total - (data.diagnostics ?? []).length} more issues omitted (run with compact:false for the full list)`,
+    );
+  }
+  if (data.error) lines.push(data.error);
+  return lines.join("\n");
 }
 
 /** Compact black: success + changed/unchanged counts + errorType. Drop individual file lists. */
@@ -322,44 +446,121 @@ export function formatBlackCompact(data: BlackResultCompact): string {
   return `black: ${data.filesChanged} reformatted, ${data.filesUnchanged} unchanged`;
 }
 
-/** Compact pip-install: success + dryRun. Drop individual package details. */
+/** Compact pip-install: success + dryRun + failure diagnostics. Drop individual package details. */
 export interface PipInstallCompact {
   [key: string]: unknown;
   success: boolean;
   alreadySatisfied: boolean;
   dryRun?: boolean;
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactPipInstallMap(data: PipInstall): PipInstallCompact {
-  return {
+  const compact: PipInstallCompact = {
     success: data.success,
     alreadySatisfied: data.alreadySatisfied,
     dryRun: data.dryRun || undefined,
   };
+  if (data.error !== undefined) compact.error = data.error;
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
+  return compact;
 }
 
 export function formatPipInstallCompact(data: PipInstallCompact): string {
+  if (!data.success) {
+    const lines = [
+      `pip install failed${data.exitCode !== undefined ? ` (exit code ${data.exitCode})` : ""}.`,
+    ];
+    if (data.error) lines.push(data.error);
+    return lines.join("\n");
+  }
   if (data.alreadySatisfied) return "All requirements already satisfied.";
-  if (!data.success) return "pip install failed.";
   const verb = data.dryRun ? "Would install" : "Installed";
   return `${verb} packages.`;
 }
 
-/** Compact pip-audit: success only. Drop individual CVE details. */
+/** Compact pip-audit vulnerability entry: identity + fix versions, truncated description. */
+export interface PipAuditVulnCompact {
+  name: string;
+  version: string;
+  id: string;
+  description: string;
+  fixVersions: string[];
+  severity?: string;
+}
+
+/** Compact pip-audit: total + severity counts + first-N vulnerability identities. */
 export interface PipAuditResultCompact {
   [key: string]: unknown;
   success: boolean;
+  total: number;
+  severityCounts?: Record<string, number>;
+  vulnerabilities?: PipAuditVulnCompact[];
+  truncated?: boolean;
+  skippedCount?: number;
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactPipAuditMap(data: PipAuditResult): PipAuditResultCompact {
-  return {
+  const vulns = data.vulnerabilities ?? [];
+  const compact: PipAuditResultCompact = {
     success: data.success,
+    total: vulns.length,
   };
+  if (vulns.length > 0) {
+    const severityCounts: Record<string, number> = {};
+    for (const v of vulns) {
+      const severity = v.severity ?? "unknown";
+      severityCounts[severity] = (severityCounts[severity] ?? 0) + 1;
+    }
+    compact.severityCounts = severityCounts;
+    compact.vulnerabilities = vulns.slice(0, COMPACT_MAX_VULNS).map((v) => ({
+      name: v.name,
+      version: v.version,
+      id: v.id,
+      description:
+        v.description.length > COMPACT_VULN_DESCRIPTION_MAX
+          ? v.description.slice(0, COMPACT_VULN_DESCRIPTION_MAX) + "…"
+          : v.description,
+      fixVersions: v.fixVersions,
+      ...(v.severity ? { severity: v.severity } : {}),
+    }));
+    if (vulns.length > COMPACT_MAX_VULNS) compact.truncated = true;
+  }
+  if (data.skipped && data.skipped.length > 0) compact.skippedCount = data.skipped.length;
+  if (data.error !== undefined) compact.error = data.error;
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
+  return compact;
 }
 
 export function formatPipAuditCompact(data: PipAuditResultCompact): string {
-  if (data.success) return "No vulnerabilities found.";
-  return "Vulnerabilities found.";
+  if (data.error && data.total === 0) {
+    return [
+      `pip-audit: audit failed (exit code ${data.exitCode ?? "?"}) — result is NOT a clean scan.`,
+      data.error,
+    ].join("\n");
+  }
+  if (data.total === 0) return "No vulnerabilities found.";
+
+  const severityPart = data.severityCounts
+    ? ` (${Object.entries(data.severityCounts)
+        .map(([sev, count]) => `${count} ${sev}`)
+        .join(", ")})`
+    : "";
+  const lines = [`${data.total} vulnerabilities${severityPart}:`];
+  for (const v of data.vulnerabilities ?? []) {
+    const fix = v.fixVersions.length ? ` (fix: ${v.fixVersions.join(", ")})` : "";
+    const severity = v.severity ? ` [${v.severity}]` : "";
+    lines.push(`  ${v.name}==${v.version} ${v.id}${severity}${fix}`);
+  }
+  if (data.truncated) {
+    lines.push(
+      `  … ${data.total - (data.vulnerabilities ?? []).length} more omitted (run with compact:false for the full list)`,
+    );
+  }
+  return lines.join("\n");
 }
 
 /** Compact uv-install: success + error info. Drop individual packages. */
@@ -391,8 +592,9 @@ export function formatUvInstallCompact(data: UvInstallCompact): string {
   return "Installed packages.";
 }
 
-/** Compact uv-run: exitCode. Drop stdout/stderr. */
-export interface UvRunCompact {
+/** Compact uv-run: exitCode + truncated stdout/stderr streams (the #983/#1020 pattern).
+ *  Streams are trimmed to the shared compact budget instead of being dropped. */
+export interface UvRunCompact extends CompactStreamFields {
   [key: string]: unknown;
   exitCode: number;
   success: boolean;
@@ -404,13 +606,24 @@ export function compactUvRunMap(data: UvRun): UvRunCompact {
     exitCode: data.exitCode,
     success: data.success,
     truncated: data.truncated,
+    ...compactStreamFields(data.stdout, data.commandStderr ?? data.stderr),
   };
 }
 
 export function formatUvRunCompact(data: UvRunCompact): string {
   const status = data.success ? "completed" : `failed (exit ${data.exitCode})`;
   const truncated = data.truncated ? " (truncated)" : "";
-  return `uv run ${status}${truncated}`;
+  const lines = [`uv run ${status}${truncated}`];
+  if (data.stdout?.trim()) {
+    lines.push("stdout:", data.stdout.trim());
+  }
+  if (data.stderr?.trim()) {
+    lines.push("stderr:", data.stderr.trim());
+  }
+  if (data.stdoutTruncated || data.stderrTruncated) {
+    lines.push("… streams truncated to compact budget (run with compact:false for full output)");
+  }
+  return lines.join("\n");
 }
 
 // ── pip-list formatters ──────────────────────────────────────────────
@@ -429,24 +642,56 @@ export function formatPipList(data: PipList): string {
   return lines.join("\n");
 }
 
-/** Compact pip-list: success + error only. Drop individual package details. */
+/** Compact pip-list package entry: name/version (+ latest when outdated=true). */
+export interface PipListPackageCompact {
+  name: string;
+  version: string;
+  latestVersion?: string;
+}
+
+/** Compact pip-list: total + first-N name/version pairs. Drop location metadata. */
 export interface PipListCompact {
   [key: string]: unknown;
   success: boolean;
+  total: number;
+  packages?: PipListPackageCompact[];
+  truncated?: boolean;
   error?: string;
 }
 
 export function compactPipListMap(data: PipList): PipListCompact {
-  return {
+  const packages = data.packages ?? [];
+  const compact: PipListCompact = {
     success: data.success,
+    total: packages.length,
     error: data.error,
   };
+  if (packages.length > 0) {
+    compact.packages = packages.slice(0, COMPACT_MAX_ENTRIES).map((p) => ({
+      name: p.name,
+      version: p.version,
+      ...(p.latestVersion ? { latestVersion: p.latestVersion } : {}),
+    }));
+    if (packages.length > COMPACT_MAX_ENTRIES) compact.truncated = true;
+  }
+  return compact;
 }
 
 export function formatPipListCompact(data: PipListCompact): string {
   if (data.error) return `pip list error: ${data.error}`;
-  if (data.success) return "Packages listed.";
-  return "No packages installed.";
+  if (data.total === 0) return "No packages installed.";
+
+  const lines = [`${data.total} packages installed:`];
+  for (const pkg of data.packages ?? []) {
+    const latest = pkg.latestVersion ? ` (latest: ${pkg.latestVersion})` : "";
+    lines.push(`  ${pkg.name}==${pkg.version}${latest}`);
+  }
+  if (data.truncated) {
+    lines.push(
+      `  … ${data.total - (data.packages ?? []).length} more omitted (run with compact:false for the full list)`,
+    );
+  }
+  return lines.join("\n");
 }
 
 // ── pip-show formatters ──────────────────────────────────────────────
@@ -532,6 +777,9 @@ export function formatPipShowCompact(data: PipShowCompact): string {
 
 /** Formats structured ruff format results into a human-readable summary. */
 export function formatRuffFormat(data: RuffFormatResult): string {
+  if (data.error && data.filesChanged === 0) {
+    return [`ruff format: run failed (exit code ${data.exitCode ?? "?"}).`, data.error].join("\n");
+  }
   if (data.success && data.filesChanged === 0) {
     const unchanged = data.filesUnchanged > 0 ? ` (${data.filesUnchanged} unchanged)` : "";
     return `ruff format: all files already formatted.${unchanged}`;
@@ -558,18 +806,26 @@ export interface RuffFormatResultCompact {
   filesChanged: number;
   filesUnchanged: number;
   checkMode?: boolean;
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactRuffFormatMap(data: RuffFormatResult): RuffFormatResultCompact {
-  return {
+  const compact: RuffFormatResultCompact = {
     success: data.success,
     filesChanged: data.filesChanged,
     filesUnchanged: data.filesUnchanged,
     checkMode: data.checkMode || undefined,
   };
+  if (data.error !== undefined) compact.error = data.error;
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
+  return compact;
 }
 
 export function formatRuffFormatCompact(data: RuffFormatResultCompact): string {
+  if (data.error && data.filesChanged === 0) {
+    return [`ruff format: run failed (exit code ${data.exitCode ?? "?"}).`, data.error].join("\n");
+  }
   if (data.success && data.filesChanged === 0) {
     const unchanged = data.filesUnchanged > 0 ? ` (${data.filesUnchanged} unchanged)` : "";
     return `ruff format: all files already formatted.${unchanged}`;
@@ -912,15 +1168,43 @@ export function formatPyenv(data: PyenvResult): string {
   }
 }
 
-/** Compact pyenv: action + success + key value only. */
+/** Compact pyenv: action + success + key value, keeping version lists for list
+ *  actions (the whole point of calling them) with a cap on the huge installList. */
 export interface PyenvResultCompact {
   [key: string]: unknown;
   action: string;
   success: boolean;
   keyValue?: string;
+  versions?: string[];
+  current?: string;
+  availableVersionCount?: number;
+  availableVersions?: string[];
+  truncated?: boolean;
+  error?: string;
 }
 
 export function compactPyenvMap(data: PyenvResult): PyenvResultCompact {
+  const compact: PyenvResultCompact = {
+    action: data.action,
+    success: data.success,
+  };
+  if (data.error !== undefined) compact.error = data.error;
+
+  if (data.action === "versions") {
+    if (data.versions) compact.versions = data.versions;
+    if (data.current) compact.current = data.current;
+    return compact;
+  }
+  if (data.action === "installList") {
+    const avail = data.availableVersions ?? [];
+    compact.availableVersionCount = avail.length;
+    if (avail.length > 0) {
+      compact.availableVersions = avail.slice(0, COMPACT_MAX_ENTRIES);
+      if (avail.length > COMPACT_MAX_ENTRIES) compact.truncated = true;
+    }
+    return compact;
+  }
+
   let keyValue: string | undefined;
   if (data.action === "version") keyValue = data.current;
   if (data.action === "local") keyValue = data.localVersion;
@@ -928,15 +1212,34 @@ export function compactPyenvMap(data: PyenvResult): PyenvResultCompact {
   if (data.action === "install") keyValue = data.installed;
   if (data.action === "uninstall") keyValue = data.uninstalled;
   if (data.action === "which") keyValue = data.commandPath;
-  return {
-    action: data.action,
-    success: data.success,
-    keyValue,
-  };
+  compact.keyValue = keyValue;
+  return compact;
 }
 
 export function formatPyenvCompact(data: PyenvResultCompact): string {
-  if (!data.success) return `pyenv ${data.action} failed.`;
+  if (!data.success) {
+    return `pyenv ${data.action} failed${data.error ? `: ${data.error}` : "."}`;
+  }
+  if (data.versions) {
+    const lines = [`${data.versions.length} versions installed:`];
+    for (const v of data.versions) {
+      const marker = v === data.current ? " *" : "";
+      lines.push(`  ${v}${marker}`);
+    }
+    return lines.join("\n");
+  }
+  if (data.availableVersionCount !== undefined) {
+    const lines = [`${data.availableVersionCount} versions available for installation:`];
+    for (const v of data.availableVersions ?? []) {
+      lines.push(`  ${v}`);
+    }
+    if (data.truncated) {
+      lines.push(
+        `  … ${data.availableVersionCount - (data.availableVersions ?? []).length} more omitted (run with compact:false for the full list)`,
+      );
+    }
+    return lines.join("\n");
+  }
   if (data.keyValue) return `pyenv ${data.action}: ${data.keyValue}`;
   return `pyenv ${data.action}: success.`;
 }
@@ -946,7 +1249,16 @@ export function formatPyenvCompact(data: PyenvResultCompact): string {
 /** Formats structured poetry results into a human-readable summary.
  *  action is passed separately since it is not included in the output schema. */
 export function formatPoetry(data: PoetryResult, action: string): string {
-  if (!data.success) return `poetry ${action} failed.`;
+  if (!data.success) {
+    const lines = [
+      `poetry ${action} failed${data.exitCode !== undefined ? ` (exit code ${data.exitCode})` : ""}.`,
+    ];
+    for (const m of data.messages ?? []) {
+      lines.push(`  ${m}`);
+    }
+    if (data.error) lines.push(data.error);
+    return lines.join("\n");
+  }
 
   if (action === "show") {
     const pkgs = data.packages ?? [];
@@ -989,20 +1301,70 @@ export function formatPoetry(data: PoetryResult, action: string): string {
   return lines.join("\n");
 }
 
-/** Compact poetry: success only. Drop individual package/artifact details.
+/** Compact poetry: counts + first-N entries per collection. Drop descriptions.
  *  action is not in the Zod schema so it must not appear in compact output. */
 export interface PoetryResultCompact {
   [key: string]: unknown;
   success: boolean;
+  packageCount?: number;
+  packages?: { name: string; version: string }[];
+  artifactCount?: number;
+  artifacts?: { file: string }[];
+  messageCount?: number;
+  messages?: string[];
+  truncated?: boolean;
+  error?: string;
+  exitCode?: number;
 }
 
 export function compactPoetryMap(data: PoetryResult): PoetryResultCompact {
-  return {
+  const compact: PoetryResultCompact = {
     success: data.success,
   };
+  if (data.packages) {
+    compact.packageCount = data.packages.length;
+    compact.packages = data.packages
+      .slice(0, COMPACT_MAX_ENTRIES)
+      .map((p) => ({ name: p.name, version: p.version }));
+    if (data.packages.length > COMPACT_MAX_ENTRIES) compact.truncated = true;
+  }
+  if (data.artifacts) {
+    compact.artifactCount = data.artifacts.length;
+    compact.artifacts = data.artifacts.slice(0, COMPACT_MAX_ENTRIES).map((a) => ({ file: a.file }));
+    if (data.artifacts.length > COMPACT_MAX_ENTRIES) compact.truncated = true;
+  }
+  if (data.messages) {
+    compact.messageCount = data.messages.length;
+    compact.messages = data.messages.slice(0, COMPACT_MAX_MESSAGES);
+    if (data.messages.length > COMPACT_MAX_MESSAGES) compact.truncated = true;
+  }
+  if (data.error !== undefined) compact.error = data.error;
+  if (data.exitCode !== undefined) compact.exitCode = data.exitCode;
+  return compact;
 }
 
 export function formatPoetryCompact(data: PoetryResultCompact): string {
-  if (!data.success) return "poetry: failed.";
-  return "poetry: success.";
+  const lines = [data.success ? "poetry: success." : "poetry: failed."];
+  if (data.packageCount !== undefined) {
+    lines.push(`${data.packageCount} packages:`);
+    for (const pkg of data.packages ?? []) {
+      lines.push(`  ${pkg.name}==${pkg.version}`);
+    }
+  }
+  if (data.artifactCount !== undefined) {
+    lines.push(`${data.artifactCount} artifacts:`);
+    for (const a of data.artifacts ?? []) {
+      lines.push(`  ${a.file}`);
+    }
+  }
+  if (data.messages && data.messages.length > 0) {
+    for (const m of data.messages) {
+      lines.push(`  ${m}`);
+    }
+  }
+  if (data.truncated) {
+    lines.push("  … entries omitted (run with compact:false for the full list)");
+  }
+  if (data.error) lines.push(data.error);
+  return lines.join("\n");
 }

--- a/packages/server-python/src/lib/parsers.ts
+++ b/packages/server-python/src/lib/parsers.ts
@@ -19,6 +19,7 @@ import type {
   PoetryResult,
 } from "../schemas/index.js";
 import { z } from "zod";
+import { surfaceEmptyFailure } from "@paretools/shared";
 
 type MypyDiagnostic = z.infer<typeof MypyDiagnosticSchema>;
 
@@ -65,20 +66,37 @@ export function parsePipInstall(stdout: string, stderr: string, exitCode: number
     }
   }
 
+  const errors: string[] = [];
   for (const line of lines) {
     const trimmed = line.trim();
     if (/^(WARNING|DEPRECATION):/i.test(trimmed)) {
       warnings.push(trimmed);
     }
+    if (/^ERROR:/i.test(trimmed)) {
+      errors.push(trimmed);
+    }
   }
 
-  return {
+  const data: PipInstall = {
     success: exitCode === 0,
     installed,
     alreadySatisfied,
     warnings: warnings.length > 0 ? warnings : undefined,
     dryRun,
   };
+  // pip reports failures as "ERROR: ..." lines (often on stderr); surface them
+  // instead of returning a bare success:false with no explanation (#1024).
+  if (exitCode !== 0) {
+    data.exitCode = exitCode;
+    if (errors.length > 0) data.error = errors.join("\n");
+  }
+  return surfaceEmptyFailure(
+    data,
+    { exitCode, stdout, stderr },
+    {
+      isEmpty: (d) => (d.installed ?? []).length === 0,
+    },
+  );
 }
 
 const MYPY_RE = /^(.+?):(\d+)(?::(\d+))?: (error|warning|note): (.+?)(?:\s+\[([^\]]+)\])?$/;
@@ -94,18 +112,50 @@ interface MypyJsonEntry {
   severity: "error" | "warning" | "note";
 }
 
+/** Maximum size of the error detail attached to failed mypy runs. */
+const MYPY_ERROR_DETAIL_MAX = 4096;
+
+/** mypy exits 1 when type errors are found (a normal, parseable run) and 2+ on
+ *  usage/config errors (bad flags, unreadable config, internal crash). Surfaces
+ *  the latter so a crashed run does not read as a clean pass (#1024):
+ *  - non-zero exit with zero diagnostics → attach stderr/stdout tail as `error`
+ *  - exit > 1 with diagnostics → attach stderr as `error` alongside them */
+function attachMypyFailure(
+  data: MypyResult,
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): MypyResult {
+  if (exitCode === 0) return data;
+  if ((data.diagnostics ?? []).length === 0) {
+    return surfaceEmptyFailure(data, { exitCode, stdout, stderr }, { isEmpty: () => true });
+  }
+  if (exitCode > 1) {
+    const out: MypyResult = { ...data, exitCode };
+    const detail = stderr.trim();
+    if (detail) {
+      out.error =
+        detail.length > MYPY_ERROR_DETAIL_MAX
+          ? `… (output truncated)\n${detail.slice(-MYPY_ERROR_DETAIL_MAX)}`
+          : detail;
+    }
+    return out;
+  }
+  return data;
+}
+
 /** Parses mypy JSON output (from `--output json`) into structured diagnostics. */
-export function parseMypyJsonOutput(stdout: string, exitCode: number): MypyResult {
+export function parseMypyJsonOutput(stdout: string, exitCode: number, stderr = ""): MypyResult {
   let entries: MypyJsonEntry[];
   try {
     entries = JSON.parse(stdout);
   } catch {
     // Fall back to text parsing if JSON parsing fails (older mypy without --output json)
-    return parseMypyTextOutput(stdout, exitCode);
+    return parseMypyTextOutput(stdout, exitCode, stderr);
   }
 
   if (!Array.isArray(entries)) {
-    return parseMypyTextOutput(stdout, exitCode);
+    return parseMypyTextOutput(stdout, exitCode, stderr);
   }
 
   const diagnostics: MypyDiagnostic[] = entries.map((e) => ({
@@ -117,14 +167,11 @@ export function parseMypyJsonOutput(stdout: string, exitCode: number): MypyResul
     code: e.code || undefined,
   }));
 
-  return {
-    success: exitCode === 0,
-    diagnostics,
-  };
+  return attachMypyFailure({ success: exitCode === 0, diagnostics }, stdout, stderr, exitCode);
 }
 
 /** Parses mypy text output into structured diagnostics (fallback for older mypy without JSON). */
-export function parseMypyTextOutput(stdout: string, exitCode: number): MypyResult {
+export function parseMypyTextOutput(stdout: string, exitCode: number, stderr = ""): MypyResult {
   const lines = stdout.split("\n");
   const diagnostics: MypyDiagnostic[] = [];
 
@@ -142,10 +189,7 @@ export function parseMypyTextOutput(stdout: string, exitCode: number): MypyResul
     }
   }
 
-  return {
-    success: exitCode === 0,
-    diagnostics,
-  };
+  return attachMypyFailure({ success: exitCode === 0, diagnostics }, stdout, stderr, exitCode);
 }
 
 /** Parses mypy output: tries JSON first, falls back to text parsing.
@@ -160,7 +204,14 @@ export function parseRuffJson(stdout: string, exitCode: number, stderr = ""): Ru
   try {
     entries = JSON.parse(stdout);
   } catch {
-    return { success: exitCode === 0, diagnostics: [] };
+    // ruff exits 1 with valid JSON when violations are found; unparseable
+    // output on a non-zero exit is a crashed/misconfigured run, not a clean
+    // pass — surface stderr instead of an empty diagnostics list (#1024).
+    return surfaceEmptyFailure(
+      { success: exitCode === 0, diagnostics: [] },
+      { exitCode, stdout, stderr },
+      { isEmpty: () => true },
+    );
   }
 
   const diagnostics = entries.map((e) => ({
@@ -218,13 +269,20 @@ interface RuffJsonEntry {
   url?: string;
 }
 
-/** Parses `pip-audit --format json` output into structured vulnerability data with fix versions. */
-export function parsePipAuditJson(stdout: string, exitCode: number): PipAuditResult {
+/** Parses `pip-audit --format json` output into structured vulnerability data with fix versions.
+ *  pip-audit exits 1 both when vulnerabilities are found (a successful audit with valid JSON)
+ *  and when the audit itself fails; a non-zero exit with no parseable vulnerabilities is a
+ *  crashed audit and must not read as "0 vulnerabilities" (#1024). */
+export function parsePipAuditJson(stdout: string, exitCode: number, stderr = ""): PipAuditResult {
   let data: PipAuditJson;
   try {
     data = JSON.parse(stdout);
   } catch {
-    return { success: exitCode === 0, vulnerabilities: [] };
+    return surfaceEmptyFailure(
+      { success: exitCode === 0, vulnerabilities: [] },
+      { exitCode, stdout, stderr },
+      { isEmpty: () => true },
+    );
   }
 
   const byPackage: NonNullable<PipAuditResult["byPackage"]> = [];
@@ -253,12 +311,18 @@ export function parsePipAuditJson(stdout: string, exitCode: number): PipAuditRes
     return packageVulns;
   });
 
-  return {
-    success: exitCode === 0,
-    vulnerabilities,
-    byPackage: byPackage.length > 0 ? byPackage : undefined,
-    skipped: skipped.length > 0 ? skipped : undefined,
-  };
+  return surfaceEmptyFailure(
+    {
+      success: exitCode === 0,
+      vulnerabilities,
+      byPackage: byPackage.length > 0 ? byPackage : undefined,
+      skipped: skipped.length > 0 ? skipped : undefined,
+    },
+    { exitCode, stdout, stderr },
+    // Exit 1 with parsed vulnerabilities is the normal "vulns found" outcome;
+    // only a non-zero exit with nothing parsed gets an error attached.
+    { isEmpty: (d) => (d.vulnerabilities ?? []).length === 0 },
+  );
 }
 
 interface PipAuditJson {
@@ -922,13 +986,20 @@ export function parseRuffFormatOutput(
   const unchangedMatch = output.match(/(\d+) files? (?:would be )?left unchanged/);
   const filesUnchanged = unchangedMatch ? parseInt(unchangedMatch[1], 10) : 0;
 
-  return {
-    success: exitCode === 0,
-    filesChanged: filesChanged || files.length,
-    filesUnchanged,
-    files: files.length > 0 ? files : undefined,
-    checkMode,
-  };
+  // A non-zero exit with no file matches means ruff format crashed (bad config,
+  // invalid flag, unreadable path) rather than "files need reformatting" —
+  // surface stderr instead of a silent zeroed result (#1024).
+  return surfaceEmptyFailure(
+    {
+      success: exitCode === 0,
+      filesChanged: filesChanged || files.length,
+      filesUnchanged,
+      files: files.length > 0 ? files : undefined,
+      checkMode,
+    },
+    { exitCode, stdout, stderr },
+    { isEmpty: (d) => d.filesChanged === 0 && (d.files ?? []).length === 0 },
+  );
 }
 
 // ── conda parsers ────────────────────────────────────────────────────
@@ -1171,7 +1242,10 @@ const POETRY_BUILT_RE = /Built\s+(\S+)/;
 /** Regex matching `poetry add/remove` installed/removed lines with version e.g. "  - Installing requests (2.31.0)" */
 const POETRY_INSTALL_LINE_RE = /(?:Installing|Updating|Removing)\s+(\S+)\s+\(([^)]+)\)/;
 
-/** Parses poetry output into structured data based on the action performed. */
+/** Parses poetry output into structured data based on the action performed.
+ *  When an action-specific parse finds nothing (e.g. the run failed before doing
+ *  any work), the raw output lines are kept as `messages` — mirroring the
+ *  check/lock/export branch — so failures are never silently zeroed (#1024). */
 export function parsePoetryOutput(
   stdout: string,
   stderr: string,
@@ -1180,6 +1254,25 @@ export function parsePoetryOutput(
 ): PoetryResult {
   const output = stdout + "\n" + stderr;
   const lines = output.split("\n");
+
+  /** Raw output lines fallback used when a branch-specific parse finds nothing. */
+  const fallbackMessages = (): string[] | undefined => {
+    const messages = lines.map((l) => l.trim()).filter(Boolean);
+    return messages.length > 0 ? messages : undefined;
+  };
+
+  /** Attaches error/exitCode when the run failed and produced nothing at all. */
+  const finish = (data: PoetryResult): PoetryResult =>
+    surfaceEmptyFailure(
+      data,
+      { exitCode, stdout, stderr },
+      {
+        isEmpty: (d) =>
+          (d.packages ?? []).length === 0 &&
+          (d.artifacts ?? []).length === 0 &&
+          (d.messages ?? []).length === 0,
+      },
+    );
 
   if (action === "show") {
     const packages: { name: string; version: string; description?: string }[] = [];
@@ -1196,10 +1289,11 @@ export function parsePoetryOutput(
         });
       }
     }
-    return {
+    return finish({
       success: exitCode === 0,
       packages,
-    };
+      messages: packages.length === 0 ? fallbackMessages() : undefined,
+    });
   }
 
   if (action === "build") {
@@ -1210,18 +1304,18 @@ export function parsePoetryOutput(
         artifacts.push({ file: match[1] });
       }
     }
-    return {
+    return finish({
       success: exitCode === 0,
       artifacts,
-    };
+      messages: artifacts.length === 0 ? fallbackMessages() : undefined,
+    });
   }
 
   if (action === "check" || action === "lock" || action === "export") {
-    const messages = lines.map((l) => l.trim()).filter(Boolean);
-    return {
+    return finish({
       success: exitCode === 0,
-      messages: messages.length > 0 ? messages : undefined,
-    };
+      messages: fallbackMessages(),
+    });
   }
 
   // install, add, remove, update — parse installed/updated/removed packages
@@ -1233,8 +1327,9 @@ export function parsePoetryOutput(
     }
   }
 
-  return {
+  return finish({
     success: exitCode === 0,
     packages,
-  };
+    messages: packages.length === 0 ? fallbackMessages() : undefined,
+  });
 }

--- a/packages/server-python/src/schemas/index.ts
+++ b/packages/server-python/src/schemas/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { EmptyFailureSchemaFields, CompactStreamSchemaFields } from "@paretools/shared";
 
 /** Zod schema for structured pip install output with installed packages and satisfaction status. */
 export const PipInstallSchema = z.object({
@@ -14,6 +15,7 @@ export const PipInstallSchema = z.object({
   alreadySatisfied: z.boolean(),
   warnings: z.array(z.string()).optional(),
   dryRun: z.boolean().optional(),
+  ...EmptyFailureSchemaFields,
 });
 
 export type PipInstall = z.infer<typeof PipInstallSchema>;
@@ -32,6 +34,7 @@ export const MypyDiagnosticSchema = z.object({
 export const MypyResultSchema = z.object({
   success: z.boolean(),
   diagnostics: z.array(MypyDiagnosticSchema).optional(),
+  ...EmptyFailureSchemaFields,
 });
 
 export type MypyResult = z.infer<typeof MypyResultSchema>;
@@ -58,6 +61,7 @@ export const RuffResultSchema = z.object({
   success: z.boolean(),
   diagnostics: z.array(RuffDiagnosticSchema).optional(),
   fixedCount: z.number().optional(),
+  ...EmptyFailureSchemaFields,
 });
 
 export type RuffResult = z.infer<typeof RuffResultSchema>;
@@ -94,6 +98,7 @@ export const PipAuditResultSchema = z.object({
       }),
     )
     .optional(),
+  ...EmptyFailureSchemaFields,
 });
 
 export type PipAuditResult = z.infer<typeof PipAuditResultSchema>;
@@ -153,7 +158,8 @@ export const UvInstallSchema = z.object({
 
 export type UvInstall = z.infer<typeof UvInstallSchema>;
 
-/** Zod schema for structured uv run output with exit code and stdout/stderr. */
+/** Zod schema for structured uv run output with exit code and stdout/stderr.
+ *  Compact mode keeps truncated streams and sets the CompactStream metadata fields. */
 export const UvRunSchema = z.object({
   exitCode: z.number(),
   stdout: z.string().optional(),
@@ -162,6 +168,7 @@ export const UvRunSchema = z.object({
   uvDiagnostics: z.array(z.string()).optional(),
   truncated: z.boolean().optional(),
   success: z.boolean(),
+  ...CompactStreamSchemaFields,
 });
 
 export type UvRun = z.infer<typeof UvRunSchema>;
@@ -259,6 +266,7 @@ export const RuffFormatResultSchema = z.object({
   filesUnchanged: z.number(),
   files: z.array(z.string()).optional(),
   checkMode: z.boolean().optional(),
+  ...EmptyFailureSchemaFields,
 });
 
 export type RuffFormatResult = z.infer<typeof RuffFormatResultSchema>;
@@ -475,6 +483,7 @@ export const PoetryResultSchema = z.object({
   packages: z.array(PoetryPackageSchema).optional(),
   artifacts: z.array(PoetryArtifactSchema).optional(),
   messages: z.array(z.string()).optional(),
+  ...EmptyFailureSchemaFields,
 });
 
 export type PoetryResult = z.infer<typeof PoetryResultSchema>;

--- a/packages/server-python/src/tools/mypy.ts
+++ b/packages/server-python/src/tools/mypy.ts
@@ -197,7 +197,7 @@ export function registerMypyTool(server: McpServer) {
       }
 
       const result = await mypy(args, cwd, pythonPath);
-      const data = parseMypyJsonOutput(result.stdout, result.exitCode);
+      const data = parseMypyJsonOutput(result.stdout, result.exitCode, result.stderr);
       return compactDualOutput(
         data,
         result.stdout,

--- a/packages/server-python/src/tools/pip-audit.ts
+++ b/packages/server-python/src/tools/pip-audit.ts
@@ -112,7 +112,7 @@ export function registerPipAuditTool(server: McpServer) {
 
       // pip-audit is a standalone binary, NOT a pip subcommand
       const result = await pipAudit(args, cwd);
-      const data = parsePipAuditJson(result.stdout, result.exitCode);
+      const data = parsePipAuditJson(result.stdout, result.exitCode, result.stderr);
       return compactDualOutput(
         data,
         result.stdout,


### PR DESCRIPTION
## Summary

Implements the `server-python` slice of the two systemic-audit epics. The pytest tool was already fixed in #1023 and is untouched here.

### Silent empty failures (#1024) — `src/lib/parsers.ts`

All fixes use the new `surfaceEmptyFailure` helper from `@paretools/shared` (#1026); affected schemas gain optional `error`/`exitCode` via `EmptyFailureSchemaFields`.

- **pip-audit** (highest priority): a crashed audit (unparseable output on non-zero exit) now attaches `error` + `exitCode` instead of reading as "0 vulnerabilities". Exit 1 with parsed vulnerabilities remains a normal "vulns found" result; stderr is now passed to the parser.
- **mypy**: exit 1 with diagnostics stays normal; exit > 1 (usage/config error) or non-zero with zero diagnostics now surfaces stderr. Applies to both the JSON and text-fallback parsers; the tool now passes stderr through.
- **ruff-check**: the existing stderr param (previously only used for the "Fixed N" regex) is reused to surface unparseable failures.
- **ruff-format**: non-zero exit with no file matches surfaces stderr (check-mode exit 1 with matches is unaffected).
- **pip-install**: pip's `ERROR:` lines are captured into `error`; failures without `ERROR:` lines fall back to the stderr tail.
- **poetry**: install/add/remove/update/show/build now keep raw output lines as `messages` when the branch-specific parse finds nothing — mirroring the existing check/lock/export behavior — with a fallback `error` when the run produced no output at all.

### Compact-mode payload loss (#1022) — `src/lib/formatters.ts`

- `compactMypyMap`: was `{success}` only → errorCount/warningCount + first-20 diagnostics + `truncated` flag.
- `compactRuffMap`: total + fixableCount + first-20 diagnostics (schema-compatible entries incl. `fixable`).
- `compactPipAuditMap`: was `{success}` only → total + severity counts + first-10 vulnerability identities (id/package/version/fixVersions, truncated description).
- `compactPipListMap`: was `{success, error}` only → total + first-50 name/version pairs, keeping `latestVersion` in outdated mode.
- `compactPoetryMap`: was `{success}` only → package/artifact/message counts + capped entries.
- `compactUvRunMap`: now uses `compactStreamFields` from shared (the #983/#1020 pattern) — truncated stdout/stderr instead of dropped streams; `UvRunSchema` gains `CompactStreamSchemaFields`.
- `compactPyenvMap`: keeps `versions[]`/`current` for the versions action and a capped `availableVersions` (+count) for installList.
- All affected compact mappers pass through the new `error`/`exitCode` fields; compact and full text formatters updated accordingly (a crashed pip-audit now prints "audit failed — result is NOT a clean scan" instead of "No vulnerabilities found.").

## Testing

- New `__tests__/silent-failures.test.ts` with realistic fixtures (real pip 25.2 error output captured on this machine, real ruff/mypy/poetry/pip-audit failure shapes) covering every parser fix including the "don't attach on normal exit-1" cases.
- Updated `compact.test.ts`, `formatters.test.ts`, `pyenv.test.ts` to assert the new compact payloads, caps, and truncation flags.
- `@paretools/python`: 482 tests passing (13 files) — unit, integration, and fidelity.
- `pnpm lint` clean (one pre-existing warning in `packages/shared/src/server.ts`, untouched); `pnpm format:check` clean.

Part of #1022 and #1024.