### PR TITLE
fix(git): correct `add` pathspec expansion and shrink `branch` mutation output

### DIFF
--- a/.changeset/fix-1057-1037-git-add-branch.md
+++ b/.changeset/fix-1057-1037-git-add-branch.md
@@ -1,0 +1,5 @@
+---
+"@paretools/git": patch
+---
+
+fix(git): `add` stages and reports "." / directory paths correctly; `branch` delete returns a compact confirmation instead of the full listing

--- a/docs/tool-schemas/git/add.md
+++ b/docs/tool-schemas/git/add.md
@@ -83,5 +83,7 @@ Nothing specified, nothing added.
 
 - No compact mode; the response is already concise
 - After staging, Pare runs `git status --porcelain=v1` to determine which files are staged
-- File path resolution handles case sensitivity on Windows
+- File path resolution handles case sensitivity on Windows for single-file pathspecs;
+  `.`, directory, and glob pathspecs reach git untouched so they expand the way the CLI
+  expands them (#1057)
 - Either `files` or `all: true` must be provided; omitting both throws an error

--- a/docs/tool-schemas/git/branch.md
+++ b/docs/tool-schemas/git/branch.md
@@ -68,6 +68,62 @@ Lists, creates, or deletes branches. Returns structured branch data.
 </tr>
 </table>
 
+## Success - Mutations (create / delete / rename / setUpstream)
+
+Mutations return a compact confirmation rather than the post-mutation listing. On repos
+with hundreds of branches the listing ran to tens of thousands of characters and blew past
+client output caps (#1037). Call `branch` again with no mutation param to list.
+
+<table>
+<tr><th></th><th>Standard CLI Output</th><th>Pare Response</th></tr>
+<tr>
+<td><strong>Delete</strong></td>
+<td>
+
+```
+Deleted branch feature/auth (was a1b2c3d).
+```
+
+</td>
+<td>
+
+```json
+{
+  "success": true,
+  "action": "delete",
+  "deleted": ["feature/auth"],
+  "force": false
+}
+```
+
+</td>
+</tr>
+<tr>
+<td><strong>Create</strong></td>
+<td>
+
+```
+
+```
+
+</td>
+<td>
+
+```json
+{
+  "success": true,
+  "action": "create",
+  "branch": "feature/auth",
+  "startPoint": "main",
+  "force": false,
+  "switched": false
+}
+```
+
+</td>
+</tr>
+</table>
+
 ## Token Savings
 
 | Scenario         | CLI Tokens | Pare Full | Pare Compact | Savings |
@@ -79,7 +135,11 @@ Lists, creates, or deletes branches. Returns structured branch data.
 
 ## Notes
 
-- Create uses `git checkout -b` internally, switching to the new branch
+- Create uses `git branch <name>` and only switches when `switchAfterCreate` is set
 - Delete uses `git branch -d` (safe delete); branches with unmerged changes will error
+- Mutations return `{ success, action, ... }` and omit `branches` / `current`; list mode
+  returns `{ branches, current }` and omits the mutation fields
+- When several mutations are combined in one call, the confirmation describes the last one
+  performed (rename -> setUpstream -> create -> delete)
 - Compact mode reduces branches to a simple string array, dropping `current` and `upstream` metadata per branch
 - The `current` field at the top level always identifies the active branch

--- a/packages/server-git/__tests__/add-pathspec.test.ts
+++ b/packages/server-git/__tests__/add-pathspec.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression tests for #1057 — `add` with `files: ["."]` staged nothing and a
+ * directory pathspec staged only one file.
+ *
+ * These run against real temp repos (no git mocking) because the bug lived in the
+ * interaction between the pathspec we hand to git and what git actually expands.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { registerAddTool } from "../src/tools/add.js";
+import { resolveFilePath } from "../src/lib/git-runner.js";
+import { GitAddSchema } from "../src/schemas/index.js";
+
+type ToolHandler = (params: Record<string, unknown>) => Promise<{
+  content: unknown;
+  structuredContent: Record<string, unknown>;
+}>;
+
+class FakeServer {
+  tools = new Map<string, { handler: ToolHandler }>();
+  registerTool(name: string, _config: Record<string, unknown>, handler: ToolHandler) {
+    this.tools.set(name, { handler });
+  }
+}
+
+function run(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+/** Staged paths per `git status --porcelain` (index column is not " " or "?"). */
+function stagedPaths(cwd: string): string[] {
+  return run(["status", "--porcelain=v1"], cwd)
+    .split("\n")
+    .filter(Boolean)
+    .filter((line) => line[0] !== " " && line[0] !== "?")
+    .map((line) => line.slice(3).trim())
+    .sort();
+}
+
+describe("add pathspec expansion (#1057)", () => {
+  let repoDir: string;
+  let handler: ToolHandler;
+
+  const DEFAULTS = { all: false };
+
+  beforeEach(() => {
+    repoDir = mkdtempSync(join(tmpdir(), "pare-git-add-pathspec-"));
+    run(["init"], repoDir);
+    run(["config", "user.email", "test@test.com"], repoDir);
+    run(["config", "user.name", "Test"], repoDir);
+    run(["config", "core.autocrlf", "false"], repoDir);
+
+    // Nested tree with tracked files at several depths.
+    mkdirSync(join(repoDir, "site", "public", "assets"), { recursive: true });
+    mkdirSync(join(repoDir, "docs"), { recursive: true });
+    writeFileSync(join(repoDir, "README.md"), "# readme\n");
+    writeFileSync(join(repoDir, "docs", "hub-design.md"), "# hub\n");
+    writeFileSync(join(repoDir, "site", "public", "building.html"), "<p>a</p>\n");
+    writeFileSync(join(repoDir, "site", "public", "index.html"), "<p>b</p>\n");
+    writeFileSync(join(repoDir, "site", "public", "assets", "app.css"), "a{}\n");
+    run(["add", "-A"], repoDir);
+    run(["commit", "-m", "init"], repoDir);
+
+    // Dirty the tree: modifications at several depths plus untracked files.
+    writeFileSync(join(repoDir, "README.md"), "# readme changed\n");
+    writeFileSync(join(repoDir, "docs", "hub-design.md"), "# hub changed\n");
+    writeFileSync(join(repoDir, "site", "public", "building.html"), "<p>a changed</p>\n");
+    writeFileSync(join(repoDir, "site", "public", "index.html"), "<p>b changed</p>\n");
+    writeFileSync(join(repoDir, "site", "public", "assets", "app.css"), "a{color:red}\n");
+    writeFileSync(join(repoDir, "site", "public", "new-page.html"), "<p>new</p>\n");
+    writeFileSync(join(repoDir, "site", "public", "assets", "new.css"), "b{}\n");
+    writeFileSync(join(repoDir, "untracked-root.txt"), "root\n");
+
+    const server = new FakeServer();
+    registerAddTool(server as never);
+    handler = server.tools.get("add")!.handler;
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('files: ["."] stages every modified and untracked file in the repo', async () => {
+    const result = await handler({ ...DEFAULTS, path: repoDir, files: ["."] });
+    const parsed = GitAddSchema.parse(result.structuredContent);
+
+    const expected = [
+      "README.md",
+      "docs/hub-design.md",
+      "site/public/assets/app.css",
+      "site/public/assets/new.css",
+      "site/public/building.html",
+      "site/public/index.html",
+      "site/public/new-page.html",
+      "untracked-root.txt",
+    ].sort();
+
+    expect(stagedPaths(repoDir)).toEqual(expected);
+    // The returned list must reflect everything that got staged, not just the input.
+    expect(parsed.files.map((f) => f.file).sort()).toEqual(expected);
+    expect(parsed.files.find((f) => f.file === "untracked-root.txt")?.status).toBe("added");
+    expect(parsed.files.find((f) => f.file === "README.md")?.status).toBe("modified");
+  });
+
+  it("a directory pathspec stages everything under that directory", async () => {
+    const result = await handler({
+      ...DEFAULTS,
+      path: repoDir,
+      files: ["site/public", "docs/hub-design.md"],
+    });
+    const parsed = GitAddSchema.parse(result.structuredContent);
+
+    const expected = [
+      "docs/hub-design.md",
+      "site/public/assets/app.css",
+      "site/public/assets/new.css",
+      "site/public/building.html",
+      "site/public/index.html",
+      "site/public/new-page.html",
+    ].sort();
+
+    expect(stagedPaths(repoDir)).toEqual(expected);
+    expect(parsed.files.map((f) => f.file).sort()).toEqual(expected);
+    // Files outside the pathspec stay unstaged.
+    expect(stagedPaths(repoDir)).not.toContain("README.md");
+    expect(stagedPaths(repoDir)).not.toContain("untracked-root.txt");
+  });
+
+  it("a directory pathspec with Windows backslashes stages the whole directory", async () => {
+    await handler({ ...DEFAULTS, path: repoDir, files: ["site\\public\\assets"] });
+
+    expect(stagedPaths(repoDir)).toEqual(
+      ["site/public/assets/app.css", "site/public/assets/new.css"].sort(),
+    );
+  });
+
+  it("a trailing-slash directory pathspec stages the whole directory", async () => {
+    await handler({ ...DEFAULTS, path: repoDir, files: ["site/public/assets/"] });
+
+    expect(stagedPaths(repoDir)).toEqual(
+      ["site/public/assets/app.css", "site/public/assets/new.css"].sort(),
+    );
+  });
+
+  it("a glob pathspec reaches git verbatim", async () => {
+    await handler({ ...DEFAULTS, path: repoDir, files: ["site/public/*.html"] });
+
+    expect(stagedPaths(repoDir)).toEqual(
+      ["site/public/building.html", "site/public/index.html", "site/public/new-page.html"].sort(),
+    );
+  });
+
+  it("single-file pathspecs still get their casing canonicalised", async () => {
+    // The reason resolveFilePath exists — must survive the #1057 fix.
+    const resolved = await resolveFilePath("readme.md", repoDir);
+    expect(resolved.toLowerCase()).toBe("readme.md");
+    if (process.platform === "win32" || process.platform === "darwin") {
+      expect(resolved).toBe("README.md");
+    }
+  });
+
+  it("resolveFilePath leaves directory and dot pathspecs untouched", async () => {
+    expect(await resolveFilePath(".", repoDir)).toBe(".");
+    expect(await resolveFilePath("site/public", repoDir)).toBe("site/public");
+    expect(await resolveFilePath("site\\public", repoDir)).toBe("site/public");
+    expect(await resolveFilePath("site/public/*.html", repoDir)).toBe("site/public/*.html");
+  });
+});

--- a/packages/server-git/__tests__/integration.test.ts
+++ b/packages/server-git/__tests__/integration.test.ts
@@ -456,6 +456,53 @@ describe("@paretools/git write-tool integration", () => {
     });
   });
 
+  /** Lists branch names via the tool's list mode (no mutation params). */
+  async function listBranchNames(): Promise<string[]> {
+    const listed = await client.callTool(
+      { name: "branch", arguments: { path: tempDir, compact: false } },
+      undefined,
+      { timeout: CALL_TIMEOUT },
+    );
+    const sc = listed.structuredContent as Record<string, unknown>;
+    return (sc.branches as Record<string, unknown>[]).map((b) => b.name as string);
+  }
+
+  describe("branch list mode", () => {
+    it("returns the full listing when no mutation is requested", async () => {
+      const result = await client.callTool(
+        { name: "branch", arguments: { path: tempDir, compact: false } },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBeUndefined();
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(Array.isArray(sc.branches)).toBe(true);
+      expect(typeof sc.current).toBe("string");
+      // List mode carries no mutation confirmation fields.
+      expect(sc.action).toBeUndefined();
+    });
+  });
+
+  describe("branch mutation confirmations (#1037)", () => {
+    it("create returns a confirmation instead of the branch listing", async () => {
+      const result = await client.callTool(
+        { name: "branch", arguments: { path: tempDir, create: "confirm-create-test" } },
+        undefined,
+        { timeout: CALL_TIMEOUT },
+      );
+
+      expect(result.isError).toBeUndefined();
+      const sc = result.structuredContent as Record<string, unknown>;
+      expect(sc).toMatchObject({ success: true, action: "create", branch: "confirm-create-test" });
+      expect(sc.branches).toBeUndefined();
+      expect(sc.current).toBeUndefined();
+      expect(await listBranchNames()).toContain("confirm-create-test");
+
+      gitInTemp(["branch", "-D", "confirm-create-test"]);
+    });
+  });
+
   describe("branch forceDelete", () => {
     it("force-deletes with forceDelete=true and delete=branchName", async () => {
       // Create an unmerged branch so only -D works
@@ -472,9 +519,15 @@ describe("@paretools/git write-tool integration", () => {
       expect(result.isError).toBeUndefined();
       const sc = result.structuredContent as Record<string, unknown>;
       expect(sc).toBeDefined();
-      // The deleted branch should no longer appear in the list
-      const branches = sc.branches as Record<string, unknown>[];
-      expect(branches.find((b) => b.name === "fd-bool-test")).toBeUndefined();
+      // Deletes return a compact confirmation, not the full listing (#1037)
+      expect(sc).toMatchObject({
+        success: true,
+        action: "delete",
+        deleted: ["fd-bool-test"],
+        force: true,
+      });
+      expect(sc.branches).toBeUndefined();
+      expect(await listBranchNames()).not.toContain("fd-bool-test");
     });
 
     it("force-deletes with forceDelete=branchName (string)", async () => {
@@ -491,10 +544,14 @@ describe("@paretools/git write-tool integration", () => {
 
       expect(result.isError).toBeUndefined();
       const sc = result.structuredContent as Record<string, unknown>;
-      expect(sc).toBeDefined();
-      // The deleted branch should no longer appear in the list
-      const branches = sc.branches as Record<string, unknown>[];
-      expect(branches.find((b) => b.name === "fd-string-test")).toBeUndefined();
+      expect(sc).toMatchObject({
+        success: true,
+        action: "delete",
+        deleted: ["fd-string-test"],
+        force: true,
+      });
+      expect(sc.branches).toBeUndefined();
+      expect(await listBranchNames()).not.toContain("fd-string-test");
     });
   });
 
@@ -512,8 +569,14 @@ describe("@paretools/git write-tool integration", () => {
 
       expect(result.isError).toBeUndefined();
       const sc = result.structuredContent as Record<string, unknown>;
-      const branches = sc.branches as Record<string, unknown>[];
-      expect(branches.find((b) => b.name === "single-del-test")).toBeUndefined();
+      expect(sc).toMatchObject({
+        success: true,
+        action: "delete",
+        deleted: ["single-del-test"],
+        force: false,
+      });
+      expect(sc.branches).toBeUndefined();
+      expect(await listBranchNames()).not.toContain("single-del-test");
     });
 
     it("deletes an array of branches", async () => {
@@ -534,10 +597,16 @@ describe("@paretools/git write-tool integration", () => {
 
       expect(result.isError).toBeUndefined();
       const sc = result.structuredContent as Record<string, unknown>;
-      const branches = sc.branches as Record<string, unknown>[];
-      expect(branches.find((b) => b.name === "batch-del-1")).toBeUndefined();
-      expect(branches.find((b) => b.name === "batch-del-2")).toBeUndefined();
-      expect(branches.find((b) => b.name === "batch-del-3")).toBeUndefined();
+      expect(sc).toMatchObject({
+        success: true,
+        action: "delete",
+        deleted: ["batch-del-1", "batch-del-2", "batch-del-3"],
+      });
+      expect(sc.branches).toBeUndefined();
+      const remaining = await listBranchNames();
+      expect(remaining).not.toContain("batch-del-1");
+      expect(remaining).not.toContain("batch-del-2");
+      expect(remaining).not.toContain("batch-del-3");
     });
 
     it("fails when one branch in an array does not exist", async () => {
@@ -574,9 +643,16 @@ describe("@paretools/git write-tool integration", () => {
 
       expect(result.isError).toBeUndefined();
       const sc = result.structuredContent as Record<string, unknown>;
-      const branches = sc.branches as Record<string, unknown>[];
-      expect(branches.find((b) => b.name === "batch-fd-1")).toBeUndefined();
-      expect(branches.find((b) => b.name === "batch-fd-2")).toBeUndefined();
+      expect(sc).toMatchObject({
+        success: true,
+        action: "delete",
+        deleted: ["batch-fd-1", "batch-fd-2"],
+        force: true,
+      });
+      expect(sc.branches).toBeUndefined();
+      const left = await listBranchNames();
+      expect(left).not.toContain("batch-fd-1");
+      expect(left).not.toContain("batch-fd-2");
     });
 
     it("rejects flag injection in delete array elements", async () => {
@@ -615,9 +691,14 @@ describe("@paretools/git write-tool integration", () => {
 
       expect(result.isError).toBeUndefined();
       const sc = result.structuredContent as Record<string, unknown>;
-      expect(sc).toBeDefined();
-      const branches = sc.branches as Record<string, unknown>[];
-      expect(branches.find((b) => b.name === "fd-str-batch-test")).toBeUndefined();
+      expect(sc).toMatchObject({
+        success: true,
+        action: "delete",
+        deleted: ["fd-str-batch-test"],
+        force: true,
+      });
+      expect(sc.branches).toBeUndefined();
+      expect(await listBranchNames()).not.toContain("fd-str-batch-test");
     });
   });
 

--- a/packages/server-git/__tests__/p2-gaps.test.ts
+++ b/packages/server-git/__tests__/p2-gaps.test.ts
@@ -97,13 +97,21 @@ describe("Git P2 gaps", () => {
     const server = new FakeServer();
     registerBranchTool(server as never);
     const handler = server.tools.get("branch")!.handler;
-    vi.mocked(git)
-      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 })
-      .mockResolvedValueOnce({ stdout: "* main", stderr: "", exitCode: 0 });
+    // Mutations no longer list afterwards (#1037), so only the create call runs.
+    vi.mocked(git).mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
 
-    await handler({ create: "feature/new" });
+    const out = (await handler({ create: "feature/new" })) as {
+      structuredContent: Record<string, unknown>;
+    };
     expect(vi.mocked(git).mock.calls[0][0]).toEqual(["branch", "feature/new"]);
     expect(vi.mocked(git).mock.calls.some((c) => c[0][0] === "switch")).toBe(false);
+    expect(vi.mocked(git).mock.calls).toHaveLength(1);
+    expect(out.structuredContent).toMatchObject({
+      success: true,
+      action: "create",
+      branch: "feature/new",
+      switched: false,
+    });
   });
 
   it("#246 parses lastCommit in branch listings", () => {

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -2,6 +2,7 @@ import type {
   GitStatus,
   GitLog,
   GitDiff,
+  GitBranchMutation,
   GitBranchFull,
   GitShow,
   GitAdd,
@@ -96,6 +97,26 @@ export function formatBranch(b: GitBranchFull): string {
       return `${prefix}${br.name}${upstream}${merged}`;
     })
     .join("\n");
+}
+
+/** Formats a branch mutation confirmation into a one-line human-readable summary. */
+export function formatBranchMutation(m: GitBranchMutation): string {
+  const forced = m.force ? " (forced)" : "";
+  switch (m.action) {
+    case "delete": {
+      const names = m.deleted ?? [];
+      return `Deleted ${names.length} branch(es)${forced}: ${names.join(", ")}`;
+    }
+    case "create": {
+      const from = m.startPoint ? ` from ${m.startPoint}` : "";
+      const switched = m.switched ? " and switched to it" : "";
+      return `Created branch ${m.branch}${from}${forced}${switched}`;
+    }
+    case "rename":
+      return `Renamed current branch to ${m.branch}${forced}`;
+    case "set-upstream":
+      return `Set upstream to ${m.upstream}`;
+  }
 }
 
 /** Formats a blob extraction result into a human-readable view with file header. */

--- a/packages/server-git/src/lib/git-runner.ts
+++ b/packages/server-git/src/lib/git-runner.ts
@@ -1,3 +1,5 @@
+import { stat } from "node:fs/promises";
+import { isAbsolute, join } from "node:path";
 import { run, type RunOptions, type RunResult } from "@paretools/shared";
 
 export async function git(
@@ -19,6 +21,51 @@ export function normalizePath(filePath: string): string {
 }
 
 /**
+ * Pathspecs that must never be rewritten by casing resolution.
+ *
+ * `resolveFilePath` exists to canonicalise the *casing* of a single file path.
+ * Anything that can legitimately match many files — ".", a directory, a glob, or
+ * pathspec magic — must be handed to git untouched, otherwise it collapses to a
+ * single tracked file (see #1057).
+ */
+function isMultiMatchPathspec(pathspec: string): boolean {
+  if (pathspec === "" || pathspec === "." || pathspec === "./" || pathspec === "..") return true;
+  // Trailing slash ⇒ explicitly a directory.
+  if (pathspec.endsWith("/")) return true;
+  // Glob / wildcard pathspecs.
+  if (/[*?[\]]/.test(pathspec)) return true;
+  // Pathspec magic, e.g. ":(icase)foo" or ":!excluded".
+  if (pathspec.startsWith(":")) return true;
+  return false;
+}
+
+/** True when the pathspec points at an existing directory on disk. */
+async function isDirectoryPathspec(pathspec: string, cwd: string): Promise<boolean> {
+  try {
+    const stats = await stat(isAbsolute(pathspec) ? pathspec : join(cwd, pathspec));
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Picks the tracked path that is a case-variant of the requested path.
+ *
+ * `git ls-files -- <pathspec>` returns *every* file under a directory pathspec, so
+ * blindly taking the first line rewrites "src" into "src/a.ts". Only accept a
+ * result that differs from the input by casing alone.
+ */
+function pickCaseVariant(stdout: string, normalized: string): string | undefined {
+  const target = normalized.toLowerCase();
+  return stdout
+    .trim()
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0 && line.toLowerCase() === target);
+}
+
+/**
  * Resolves a file path to its canonical casing as tracked by git.
  *
  * On Windows (case-insensitive filesystem), git pathspecs are still case-sensitive.
@@ -29,6 +76,9 @@ export function normalizePath(filePath: string): string {
  * On case-sensitive filesystems (Linux/macOS), this still works correctly —
  * it will only match if the casing is exact, which is the expected behavior.
  *
+ * Directory, ".", and glob pathspecs are passed through unchanged so they keep
+ * expanding the way git expands them (#1057).
+ *
  * @param filePath - The user-provided file path
  * @param cwd - The repository working directory
  * @returns The canonical file path from git, or the normalized original if not tracked
@@ -36,25 +86,26 @@ export function normalizePath(filePath: string): string {
 export async function resolveFilePath(filePath: string, cwd: string): Promise<string> {
   const normalized = normalizePath(filePath);
 
-  // Use git ls-files with case-insensitive matching (-i) and glob pattern (--exclude)
-  // to find the canonical path. We use -i flag only on case-insensitive filesystems.
+  // Multi-match pathspecs (".", dirs, globs) must reach git verbatim.
+  if (isMultiMatchPathspec(normalized)) return normalized;
+  if (await isDirectoryPathspec(normalized, cwd)) return normalized;
+
+  // Exact match — git tracks the path with this casing already.
   const result = await git(["ls-files", "--", normalized], cwd);
-
-  if (result.exitCode === 0 && result.stdout.trim()) {
-    // Exact match found — return the canonical path from git
-    return result.stdout.trim().split("\n")[0];
+  if (result.exitCode === 0) {
+    const exact = pickCaseVariant(result.stdout, normalized);
+    if (exact) return exact;
   }
 
-  // No exact match — try case-insensitive lookup via ls-files with icase pathspec magic
+  // No exact match — try case-insensitive lookup via ls-files with icase pathspec magic.
   const icaseResult = await git(["ls-files", "--", `:(icase)${normalized}`], cwd);
-
-  if (icaseResult.exitCode === 0 && icaseResult.stdout.trim()) {
-    const matches = icaseResult.stdout.trim().split("\n");
-    // Return the first match (there should typically be only one on case-insensitive FS)
-    return matches[0];
+  if (icaseResult.exitCode === 0) {
+    const icase = pickCaseVariant(icaseResult.stdout, normalized);
+    if (icase) return icase;
   }
 
-  // File not tracked by git — return normalized path as-is
+  // Not a tracked single file (untracked, deleted, or a directory that no longer
+  // exists on disk) — return the normalized path and let git interpret it.
   return normalized;
 }
 

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -78,11 +78,49 @@ export const GitBranchEntrySchema = z.object({
   unmerged: z.number().optional(),
 });
 
-/** Zod schema for structured git branch output listing all branches and the current branch. */
+/** Zod schema for structured git branch output.
+ *
+ *  Covers both modes with a single z.object() of optional fields (z.union() is not
+ *  supported by the MCP SDK for outputSchema — same approach as GitWorktreeOutputSchema):
+ *  - list mode returns `branches` + `current`
+ *  - mutation modes (create / delete / rename / set-upstream) return a compact
+ *    confirmation instead of the full listing, which on repos with many branches ran
+ *    to tens of thousands of characters and blew past client output caps (#1037).
+ */
 export const GitBranchSchema = z.object({
-  branches: z.union([z.array(GitBranchEntrySchema), z.array(z.string())]),
-  current: z.string(),
+  /** Present in list mode. */
+  branches: z.union([z.array(GitBranchEntrySchema), z.array(z.string())]).optional(),
+  /** Present in list mode - the checked-out branch. */
+  current: z.string().optional(),
+  /** Present for mutations - whether the operation succeeded. */
+  success: z.boolean().optional(),
+  /** Mutation performed. */
+  action: z.enum(["create", "delete", "rename", "set-upstream"]).optional(),
+  /** Branch affected by create / rename / set-upstream. */
+  branch: z.string().optional(),
+  /** Branch names removed by a delete. */
+  deleted: z.array(z.string()).optional(),
+  /** Start point used when creating a branch. */
+  startPoint: z.string().optional(),
+  /** Upstream ref set by set-upstream. */
+  upstream: z.string().optional(),
+  /** Whether the mutation used a force flag (-D / -M / -f). */
+  force: z.boolean().optional(),
+  /** Whether a created branch was also checked out. */
+  switched: z.boolean().optional(),
 });
+
+/** Compact confirmation returned by branch mutations (create/delete/rename/set-upstream). */
+export type GitBranchMutation = {
+  success: boolean;
+  action: "create" | "delete" | "rename" | "set-upstream";
+  branch?: string;
+  deleted?: string[];
+  startPoint?: string;
+  upstream?: string;
+  force?: boolean;
+  switched?: boolean;
+};
 
 /** Full branch data (always returned by parser, before compact projection). */
 export type GitBranchFull = {

--- a/packages/server-git/src/tools/branch.ts
+++ b/packages/server-git/src/tools/branch.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   compactDualOutput,
+  dualOutput,
   INPUT_LIMITS,
   compactInput,
   repoPathInput,
@@ -10,8 +11,13 @@ import {
 import { assertNoFlagInjection, assertValidSortKey } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
 import { parseBranch, parseRevListCount } from "../lib/parsers.js";
-import { formatBranch, compactBranchMap, formatBranchCompact } from "../lib/formatters.js";
-import { GitBranchSchema } from "../schemas/index.js";
+import {
+  formatBranch,
+  compactBranchMap,
+  formatBranchCompact,
+  formatBranchMutation,
+} from "../lib/formatters.js";
+import { GitBranchSchema, type GitBranchMutation } from "../schemas/index.js";
 
 /** Registers the `branch` tool on the given MCP server. */
 export function registerBranchTool(server: McpServer) {
@@ -20,7 +26,7 @@ export function registerBranchTool(server: McpServer) {
     {
       title: "Git Branch",
       description:
-        "Lists, creates, renames, or deletes branches. Returns structured branch data. Pass `path` to target a specific repo or worktree — when omitted, operates on the server's own working directory, not the caller's (see #876).",
+        "Lists, creates, renames, or deletes branches. List mode returns `{ branches, current }`. Mutations (create/delete/rename/setUpstream) return a compact confirmation `{ success, action, ... }` instead of the full listing — call again without a mutation param to list. When several mutations are combined in one call, the confirmation describes the last one performed. Pass `path` to target a specific repo or worktree — when omitted, operates on the server's own working directory, not the caller's (see #876).",
       annotations: { readOnlyHint: true },
       inputSchema: {
         path: repoPathInput,
@@ -130,6 +136,12 @@ export function registerBranchTool(server: McpServer) {
     }) => {
       const cwd = path || process.cwd();
 
+      // Mutations return a compact confirmation rather than the post-mutation
+      // listing, which on repos with many branches ran to tens of thousands of
+      // characters and overflowed client output caps (#1037). When more than one
+      // mutation is requested in a single call, the last one performed wins.
+      let mutation: GitBranchMutation | undefined;
+
       // Rename branch
       if (rename) {
         assertNoFlagInjection(rename, "branch name");
@@ -138,6 +150,7 @@ export function registerBranchTool(server: McpServer) {
         if (result.exitCode !== 0) {
           throw new Error(`Failed to rename branch: ${result.stderr}`);
         }
+        mutation = { success: true, action: "rename", branch: rename, force: !!force };
       }
 
       // Set upstream
@@ -147,6 +160,7 @@ export function registerBranchTool(server: McpServer) {
         if (result.exitCode !== 0) {
           throw new Error(`Failed to set upstream: ${result.stderr}`);
         }
+        mutation = { success: true, action: "set-upstream", upstream: setUpstream };
       }
 
       // Create branch
@@ -169,6 +183,15 @@ export function registerBranchTool(server: McpServer) {
             throw new Error(`Branch created but failed to switch: ${switchResult.stderr}`);
           }
         }
+
+        mutation = {
+          success: true,
+          action: "create",
+          branch: create,
+          ...(startPoint ? { startPoint } : {}),
+          force: !!force,
+          switched: !!switchAfterCreate,
+        };
       }
 
       // Delete branch(es)
@@ -200,6 +223,18 @@ export function registerBranchTool(server: McpServer) {
         if (result.exitCode !== 0) {
           throw new Error(`Failed to delete branch(es): ${result.stderr}`);
         }
+        mutation = {
+          success: true,
+          action: "delete",
+          deleted: [...branchesToDelete],
+          force: isForceDelete,
+        };
+      }
+
+      // A mutation was requested — return the compact confirmation and skip the
+      // (potentially huge) listing entirely.
+      if (mutation) {
+        return dualOutput(mutation, formatBranchMutation);
       }
 
       // List branches — always use -vv to get upstream tracking info

--- a/tests/smoke/mocked/git-tools-1.smoke.test.ts
+++ b/tests/smoke/mocked/git-tools-1.smoke.test.ts
@@ -613,24 +613,46 @@ describe("Smoke: git.branch", () => {
     expect(Array.isArray(parsed.branches)).toBe(true);
   });
 
-  // S2: Create branch
-  it("S2 [P0] create branch", async () => {
+  // S2: Create branch — mutations return a confirmation, not the listing (#1037)
+  it("S2 [P0] create branch returns a compact confirmation", async () => {
     // git branch feature-x
     mockGit("");
-    // git branch -vv (listing after create)
-    mockGit("* main       abc1234 latest commit\n  feature-x  def5678 new branch\n");
     const { parsed } = await callAndValidate({ ...DEFAULTS, create: "feature-x" });
-    expect(parsed.current).toBe("main");
+    expect(parsed).toMatchObject({
+      success: true,
+      action: "create",
+      branch: "feature-x",
+      switched: false,
+    });
+    expect(parsed.branches).toBeUndefined();
+    // No listing call is made.
+    expect(vi.mocked(git).mock.calls).toHaveLength(1);
   });
 
-  // S3: Delete branch
-  it("S3 [P0] delete branch", async () => {
+  // S3: Delete branch — must not return the full listing (#1037)
+  it("S3 [P0] delete branch returns a compact confirmation", async () => {
     // git branch -d feature-x
     mockGit("Deleted branch feature-x (was def5678).");
-    // git branch -vv
-    mockGit("* main       abc1234 latest commit\n");
-    const { parsed } = await callAndValidate({ ...DEFAULTS, delete: "feature-x" });
-    expect(parsed.current).toBe("main");
+    const { parsed, result } = await callAndValidate({ ...DEFAULTS, delete: "feature-x" });
+    expect(parsed).toMatchObject({
+      success: true,
+      action: "delete",
+      deleted: ["feature-x"],
+      force: false,
+    });
+    expect(parsed.branches).toBeUndefined();
+    expect(parsed.current).toBeUndefined();
+    // No post-delete listing call.
+    expect(vi.mocked(git).mock.calls).toHaveLength(1);
+    expect((result.content as Array<{ text: string }>)[0].text).toContain("Deleted 1 branch(es)");
+  });
+
+  // S3b: Deleting many branches lists them all in one confirmation
+  it("S3b [P1] batch delete confirmation names every deleted branch", async () => {
+    mockGit("Deleted branch a (was 1111111).\nDeleted branch b (was 2222222).");
+    const { parsed } = await callAndValidate({ ...DEFAULTS, delete: ["a", "b"] });
+    expect(parsed.deleted).toEqual(["a", "b"]);
+    expect(vi.mocked(git).mock.calls).toHaveLength(1);
   });
 
   // S4: Flag injection in create
@@ -653,36 +675,41 @@ describe("Smoke: git.branch", () => {
     mockGit("");
     // git switch feat
     mockGit("Switched to branch 'feat'");
-    // git branch -vv
-    mockGit("  main  abc1234 latest commit\n* feat  def5678 new branch\n");
     const { parsed } = await callAndValidate({
       ...DEFAULTS,
       create: "feat",
       switchAfterCreate: true,
     });
-    expect(parsed.current).toBe("feat");
+    expect(parsed).toMatchObject({
+      success: true,
+      action: "create",
+      branch: "feat",
+      switched: true,
+    });
   });
 
   // S7: Create with start point
   it("S7 [P1] create with start point", async () => {
     // git branch feat HEAD~3
     mockGit("");
-    // git branch -vv
-    mockGit("* main  abc1234 latest\n  feat  1112222 older commit\n");
-    await callAndValidate({ ...DEFAULTS, create: "feat", startPoint: "HEAD~3" });
+    const { parsed } = await callAndValidate({
+      ...DEFAULTS,
+      create: "feat",
+      startPoint: "HEAD~3",
+    });
     const createArgs = vi.mocked(git).mock.calls[0][0];
     expect(createArgs).toContain("feat");
     expect(createArgs).toContain("HEAD~3");
+    expect(parsed.startPoint).toBe("HEAD~3");
   });
 
   // S8: Rename current branch
   it("S8 [P1] rename current branch", async () => {
     // git branch -m new-name
     mockGit("");
-    // git branch -vv
-    mockGit("* new-name  abc1234 latest commit\n");
     const { parsed } = await callAndValidate({ ...DEFAULTS, rename: "new-name" });
-    expect(parsed.current).toBe("new-name");
+    expect(parsed).toMatchObject({ success: true, action: "rename", branch: "new-name" });
+    expect(parsed.branches).toBeUndefined();
   });
 
   // S9: List all (including remotes)
@@ -705,9 +732,12 @@ describe("Smoke: git.branch", () => {
   it("S11 [P1] set upstream tracking", async () => {
     // git branch --set-upstream-to=origin/main
     mockGit("Branch 'main' set up to track 'origin/main'.");
-    // git branch -vv
-    mockGit("* main  abc1234 [origin/main] latest\n");
-    await callAndValidate({ ...DEFAULTS, setUpstream: "origin/main" });
+    const { parsed } = await callAndValidate({ ...DEFAULTS, setUpstream: "origin/main" });
+    expect(parsed).toMatchObject({
+      success: true,
+      action: "set-upstream",
+      upstream: "origin/main",
+    });
     const upstreamArgs = vi.mocked(git).mock.calls[0][0];
     expect(upstreamArgs.some((a: string) => a.includes("--set-upstream-to=origin/main"))).toBe(
       true,
@@ -718,11 +748,14 @@ describe("Smoke: git.branch", () => {
   it("S12 [P2] force delete unmerged branch", async () => {
     // git branch -D feat
     mockGit("Deleted branch feat (was abc1234).");
-    // git branch -vv
-    mockGit("* main  abc1234 latest\n");
-    await callAndValidate({ ...DEFAULTS, delete: "feat", forceDelete: true });
+    const { parsed } = await callAndValidate({
+      ...DEFAULTS,
+      delete: "feat",
+      forceDelete: true,
+    });
     const deleteArgs = vi.mocked(git).mock.calls[0][0];
     expect(deleteArgs).toContain("-D");
+    expect(parsed).toMatchObject({ action: "delete", deleted: ["feat"], force: true });
   });
 
   // S13: Sort by date (note: assertNoFlagInjection blocks leading "-")
@@ -745,7 +778,7 @@ describe("Smoke: git.branch", () => {
   it("S15 [P2] compact: false returns full branch data", async () => {
     mockGit(BRANCH_LIST);
     const { parsed } = await callAndValidate({ ...DEFAULTS, compact: false });
-    expect(parsed.branches.length).toBeGreaterThanOrEqual(1);
+    expect(parsed.branches!.length).toBeGreaterThanOrEqual(1);
   });
 
   // S16: Schema validation

--- a/tests/smoke/scenarios/git-tools.md
+++ b/tests/smoke/scenarios/git-tools.md
@@ -173,26 +173,27 @@ This file contains scenario mappings for all 23 git tools in `@paretools/git`, e
 
 ### Scenarios
 
-| #   | Scenario                     | Params                                              | Expected Output                                  | Priority | Status   |
-| --- | ---------------------------- | --------------------------------------------------- | ------------------------------------------------ | -------- | -------- |
-| 1   | List branches                | `{ path }`                                          | `branches` array, `current` set to active branch | P0       | complete |
-| 2   | Create branch                | `{ path, create: "feature-x" }`                     | Branch created, appears in listing               | P0       | complete |
-| 3   | Delete branch                | `{ path, delete: "feature-x" }`                     | Branch deleted, removed from listing             | P0       | complete |
-| 4   | Flag injection in create     | `{ path, create: "--exec=evil" }`                   | `assertNoFlagInjection` throws                   | P0       | complete |
-| 5   | Not a git repo               | `{ path: "/tmp/not-a-repo" }`                       | Error thrown                                     | P0       | complete |
-| 6   | Create and switch            | `{ path, create: "feat", switchAfterCreate: true }` | Branch created, `current` now "feat"             | P1       | complete |
-| 7   | Create with start point      | `{ path, create: "feat", startPoint: "HEAD~3" }`    | Branch created from specified ref                | P1       | complete |
-| 8   | Rename current branch        | `{ path, rename: "new-name" }`                      | Branch renamed, `current` reflects new name      | P1       | complete |
-| 9   | List all (including remotes) | `{ path, all: true }`                               | Remote branches included in listing              | P1       | complete |
-| 10  | Filter merged branches       | `{ path, merged: true }`                            | Only merged branches returned                    | P1       | complete |
-| 11  | Set upstream                 | `{ path, setUpstream: "origin/main" }`              | Upstream tracking configured                     | P1       | complete |
-| 12  | Force delete unmerged        | `{ path, delete: "feat", forceDelete: true }`       | Unmerged branch deleted                          | P2       | complete |
-| 13  | Sort by date                 | `{ path, sort: "-committerdate" }`                  | Branches sorted by commit date                   | P2       | complete |
-| 14  | Contains filter              | `{ path, contains: "abc123" }`                      | Only branches containing commit                  | P2       | complete |
-| 15  | Compact vs full output       | `{ path, compact: false }`                          | Full branch data with upstream, lastCommit       | P2       | complete |
-| 16  | Schema validation            | all scenarios                                       | Output validates against `GitBranchSchema`       | P0       | complete |
+| #   | Scenario                     | Params                                              | Expected Output                                                          | Priority | Status   |
+| --- | ---------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------ | -------- | -------- |
+| 1   | List branches                | `{ path }`                                          | `branches` array, `current` set to active branch                         | P0       | complete |
+| 2   | Create branch                | `{ path, create: "feature-x" }`                     | `{ success, action: "create", branch }` confirmation                     | P0       | complete |
+| 3   | Delete branch                | `{ path, delete: "feature-x" }`                     | `{ success, action: "delete", deleted, force }` confirmation, no listing | P0       | complete |
+| 3b  | Batch delete confirmation    | `{ path, delete: ["a", "b"] }`                      | `deleted` names every branch removed                                     | P1       | complete |
+| 4   | Flag injection in create     | `{ path, create: "--exec=evil" }`                   | `assertNoFlagInjection` throws                                           | P0       | complete |
+| 5   | Not a git repo               | `{ path: "/tmp/not-a-repo" }`                       | Error thrown                                                             | P0       | complete |
+| 6   | Create and switch            | `{ path, create: "feat", switchAfterCreate: true }` | Confirmation with `switched: true`                                       | P1       | complete |
+| 7   | Create with start point      | `{ path, create: "feat", startPoint: "HEAD~3" }`    | Confirmation carries `startPoint`                                        | P1       | complete |
+| 8   | Rename current branch        | `{ path, rename: "new-name" }`                      | `{ success, action: "rename", branch }` confirmation                     | P1       | complete |
+| 9   | List all (including remotes) | `{ path, all: true }`                               | Remote branches included in listing                                      | P1       | complete |
+| 10  | Filter merged branches       | `{ path, merged: true }`                            | Only merged branches returned                                            | P1       | complete |
+| 11  | Set upstream                 | `{ path, setUpstream: "origin/main" }`              | `{ success, action: "set-upstream", upstream }` confirmation             | P1       | complete |
+| 12  | Force delete unmerged        | `{ path, delete: "feat", forceDelete: true }`       | Unmerged branch deleted                                                  | P2       | complete |
+| 13  | Sort by date                 | `{ path, sort: "-committerdate" }`                  | Branches sorted by commit date                                           | P2       | complete |
+| 14  | Contains filter              | `{ path, contains: "abc123" }`                      | Only branches containing commit                                          | P2       | complete |
+| 15  | Compact vs full output       | `{ path, compact: false }`                          | Full branch data with upstream, lastCommit                               | P2       | complete |
+| 16  | Schema validation            | all scenarios                                       | Output validates against `GitBranchSchema`                               | P0       | complete |
 
-**Summary: P0=6, P1=5, P2=5, Total=16**
+**Summary: P0=6, P1=6, P2=5, Total=17**
 
 ---
 

--- a/tests/smoke/suite/git-tools-1.recorded.test.ts
+++ b/tests/smoke/suite/git-tools-1.recorded.test.ts
@@ -317,7 +317,7 @@ describe("Recorded: git.branch", () => {
     // branch -vv (list call)
     mockGit(loadFixture("branch", "s01-list.txt"));
     const { parsed } = await callAndValidate({ compact: false });
-    expect(parsed.branches.length).toBeGreaterThanOrEqual(2);
+    expect(parsed.branches!.length).toBeGreaterThanOrEqual(2);
     expect(parsed.current).toBe("main");
     // Verify branch data (full mode returns objects)
     const branches = parsed.branches as Array<Record<string, unknown>>;
@@ -326,23 +326,26 @@ describe("Recorded: git.branch", () => {
     expect(main!.lastCommit).toMatch(/^[0-9a-f]{7,}$/);
   });
 
-  it("S2 [recorded] create branch (then list)", async () => {
-    // Call 1: git branch <name> (create)
+  it("S2 [recorded] create branch confirms, then a follow-up list shows it", async () => {
+    // Call 1: git branch <name> (create) — returns a confirmation, no listing (#1037)
     mockGit("");
-    // Call 2: git branch -vv (list)
+    const { parsed: created } = await callAndValidate({ create: "test-branch", compact: false });
+    expect(created).toMatchObject({ success: true, action: "create", branch: "test-branch" });
+    expect(created.branches).toBeUndefined();
+
+    // Call 2: a separate list call surfaces the new branch
     mockGit(loadFixture("branch", "s02-after-create.txt"));
-    const { parsed } = await callAndValidate({ create: "test-branch", compact: false });
-    expect(parsed.branches.length).toBeGreaterThanOrEqual(3);
+    const { parsed } = await callAndValidate({ compact: false });
+    expect(parsed.branches!.length).toBeGreaterThanOrEqual(3);
     const branches = parsed.branches as Array<Record<string, unknown>>;
-    const created = branches.find((b) => b.name === "test-branch");
-    expect(created).toBeDefined();
+    expect(branches.find((b) => b.name === "test-branch")).toBeDefined();
   });
 
   it("S9 [recorded] all branches including remotes", async () => {
     // branch -vv -a (list all)
     mockGit(loadFixture("branch", "s09-all.txt"));
     const { parsed } = await callAndValidate({ all: true, compact: false });
-    expect(parsed.branches.length).toBeGreaterThanOrEqual(2);
+    expect(parsed.branches!.length).toBeGreaterThanOrEqual(2);
     // Should include remote branches (full mode returns objects)
     const branches = parsed.branches as Array<Record<string, unknown>>;
     const remotes = branches.filter((b) => (b.name as string).startsWith("remotes/"));


### PR DESCRIPTION
Fixes two independent `@paretools/git` bugs.

## Bug A — `add` with `files: ["."]` staged nothing; directory paths staged one file (#1057)

**Root cause:** `resolveFilePath()` in `packages/server-git/src/lib/git-runner.ts` canonicalises path *casing* by running `git ls-files -- <pathspec>` and taking `stdout.split("\n")[0]`. For a pathspec that legitimately matches many files, that first line is an arbitrary tracked file, and the rewritten pathspec is what actually reaches git. So `files: ["."]` became the first tracked file in the repo (staging nothing when that file was clean), and `files: ["site/public"]` became `site/public/building.html` — exactly the two repros in the issue. Nothing was being filtered on the way out: the reported `files` list comes from a full `status --porcelain` parse and was accurately reporting that only one file got staged.

**Fix:** pass multi-match pathspecs (`.`, `./`, `..`, trailing slash, an existing directory on disk, globs, pathspec magic) through to git untouched, and for everything else only accept an `ls-files` hit that is a case-variant of the requested path. Single-file case canonicalisation on Windows — the reason the function exists — is unchanged. Backslash input is still normalised to forward slashes before any of this, so `site\public\assets` works.

New `packages/server-git/__tests__/add-pathspec.test.ts` builds a real temp repo (nested dirs, modified + untracked files at several depths) and asserts via `git status --porcelain` that `.`, a directory, a backslash directory, a trailing-slash directory and a glob each stage everything under them, and that the returned `files` list matches. Verified these 7 tests fail 6/7 against the pre-fix code with the original symptom (`site/public` -> only `building.html`).

## Bug B — `branch` delete returned the entire branch listing (#1037)

**Root cause:** every mutation branch in `packages/server-git/src/tools/branch.ts` fell through to the shared `branch -vv` listing at the end of the handler, so a successful delete returned the full `{ branches, current }` payload — 53k characters on a repo with hundreds of branches, past the MCP client's per-result cap.

**Fix:** `create`, `delete`, `rename` and `setUpstream` now return a compact confirmation and skip the listing (and the `mergedInto` rev-list loop) entirely.

### Behavior change to the branch tool's output shape

List mode is **unchanged**: `{ branches, current }`.

Mutations now return, instead of the listing:

| action | payload |
|---|---|
| delete | `{ success: true, action: "delete", deleted: ["a", "b"], force }` |
| create | `{ success: true, action: "create", branch, startPoint?, force, switched }` |
| rename | `{ success: true, action: "rename", branch, force }` |
| setUpstream | `{ success: true, action: "set-upstream", upstream }` |

- `deleted` is always an array so single and batch deletes have one shape.
- Mutation results omit `branches`/`current`; list results omit the mutation fields. Callers that relied on the post-mutation listing should call `branch` again with no mutation param.
- When several mutations are combined in one call the confirmation describes the last one performed (rename -> setUpstream -> create -> delete). Documented in the tool description and `docs/tool-schemas/git/branch.md`.

`GitBranchSchema` models both shapes as a single `z.object()` of optional fields rather than a `z.union()`, following the existing `GitWorktreeOutputSchema` precedent (the MCP SDK does not accept unions for `outputSchema`).

## Verification

- `pnpm --filter @paretools/git test` — 733 passed
- `pnpm smoke` — 2325 passed (updated the branch scenarios in `tests/smoke/mocked/git-tools-1.smoke.test.ts` and `tests/smoke/suite/git-tools-1.recorded.test.ts` that pinned the old post-mutation listing, plus the scenario table)
- `pnpm test` (full monorepo) — green
- `pnpm build`, `pnpm lint`, `pnpm format:check` — clean

Changeset: `.changeset/fix-1057-1037-git-add-branch.md` (patch, `@paretools/git`).

Filed #1070 separately for an unrelated bug noticed during the full test run: the server-lint integration tests run `biome-format` (a write op) against the repo's own `packages/server-lint/src/lib/formatters.ts`, so `pnpm test` dirties the working tree.

Closes #1057
Closes #1037