### PR TITLE
test(lint): run write-mode integration tests against temp fixtures

### DIFF
--- a/packages/server-lint/__tests__/fixtures/unconfigured-project/README.md
+++ b/packages/server-lint/__tests__/fixtures/unconfigured-project/README.md
@@ -1,0 +1,6 @@
+# unconfigured-project
+
+Fixture with **no** linter/formatter config files (no `biome.json`, no `.prettierrc`,
+no `eslint.config.*`). Used by tests that exercise "tool is not configured" code
+paths. Because some formatters (Biome 2.x) happily format without a config, tests
+must copy this fixture to a temp dir before running any write/fix mode against it.

--- a/packages/server-lint/__tests__/fixtures/unconfigured-project/package.json
+++ b/packages/server-lint/__tests__/fixtures/unconfigured-project/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "unconfigured-fixture",
+  "version": "1.0.0",
+  "private": true
+}

--- a/packages/server-lint/__tests__/fixtures/unconfigured-project/src/sample.js
+++ b/packages/server-lint/__tests__/fixtures/unconfigured-project/src/sample.js
@@ -1,0 +1,3 @@
+const greeting = "hello";
+const target = "world";
+module.exports = { greeting, target };

--- a/packages/server-lint/__tests__/integration.test.ts
+++ b/packages/server-lint/__tests__/integration.test.ts
@@ -3,15 +3,39 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { cpSync, mkdtempSync, rmSync } from "node:fs";
+import { cpSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
-const SERVER_PATH = resolve(__dirname, "../dist/index.js");
+const PKG_ROOT = resolve(__dirname, "..");
+const SERVER_PATH = resolve(PKG_ROOT, "dist/index.js");
+const SRC_DIR = resolve(PKG_ROOT, "src");
 const FIXTURES_DIR = resolve(__dirname, "fixtures");
 
 /** MCP SDK defaults to 60 s request timeout; override for CI where npx + cmd.exe is slow. */
 const CALL_TIMEOUT = { timeout: 180_000 };
+
+/**
+ * Content hash of every file under `dir`.
+ *
+ * Guards against a write/fix-mode tool being pointed at real repo source: any
+ * test that formats or fixes files must run against a temp fixture copy, never
+ * against `PKG_ROOT`. See issue #1034 — `biome format --write` needs no config
+ * file, so a "not configured" test aimed at the package root silently rewrote
+ * `src/lib/formatters.ts` in the working tree.
+ */
+function hashTree(dir: string): string {
+  const hash = createHash("sha256");
+  const entries = (readdirSync(dir, { recursive: true, encoding: "utf8" }) as string[]).sort();
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    if (!statSync(full).isFile()) continue;
+    hash.update(entry.replace(/\\/g, "/"));
+    hash.update(readFileSync(full));
+  }
+  return hash.digest("hex");
+}
 
 // ---------------------------------------------------------------------------
 // Tool listing & schema tests
@@ -20,8 +44,11 @@ const CALL_TIMEOUT = { timeout: 180_000 };
 describe("@paretools/lint integration", () => {
   let client: Client;
   let transport: StdioClientTransport;
+  let srcHashBefore: string;
 
   beforeAll(async () => {
+    srcHashBefore = hashTree(SRC_DIR);
+
     transport = new StdioClientTransport({
       command: "node",
       args: [SERVER_PATH],
@@ -34,6 +61,9 @@ describe("@paretools/lint integration", () => {
 
   afterAll(async () => {
     await transport.close();
+    // No test in this file may mutate real package source — write/fix modes
+    // must always target a temp fixture copy.
+    expect(hashTree(SRC_DIR)).toBe(srcHashBefore);
   }, 30_000);
 
   it("lists all 9 tools", async () => {
@@ -242,11 +272,12 @@ describe("@paretools/lint integration", () => {
     });
 
     it("returns structured Prettier write result for already-formatted file", async () => {
-      const pkgPath = resolve(__dirname, "..");
+      // Must run against the temp copy, never the real package source: this is a
+      // --write invocation and would rewrite repo files in place.
       const result = await client.callTool(
         {
           name: "prettier-format",
-          arguments: { path: pkgPath, patterns: ["src/lib/formatters.ts"] },
+          arguments: { path: tempDir, patterns: ["formatted.js"] },
         },
         undefined,
         CALL_TIMEOUT,
@@ -373,20 +404,26 @@ describe("@paretools/lint integration", () => {
 
   describe("biome-format", () => {
     let tempDir: string;
+    let unconfiguredDir: string;
 
     beforeEach(() => {
       tempDir = mkdtempSync(join(tmpdir(), "pare-lint-biome-"));
       cpSync(resolve(FIXTURES_DIR, "biome-project"), tempDir, { recursive: true });
+
+      // A project with no biome.json. Biome 2.x formats without a config, so this
+      // must be a temp copy too — pointing it at real source rewrites files (#1034).
+      unconfiguredDir = mkdtempSync(join(tmpdir(), "pare-lint-biome-noconfig-"));
+      cpSync(resolve(FIXTURES_DIR, "unconfigured-project"), unconfiguredDir, { recursive: true });
     });
 
     afterEach(() => {
       rmSync(tempDir, { recursive: true, force: true });
+      rmSync(unconfiguredDir, { recursive: true, force: true });
     });
 
     it("returns structured result when biome is not configured", async () => {
-      const pkgPath = resolve(__dirname, "..");
       const result = await client.callTool(
-        { name: "biome-format", arguments: { path: pkgPath, patterns: ["src/lib/formatters.ts"] } },
+        { name: "biome-format", arguments: { path: unconfiguredDir, patterns: ["src/"] } },
         undefined,
         CALL_TIMEOUT,
       );


### PR DESCRIPTION
## Problem

`packages/server-lint/__tests__/integration.test.ts` had two `--write` invocations aimed at the **real** package root instead of a temp fixture copy:

| Test | Call |
|---|---|
| `biome-format > returns structured result when biome is not configured` | `{ path: pkgPath, patterns: ["src/lib/formatters.ts"] }` |
| `prettier-format > returns structured Prettier write result for already-formatted file` | `{ path: pkgPath, patterns: ["src/lib/formatters.ts"] }` |

The biome one assumed "no config means nothing happens", but Biome 2.x formats using its defaults without requiring a config file. So on any machine where `npx @biomejs/biome` resolves, running the lint suite rewrote `packages/server-lint/src/lib/formatters.ts` in the working tree (spaces to tabs, ~430 lines) and left `pnpm format:check` failing. Confirmed locally against Biome 2.5.9.

The prettier one wrote to the same real file and was a no-op only because that file happens to already be Prettier-formatted — one formatting-config change away from the same bug.

## Fix

Both tests move to the `mkdtempSync` + `cpSync` pattern the sibling tests in the same file already use:

- **prettier-format** now targets `formatted.js` inside the existing temp copy of `fixtures/prettier-project`, preserving the "already-formatted file" intent.
- **biome-format** gets a second temp copy per test, of a new `fixtures/unconfigured-project` that deliberately ships no `biome.json` / `.prettierrc` / `eslint.config.*`. The "not configured" path is still genuinely exercised — just not against repo source.

## Guard

`beforeAll` hashes every file under `packages/server-lint/src`; `afterAll` asserts the hash is unchanged. A content hash rather than `git status` so it cannot false-positive on a developer who is mid-edit in `src` while running tests, and so it needs no git dependency in CI.

Verified the guard actually bites: temporarily restoring the original `pkgPath` argument makes the suite fail with a hash mismatch, and `formatters.ts` shows up modified. With the fix in place, `git status` after a full run is clean.

## Audit

Checked every other test that could write to real files:

- The remaining `pkgPath` calls in `integration.test.ts` (`lint`, `format-check`, `biome-check`, `stylelint`, `shellcheck`, `hadolint`, `oxlint`) are all read-only — no `--fix`, no `--write`.
- The other 12 files in `packages/server-lint/__tests__/` never touch real repo paths; they are parser/formatter unit tests over static fixtures, or use their own temp dirs (`shellcheck-patterns.test.ts`).
- `tests/smoke/mocked/lint-tools.smoke.test.ts` mocks the entire lint-runner module, so no CLI ever executes.

## Verification

- `pnpm --filter @paretools/lint test` — 298 passed, 0 failed
- `pnpm format:check` — clean
- `pnpm lint` — 0 errors (1 pre-existing warning in `packages/shared/src/server.ts`, untouched)
- `git status` after a full test run — clean

Test-only change, so no changeset.

Closes #1034
