### PR TITLE
ci: bump github/codeql-action to v4.37.7 in lockstep + group future action bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # codeql-action init/autobuild/analyze/upload-sarif must move together;
+      # a lone bump fails Analyze with "Loaded a configuration file for version
+      # X, but running version Y".
+      codeql:
+        patterns: ["github/codeql-action*"]
+      github-actions:
+        patterns: ["*"]
+        exclude-patterns: ["github/codeql-action*"]
     labels:
       - "dependencies"
       - "ci"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,12 +21,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
-      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v3
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: javascript-typescript
 
-      - uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v3
+      - uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
 
-      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v3
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,6 +33,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3
+      - uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Replaces the four per-step Dependabot PRs #1038, #1040, #1042, #1043.

**Why they were red:** Dependabot bumped `init`, `autobuild`, `analyze`, `upload-sarif` in separate PRs. Each one alone runs mixed versions and CodeQL `Analyze` fails with `Loaded a configuration file for version '4.37.7', but running version '4.37.1'`.

**This PR:**
- bumps all four `github/codeql-action/*` refs together to v4.37.7 (`ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd`) in `codeql.yml` + `scorecard.yml`
- adds Dependabot `groups` for the `github-actions` ecosystem: `codeql` (all `github/codeql-action*`) and `github-actions` (everything else) so this doesn't recur.

CI-only; no changeset.