### PR TITLE
fix(python,test): parse pytest counts only from the final summary line

### DIFF
--- a/.changeset/fix-1061-pytest-summary-counts.md
+++ b/.changeset/fix-1061-pytest-summary-counts.md
@@ -1,0 +1,16 @@
+---
+"@paretools/python": patch
+"@paretools/test": patch
+---
+
+fix(python,test): parse pytest counts only from the final summary line
+
+The pytest summary parser scanned every output line for `N passed` / `N failed`
+patterns, so free text that happened to contain a number next to a status word —
+notably libpq's skip reason `port 5555 failed: Connection refused` — was scraped
+as a count, producing self-contradictory results such as `failed: 5555` with
+`success: true` and an empty `failures[]`. Counts now come only from pytest's own
+final summary line (`===== N passed, M skipped in Xs =====`, also matched
+undecorated under `-q`, last occurrence wins), a consistency guard zeroes
+failure/error counts that have neither a summary line nor a parsed failure block
+behind them, and a run with failures is never reported as a success.

--- a/packages/server-python/__tests__/pytest.test.ts
+++ b/packages/server-python/__tests__/pytest.test.ts
@@ -286,3 +286,121 @@ describe("formatPytest", () => {
     expect(output).toContain("ModuleNotFoundError: No module named 'mypkg'");
   });
 });
+
+// Real shape of a run with Postgres-gated skips: the skip reason carries libpq's
+// "port 5555 failed: Connection refused" text, which the old line-by-line
+// scraper read as `failed: 5555`. See issues #1061 / #1045.
+const PYTEST_SKIP_REASON_WITH_PORT = [
+  "============================= test session starts =============================",
+  "platform win32 -- Python 3.13.1, pytest-8.3.4, pluggy-1.5.0",
+  "rootdir: C:\proj",
+  "plugins: anyio-4.6.2, asyncio-0.24.0, cov-6.0.0",
+  "collected 201 items",
+  "",
+  "tests/test_api.py ......................................          [ 25%]",
+  "tests/test_db.py ssss                                             [ 27%]",
+  "tests/test_engine.py ..................................           [100%]",
+  "",
+  "=========================== short test summary info ===========================",
+  'SKIPPED [1] tests/test_db.py:12: postgres_only: connection to server at "localhost" (127.0.0.1), port 5555 failed: Connection refused',
+  'SKIPPED [1] tests/test_db.py:20: postgres_only: connection to server at "localhost" (127.0.0.1), port 5555 failed: Connection refused',
+  "SKIPPED [2] tests/conftest.py:88: requires Postgres on port 5555",
+  "======================= 197 passed, 4 skipped in 12.34s =======================",
+].join("\n");
+
+describe("parsePytestOutput — counts come only from the summary line (#1061)", () => {
+  it("ignores numbers in skip reasons instead of scraping them as failures", () => {
+    const result = parsePytestOutput(PYTEST_SKIP_REASON_WITH_PORT, "", 0);
+
+    expect(result.failed).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(result.success).toBe(true);
+    expect(result.passed).toBe(197);
+    expect(result.skipped).toBe(4);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("ignores a port number in a captured log line on stderr", () => {
+    const stderr = [
+      "WARNING  db.session:session.py:44 could not connect on port 5555 failed: Connection refused",
+    ].join("\n");
+
+    const result = parsePytestOutput("1465 passed, 12 skipped in 98.20s", stderr, 0);
+
+    expect(result.failed).toBe(0);
+    expect(result.passed).toBe(1465);
+    expect(result.skipped).toBe(12);
+    expect(result.success).toBe(true);
+  });
+
+  it("takes the last summary line when several are printed", () => {
+    const stdout = [
+      "==================== 1 failed, 1 passed in 0.50s ====================",
+      "Rerunning failed tests…",
+      "==================== 2 passed in 0.90s ====================",
+    ].join("\n");
+
+    const result = parsePytestOutput(stdout, "", 0);
+
+    expect(result.passed).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.success).toBe(true);
+  });
+
+  it("does not treat the short test summary header as a counts line", () => {
+    const stdout = [
+      "=========================== short test summary info ===========================",
+      "SKIPPED [1] tests/test_db.py:12: needs 5555 error budget",
+      "======================= 3 passed, 1 skipped in 0.42s =======================",
+    ].join("\n");
+
+    const result = parsePytestOutput(stdout, "", 0);
+
+    expect(result.passed).toBe(3);
+    expect(result.skipped).toBe(1);
+    expect(result.errors).toBe(0);
+  });
+
+  it("reports zero rather than a fabricated count when no summary line exists", () => {
+    const stdout = [
+      "Connecting to fixture host…",
+      "connection to server at localhost, port 5555 failed: Connection refused",
+      "42 error budget exceeded",
+    ].join("\n");
+
+    const result = parsePytestOutput(stdout, "", 1);
+
+    expect(result.failed).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(result.passed).toBe(0);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("never reports success alongside failures", () => {
+    // Defensive: a wrapper swallowing pytest's exit code must not flip the verdict.
+    const result = parsePytestOutput("==== 1 failed, 2 passed in 0.30s ====", "", 0);
+
+    expect(result.failed).toBe(1);
+    expect(result.success).toBe(false);
+  });
+
+  it("still parses the undecorated summary line emitted by pytest -q", () => {
+    const result = parsePytestOutput("....s\n4 passed, 1 skipped in 0.52s", "", 0);
+
+    expect(result.passed).toBe(4);
+    expect(result.skipped).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
+  it("parses a summary line with an elapsed-time suffix", () => {
+    const result = parsePytestOutput(
+      "==== 120 passed, 3 skipped in 3612.10s (1:00:12) ====",
+      "",
+      0,
+    );
+
+    expect(result.passed).toBe(120);
+    expect(result.skipped).toBe(3);
+    expect(result.failed).toBe(0);
+  });
+});

--- a/packages/server-python/src/lib/parsers.ts
+++ b/packages/server-python/src/lib/parsers.ts
@@ -350,6 +350,40 @@ function extractCount(line: string, label: RegExp): number {
 /** Maximum size of the errorOutput diagnostic attached to failed empty pytest runs. */
 const PYTEST_ERROR_OUTPUT_MAX = 4_000;
 
+/** One "N label" token of pytest's final summary line ("3 passed", "1 xfailed",
+ *  "2 subtests passed"), or the literal "no tests ran". */
+const PYTEST_COUNT_TOKEN = String.raw`(?:\d+ [a-z]+(?: [a-z]+)?|no tests ran)`;
+
+/** The body of pytest's final summary line, e.g. "3 passed, 1 failed in 1.23s".
+ *  Deliberately anchored and strict: the ENTIRE body must be comma-separated
+ *  count tokens followed by a duration. Free text that merely happens to contain
+ *  a number followed by a status word — e.g. the psycopg skip reason
+ *  `port 5555 failed: Connection refused` — can never satisfy it, so counts are
+ *  never scraped out of arbitrary output. See issues #1061 / #1045. */
+const PYTEST_SUMMARY_BODY_RE = new RegExp(
+  String.raw`^${PYTEST_COUNT_TOKEN}(?:,\s*${PYTEST_COUNT_TOKEN})*\s+in\s+[\d.]+s(?:\s*\([^)]*\))?$`,
+);
+
+/** Strips pytest's "=" rule padding: "==== 3 passed in 1s ====" -> "3 passed in 1s". */
+const PYTEST_RULE_RE = /^=+\s*(.*?)\s*=+$/;
+
+/** Finds pytest's own final summary line (the `==== N passed, M failed in Xs ====`
+ *  line, also emitted undecorated under `-q`). The LAST match wins, since reruns
+ *  and plugins can emit more than one. Returns null when pytest never printed one
+ *  (crash before the summary, truncated capture) — counts are then unknown, not
+ *  guessed. */
+function findPytestSummaryLine(lines: string[]): string | null {
+  let summary: string | null = null;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    const ruled = line.match(PYTEST_RULE_RE);
+    const body = ruled ? ruled[1] : line;
+    if (PYTEST_SUMMARY_BODY_RE.test(body)) summary = body;
+  }
+  return summary;
+}
+
 /** Picks the stream most likely to explain a failed pytest run.
  *  Collection errors ("ERRORS" section, ModuleNotFoundError) land on stdout;
  *  plugin/startup crashes (tracebacks) land on stderr. Prefers whichever stream
@@ -398,22 +432,23 @@ export function parsePytestOutput(stdout: string, stderr: string, exitCode: numb
   const output = stdout + "\n" + stderr;
   const lines = output.split("\n");
 
-  // Find the summary line (e.g., "=== 3 passed, 1 failed in 0.52s ===")
+  // Counts come ONLY from pytest's own final summary line
+  // (e.g. "=== 3 passed, 1 failed in 0.52s ==="), never from arbitrary output
+  // lines — a skip reason like "port 5555 failed: Connection refused" used to be
+  // scraped as `failed: 5555`. See issues #1061 / #1045.
+  const summaryLine = findPytestSummaryLine(lines);
   let passed = 0;
   let failed = 0;
   let errors = 0;
   let skipped = 0;
   let warnings = 0;
 
-  for (const line of lines) {
-    // Match lines containing pytest summary markers (== ... in Xs ==) or standalone counts
-    if (/\d+ (?:passed|failed|error|skipped|warning)/.test(line) || /in [\d.]+s/.test(line)) {
-      passed = Math.max(passed, extractCount(line, /(\d+) passed/));
-      failed = Math.max(failed, extractCount(line, /(\d+) failed/));
-      errors = Math.max(errors, extractCount(line, /(\d+) errors?/));
-      skipped = Math.max(skipped, extractCount(line, /(\d+) skipped/));
-      warnings = Math.max(warnings, extractCount(line, /(\d+) warnings?/));
-    }
+  if (summaryLine) {
+    passed = extractCount(summaryLine, /(\d+) passed\b/);
+    failed = extractCount(summaryLine, /(\d+) failed\b/);
+    errors = extractCount(summaryLine, /(\d+) errors?\b/);
+    skipped = extractCount(summaryLine, /(\d+) skipped\b/);
+    warnings = extractCount(summaryLine, /(\d+) warnings?\b/);
   }
 
   // Check for "no tests ran" case
@@ -468,9 +503,18 @@ export function parsePytestOutput(stdout: string, stderr: string, exitCode: numb
     failures.push({ test: testName, message });
   }
 
+  // Consistency guard (#1061): a failure/error count must be traceable to either
+  // pytest's summary line or a parsed failure block. Without both, report zero
+  // rather than fabricating a number the rest of the payload contradicts.
+  if (!summaryLine && failures.length === 0) {
+    failed = 0;
+    errors = 0;
+  }
+
   return attachEmptyRunDiagnostics(
     {
-      success: exitCode === 0,
+      // A run with failures/errors is never a success, whatever the exit code says.
+      success: exitCode === 0 && failed === 0 && errors === 0,
       passed,
       failed,
       errors,

--- a/packages/server-test/__tests__/pytest-parser.test.ts
+++ b/packages/server-test/__tests__/pytest-parser.test.ts
@@ -48,6 +48,54 @@ describe("parsePytestOutput", () => {
     expect(result.summary.total).toBe(0);
     expect(result.failures).toHaveLength(0);
   });
+
+  // Skip reasons carrying libpq's "port 5555 failed: Connection refused" text used
+  // to be scraped as a failure count. See issues #1061 / #1045.
+  it("ignores numbers in skip reasons and parses only the summary line (#1061)", () => {
+    const stdout = [
+      "============================= test session starts =============================",
+      "collected 201 items",
+      "",
+      "tests/test_db.py::test_query SKIPPED",
+      "",
+      "=========================== short test summary info ===========================",
+      'SKIPPED [1] tests/test_db.py:12: postgres_only: connection to server at "localhost" (127.0.0.1), port 5555 failed: Connection refused',
+      "SKIPPED [3] tests/conftest.py:88: requires Postgres on port 5555",
+      "======================= 197 passed, 4 skipped in 12.34s =======================",
+    ].join("\n");
+
+    const result = parsePytestOutput(stdout);
+
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.passed).toBe(197);
+    expect(result.summary.skipped).toBe(4);
+    expect(result.summary.total).toBe(201);
+    expect(result.summary.duration).toBe(12.34);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("parses the undecorated summary line emitted by pytest -q", () => {
+    const result = parsePytestOutput("....s\n4 passed, 1 skipped in 0.52s");
+
+    expect(result.summary.passed).toBe(4);
+    expect(result.summary.skipped).toBe(1);
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.duration).toBe(0.52);
+  });
+
+  it("takes the last summary line when several are printed", () => {
+    const stdout = [
+      "==================== 1 failed, 1 passed in 0.50s ====================",
+      "Rerunning failed tests…",
+      "==================== 2 passed in 0.90s ====================",
+    ].join("\n");
+
+    const result = parsePytestOutput(stdout);
+
+    expect(result.summary.passed).toBe(2);
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.duration).toBe(0.9);
+  });
 });
 
 describe("parsePytestCoverage", () => {

--- a/packages/server-test/src/lib/parsers/pytest.ts
+++ b/packages/server-test/src/lib/parsers/pytest.ts
@@ -1,5 +1,42 @@
 import type { TestRun, Coverage } from "../../schemas/index.js";
 
+/** One "N label" token of pytest's final summary line ("3 passed", "1 xfailed",
+ *  "2 subtests passed"), or the literal "no tests ran". */
+const PYTEST_COUNT_TOKEN = String.raw`(?:\d+ [a-z]+(?: [a-z]+)?|no tests ran)`;
+
+/** The body of pytest's final summary line, e.g. "1 failed, 9 passed in 0.42s".
+ *  Deliberately anchored and strict: the ENTIRE body must be comma-separated
+ *  count tokens followed by a duration, so free text containing a number next to
+ *  a status word (e.g. the skip reason `port 5555 failed: Connection refused`)
+ *  can never be read as a count. See issues #1061 / #1045. */
+const PYTEST_SUMMARY_BODY_RE = new RegExp(
+  String.raw`^${PYTEST_COUNT_TOKEN}(?:,\s*${PYTEST_COUNT_TOKEN})*\s+in\s+[\d.]+s(?:\s*\([^)]*\))?$`,
+);
+
+/** Strips pytest's "=" rule padding: "==== 3 passed in 1s ====" -> "3 passed in 1s". */
+const PYTEST_RULE_RE = /^=+\s*(.*?)\s*=+$/;
+
+/** Finds pytest's own final summary line (also emitted undecorated under `-q`).
+ *  The LAST match wins; null means pytest never printed one, so counts stay zero
+ *  instead of being guessed from unrelated output. */
+function findPytestSummaryLine(lines: string[]): string | null {
+  let summary: string | null = null;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    const ruled = line.match(PYTEST_RULE_RE);
+    const body = ruled ? ruled[1] : line;
+    if (PYTEST_SUMMARY_BODY_RE.test(body)) summary = body;
+  }
+  return summary;
+}
+
+function countFrom(summary: string | null, label: RegExp): number {
+  if (!summary) return 0;
+  const m = summary.match(label);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
 /**
  * Parses pytest verbose output (-v) into structured data.
  *
@@ -13,15 +50,15 @@ import type { TestRun, Coverage } from "../../schemas/index.js";
 export function parsePytestOutput(stdout: string): TestRun {
   const lines = stdout.split("\n");
 
-  // Parse summary line: "1 failed, 9 passed, 2 skipped in 0.42s"
-  const summaryMatch = stdout.match(
-    /=+ (?:(\d+) failed)?[, ]*(?:(\d+) passed)?[, ]*(?:(\d+) skipped)?[, ]*(?:(\d+) error)?[, ]*in ([\d.]+)s/,
-  );
+  // Counts come ONLY from pytest's final summary line
+  // ("1 failed, 9 passed, 2 skipped in 0.42s"), never from arbitrary output.
+  const summaryLine = findPytestSummaryLine(lines);
 
-  const failed = summaryMatch ? parseInt(summaryMatch[1] || "0", 10) : 0;
-  const passed = summaryMatch ? parseInt(summaryMatch[2] || "0", 10) : 0;
-  const skipped = summaryMatch ? parseInt(summaryMatch[3] || "0", 10) : 0;
-  const duration = summaryMatch ? parseFloat(summaryMatch[5] || "0") : 0;
+  const failed = countFrom(summaryLine, /(\d+) failed\b/);
+  const passed = countFrom(summaryLine, /(\d+) passed\b/);
+  const skipped = countFrom(summaryLine, /(\d+) skipped\b/);
+  const durationMatch = summaryLine?.match(/in ([\d.]+)s/);
+  const duration = durationMatch ? parseFloat(durationMatch[1]) : 0;
 
   // Parse failures from short test summary
   const failures: TestRun["failures"] = [];


### PR DESCRIPTION
## Problem

`mcp__pare-python__pytest` reported `"failed": 5555` for a run whose real summary was `197 passed, 4 skipped` — with `success: true` and `failures: []` in the same payload (issues #1061 / #1045).

The parser scanned **every** output line for count patterns:

```ts
if (/\d+ (?:passed|failed|error|skipped|warning)/.test(line) || /in [\d.]+s/.test(line)) {
  failed = Math.max(failed, extractCount(line, /(\d+) failed/));
  ...
}
```

A Postgres-gated skip reason carries libpq's error text verbatim:

```
SKIPPED [1] tests/test_db.py:12: postgres_only: connection to server at "localhost" (127.0.0.1), port 5555 failed: Connection refused
```

`5555 failed` matched `(\d+) failed`, and `Math.max` locked the bogus number in. The count and the pass/fail verdict came from different paths, so `success` stayed `true`.

## Fix

- **Counts come only from pytest's own final summary line.** A strict, fully anchored grammar accepts a line whose *entire* body is comma-separated `N <label>` tokens (or `no tests ran`) followed by `in <duration>s` — with or without the `=====` rule padding, since `-q` prints it undecorated. Free text can't satisfy it. The **last** match wins (reruns/plugins can print more than one).
- **Consistency guard:** if there is no summary line and no parsed failure block, `failed`/`errors` are reported as `0` rather than a fabricated number.
- **`success` can no longer contradict the counts:** a run with `failed > 0` or `errors > 0` is never `success: true`.

Same bug class fixed in `packages/server-test` (`mcp__pare-test__run` pytest path): its regex was `=`-anchored but took the *first* match, mis-ordered categories, and returned all-zero counts for `pytest -q` output. It now uses the same summary-line detection.

## Tests

New regression cases in `packages/server-python/__tests__/pytest.test.ts` and `packages/server-test/__tests__/pytest-parser.test.ts`, using realistic pytest output with `-rs` short-summary `SKIPPED [1] tests/x.py:12: ... port 5555 failed: Connection refused` lines: assert `failed: 0`, `success: true`, `passed: 197`, `skipped: 4`. Also covers the port number appearing in a captured log line on stderr, multiple summary lines (last wins), the `short test summary info` header not being read as counts, no-summary-line output, `-q` undecorated summaries, and `in 3612.10s (1:00:12)` elapsed suffixes.

No existing test pinned the buggy behavior — none were changed.

`pnpm --filter @paretools/python test` (505 passed), `pnpm --filter @paretools/test test` (all green), `pnpm build`, `pnpm lint`, `pnpm format:check` all pass locally.

Closes #1061
Closes #1045
