### PR TITLE
chore(deps): bump brace-expansion/fast-uri overrides to clear Trivy HIGH findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
       "flatted": ">=3.4.2",
       "express-rate-limit": ">=8.2.2",
       "path-to-regexp": ">=8.4.0",
-      "brace-expansion": ">=5.0.5",
-      "fast-uri": ">=3.1.2"
+      "brace-expansion": ">=5.0.9",
+      "fast-uri": ">=4.1.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ overrides:
   flatted: '>=3.4.2'
   express-rate-limit: '>=8.2.2'
   path-to-regexp: '>=8.4.0'
-  brace-expansion: '>=5.0.5'
-  fast-uri: '>=3.1.2'
+  brace-expansion: '>=5.0.9'
+  fast-uri: '>=4.1.2'
 
 importers:
 
@@ -1765,8 +1765,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -2060,8 +2060,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -4070,7 +4070,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4116,7 +4116,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4432,7 +4432,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -4797,11 +4797,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(webpack@5.109.2):
     dependencies:


### PR DESCRIPTION
Nightly `audit` job has failed every night since 2026-08-04 on two transitive HIGH findings in `pnpm-lock.yaml`:

- `brace-expansion` 5.0.8 → CVE-2026-69152 (fixed 5.0.9)
- `fast-uri` 4.1.1 → CVE-2026-18446 (fixed 4.1.2)

Bumps the existing `pnpm.overrides` floors and regenerates the lockfile. No published package behavior change; no changeset.

Closes #1044, #1046, #1047, #1048, #1049, #1050, #1051, #1055, #1056, #1058, #1060, #1062, #1063, #1065.
Also closes #1036 and #1059 (their extra `build-and-test` failure was the k8s integration Windows 180s timeout, tracked separately).