### PR TITLE
fix: declare compact-only fields in output schemas so structuredContent validates

### DIFF
--- a/.changeset/declare-compact-only-fields.md
+++ b/.changeset/declare-compact-only-fields.md
@@ -1,0 +1,9 @@
+---
+"@paretools/shared": patch
+"@paretools/python": patch
+"@paretools/lint": patch
+"@paretools/go": patch
+"@paretools/cargo": patch
+---
+
+Declare compact-only fields in output schemas so structuredContent validates against the registered outputSchema. Compact mappers emitted fields (e.g. `total`, `truncated`, counts) that the Zod outputSchemas did not declare; the MCP SDK converts outputSchema to JSON Schema with `additionalProperties: false` and AJV-validates structuredContent, so compact responses failed with `MCP error -32602` whenever compact mode engaged. Adds `@paretools/shared/testing` with SDK-equivalent schema validation helpers for regression tests.

--- a/packages/server-cargo/__tests__/compact-schema.test.ts
+++ b/packages/server-cargo/__tests__/compact-schema.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Regression tests for #1022/#1025: compact mapper outputs must validate
+ * against the registered Zod outputSchema the way the MCP SDK does (JSON
+ * Schema with additionalProperties: false + AJV). Zod .parse() strips unknown
+ * keys silently, so it cannot catch compact-only fields missing from schemas.
+ */
+import { describe, it, expect } from "vitest";
+import { validateToolOutput } from "@paretools/shared/testing";
+import {
+  compactBuildMap,
+  compactTestMap,
+  compactClippyMap,
+  compactRunMap,
+  compactAddMap,
+  compactRemoveMap,
+  compactFmtMap,
+  compactDocMap,
+  compactUpdateMap,
+  compactTreeMap,
+  compactAuditMap,
+} from "../src/lib/formatters.js";
+import {
+  CargoBuildResultSchema,
+  CargoTestResultSchema,
+  CargoClippyResultSchema,
+  CargoRunResultSchema,
+  CargoAddResultSchema,
+  CargoRemoveResultSchema,
+  CargoFmtResultSchema,
+  CargoDocResultSchema,
+  CargoUpdateResultSchema,
+  CargoTreeResultSchema,
+  CargoAuditResultSchema,
+} from "../src/schemas/index.js";
+import type { CargoAuditResult } from "../src/schemas/index.js";
+
+function expectValid(schema: unknown, payload: unknown) {
+  const result = validateToolOutput(schema, payload);
+  expect(result.errorMessage ?? "valid").toBe("valid");
+  expect(result.valid).toBe(true);
+}
+
+const diagnostic = {
+  file: "src/main.rs",
+  line: 3,
+  column: 5,
+  severity: "error" as const,
+  code: "E0425",
+  message: "cannot find value `foo`",
+  suggestion: "did you mean `for`?",
+};
+
+describe("compact outputs validate against registered outputSchemas (SDK-style)", () => {
+  it("build", () => {
+    expectValid(
+      CargoBuildResultSchema,
+      compactBuildMap({
+        success: false,
+        diagnostics: [diagnostic],
+        timings: { generated: true, format: "html", reportPath: "target/cargo-timings.html" },
+        error: "tail",
+        exitCode: 101,
+      }),
+    );
+  });
+
+  it("test", () => {
+    expectValid(
+      CargoTestResultSchema,
+      compactTestMap({
+        success: false,
+        tests: [
+          { name: "tests::works", status: "ok" },
+          { name: "tests::broken", status: "FAILED", output: "assertion failed" },
+        ],
+        passed: 1,
+        failed: 1,
+        ignored: 0,
+        compilationDiagnostics: [diagnostic],
+        error: "tail",
+        exitCode: 101,
+      }),
+    );
+  });
+
+  it("clippy", () => {
+    expectValid(
+      CargoClippyResultSchema,
+      compactClippyMap({
+        success: false,
+        diagnostics: [diagnostic],
+        error: "tail",
+        exitCode: 101,
+      }),
+    );
+  });
+
+  it("run", () => {
+    expectValid(
+      CargoRunResultSchema,
+      compactRunMap({
+        exitCode: 1,
+        success: false,
+        stdout: "line\n".repeat(500),
+        stderr: "err\n".repeat(500),
+        failureType: "runtime",
+        stdoutTruncated: true,
+      }),
+    );
+  });
+
+  it("add (compact packages field)", () => {
+    const compact = compactAddMap({
+      success: true,
+      added: [
+        { name: "serde", version: "1.0.200", featuresActivated: ["derive"] },
+        { name: "tokio", version: "1.40.0" },
+      ],
+      dependencyType: "dev",
+      dryRun: true,
+    });
+    expect(compact.packages).toEqual(["serde", "tokio"]);
+    expectValid(CargoAddResultSchema, compact);
+  });
+
+  it("remove", () => {
+    expectValid(
+      CargoRemoveResultSchema,
+      compactRemoveMap({
+        success: false,
+        removed: ["serde"],
+        partialSuccess: true,
+        failedPackages: ["tokio"],
+        dependencyType: "normal",
+        error: "not found",
+      }),
+    );
+  });
+
+  it("fmt", () => {
+    expectValid(
+      CargoFmtResultSchema,
+      compactFmtMap({ success: false, needsFormatting: true, filesChanged: 3 }),
+    );
+  });
+
+  it("doc", () => {
+    expectValid(
+      CargoDocResultSchema,
+      compactDocMap({
+        success: true,
+        warnings: 1,
+        warningDetails: [{ file: "src/lib.rs", line: 10, message: "missing docs" }],
+      }),
+    );
+  });
+
+  it("update", () => {
+    expectValid(
+      CargoUpdateResultSchema,
+      compactUpdateMap({
+        success: true,
+        updated: [{ name: "serde", from: "1.0.199", to: "1.0.200" }],
+        totalUpdated: 1,
+      }),
+    );
+  });
+
+  it("tree", () => {
+    expectValid(
+      CargoTreeResultSchema,
+      compactTreeMap({
+        success: true,
+        dependencies: [{ name: "serde", version: "1.0.200", depth: 1 }],
+        packages: 42,
+      }),
+    );
+  });
+
+  it("audit (truncation + top-level severity counts)", () => {
+    const data: CargoAuditResult = {
+      success: false,
+      vulnerabilities: Array.from({ length: 15 }, (_, i) => ({
+        id: `RUSTSEC-2024-${String(i).padStart(4, "0")}`,
+        package: `crate${i}`,
+        version: "1.0.0",
+        severity: i % 2 === 0 ? ("high" as const) : ("medium" as const),
+        title: `vuln ${i}`,
+        patched: [">=1.0.1"],
+        cvssScore: 7.5,
+      })),
+      summary: { total: 15, critical: 0, high: 8, medium: 7, low: 0, informational: 0, unknown: 0 },
+      fixesApplied: 2,
+      error: "tail",
+      exitCode: 1,
+    };
+    const compact = compactAuditMap(data);
+    expect(compact.omittedVulnerabilities).toBe(5);
+    expect(compact.total).toBe(15);
+    expectValid(CargoAuditResultSchema, compact);
+  });
+});

--- a/packages/server-cargo/src/schemas/index.ts
+++ b/packages/server-cargo/src/schemas/index.ts
@@ -106,6 +106,10 @@ export const CargoAddResultSchema = z.object({
     .boolean()
     .optional()
     .describe("True when --dry-run was used; Cargo.toml was not modified"),
+  packages: z
+    .array(z.string())
+    .optional()
+    .describe("Added package names (set in compact output in place of the added list)"),
   error: z.string().optional(),
 });
 
@@ -246,6 +250,17 @@ export const CargoAuditResultSchema = z.object({
     .number()
     .optional()
     .describe("Number of fixes applied when using cargo audit fix"),
+  // Top-level severity counts (set in compact output in place of the nested summary).
+  total: z.number().optional().describe("Total vulnerability count (set in compact output)"),
+  critical: z.number().optional().describe("Critical severity count (set in compact output)"),
+  high: z.number().optional().describe("High severity count (set in compact output)"),
+  medium: z.number().optional().describe("Medium severity count (set in compact output)"),
+  low: z.number().optional().describe("Low severity count (set in compact output)"),
+  informational: z
+    .number()
+    .optional()
+    .describe("Informational severity count (set in compact output)"),
+  unknown: z.number().optional().describe("Unknown severity count (set in compact output)"),
   omittedVulnerabilities: z
     .number()
     .optional()

--- a/packages/server-go/__tests__/compact-schema.test.ts
+++ b/packages/server-go/__tests__/compact-schema.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Regression tests for #1022/#1025: compact mapper outputs must validate
+ * against the registered Zod outputSchema the way the MCP SDK does (JSON
+ * Schema with additionalProperties: false + AJV). Zod .parse() strips unknown
+ * keys silently, so it cannot catch compact-only fields missing from schemas.
+ */
+import { describe, it, expect } from "vitest";
+import { validateToolOutput } from "@paretools/shared/testing";
+import {
+  compactBuildMap,
+  compactTestMap,
+  compactVetMap,
+  compactFmtMap,
+  compactRunMap,
+  compactGenerateMap,
+  compactModTidyMap,
+  compactEnvMap,
+  compactListMap,
+  compactGetMap,
+  compactGolangciLintMap,
+} from "../src/lib/formatters.js";
+import {
+  GoBuildResultSchema,
+  GoTestResultSchema,
+  GoVetResultSchema,
+  GoFmtResultSchema,
+  GoRunResultSchema,
+  GoGenerateResultSchema,
+  GoModTidyResultSchema,
+  GoEnvResultSchema,
+  GoListResultSchema,
+  GoGetResultSchema,
+  GolangciLintResultSchema,
+} from "../src/schemas/index.js";
+import type { GoEnvResult, GolangciLintResult } from "../src/schemas/index.js";
+
+function expectValid(schema: unknown, payload: unknown) {
+  const result = validateToolOutput(schema, payload);
+  expect(result.errorMessage ?? "valid").toBe("valid");
+  expect(result.valid).toBe(true);
+}
+
+describe("compact outputs validate against registered outputSchemas (SDK-style)", () => {
+  it("build", () => {
+    expectValid(
+      GoBuildResultSchema,
+      compactBuildMap({
+        success: false,
+        errors: [{ file: "main.go", line: 3, column: 5, message: "undefined: foo" }],
+        rawErrors: ["package x is not in std"],
+        buildCache: { estimatedHits: 3, estimatedMisses: 1, totalPackages: 4 },
+      }),
+    );
+  });
+
+  it("test", () => {
+    expectValid(
+      GoTestResultSchema,
+      compactTestMap({
+        success: false,
+        passed: 3,
+        failed: 1,
+        skipped: 0,
+        packageFailures: [{ package: "example.com/pkg", output: "build failed" }],
+        error: "go: cannot find main module",
+        exitCode: 1,
+      }),
+    );
+  });
+
+  it("vet", () => {
+    expectValid(
+      GoVetResultSchema,
+      compactVetMap({
+        success: false,
+        diagnostics: [{ file: "main.go", line: 10, message: "printf verb mismatch" }],
+      }),
+    );
+  });
+
+  it("fmt", () => {
+    expectValid(
+      GoFmtResultSchema,
+      compactFmtMap({
+        success: false,
+        filesChanged: 2,
+        parseErrors: [{ file: "bad.go", line: 1, column: 1, message: "expected 'package'" }],
+      }),
+    );
+  });
+
+  it("run", () => {
+    expectValid(
+      GoRunResultSchema,
+      compactRunMap({
+        exitCode: 1,
+        success: false,
+        stdout: "line\n".repeat(500),
+        stderr: "err\n".repeat(500),
+        timedOut: true,
+        stdoutTruncated: true,
+      }),
+    );
+  });
+
+  it("generate (directiveCount)", () => {
+    const compact = compactGenerateMap({
+      success: true,
+      output: "generated",
+      directives: [
+        { file: "gen.go", line: 3, command: "stringer", status: "completed" },
+        { file: "gen.go", line: 9, command: "mockgen", status: "completed" },
+      ],
+    });
+    expect(compact.directiveCount).toBe(2);
+    expectValid(GoGenerateResultSchema, compact);
+  });
+
+  it("mod-tidy (module counts)", () => {
+    const compact = compactModTidyMap({
+      success: true,
+      summary: "tidied",
+      madeChanges: true,
+      addedModules: ["example.com/a v1.0.0", "example.com/b v2.0.0"],
+      removedModules: ["example.com/c v0.1.0"],
+    });
+    expect(compact.addedModuleCount).toBe(2);
+    expect(compact.removedModuleCount).toBe(1);
+    expectValid(GoModTidyResultSchema, compact);
+  });
+
+  it("env (queried vars surface as top-level keys)", () => {
+    const data: GoEnvResult = {
+      success: true,
+      vars: { GOCACHE: "/home/u/.cache/go-build", GOFLAGS: "-mod=mod" },
+      goroot: "/usr/local/go",
+      gopath: "/home/u/go",
+      goversion: "go1.24.0",
+      goos: "linux",
+      goarch: "amd64",
+      cgoEnabled: true,
+    };
+    const compact = compactEnvMap(data, ["GOCACHE", "GOFLAGS"]);
+    expect(compact.GOCACHE).toBe("/home/u/.cache/go-build");
+    expectValid(GoEnvResultSchema, compact);
+  });
+
+  it("list (packageCount)", () => {
+    const compact = compactListMap({
+      success: true,
+      packages: [{ dir: "/p", importPath: "example.com/p", name: "p" }],
+      modules: [{ path: "example.com/m", version: "v1.0.0" }],
+    });
+    expect(compact.packageCount).toBe(2);
+    expectValid(GoListResultSchema, compact);
+  });
+
+  it("get (resolvedCount + failing packages)", () => {
+    const compact = compactGetMap({
+      success: false,
+      resolvedPackages: [{ package: "example.com/a", newVersion: "v1.2.3" }],
+      packages: [
+        { path: "example.com/b", error: "connection timed out", errorType: "timeout" },
+        { path: "example.com/a", version: "v1.2.3" },
+      ],
+    });
+    expect(compact.resolvedCount).toBe(1);
+    expectValid(GoGetResultSchema, compact);
+  });
+
+  it("golangci-lint (truncation triggered)", () => {
+    const data: GolangciLintResult = {
+      errors: 20,
+      warnings: 5,
+      resultsTruncated: true,
+      diagnostics: Array.from({ length: 25 }, (_, i) => ({
+        file: `pkg/file${i}.go`,
+        line: i + 1,
+        column: 2,
+        linter: "govet",
+        severity: i % 2 === 0 ? ("error" as const) : ("warning" as const),
+        message: `issue ${i}`,
+        fix: { text: "replacement" },
+      })),
+      error: "tail",
+      exitCode: 1,
+    };
+    const compact = compactGolangciLintMap(data);
+    expect(compact.diagnosticsOmitted).toBe(5);
+    expectValid(GolangciLintResultSchema, compact);
+  });
+});

--- a/packages/server-go/src/lib/formatters.ts
+++ b/packages/server-go/src/lib/formatters.ts
@@ -417,8 +417,8 @@ export interface GoModTidyCompact {
   success: boolean;
   summary?: string;
   madeChanges?: boolean;
-  addedModules?: number;
-  removedModules?: number;
+  addedModuleCount?: number;
+  removedModuleCount?: number;
   errorType?: GoModTidyResult["errorType"];
 }
 
@@ -428,8 +428,8 @@ export function compactModTidyMap(data: GoModTidyResult): GoModTidyCompact {
   };
   if (data.summary) compact.summary = data.summary;
   if (data.madeChanges !== undefined) compact.madeChanges = data.madeChanges;
-  if (data.addedModules?.length) compact.addedModules = data.addedModules.length;
-  if (data.removedModules?.length) compact.removedModules = data.removedModules.length;
+  if (data.addedModules?.length) compact.addedModuleCount = data.addedModules.length;
+  if (data.removedModules?.length) compact.removedModuleCount = data.removedModules.length;
   if (data.errorType) compact.errorType = data.errorType;
   return compact;
 }

--- a/packages/server-go/src/schemas/index.ts
+++ b/packages/server-go/src/schemas/index.ts
@@ -100,6 +100,10 @@ export const GoModTidyResultSchema = z.object({
   summary: z.string().optional(),
   addedModules: z.array(z.string()).optional(),
   removedModules: z.array(z.string()).optional(),
+  /** Count of added modules (set in compact output in place of the addedModules list). */
+  addedModuleCount: z.number().optional(),
+  /** Count of removed modules (set in compact output in place of the removedModules list). */
+  removedModuleCount: z.number().optional(),
   errorType: z.enum(["network", "checksum", "syntax", "unknown"]).optional(),
   /** Whether go mod tidy actually changed go.mod/go.sum (true) or they were already tidy (false). */
   madeChanges: z.boolean().optional(),
@@ -150,21 +154,29 @@ export const GoGenerateResultSchema = z.object({
   timedOut: z.boolean().optional(),
   /** Parsed per-directive status from -v or -x output. */
   directives: z.array(GoGenerateDirectiveSchema).optional(),
+  /** Count of parsed directives (set in compact output in place of the directives list). */
+  directiveCount: z.number().optional(),
 });
 
 export type GoGenerateResult = z.infer<typeof GoGenerateResultSchema>;
 
 /** Zod schema for structured go env output with environment variables and key fields. */
-export const GoEnvResultSchema = z.object({
-  success: z.boolean(),
-  vars: z.record(z.string(), z.string()).optional(),
-  goroot: z.string(),
-  gopath: z.string(),
-  goversion: z.string(),
-  goos: z.string(),
-  goarch: z.string(),
-  cgoEnabled: z.boolean().optional(),
-});
+export const GoEnvResultSchema = z
+  .object({
+    success: z.boolean(),
+    vars: z.record(z.string(), z.string()).optional(),
+    goroot: z.string(),
+    gopath: z.string(),
+    goversion: z.string(),
+    goos: z.string(),
+    goarch: z.string(),
+    cgoEnabled: z.boolean().optional(),
+  })
+  // Compact mode surfaces explicitly queried variables (Gap #150) as top-level
+  // string entries (e.g. GOCACHE) — allow them through schema validation.
+  // z.unknown() (not z.string()) keeps the inferred type's index signature
+  // compatible with the declared boolean/record fields.
+  .catchall(z.unknown());
 
 export type GoEnvResult = z.infer<typeof GoEnvResultSchema>;
 
@@ -205,6 +217,8 @@ export const GoListResultSchema = z.object({
   packages: z.array(GoListPackageSchema).optional(),
   /** Module list (populated when modules mode is used). */
   modules: z.array(GoListModuleSchema).optional(),
+  /** Combined package/module count (set in compact output in place of the lists). */
+  packageCount: z.number().optional(),
 });
 
 export type GoListResult = z.infer<typeof GoListResultSchema>;
@@ -237,6 +251,8 @@ export const GoGetResultSchema = z.object({
   resolvedPackages: z.array(GoGetResolvedPackageSchema).optional(),
   /** Per-package status showing success/failure for each requested package. */
   packages: z.array(GoGetPackageStatusSchema).optional(),
+  /** Count of resolved packages (set in compact output in place of resolvedPackages). */
+  resolvedCount: z.number().optional(),
   goModChanges: z
     .object({
       added: z.array(z.string()),
@@ -284,6 +300,8 @@ export const GolangciLintResultSchema = z.object({
   errors: z.number(),
   warnings: z.number(),
   resultsTruncated: z.boolean().optional(),
+  /** Number of diagnostics omitted from the compact list (only set when the cap was hit). */
+  diagnosticsOmitted: z.number().optional(),
   /** Linter failure output (config error, crash) surfaced when the run failed with no parseable diagnostics (#1024). */
   ...EmptyFailureSchemaFields,
 });

--- a/packages/server-lint/__tests__/compact-schema.test.ts
+++ b/packages/server-lint/__tests__/compact-schema.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression tests for #1022/#1025: compact mapper outputs must validate
+ * against the registered Zod outputSchema the way the MCP SDK does (JSON
+ * Schema with additionalProperties: false + AJV). Zod .parse() strips unknown
+ * keys silently, so it cannot catch compact-only fields missing from schemas.
+ */
+import { describe, it, expect } from "vitest";
+import { validateToolOutput } from "@paretools/shared/testing";
+import {
+  compactLintMap,
+  compactFormatCheckMap,
+  compactFormatWriteMap,
+} from "../src/lib/formatters.js";
+import {
+  LintResultSchema,
+  FormatCheckResultSchema,
+  FormatWriteResultSchema,
+} from "../src/schemas/index.js";
+import type { LintResult, FormatCheckResult, FormatWriteResult } from "../src/schemas/index.js";
+
+function expectValid(schema: unknown, payload: unknown) {
+  const result = validateToolOutput(schema, payload);
+  expect(result.errorMessage ?? "valid").toBe("valid");
+  expect(result.valid).toBe(true);
+}
+
+describe("compact outputs validate against registered outputSchemas (SDK-style)", () => {
+  it("lint (truncation + deprecationCount triggered)", () => {
+    const data: LintResult = {
+      errors: 20,
+      warnings: 10,
+      filesChecked: 12,
+      diagnostics: Array.from({ length: 30 }, (_, i) => ({
+        file: `src/file${i}.ts`,
+        line: i + 1,
+        column: 2,
+        severity: i % 3 === 0 ? ("error" as const) : ("warning" as const),
+        rule: "no-unused-vars",
+        message: `unused var ${i}`,
+      })),
+      fixableErrorCount: 4,
+      fixableWarningCount: 2,
+      deprecations: [{ text: "rule X is deprecated", reference: "https://eslint.org" }],
+      error: "tail",
+      exitCode: 1,
+    };
+    const compact = compactLintMap(data);
+    expect(compact.diagnosticsTruncated).toBe(true);
+    expect(compact.deprecationCount).toBe(1);
+    expectValid(LintResultSchema, compact);
+  });
+
+  it("format-check (truncation triggered)", () => {
+    const data: FormatCheckResult = {
+      formatted: false,
+      files: Array.from({ length: 60 }, (_, i) => `src/file${i}.ts`),
+      error: "tail",
+      exitCode: 1,
+    };
+    const compact = compactFormatCheckMap(data);
+    expect(compact.filesTruncated).toBe(true);
+    expectValid(FormatCheckResultSchema, compact);
+  });
+
+  it("format-write (truncation triggered)", () => {
+    const data: FormatWriteResult = {
+      success: true,
+      filesChanged: 60,
+      filesUnchanged: 5,
+      files: Array.from({ length: 60 }, (_, i) => `src/file${i}.ts`),
+    };
+    const compact = compactFormatWriteMap(data);
+    expect(compact.filesTruncated).toBe(true);
+    expectValid(FormatWriteResultSchema, compact);
+  });
+
+  it("format-write (error path)", () => {
+    expectValid(
+      FormatWriteResultSchema,
+      compactFormatWriteMap({ success: false, filesChanged: 0, errorMessage: "prettier crashed" }),
+    );
+  });
+});

--- a/packages/server-lint/src/schemas/index.ts
+++ b/packages/server-lint/src/schemas/index.ts
@@ -31,6 +31,8 @@ export const LintResultSchema = z.object({
   diagnosticsTruncated: z.boolean().optional(),
   /** Number of diagnostics omitted from the compact list (set alongside diagnosticsTruncated). */
   omittedCount: z.number().optional(),
+  /** Number of deprecation warnings (set in compact output in place of the deprecations list). */
+  deprecationCount: z.number().optional(),
   ...EmptyFailureSchemaFields,
 });
 

--- a/packages/server-npm/__tests__/compact-schema.test.ts
+++ b/packages/server-npm/__tests__/compact-schema.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression tests for #1022/#1025: compact mapper outputs must validate
+ * against the registered Zod outputSchema the way the MCP SDK does (JSON
+ * Schema with additionalProperties: false + AJV). Zod .parse() strips unknown
+ * keys silently, so it cannot catch compact-only fields missing from schemas.
+ */
+import { describe, it, expect } from "vitest";
+import { validateToolOutput } from "@paretools/shared/testing";
+import { compactListMap, compactInfoMap, compactSearchMap } from "../src/lib/formatters.js";
+import { NpmListSchema, NpmInfoSchema, NpmSearchSchema } from "../src/schemas/index.js";
+import type { NpmList, NpmInfo, NpmSearch } from "../src/schemas/index.js";
+
+function expectValid(schema: unknown, payload: unknown) {
+  const result = validateToolOutput(schema, payload);
+  expect(result.errorMessage ?? "valid").toBe("valid");
+  expect(result.valid).toBe(true);
+}
+
+describe("compact outputs validate against registered outputSchemas (SDK-style)", () => {
+  it("list (truncation triggered)", () => {
+    const data: NpmList = {
+      packageManager: "npm",
+      name: "my-app",
+      version: "1.0.0",
+      dependencies: Object.fromEntries(
+        Array.from({ length: 25 }, (_, i) => [
+          `pkg${i}`,
+          {
+            version: "1.0.0",
+            type: "dependency" as const,
+            dependencies: { [`nested${i}`]: { version: "0.1.0" } },
+          },
+        ]),
+      ),
+      problems: ["missing: left-pad@1.0.0"],
+    };
+    const compact = compactListMap(data);
+    expect(compact.omittedDependencyCount).toBe(5);
+    expect(compact.dependencyCount).toBe(50);
+    expectValid(NpmListSchema, compact);
+  });
+
+  it("info", () => {
+    const data: NpmInfo = {
+      packageManager: "npm",
+      name: "react",
+      version: "19.0.0",
+      description: "React library",
+      license: "MIT",
+      homepage: "https://react.dev",
+      isDeprecated: false,
+      dependencies: { "loose-envify": "^1.1.0" },
+      versions: ["18.0.0", "19.0.0"],
+    };
+    expectValid(NpmInfoSchema, compactInfoMap(data));
+  });
+
+  it("search", () => {
+    const data: NpmSearch = {
+      packageManager: "npm",
+      packages: [
+        {
+          name: "react",
+          version: "19.0.0",
+          description: "React library",
+          author: "meta",
+          date: "2026-01-01",
+          keywords: ["ui"],
+          score: 0.9,
+          links: { npm: "https://npmjs.com/react" },
+          scope: "unscoped",
+        },
+      ],
+    };
+    expectValid(NpmSearchSchema, compactSearchMap(data));
+  });
+});

--- a/packages/server-python/__tests__/compact-schema.test.ts
+++ b/packages/server-python/__tests__/compact-schema.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Regression tests for #1022/#1025: every compact mapper's output must
+ * validate against the tool's registered Zod outputSchema the way the MCP SDK
+ * does (JSON Schema with additionalProperties: false + AJV). Zod's .parse()
+ * silently strips unknown keys, so plain parse() assertions cannot catch
+ * compact-only fields missing from the schema.
+ */
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { validateToolOutput } from "@paretools/shared/testing";
+import {
+  compactPytestMap,
+  compactMypyMap,
+  compactRuffMap,
+  compactBlackMap,
+  compactPipInstallMap,
+  compactPipAuditMap,
+  compactUvInstallMap,
+  compactUvRunMap,
+  compactPipListMap,
+  compactPipShowMap,
+  compactRuffFormatMap,
+  compactCondaResultMap,
+  compactPyenvMap,
+  compactPoetryMap,
+} from "../src/lib/formatters.js";
+import {
+  PytestResultSchema,
+  MypyResultSchema,
+  RuffResultSchema,
+  BlackResultSchema,
+  PipInstallSchema,
+  PipAuditResultSchema,
+  UvInstallSchema,
+  UvRunSchema,
+  PipListSchema,
+  PipShowSchema,
+  RuffFormatResultSchema,
+  PoetryResultSchema,
+} from "../src/schemas/index.js";
+import type {
+  PytestResult,
+  MypyResult,
+  RuffResult,
+  PipAuditResult,
+  PipList,
+  PipShow,
+  PoetryResult,
+  CondaResult,
+  PyenvResult,
+} from "../src/schemas/index.js";
+
+function expectValid(schema: unknown, payload: unknown) {
+  const result = validateToolOutput(schema, payload);
+  expect(result.errorMessage ?? "valid").toBe("valid");
+  expect(result.valid).toBe(true);
+}
+
+describe("compact outputs validate against registered outputSchemas (SDK-style)", () => {
+  it("pytest", () => {
+    const data: PytestResult = {
+      success: false,
+      passed: 1,
+      failed: 2,
+      errors: 0,
+      skipped: 1,
+      warnings: 1,
+      failures: [
+        { test: "tests/test_a.py::test_one", message: "assert 1 == 2" },
+        { test: "tests/test_a.py::test_two", message: "boom" },
+      ],
+      exitCode: 1,
+      errorOutput: "tail of output",
+    };
+    expectValid(PytestResultSchema, compactPytestMap(data));
+  });
+
+  it("mypy (truncation triggered)", () => {
+    const data: MypyResult = {
+      success: false,
+      diagnostics: Array.from({ length: 25 }, (_, i) => ({
+        file: `src/mod_${i}.py`,
+        line: i + 1,
+        column: 3,
+        severity: "error" as const,
+        message: `bad type ${i}`,
+        code: "arg-type",
+      })),
+      error: "tail",
+      exitCode: 1,
+    };
+    const compact = compactMypyMap(data);
+    expect(compact.truncated).toBe(true);
+    expectValid(MypyResultSchema, compact);
+  });
+
+  it("ruff (truncation triggered)", () => {
+    const data: RuffResult = {
+      success: false,
+      diagnostics: Array.from({ length: 25 }, (_, i) => ({
+        file: `src/mod_${i}.py`,
+        line: i + 1,
+        column: 2,
+        code: "E501",
+        message: "line too long",
+        fixable: i % 2 === 0,
+      })),
+      fixedCount: 2,
+      error: "tail",
+      exitCode: 1,
+    };
+    const compact = compactRuffMap(data);
+    expect(compact.truncated).toBe(true);
+    expectValid(RuffResultSchema, compact);
+  });
+
+  it("black", () => {
+    expectValid(
+      BlackResultSchema,
+      compactBlackMap({
+        success: false,
+        filesChanged: 2,
+        filesUnchanged: 5,
+        errorType: "check_failed",
+      }),
+    );
+  });
+
+  it("pip-install", () => {
+    expectValid(
+      PipInstallSchema,
+      compactPipInstallMap({
+        success: false,
+        alreadySatisfied: false,
+        dryRun: true,
+        error: "resolver error",
+        exitCode: 1,
+      }),
+    );
+  });
+
+  it("pip-audit (truncation triggered)", () => {
+    const data: PipAuditResult = {
+      success: false,
+      vulnerabilities: Array.from({ length: 12 }, (_, i) => ({
+        name: `pkg${i}`,
+        version: "1.0.0",
+        id: `GHSA-${i}`,
+        description: "x".repeat(200),
+        fixVersions: ["1.0.1"],
+        severity: i % 2 === 0 ? "HIGH" : undefined,
+      })),
+      skipped: [{ name: "local-pkg", reason: "not on PyPI" }],
+      error: "tail",
+      exitCode: 1,
+    };
+    const compact = compactPipAuditMap(data);
+    expect(compact.truncated).toBe(true);
+    expect(compact.skippedCount).toBe(1);
+    expectValid(PipAuditResultSchema, compact);
+  });
+
+  it("uv-install", () => {
+    expectValid(
+      UvInstallSchema,
+      compactUvInstallMap({
+        success: false,
+        error: "conflict",
+        resolutionConflicts: [{ package: "numpy", constraint: ">=2" }],
+      }),
+    );
+  });
+
+  it("uv-run", () => {
+    expectValid(
+      UvRunSchema,
+      compactUvRunMap({
+        exitCode: 1,
+        success: false,
+        stdout: "line\n".repeat(500),
+        stderr: "err\n".repeat(500),
+        commandStderr: "err\n".repeat(500),
+        truncated: true,
+      }),
+    );
+  });
+
+  it("pip-list (truncation triggered — the #1025 failure)", () => {
+    const data: PipList = {
+      success: true,
+      packages: Array.from({ length: 60 }, (_, i) => ({
+        name: `pkg${i}`,
+        version: "1.0.0",
+        latestVersion: i % 3 === 0 ? "2.0.0" : undefined,
+      })),
+    };
+    const compact = compactPipListMap(data);
+    expect(compact.total).toBe(60);
+    expect(compact.truncated).toBe(true);
+    expectValid(PipListSchema, compact);
+  });
+
+  it("pip-list (error path)", () => {
+    expectValid(PipListSchema, compactPipListMap({ success: false, error: "invalid JSON output" }));
+  });
+
+  it("pip-show", () => {
+    const data: PipShow = {
+      success: true,
+      name: "requests",
+      version: "2.31.0",
+      summary: "HTTP for Humans",
+      requires: ["urllib3", "idna"],
+      packages: [
+        { name: "requests", version: "2.31.0", summary: "HTTP for Humans" },
+        { name: "urllib3", version: "2.0.0", summary: "HTTP client" },
+      ],
+    };
+    const compact = compactPipShowMap(data);
+    expect(compact.packageCount).toBe(2);
+    expectValid(PipShowSchema, compact);
+  });
+
+  it("ruff-format", () => {
+    expectValid(
+      RuffFormatResultSchema,
+      compactRuffFormatMap({
+        success: false,
+        filesChanged: 0,
+        filesUnchanged: 3,
+        checkMode: true,
+        error: "tail",
+        exitCode: 2,
+      }),
+    );
+  });
+
+  it("poetry (truncation triggered)", () => {
+    const data: PoetryResult = {
+      success: true,
+      packages: Array.from({ length: 60 }, (_, i) => ({
+        name: `pkg${i}`,
+        version: "1.0.0",
+        description: "desc",
+      })),
+      artifacts: Array.from({ length: 60 }, (_, i) => ({ file: `dist/pkg-${i}.whl` })),
+      messages: Array.from({ length: 25 }, (_, i) => `message ${i}`),
+      error: "tail",
+      exitCode: 1,
+    };
+    const compact = compactPoetryMap(data);
+    expect(compact.truncated).toBe(true);
+    expectValid(PoetryResultSchema, compact);
+  });
+
+  // conda and pyenv register a passthrough outputSchema, so extra compact-only
+  // fields are allowed — locked here so a future schema tightening is caught.
+  const passthroughSchema = z.object({ action: z.string() }).passthrough();
+
+  it("conda (passthrough outputSchema)", () => {
+    const data: CondaResult = {
+      action: "list",
+      packages: [{ name: "numpy", version: "2.0.0", channel: "defaults" }],
+      total: 1,
+      environment: "base",
+    };
+    expectValid(passthroughSchema, compactCondaResultMap(data));
+  });
+
+  it("pyenv (passthrough outputSchema)", () => {
+    const data: PyenvResult = {
+      action: "installList",
+      success: true,
+      availableVersions: Array.from({ length: 60 }, (_, i) => `3.${i}.0`),
+    };
+    const compact = compactPyenvMap(data);
+    expect(compact.truncated).toBe(true);
+    expectValid(passthroughSchema, compact);
+  });
+});

--- a/packages/server-python/src/schemas/index.ts
+++ b/packages/server-python/src/schemas/index.ts
@@ -34,6 +34,15 @@ export const MypyDiagnosticSchema = z.object({
 export const MypyResultSchema = z.object({
   success: z.boolean(),
   diagnostics: z.array(MypyDiagnosticSchema).optional(),
+  errorCount: z.number().optional().describe("Count of error diagnostics (set in compact output)"),
+  warningCount: z
+    .number()
+    .optional()
+    .describe("Count of warning diagnostics (set in compact output)"),
+  truncated: z
+    .boolean()
+    .optional()
+    .describe("Whether the compact diagnostics list was capped (only set when true)"),
   ...EmptyFailureSchemaFields,
 });
 
@@ -61,6 +70,15 @@ export const RuffResultSchema = z.object({
   success: z.boolean(),
   diagnostics: z.array(RuffDiagnosticSchema).optional(),
   fixedCount: z.number().optional(),
+  total: z.number().optional().describe("Total diagnostic count (set in compact output)"),
+  fixableCount: z
+    .number()
+    .optional()
+    .describe("Count of fixable diagnostics (set in compact output)"),
+  truncated: z
+    .boolean()
+    .optional()
+    .describe("Whether the compact diagnostics list was capped (only set when true)"),
   ...EmptyFailureSchemaFields,
 });
 
@@ -98,6 +116,19 @@ export const PipAuditResultSchema = z.object({
       }),
     )
     .optional(),
+  total: z.number().optional().describe("Total vulnerability count (set in compact output)"),
+  severityCounts: z
+    .record(z.string(), z.number())
+    .optional()
+    .describe("Vulnerability counts per severity (set in compact output)"),
+  truncated: z
+    .boolean()
+    .optional()
+    .describe("Whether the compact vulnerability list was capped (only set when true)"),
+  skippedCount: z
+    .number()
+    .optional()
+    .describe("Count of packages skipped by the audit (set in compact output)"),
   ...EmptyFailureSchemaFields,
 });
 
@@ -118,6 +149,10 @@ export const PytestResultSchema = z.object({
   skipped: z.number(),
   warnings: z.number().describe("Count of warnings from pytest warnings summary"),
   failures: z.array(PytestFailureSchema).optional(),
+  failedTests: z
+    .array(z.string())
+    .optional()
+    .describe("Names of failed tests (set in compact output)"),
   exitCode: z
     .number()
     .optional()
@@ -215,6 +250,11 @@ export const PipListPackageSchema = z.object({
 export const PipListSchema = z.object({
   success: z.boolean(),
   packages: z.array(PipListPackageSchema).optional(),
+  total: z.number().optional().describe("Total installed package count (set in compact output)"),
+  truncated: z
+    .boolean()
+    .optional()
+    .describe("Whether the compact package list was capped (only set when true)"),
   error: z.string().optional().describe("Parse error message when JSON parsing fails"),
   rawOutput: z.string().optional().describe("Raw CLI output included when parsing fails"),
 });
@@ -241,7 +281,14 @@ export const PipShowPackageSchema = z.object({
  *  Supports both single and multiple packages. */
 export const PipShowSchema = z.object({
   success: z.boolean(),
-  packages: z.array(PipShowPackageSchema).describe("Array of package info (one or more)"),
+  packages: z
+    .array(PipShowPackageSchema)
+    .optional()
+    .describe("Array of package info (one or more); omitted in compact output"),
+  packageCount: z
+    .number()
+    .optional()
+    .describe("Number of packages returned (set in compact output)"),
   // Keep top-level fields for backward compat (first package)
   name: z.string(),
   version: z.string(),
@@ -483,6 +530,13 @@ export const PoetryResultSchema = z.object({
   packages: z.array(PoetryPackageSchema).optional(),
   artifacts: z.array(PoetryArtifactSchema).optional(),
   messages: z.array(z.string()).optional(),
+  packageCount: z.number().optional().describe("Total package count (set in compact output)"),
+  artifactCount: z.number().optional().describe("Total artifact count (set in compact output)"),
+  messageCount: z.number().optional().describe("Total message count (set in compact output)"),
+  truncated: z
+    .boolean()
+    .optional()
+    .describe("Whether any compact list was capped (only set when true)"),
   ...EmptyFailureSchemaFields,
 });
 

--- a/packages/server-security/__tests__/compact-schema.test.ts
+++ b/packages/server-security/__tests__/compact-schema.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for #1022/#1025: compact mapper outputs must validate
+ * against the registered Zod outputSchema the way the MCP SDK does (JSON
+ * Schema with additionalProperties: false + AJV). Zod .parse() strips unknown
+ * keys silently, so it cannot catch compact-only fields missing from schemas.
+ */
+import { describe, it, expect } from "vitest";
+import { validateToolOutput } from "@paretools/shared/testing";
+import {
+  compactTrivyScanMap,
+  compactSemgrepScanMap,
+  compactGitleaksScanMap,
+} from "../src/lib/formatters.js";
+import {
+  TrivyScanResultSchema,
+  SemgrepScanResultSchema,
+  GitleaksScanResultSchema,
+} from "../src/schemas/index.js";
+import type {
+  TrivyScanResultInternal,
+  SemgrepScanResultInternal,
+  GitleaksScanResultInternal,
+} from "../src/schemas/index.js";
+
+function expectValid(schema: unknown, payload: unknown) {
+  const result = validateToolOutput(schema, payload);
+  expect(result.errorMessage ?? "valid").toBe("valid");
+  expect(result.valid).toBe(true);
+}
+
+describe("compact outputs validate against registered outputSchemas (SDK-style)", () => {
+  it("trivy (truncation triggered)", () => {
+    const data: TrivyScanResultInternal = {
+      target: "alpine:3.18",
+      scanType: "image",
+      vulnerabilities: Array.from({ length: 25 }, (_, i) => ({
+        id: `CVE-2024-${1000 + i}`,
+        severity: i % 2 === 0 ? "CRITICAL" : "HIGH",
+        package: `libfoo${i}`,
+        installedVersion: "1.0.0",
+        fixedVersion: "1.0.1",
+        title: `vuln ${i}`,
+      })),
+      totalVulnerabilities: 25,
+      summary: { critical: 13, high: 12, medium: 0, low: 0, unknown: 0 },
+      error: "tail",
+      exitCode: 1,
+    };
+    const compact = compactTrivyScanMap(data);
+    expect(compact.vulnerabilitiesTruncated).toBe(true);
+    expectValid(TrivyScanResultSchema, compact);
+  });
+
+  it("semgrep (truncation triggered)", () => {
+    const data: SemgrepScanResultInternal = {
+      findings: Array.from({ length: 25 }, (_, i) => ({
+        ruleId: `rule.${i}`,
+        path: `src/file${i}.py`,
+        startLine: i + 1,
+        endLine: i + 2,
+        message: `finding ${i}`,
+        severity: "ERROR",
+        category: "security",
+      })),
+      totalFindings: 25,
+      config: "auto",
+      errors: [{ type: "ParseError", message: "could not parse", path: "src/bad.py" }],
+      summary: { error: 25, warning: 0, info: 0 },
+      error: "tail",
+      exitCode: 1,
+    };
+    const compact = compactSemgrepScanMap(data);
+    expect(compact.findingsTruncated).toBe(true);
+    expectValid(SemgrepScanResultSchema, compact);
+  });
+
+  it("gitleaks (truncation triggered)", () => {
+    const data: GitleaksScanResultInternal = {
+      findings: Array.from({ length: 25 }, (_, i) => ({
+        ruleID: "generic-api-key",
+        match: `key=${i}`,
+        secret: `secret${i}`,
+        file: `src/config${i}.ts`,
+        startLine: i + 1,
+        endLine: i + 1,
+        commit: "abc123",
+        description: "Generic API key",
+        author: "dev",
+        date: "2026-01-01",
+      })),
+      totalFindings: 25,
+      error: "tail",
+      exitCode: 1,
+    };
+    const compact = compactGitleaksScanMap(data);
+    expect(compact.findingsTruncated).toBe(true);
+    expectValid(GitleaksScanResultSchema, compact);
+  });
+});

--- a/packages/shared/__tests__/testing.test.ts
+++ b/packages/shared/__tests__/testing.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import {
+  toolOutputJsonSchema,
+  validateToolOutput,
+  expectToolOutputMatchesSchema,
+} from "../src/testing.js";
+
+describe("toolOutputJsonSchema", () => {
+  it("emits additionalProperties: false for plain z.object (SDK behavior)", () => {
+    const schema = toolOutputJsonSchema(z.object({ a: z.string() })) as Record<string, unknown>;
+    expect(schema.additionalProperties).toBe(false);
+  });
+
+  it("keeps passthrough objects open", () => {
+    const schema = toolOutputJsonSchema(z.object({ action: z.string() }).passthrough()) as Record<
+      string,
+      unknown
+    >;
+    expect(schema.additionalProperties).not.toBe(false);
+  });
+});
+
+describe("validateToolOutput", () => {
+  const schema = z.object({
+    success: z.boolean(),
+    total: z.number().optional(),
+  });
+
+  it("accepts payloads with only declared fields", () => {
+    expect(validateToolOutput(schema, { success: true, total: 3 })).toEqual({ valid: true });
+  });
+
+  it("rejects undeclared fields the way the MCP client does (-32602)", () => {
+    const result = validateToolOutput(schema, { success: true, sneaky: 1 });
+    expect(result.valid).toBe(false);
+    expect(result.errorMessage).toMatch(/additional properties/i);
+  });
+
+  it("rejects missing required fields", () => {
+    const result = validateToolOutput(schema, { total: 3 });
+    expect(result.valid).toBe(false);
+    expect(result.errorMessage).toMatch(/required/i);
+  });
+
+  it("ignores undefined-valued keys (JSON wire round-trip)", () => {
+    // In-process objects may carry `key: undefined`; on the wire those keys
+    // disappear, so they must not fail validation.
+    expect(validateToolOutput(schema, { success: true, total: undefined }).valid).toBe(true);
+  });
+
+  it("allows catchall'd extra keys of the declared type", () => {
+    const open = z.object({ success: z.boolean() }).catchall(z.string());
+    expect(validateToolOutput(open, { success: true, GOCACHE: "/tmp/cache" }).valid).toBe(true);
+    expect(validateToolOutput(open, { success: true, GOCACHE: 42 }).valid).toBe(false);
+  });
+});
+
+describe("expectToolOutputMatchesSchema", () => {
+  it("throws with the AJV detail on mismatch", () => {
+    expect(() =>
+      expectToolOutputMatchesSchema(z.object({ a: z.string() }), { a: "x", b: 1 }),
+    ).toThrow(/additional properties/i);
+  });
+
+  it("does not throw on a valid payload", () => {
+    expect(() =>
+      expectToolOutputMatchesSchema(z.object({ a: z.string() }), { a: "x" }),
+    ).not.toThrow();
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,6 +23,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "default": "./dist/testing.js"
     }
   },
   "publishConfig": {

--- a/packages/shared/src/testing.ts
+++ b/packages/shared/src/testing.ts
@@ -1,0 +1,74 @@
+/**
+ * Test-only helpers that validate tool output the exact way the MCP SDK does
+ * at runtime.
+ *
+ * Why this exists (#1022 regression class): Zod's `.parse()` silently STRIPS
+ * unknown keys, so `Schema.parse(compactMap(data))` passes even when a compact
+ * mapper emits fields the registered `outputSchema` does not declare. The MCP
+ * SDK, however, converts the Zod outputSchema to JSON Schema (where plain
+ * `z.object` becomes `additionalProperties: false`) and validates
+ * `structuredContent` with AJV on the client side — so undeclared compact-only
+ * fields fail at runtime with `MCP error -32602: data must NOT have
+ * additional properties`, but only when compact mode engages.
+ *
+ * These helpers replicate that pipeline (zod v4 `toJSONSchema` with the SDK's
+ * options + the SDK's own AJV validator) so unit tests catch the mismatch.
+ *
+ * Import from `@paretools/shared/testing` — kept out of the main entry point
+ * so production servers never load AJV.
+ */
+import * as z4mini from "zod/v4-mini";
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
+import type { JsonSchemaType } from "@modelcontextprotocol/sdk/validation/types.js";
+
+/** Result of validating a tool output payload against its registered schema. */
+export interface ToolOutputValidationResult {
+  valid: boolean;
+  /** AJV error message when invalid (mirrors the MCP client's -32602 detail). */
+  errorMessage?: string;
+}
+
+/**
+ * Converts a Zod outputSchema to JSON Schema exactly like the MCP SDK does
+ * when listing tools (zod v4 branch of `toJsonSchemaCompat`): draft-7 target,
+ * output io — which makes plain `z.object` emit `additionalProperties: false`.
+ */
+export function toolOutputJsonSchema(outputSchema: unknown): JsonSchemaType {
+  return z4mini.toJSONSchema(outputSchema as Parameters<typeof z4mini.toJSONSchema>[0], {
+    target: "draft-7",
+    io: "output",
+  }) as JsonSchemaType;
+}
+
+/**
+ * Validates a structuredContent payload against a tool's registered Zod
+ * outputSchema using the SDK's own AJV validator. The payload is JSON
+ * round-tripped first to mirror the wire (drops `undefined`-valued keys).
+ */
+export function validateToolOutput(
+  outputSchema: unknown,
+  structuredContent: unknown,
+): ToolOutputValidationResult {
+  const jsonSchema = toolOutputJsonSchema(outputSchema);
+  const validate = new AjvJsonSchemaValidator().getValidator(jsonSchema);
+  const wireData: unknown = JSON.parse(JSON.stringify(structuredContent));
+  const result = validate(wireData);
+  return result.valid ? { valid: true } : { valid: false, errorMessage: result.errorMessage };
+}
+
+/**
+ * Assertion form of {@link validateToolOutput}: throws with the AJV error
+ * detail when the payload would be rejected by an MCP client at runtime.
+ */
+export function expectToolOutputMatchesSchema(
+  outputSchema: unknown,
+  structuredContent: unknown,
+): void {
+  const result = validateToolOutput(outputSchema, structuredContent);
+  if (!result.valid) {
+    throw new Error(
+      `structuredContent does not validate against the registered outputSchema ` +
+        `(the MCP client would reject this with -32602): ${result.errorMessage}`,
+    );
+  }
+}


### PR DESCRIPTION
## Problem

The release PR (#1025) is red: `@paretools/python integration > pip-list` fails on macOS with `MCP error -32602: data must NOT have additional properties`.

Root cause is a systematic gap between how we test schemas and how the MCP SDK enforces them:

- **Zod side (our tests):** `Schema.parse(compactMap(data))` passes even when the compact mapper emits undeclared fields, because Zod `.parse()` silently **strips** unknown keys.
- **SDK side (runtime):** the SDK converts the registered `outputSchema` to JSON Schema (`z.toJSONSchema`, draft-7, output io) where plain `z.object` becomes `additionalProperties: false`, and the client AJV-validates `structuredContent` against it. Any compact-only field the schema doesn't declare fails the call.

The failure only appears when compact mode engages (payload-size dependent), which is why it surfaced as an environment-dependent integration failure instead of a unit failure.

## Fixes (schemas are the contract — missing fields declared as optional)

| Package | Tool | Fields declared |
|---|---|---|
| python | pytest | `failedTests` |
| python | mypy | `errorCount`, `warningCount`, `truncated` |
| python | ruff-check | `total`, `fixableCount`, `truncated` |
| python | pip-audit | `total`, `severityCounts`, `truncated`, `skippedCount` |
| python | pip-list | `total`, `truncated` *(the confirmed CI failure)* |
| python | pip-show | `packageCount` (+ `packages` now optional — compact omits it, and a required-but-omitted field fails AJV the same way) |
| python | poetry | `packageCount`, `artifactCount`, `messageCount`, `truncated` |
| lint | lint | `deprecationCount` |
| go | generate | `directiveCount` |
| go | mod-tidy | `addedModuleCount`, `removedModuleCount` — compact previously emitted **numbers** under `addedModules`/`removedModules`, which the schema declares as string **arrays** (type conflict, not just an undeclared key), so the compact fields were renamed |
| go | env | `.catchall(z.unknown())` — compact surfaces explicitly queried vars (Gap #150) as dynamic top-level keys |
| go | list | `packageCount` |
| go | get | `resolvedCount` |
| go | golangci-lint | `diagnosticsOmitted` |
| cargo | add | `packages` |
| cargo | audit | top-level `total`, `critical`, `high`, `medium`, `low`, `informational`, `unknown` (compact flattens the nested `summary`) |

**Already conformant (verified, no changes needed):** python black/pip-install/uv-install/uv-run/ruff-format (conda/pyenv register passthrough outputSchemas), all of server-security (trivy/semgrep/gitleaks incl. truncation flags), all of server-npm (list `dependencyCount`/`omittedDependencyCount`, info, search), go build/test/vet/fmt/run, cargo build/check/test/clippy/run/remove/fmt/doc/update/tree.

## Regression tests

- New `@paretools/shared/testing` subpath export: `validateToolOutput` / `toolOutputJsonSchema` replicate the SDK pipeline exactly (zod v4 `toJSONSchema` with `target: "draft-7"`, `io: "output"` + the SDK's own `AjvJsonSchemaValidator`), with a JSON round-trip to mirror the wire. Kept out of the main entry so servers never load AJV.
- New `__tests__/compact-schema.test.ts` in all six packages: every compact mapper is exercised with truncation paths triggered and validated SDK-style against the registered outputSchema.

## Verification

- Build + full test suites green for shared, python, lint, security, go, cargo, npm (2,555 tests)
- `@paretools/python` integration suite (incl. pip-list) passes
- `pnpm lint` and `pnpm format:check` clean
- Changeset included (patch: shared, python, lint, go, cargo; npm/security are test-only)

Found along the way and filed separately: #1034 (server-lint integration test rewrites real package source via `biome format --write`).

Part of #1022