### PR TITLE
fix(git): honest restore verification and consistent worktree removal

### DIFF
--- a/.changeset/fix-1068-1073-git-restore-prune.md
+++ b/.changeset/fix-1068-1073-git-restore-prune.md
@@ -1,0 +1,25 @@
+---
+"@paretools/git": patch
+---
+
+Fix two git-server bugs around paths and worktree removal.
+
+**`restore` verification lied about directory pathspecs (#1068).** The post-restore
+check compared `git status --porcelain` lines against the requested paths by exact
+string, so a directory pathspec (`src`, `src/`, `.`) never matched a status line and
+`verified: true` came back regardless of what was left dirty. Verification now treats
+a path as unrestored when any remaining status entry lies at or under it, and
+translates pathspecs to repo-relative form first so it stays correct when the tool
+runs from a subdirectory.
+
+**`worktree` removal could report a failure it had already half-committed to
+(#1073).** `git worktree remove` deletes the admin entry even when the recursive
+delete of the working directory fails first — on Windows a large `node_modules` tree
+trips that routinely with `Filename too long` — so `prune-merged` reported
+`remove-failed` while the worktree was in fact unregistered, leaving an orphaned
+directory that later `remove` calls rejected with "is not a working tree". Removal now
+re-checks registration on failure: still registered means a genuine failure, reported
+as `removed: false` with git's stderr in a new `error` field and nothing touched; no
+longer registered means only the directory delete failed, so the tool finishes it with
+a recursive delete and reports `removed: true` with `cleanedUp: true`. The same
+handling applies to `action: "remove"`, whose thrown error now carries git's stderr.

--- a/packages/server-git/__tests__/restore-directory-pathspec.test.ts
+++ b/packages/server-git/__tests__/restore-directory-pathspec.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Regression tests for #1068 — directory pathspecs.
+ *
+ * Two halves:
+ *   1. `restore` / `reset` / `diff` / `blame` must hand a directory pathspec to git
+ *      intact (the `resolveFilePath` rewrite from #1071 — verified here end to end).
+ *   2. `restore`'s post-restore verification must be honest about a directory
+ *      pathspec. It compared `git status` lines by exact filename, so a directory
+ *      never matched and `verified: true` came back no matter what.
+ *
+ * These run against real temp repos (no git mocking) because the bug lives in the
+ * interaction between the pathspec we hand to git and what git actually expands.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  normalizeRepoPath,
+  pathIsUnderPathspec,
+  toRepoRelativePathspec,
+} from "../src/lib/parsers.js";
+import { registerRestoreTool } from "../src/tools/restore.js";
+import { registerResetTool } from "../src/tools/reset.js";
+import { registerDiffTool } from "../src/tools/diff.js";
+import { registerBlameTool } from "../src/tools/blame.js";
+
+type ToolHandler = (params: Record<string, unknown>) => Promise<{
+  content: unknown;
+  structuredContent: Record<string, unknown>;
+}>;
+
+class FakeServer {
+  tools = new Map<string, { handler: ToolHandler }>();
+  registerTool(name: string, _config: Record<string, unknown>, handler: ToolHandler) {
+    this.tools.set(name, { handler });
+  }
+}
+
+function run(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+function readText(path: string): string {
+  return readFileSync(path, "utf8").replace(/\r\n/g, "\n");
+}
+
+/** Working-tree-modified paths per `git status --porcelain`. */
+function dirtyPaths(cwd: string): string[] {
+  return run(["status", "--porcelain=v1"], cwd)
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.slice(3).trim())
+    .sort();
+}
+
+// ── Pure helpers ─────────────────────────────────────────────────────
+
+describe("normalizeRepoPath", () => {
+  it("converts backslashes to forward slashes", () => {
+    expect(normalizeRepoPath("src\\lib\\a.ts")).toBe("src/lib/a.ts");
+  });
+
+  it("strips trailing slashes", () => {
+    expect(normalizeRepoPath("src/lib/")).toBe("src/lib");
+    expect(normalizeRepoPath("src/lib//")).toBe("src/lib");
+  });
+
+  it("strips a leading ./", () => {
+    expect(normalizeRepoPath("./src")).toBe("src");
+    expect(normalizeRepoPath("././src")).toBe("src");
+  });
+});
+
+describe("pathIsUnderPathspec (#1068)", () => {
+  it("matches the exact file", () => {
+    expect(pathIsUnderPathspec("src/a.ts", "src/a.ts")).toBe(true);
+  });
+
+  it("matches files under a directory pathspec", () => {
+    expect(pathIsUnderPathspec("src/lib/a.ts", "src")).toBe(true);
+    expect(pathIsUnderPathspec("src/lib/a.ts", "src/lib")).toBe(true);
+  });
+
+  it("tolerates trailing slashes and backslashes on either side", () => {
+    expect(pathIsUnderPathspec("src/lib/a.ts", "src/")).toBe(true);
+    expect(pathIsUnderPathspec("src\\lib\\a.ts", "src")).toBe(true);
+    expect(pathIsUnderPathspec("src/lib/a.ts", "src\\lib\\")).toBe(true);
+  });
+
+  it("does not match a sibling with a shared name prefix", () => {
+    expect(pathIsUnderPathspec("src-gen/a.ts", "src")).toBe(false);
+    expect(pathIsUnderPathspec("srcfile.ts", "src")).toBe(false);
+  });
+
+  it("does not match a parent of the pathspec", () => {
+    expect(pathIsUnderPathspec("src/a.ts", "src/lib")).toBe(false);
+  });
+
+  it("treats . and the empty pathspec as the whole repo", () => {
+    expect(pathIsUnderPathspec("anything/at/all.ts", ".")).toBe(true);
+    expect(pathIsUnderPathspec("anything/at/all.ts", "")).toBe(true);
+  });
+});
+
+describe("toRepoRelativePathspec (#1068)", () => {
+  it("passes relative paths through at the repo root", () => {
+    expect(toRepoRelativePathspec("src/lib", "/repo", "")).toBe("src/lib");
+  });
+
+  it("prepends the cwd prefix when running in a subdirectory", () => {
+    expect(toRepoRelativePathspec("lib", "/repo", "src/")).toBe("src/lib");
+    expect(toRepoRelativePathspec(".", "/repo", "src/")).toBe("src");
+  });
+
+  it("maps . to the repo root at the top level", () => {
+    expect(toRepoRelativePathspec(".", "/repo", "")).toBe(".");
+  });
+
+  it("strips the repo root from an absolute path", () => {
+    expect(toRepoRelativePathspec("/repo/src/lib", "/repo", "")).toBe("src/lib");
+    expect(toRepoRelativePathspec("C:\\repo\\src\\lib", "C:/repo", "")).toBe("src/lib");
+    expect(toRepoRelativePathspec("/repo", "/repo", "")).toBe(".");
+  });
+
+  it("leaves an absolute path outside the repo alone", () => {
+    expect(toRepoRelativePathspec("/elsewhere/src", "/repo", "")).toBe("/elsewhere/src");
+  });
+});
+
+// ── Real-repo behaviour ──────────────────────────────────────────────
+
+describe("directory pathspecs against a real repo (#1068)", () => {
+  let repoDir: string;
+  let restore: ToolHandler;
+  let reset: ToolHandler;
+  let diff: ToolHandler;
+  let blame: ToolHandler;
+
+  beforeEach(() => {
+    repoDir = mkdtempSync(join(tmpdir(), "pare-git-dir-pathspec-"));
+    run(["init"], repoDir);
+    run(["config", "user.email", "test@test.com"], repoDir);
+    run(["config", "user.name", "Test"], repoDir);
+    run(["config", "core.autocrlf", "false"], repoDir);
+
+    mkdirSync(join(repoDir, "site", "lib"), { recursive: true });
+    writeFileSync(join(repoDir, "README.md"), "# readme\n");
+    writeFileSync(join(repoDir, "site", "index.html"), "<p>v1</p>\n");
+    writeFileSync(join(repoDir, "site", "about.html"), "<p>v1</p>\n");
+    writeFileSync(join(repoDir, "site", "lib", "app.js"), "// v1\n");
+    run(["add", "-A"], repoDir);
+    run(["commit", "-m", "v1"], repoDir);
+
+    // Second commit so `source: HEAD~1` is available for the negative case.
+    writeFileSync(join(repoDir, "site", "index.html"), "<p>v2</p>\n");
+    writeFileSync(join(repoDir, "site", "about.html"), "<p>v2</p>\n");
+    writeFileSync(join(repoDir, "site", "lib", "app.js"), "// v2\n");
+    run(["add", "-A"], repoDir);
+    run(["commit", "-m", "v2"], repoDir);
+
+    const server = new FakeServer();
+    registerRestoreTool(server as never);
+    registerResetTool(server as never);
+    registerDiffTool(server as never);
+    registerBlameTool(server as never);
+    restore = server.tools.get("restore")!.handler;
+    reset = server.tools.get("reset")!.handler;
+    diff = server.tools.get("diff")!.handler;
+    blame = server.tools.get("blame")!.handler;
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  function dirtySite() {
+    writeFileSync(join(repoDir, "site", "index.html"), "<p>dirty</p>\n");
+    writeFileSync(join(repoDir, "site", "about.html"), "<p>dirty</p>\n");
+    writeFileSync(join(repoDir, "site", "lib", "app.js"), "// dirty\n");
+  }
+
+  it("restore with a directory pathspec restores every file underneath it", async () => {
+    dirtySite();
+    expect(dirtyPaths(repoDir)).toEqual(["site/about.html", "site/index.html", "site/lib/app.js"]);
+
+    const result = await restore({ path: repoDir, files: ["site"], staged: false });
+
+    expect(readText(join(repoDir, "site", "index.html"))).toBe("<p>v2</p>\n");
+    expect(readText(join(repoDir, "site", "about.html"))).toBe("<p>v2</p>\n");
+    expect(readText(join(repoDir, "site", "lib", "app.js"))).toBe("// v2\n");
+    expect(dirtyPaths(repoDir)).toEqual([]);
+
+    expect(result.structuredContent.verified).toBe(true);
+    expect(result.structuredContent.verifiedFiles).toEqual([{ file: "site", restored: true }]);
+  });
+
+  it("restore accepts a trailing slash on the directory pathspec", async () => {
+    dirtySite();
+
+    const result = await restore({ path: repoDir, files: ["site/"], staged: false });
+
+    expect(dirtyPaths(repoDir)).toEqual([]);
+    expect(result.structuredContent.verified).toBe(true);
+  });
+
+  it('restore with files: ["."] restores the whole tree', async () => {
+    dirtySite();
+    writeFileSync(join(repoDir, "README.md"), "# dirty\n");
+
+    const result = await restore({ path: repoDir, files: ["."], staged: false });
+
+    expect(dirtyPaths(repoDir)).toEqual([]);
+    expect(result.structuredContent.verified).toBe(true);
+  });
+
+  it("reports verified: false when the path is still dirty afterwards", async () => {
+    // Restoring from HEAD~1 puts the v1 content back, so every file under `site`
+    // is modified relative to HEAD. Verification must say so instead of claiming
+    // success because the directory name never appears in `git status`.
+    const result = await restore({
+      path: repoDir,
+      files: ["site"],
+      staged: false,
+      source: "HEAD~1",
+    });
+
+    expect(readText(join(repoDir, "site", "index.html"))).toBe("<p>v1</p>\n");
+    expect(dirtyPaths(repoDir)).toEqual(["site/about.html", "site/index.html", "site/lib/app.js"]);
+
+    expect(result.structuredContent.verified).toBe(false);
+    expect(result.structuredContent.verifiedFiles).toEqual([{ file: "site", restored: false }]);
+  });
+
+  it("scopes verification to the requested directory only", async () => {
+    dirtySite();
+    writeFileSync(join(repoDir, "README.md"), "# dirty\n");
+
+    // README.md is left dirty on purpose — it is not under `site`, so it must not
+    // drag the `site` verification down.
+    const result = await restore({ path: repoDir, files: ["site"], staged: false });
+
+    expect(dirtyPaths(repoDir)).toEqual(["README.md"]);
+    expect(result.structuredContent.verified).toBe(true);
+  });
+
+  it("verifies a nested directory pathspec independently of its siblings", async () => {
+    dirtySite();
+
+    const result = await restore({ path: repoDir, files: ["site/lib"], staged: false });
+
+    expect(readText(join(repoDir, "site", "lib", "app.js"))).toBe("// v2\n");
+    // Siblings outside site/lib stay dirty but must not affect this verification.
+    expect(dirtyPaths(repoDir)).toEqual(["site/about.html", "site/index.html"]);
+    expect(result.structuredContent.verified).toBe(true);
+  });
+
+  it("restore --staged with a directory pathspec unstages every file underneath", async () => {
+    dirtySite();
+    run(["add", "-A"], repoDir);
+
+    const result = await restore({ path: repoDir, files: ["site"], staged: true });
+
+    const staged = run(["status", "--porcelain=v1"], repoDir)
+      .split("\n")
+      .filter(Boolean)
+      .filter((line) => line[0] !== " " && line[0] !== "?");
+    expect(staged).toEqual([]);
+    expect(result.structuredContent.verified).toBe(true);
+  });
+
+  it("reset with a directory pathspec unstages every file underneath", async () => {
+    dirtySite();
+    run(["add", "-A"], repoDir);
+
+    await reset({ path: repoDir, ref: "HEAD", files: ["site"] });
+
+    const stillStaged = run(["status", "--porcelain=v1"], repoDir)
+      .split("\n")
+      .filter(Boolean)
+      .filter((line) => line[0] !== " " && line[0] !== "?")
+      .map((line) => line.slice(3).trim());
+    expect(stillStaged).toEqual([]);
+  });
+
+  it("diff with a directory pathspec reports every changed file underneath", async () => {
+    dirtySite();
+
+    const result = await diff({ path: repoDir, files: ["site"] });
+    const files = (result.structuredContent.files as Array<{ file: string }>).map((f) => f.file);
+
+    expect(files.sort()).toEqual(["site/about.html", "site/index.html", "site/lib/app.js"]);
+  });
+
+  it("blame surfaces git's error for a directory instead of blaming one child", async () => {
+    // `git blame` has no directory mode. Silently substituting the first tracked
+    // child produced confident, wrong output — an error is the honest answer.
+    await expect(blame({ path: repoDir, file: "site" })).rejects.toThrow(/blame failed/i);
+  });
+
+  it("blame still resolves a plain file path", async () => {
+    const result = await blame({ path: repoDir, file: "site/index.html" });
+    expect(result.structuredContent.file).toBe("site/index.html");
+  });
+});

--- a/packages/server-git/__tests__/worktree-remove-recovery.test.ts
+++ b/packages/server-git/__tests__/worktree-remove-recovery.test.ts
@@ -16,9 +16,17 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+
+/**
+ * Temp dir with the path git will report. On Windows the runner's TEMP is a short
+ * 8.3 alias (`C:\Users\RUNNER~1\...`) while git stores the resolved long path.
+ */
+function mkTempRepo(prefix: string): string {
+  return realpathSync.native(mkdtempSync(join(tmpdir(), prefix)));
+}
 
 vi.mock("../src/lib/git-runner.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/lib/git-runner.js")>();
@@ -99,7 +107,7 @@ describe("worktree removal consistency (#1073)", () => {
     vi.clearAllMocks();
     vi.mocked(git).mockImplementation(realGit);
 
-    mainRepo = mkdtempSync(join(tmpdir(), "pare-git-1073-main-"));
+    mainRepo = mkTempRepo("pare-git-1073-main-");
     run(["init", "-b", "trunk"], mainRepo);
     run(["config", "user.email", "test@test.com"], mainRepo);
     run(["config", "user.name", "Test"], mainRepo);
@@ -151,6 +159,23 @@ describe("worktree removal consistency (#1073)", () => {
     expect(isRegistered(mainRepo, wtPath)).toBe(false);
   });
 
+  it("recognises the worktree through a non-canonical path", async () => {
+    // Callers pass whatever they typed — a `.` segment here, a Windows 8.3 alias
+    // like C:\Users\RUNNER~1\... in the wild — while git reports the resolved path.
+    const messy = join(wtPath, ".") + "/./";
+    failNextRemoveAfterUnregistering(
+      mainRepo,
+      wtPath,
+      `error: failed to delete '${wtPath}': Filename too long`,
+    );
+
+    const outcome = await removeWorktree(mainRepo, messy, { force: true });
+
+    expect(outcome.removed).toBe(true);
+    expect(outcome.cleanedUp).toBe(true);
+    expect(existsSync(wtPath)).toBe(false);
+  });
+
   it("surfaces git stderr and leaves the worktree alone on a genuine failure", async () => {
     run(["worktree", "lock", wtPath], mainRepo);
 
@@ -166,7 +191,7 @@ describe("worktree removal consistency (#1073)", () => {
   });
 
   it("never deletes a directory that was not a registered worktree", async () => {
-    const stranger = mkdtempSync(join(tmpdir(), "pare-git-1073-stranger-"));
+    const stranger = mkTempRepo("pare-git-1073-stranger-");
     writeFileSync(join(stranger, "precious.txt"), "do not delete\n");
 
     const outcome = await removeWorktree(mainRepo, stranger, { force: true });
@@ -280,7 +305,7 @@ describe.skipIf(process.platform !== "win32")("worktree removal over MAX_PATH (#
     vi.clearAllMocks();
     vi.mocked(git).mockImplementation(realGit);
 
-    mainRepo = mkdtempSync(join(tmpdir(), "pare-git-1073-long-"));
+    mainRepo = mkTempRepo("pare-git-1073-long-");
     run(["init", "-b", "trunk"], mainRepo);
     run(["config", "user.email", "test@test.com"], mainRepo);
     run(["config", "user.name", "Test"], mainRepo);

--- a/packages/server-git/__tests__/worktree-remove-recovery.test.ts
+++ b/packages/server-git/__tests__/worktree-remove-recovery.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Regression tests for #1073 — `worktree` removal must never report a failure it
+ * has already half-committed to.
+ *
+ * `git worktree remove` deletes the admin entry (`.git/worktrees/<id>`) even when
+ * the recursive delete of the working directory fails first. On Windows a large
+ * `node_modules` tree trips that routinely ("Filename too long"), so the command
+ * exits non-zero while the worktree is already unregistered — `prune-merged`
+ * reported `remove-failed` and left an orphaned directory that later `remove`
+ * calls rejected with "is not a working tree".
+ *
+ * These run against real temp repos. The half-done removal is reproduced by
+ * intercepting the single `worktree remove` call and reproducing git's own end
+ * state (admin entry gone, directory intact) so the recovery path is covered on
+ * every platform, not only Windows.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+vi.mock("../src/lib/git-runner.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/lib/git-runner.js")>();
+  return { ...actual, git: vi.fn(actual.git) };
+});
+
+import { git } from "../src/lib/git-runner.js";
+import { removeWorktree } from "../src/lib/worktree-remove.js";
+import { registerWorktreeTool } from "../src/tools/worktree.js";
+
+type ToolHandler = (params: Record<string, unknown>) => Promise<{
+  content: unknown;
+  structuredContent: Record<string, unknown>;
+}>;
+
+class FakeServer {
+  tools = new Map<string, { handler: ToolHandler }>();
+  registerTool(name: string, _config: Record<string, unknown>, handler: ToolHandler) {
+    this.tools.set(name, { handler });
+  }
+}
+
+function run(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+function registeredPaths(cwd: string): string[] {
+  return run(["worktree", "list", "--porcelain"], cwd)
+    .split("\n")
+    .filter((l) => l.startsWith("worktree "))
+    .map((l) => l.slice("worktree ".length).replace(/\\/g, "/").toLowerCase());
+}
+
+function isRegistered(cwd: string, wtPath: string): boolean {
+  return registeredPaths(cwd).includes(wtPath.replace(/\\/g, "/").toLowerCase());
+}
+
+/** The unmocked runner, captured before any test swaps the implementation. */
+const realGit = vi.mocked(git).getMockImplementation()!;
+
+/** Hands the first `worktree remove` call to `onRemove`; everything else runs for real. */
+function interceptNextRemove(onRemove: () => Promise<{ stderr: string }>) {
+  let used = false;
+  vi.mocked(git).mockImplementation(async (args, cwd, opts) => {
+    if (!used && args[0] === "worktree" && args[1] === "remove") {
+      used = true;
+      const { stderr } = await onRemove();
+      return { stdout: "", stderr, exitCode: 255 };
+    }
+    return realGit(args, cwd, opts);
+  });
+}
+
+/**
+ * Replays git's own half-done removal: drop the worktree's `.git` link and prune
+ * the admin entry (so the worktree is unregistered), then report the failure git
+ * reports when the directory delete is what blew up.
+ */
+function failNextRemoveAfterUnregistering(mainRepo: string, wtPath: string, stderr: string) {
+  interceptNextRemove(async () => {
+    rmSync(join(wtPath, ".git"), { force: true, recursive: true });
+    await realGit(["worktree", "prune"], mainRepo);
+    return { stderr };
+  });
+}
+
+/** A genuine failure: git refuses the removal and changes nothing. */
+function failNextRemoveKeepingRegistration(stderr: string) {
+  interceptNextRemove(async () => ({ stderr }));
+}
+
+describe("worktree removal consistency (#1073)", () => {
+  let mainRepo: string;
+  let wtPath: string;
+  let handler: ToolHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(git).mockImplementation(realGit);
+
+    mainRepo = mkdtempSync(join(tmpdir(), "pare-git-1073-main-"));
+    run(["init", "-b", "trunk"], mainRepo);
+    run(["config", "user.email", "test@test.com"], mainRepo);
+    run(["config", "user.name", "Test"], mainRepo);
+    writeFileSync(join(mainRepo, "file.txt"), "initial\n");
+    run(["add", "-A"], mainRepo);
+    run(["commit", "-m", "init"], mainRepo);
+
+    // Merged worktree (HEAD == trunk) with an untracked node_modules-like tree.
+    wtPath = join(mainRepo, "..", `pare-git-1073-wt-${process.pid}`);
+    run(["worktree", "add", "-b", "wt-merged", wtPath, "trunk"], mainRepo);
+    const deep = join(wtPath, "node_modules", "pkg", "node_modules", "nested");
+    mkdirSync(deep, { recursive: true });
+    for (let i = 0; i < 20; i++) writeFileSync(join(deep, `f${i}.js`), "module.exports={};\n");
+
+    const server = new FakeServer();
+    registerWorktreeTool(server as never);
+    handler = server.tools.get("worktree")!.handler;
+  });
+
+  afterEach(() => {
+    rmSync(wtPath, { recursive: true, force: true });
+    rmSync(mainRepo, { recursive: true, force: true });
+  });
+
+  // ── removeWorktree helper ──────────────────────────────────────────
+
+  it("reports removed on a clean removal", async () => {
+    const outcome = await removeWorktree(mainRepo, wtPath, { force: true });
+
+    expect(outcome).toEqual({ removed: true });
+    expect(existsSync(wtPath)).toBe(false);
+    expect(isRegistered(mainRepo, wtPath)).toBe(false);
+  });
+
+  it("finishes the job when git unregistered the worktree but left the directory", async () => {
+    failNextRemoveAfterUnregistering(
+      mainRepo,
+      wtPath,
+      `error: failed to delete '${wtPath}': Filename too long`,
+    );
+
+    const outcome = await removeWorktree(mainRepo, wtPath, { force: true });
+
+    expect(outcome.removed).toBe(true);
+    expect(outcome.cleanedUp).toBe(true);
+    expect(outcome.error).toBeUndefined();
+    // No orphan left behind: gone from disk and gone from the worktree list.
+    expect(existsSync(wtPath)).toBe(false);
+    expect(isRegistered(mainRepo, wtPath)).toBe(false);
+  });
+
+  it("surfaces git stderr and leaves the worktree alone on a genuine failure", async () => {
+    run(["worktree", "lock", wtPath], mainRepo);
+
+    const outcome = await removeWorktree(mainRepo, wtPath);
+
+    expect(outcome.removed).toBe(false);
+    expect(outcome.error).toMatch(/locked/i);
+    // "remove-failed" must mean still registered, still on disk.
+    expect(existsSync(wtPath)).toBe(true);
+    expect(isRegistered(mainRepo, wtPath)).toBe(true);
+
+    run(["worktree", "unlock", wtPath], mainRepo);
+  });
+
+  it("never deletes a directory that was not a registered worktree", async () => {
+    const stranger = mkdtempSync(join(tmpdir(), "pare-git-1073-stranger-"));
+    writeFileSync(join(stranger, "precious.txt"), "do not delete\n");
+
+    const outcome = await removeWorktree(mainRepo, stranger, { force: true });
+
+    expect(outcome.removed).toBe(false);
+    expect(outcome.error).toMatch(/not a working tree/i);
+    expect(existsSync(join(stranger, "precious.txt"))).toBe(true);
+
+    rmSync(stranger, { recursive: true, force: true });
+  });
+
+  // ── action: prune-merged ───────────────────────────────────────────
+
+  it("prune-merged reports removed and cleans up after a half-done git removal", async () => {
+    failNextRemoveAfterUnregistering(
+      mainRepo,
+      wtPath,
+      `error: failed to delete '${wtPath}': Filename too long`,
+    );
+
+    const result = await handler({
+      path: mainRepo,
+      action: "prune-merged",
+      base: "trunk",
+      requireClean: false,
+    });
+    const results = result.structuredContent.results as Array<{
+      path: string;
+      branch?: string;
+      removed: boolean;
+      reason?: string;
+      error?: string;
+      cleanedUp?: boolean;
+    }>;
+    const entry = results.find((r) => r.branch === "wt-merged")!;
+
+    expect(entry.removed).toBe(true);
+    expect(entry.cleanedUp).toBe(true);
+    expect(entry.reason).toBeUndefined();
+    expect(existsSync(wtPath)).toBe(false);
+    expect(isRegistered(mainRepo, wtPath)).toBe(false);
+  });
+
+  it("prune-merged carries git stderr on remove-failed and leaves it registered", async () => {
+    failNextRemoveKeepingRegistration("fatal: validation failed, cannot remove working tree");
+
+    const result = await handler({
+      path: mainRepo,
+      action: "prune-merged",
+      base: "trunk",
+      requireClean: false,
+    });
+    const results = result.structuredContent.results as Array<{
+      branch?: string;
+      removed: boolean;
+      reason?: string;
+      error?: string;
+    }>;
+    const entry = results.find((r) => r.branch === "wt-merged")!;
+
+    expect(entry.removed).toBe(false);
+    expect(entry.reason).toBe("remove-failed");
+    expect(entry.error).toBe("fatal: validation failed, cannot remove working tree");
+    // The contract: remove-failed ⇒ still registered, still on disk.
+    expect(existsSync(wtPath)).toBe(true);
+    expect(isRegistered(mainRepo, wtPath)).toBe(true);
+  });
+
+  // ── action: remove ─────────────────────────────────────────────────
+
+  it("remove recovers from a half-done git removal instead of throwing", async () => {
+    failNextRemoveAfterUnregistering(
+      mainRepo,
+      wtPath,
+      `error: failed to delete '${wtPath}': Filename too long`,
+    );
+
+    const result = await handler({
+      path: mainRepo,
+      action: "remove",
+      worktreePath: wtPath,
+      force: true,
+    });
+
+    expect(result.structuredContent.success).toBe(true);
+    expect(result.structuredContent.cleanedUp).toBe(true);
+    expect(existsSync(wtPath)).toBe(false);
+    expect(isRegistered(mainRepo, wtPath)).toBe(false);
+  });
+
+  it("remove surfaces git stderr in the thrown error", async () => {
+    run(["worktree", "lock", wtPath], mainRepo);
+
+    await expect(
+      handler({ path: mainRepo, action: "remove", worktreePath: wtPath, force: true }),
+    ).rejects.toThrow(/locked working tree/i);
+
+    expect(existsSync(wtPath)).toBe(true);
+    expect(isRegistered(mainRepo, wtPath)).toBe(true);
+    run(["worktree", "unlock", wtPath], mainRepo);
+  });
+});
+
+// ── The real Windows trigger ─────────────────────────────────────────
+
+describe.skipIf(process.platform !== "win32")("worktree removal over MAX_PATH (#1073)", () => {
+  let mainRepo: string;
+  let wtPath: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(git).mockImplementation(realGit);
+
+    mainRepo = mkdtempSync(join(tmpdir(), "pare-git-1073-long-"));
+    run(["init", "-b", "trunk"], mainRepo);
+    run(["config", "user.email", "test@test.com"], mainRepo);
+    run(["config", "user.name", "Test"], mainRepo);
+    writeFileSync(join(mainRepo, "file.txt"), "initial\n");
+    run(["add", "-A"], mainRepo);
+    run(["commit", "-m", "init"], mainRepo);
+
+    wtPath = join(mainRepo, "..", `pare-git-1073-longwt-${process.pid}`);
+    run(["worktree", "add", "-b", "wt-long", wtPath, "trunk"], mainRepo);
+
+    // A node_modules-style tree whose leaves sit well past Windows' MAX_PATH,
+    // which is what makes git's own recursive delete fail.
+    let deep = join(wtPath, "node_modules");
+    const segment = `nested-package-directory-${"x".repeat(40)}`;
+    for (let i = 0; i < 10; i++) deep = join(deep, `${segment}${i}`);
+    mkdirSync(deep, { recursive: true });
+    writeFileSync(join(deep, "index.js"), "module.exports={};\n");
+  });
+
+  afterEach(() => {
+    rmSync(wtPath, { recursive: true, force: true });
+    rmSync(mainRepo, { recursive: true, force: true });
+  });
+
+  it("removes a worktree holding a deeper-than-MAX_PATH tree", async () => {
+    const outcome = await removeWorktree(mainRepo, wtPath, { force: true });
+
+    expect(outcome.removed).toBe(true);
+    expect(outcome.error).toBeUndefined();
+    expect(existsSync(wtPath)).toBe(false);
+    expect(isRegistered(mainRepo, wtPath)).toBe(false);
+  });
+});

--- a/packages/server-git/src/lib/formatters.ts
+++ b/packages/server-git/src/lib/formatters.ts
@@ -829,7 +829,8 @@ export function formatWorktreePrune(w: {
   for (const r of results) {
     const label = r.removed ? "removed" : `skipped [${r.reason ?? "unknown"}]`;
     const branch = r.branch ? ` (${r.branch})` : "";
-    lines.push(`  ${label}: ${r.path}${branch}`);
+    const error = r.error ? ` — ${r.error.split("\n")[0]}` : "";
+    lines.push(`  ${label}: ${r.path}${branch}${error}`);
   }
   return lines.join("\n");
 }

--- a/packages/server-git/src/lib/parsers.ts
+++ b/packages/server-git/src/lib/parsers.ts
@@ -1179,6 +1179,61 @@ export function parseBlameOutput(stdout: string, file: string): GitBlameFull {
   return { commits, file };
 }
 
+/**
+ * Normalizes a repo-relative path for pathspec comparison: backslashes become
+ * forward slashes, a leading "./" is stripped, and trailing slashes are dropped.
+ */
+export function normalizeRepoPath(p: string): string {
+  let s = p.trim().replace(/\\/g, "/");
+  while (s.startsWith("./")) s = s.slice(2);
+  s = s.replace(/\/+$/, "");
+  return s;
+}
+
+/**
+ * Rewrites a user-supplied pathspec into a path relative to the repository root,
+ * so it can be compared against `git status --porcelain` output — which is always
+ * root-relative, no matter which directory the command ran in.
+ *
+ * @param pathspec - The user path, absolute or relative to `prefix`
+ * @param repoRoot - Absolute repository root (`git rev-parse --show-toplevel`)
+ * @param prefix - cwd relative to the root (`git rev-parse --show-prefix`), "" at the root
+ */
+export function toRepoRelativePathspec(pathspec: string, repoRoot: string, prefix: string): string {
+  const normalized = normalizeRepoPath(pathspec);
+  const root = normalizeRepoPath(repoRoot);
+  const pre = normalizeRepoPath(prefix);
+
+  // Absolute path — strip the repo root when the path lives inside the repo.
+  if (/^([a-zA-Z]:\/|\/)/.test(normalized)) {
+    if (root && normalized.toLowerCase() === root.toLowerCase()) return ".";
+    if (root && normalized.toLowerCase().startsWith(`${root.toLowerCase()}/`)) {
+      return normalized.slice(root.length + 1);
+    }
+    return normalized;
+  }
+
+  if (!pre) return normalized === "" ? "." : normalized;
+  if (normalized === "" || normalized === ".") return pre;
+  return `${pre}/${normalized}`;
+}
+
+/**
+ * True when `candidate` is the pathspec itself or lies underneath it.
+ *
+ * `git status --porcelain` lists individual files, so a directory pathspec never
+ * equals a status line. Comparing by exact name therefore reported every
+ * directory restore as verified even when files under it were left untouched
+ * (#1068). Both sides are normalized first; "." and "" (the repo root) match
+ * everything.
+ */
+export function pathIsUnderPathspec(candidate: string, pathspec: string): boolean {
+  const c = normalizeRepoPath(candidate);
+  const p = normalizeRepoPath(pathspec);
+  if (p === "" || p === ".") return true;
+  return c === p || c.startsWith(`${p}/`);
+}
+
 /** Parses `git restore` result into structured restore data.
  *  Since `git restore` produces no stdout on success, we return the file list that was passed in.
  *  If verification data is provided, includes per-file verification status. */

--- a/packages/server-git/src/lib/worktree-remove.ts
+++ b/packages/server-git/src/lib/worktree-remove.ts
@@ -1,5 +1,6 @@
 import { realpathSync } from "node:fs";
 import { rm } from "node:fs/promises";
+import { resolve } from "node:path";
 import { git } from "./git-runner.js";
 import { normalizeWorktreePath, parseWorktreeList, worktreePathsEqual } from "./parsers.js";
 
@@ -93,7 +94,9 @@ export async function removeWorktree(
   if (stillRegistered !== false) return { removed: false, error };
 
   try {
-    await rm(worktreePath, { recursive: true, force: true, maxRetries: 3 });
+    // resolve() first: a caller's trailing "/." or ".." segment makes the
+    // recursive delete fail outright on Linux (EINVAL on "refusing to remove '.'").
+    await rm(resolve(worktreePath), { recursive: true, force: true, maxRetries: 3 });
   } catch (e) {
     const detail = e instanceof Error ? e.message : String(e);
     return { removed: false, error: `${error}; directory cleanup failed: ${detail}` };

--- a/packages/server-git/src/lib/worktree-remove.ts
+++ b/packages/server-git/src/lib/worktree-remove.ts
@@ -1,6 +1,27 @@
+import { realpathSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { git } from "./git-runner.js";
-import { parseWorktreeList, worktreePathsEqual } from "./parsers.js";
+import { normalizeWorktreePath, parseWorktreeList, worktreePathsEqual } from "./parsers.js";
+
+/**
+ * Resolves a path through the filesystem before normalizing it. Callers hand us
+ * whatever they typed — a short 8.3 alias like `C:\Users\RUNNER~1\...`, a `..`
+ * segment, a symlinked parent — while git stores the fully resolved path, so
+ * plain string comparison misses matches that are in fact the same directory.
+ * Falls back to normalization when the path no longer exists.
+ */
+function canonicalWorktreePath(p: string): string {
+  try {
+    return normalizeWorktreePath(realpathSync.native(p));
+  } catch {
+    return normalizeWorktreePath(p);
+  }
+}
+
+/** True when two paths name the same worktree directory. */
+function samePath(a: string, b: string): boolean {
+  return worktreePathsEqual(a, b) || canonicalWorktreePath(a) === canonicalWorktreePath(b);
+}
 
 /** Outcome of a worktree removal attempt. */
 export interface WorktreeRemoveOutcome {
@@ -19,9 +40,7 @@ export interface WorktreeRemoveOutcome {
 async function isRegistered(cwd: string, worktreePath: string): Promise<boolean | undefined> {
   const list = await git(["worktree", "list", "--porcelain"], cwd);
   if (list.exitCode !== 0) return undefined;
-  return parseWorktreeList(list.stdout).worktrees.some((w) =>
-    worktreePathsEqual(w.path, worktreePath),
-  );
+  return parseWorktreeList(list.stdout).worktrees.some((w) => samePath(w.path, worktreePath));
 }
 
 /**

--- a/packages/server-git/src/lib/worktree-remove.ts
+++ b/packages/server-git/src/lib/worktree-remove.ts
@@ -1,0 +1,84 @@
+import { rm } from "node:fs/promises";
+import { git } from "./git-runner.js";
+import { parseWorktreeList, worktreePathsEqual } from "./parsers.js";
+
+/** Outcome of a worktree removal attempt. */
+export interface WorktreeRemoveOutcome {
+  /** True when the worktree is both unregistered and gone from disk. */
+  removed: boolean;
+  /** Git's stderr (plus any cleanup error) — only set when `removed` is false. */
+  error?: string;
+  /** True when the working directory had to be deleted by the tool after git bailed. */
+  cleanedUp?: boolean;
+}
+
+/**
+ * Whether `worktreePath` is still a registered worktree of the repo at `cwd`.
+ * Returns undefined when the list itself failed, so callers can fail safe.
+ */
+async function isRegistered(cwd: string, worktreePath: string): Promise<boolean | undefined> {
+  const list = await git(["worktree", "list", "--porcelain"], cwd);
+  if (list.exitCode !== 0) return undefined;
+  return parseWorktreeList(list.stdout).worktrees.some((w) =>
+    worktreePathsEqual(w.path, worktreePath),
+  );
+}
+
+/**
+ * Removes a worktree, repairing git's half-done removal state (#1073).
+ *
+ * `git worktree remove` deletes the admin entry (`.git/worktrees/<id>`) even when
+ * the recursive delete of the working directory fails first — on Windows a large
+ * `node_modules` tree trips this routinely with `Filename too long`. The command
+ * then exits non-zero while the worktree is already unregistered, leaving an
+ * orphaned directory that later `remove` calls reject with "is not a working tree".
+ *
+ * So on failure we re-check registration:
+ *   - still registered ⇒ a genuine failure; report `removed: false` with git's stderr
+ *     and leave the worktree alone (no prune, no deletion).
+ *   - no longer registered ⇒ only the directory delete failed; finish the job with a
+ *     recursive delete and report `removed: true`.
+ *
+ * The recursive delete only ever runs for a path git had registered as a worktree
+ * before the attempt, so a "not a working tree" error can never delete a directory.
+ *
+ * @param cwd - Repository directory the git command runs in
+ * @param worktreePath - Path of the worktree to remove
+ * @param opts.force - Pass `--force` to git
+ * @param opts.wasRegistered - Skip the pre-flight list when the caller already knows
+ */
+export async function removeWorktree(
+  cwd: string,
+  worktreePath: string,
+  opts: { force?: boolean; wasRegistered?: boolean } = {},
+): Promise<WorktreeRemoveOutcome> {
+  const wasRegistered = opts.wasRegistered ?? (await isRegistered(cwd, worktreePath));
+
+  const args = ["worktree", "remove"];
+  if (opts.force) args.push("--force");
+  args.push(worktreePath);
+
+  const result = await git(args, cwd);
+  if (result.exitCode === 0) return { removed: true };
+
+  const error =
+    result.stderr.trim() ||
+    result.stdout.trim() ||
+    `git worktree remove exited with code ${result.exitCode}`;
+
+  // Only a path git had registered may be deleted from disk by us.
+  if (wasRegistered !== true) return { removed: false, error };
+
+  const stillRegistered = await isRegistered(cwd, worktreePath);
+  // Still registered (or unknown) ⇒ nothing was unregistered; report the failure as-is.
+  if (stillRegistered !== false) return { removed: false, error };
+
+  try {
+    await rm(worktreePath, { recursive: true, force: true, maxRetries: 3 });
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    return { removed: false, error: `${error}; directory cleanup failed: ${detail}` };
+  }
+
+  return { removed: true, cleanedUp: true };
+}

--- a/packages/server-git/src/schemas/index.ts
+++ b/packages/server-git/src/schemas/index.ts
@@ -695,6 +695,8 @@ export const GitWorktreeSchema = z.object({
   targetPath: z.string().optional(),
   branch: z.string(),
   head: z.string().optional(),
+  /** True when git unregistered the worktree but the directory had to be deleted by the tool. */
+  cleanedUp: z.boolean().optional(),
 });
 
 export type GitWorktree = z.infer<typeof GitWorktreeSchema>;
@@ -708,6 +710,10 @@ export const GitWorktreePruneResultSchema = z.object({
   reason: z
     .enum(["not-merged", "dirty", "locked", "main", "current", "bare", "remove-failed"])
     .optional(),
+  /** Git's stderr for a failed removal (only present with reason="remove-failed"). */
+  error: z.string().optional(),
+  /** True when git unregistered the worktree but the directory had to be deleted by the tool. */
+  cleanedUp: z.boolean().optional(),
 });
 
 export type GitWorktreePruneResult = z.infer<typeof GitWorktreePruneResultSchema>;
@@ -732,6 +738,8 @@ export const GitWorktreeOutputSchema = z.object({
   branch: z.string().optional(),
   /** HEAD commit (present for mutate actions). */
   head: z.string().optional(),
+  /** True when the worktree directory had to be deleted by the tool (remove action). */
+  cleanedUp: z.boolean().optional(),
   /** Base ref evaluated (only present for prune-merged). */
   base: z.string().optional(),
   /** Per-worktree removal results (only present for prune-merged). */

--- a/packages/server-git/src/tools/restore.ts
+++ b/packages/server-git/src/tools/restore.ts
@@ -2,7 +2,12 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dualOutput, assertNoFlagInjection, INPUT_LIMITS, repoPathInput } from "@paretools/shared";
 import { git, resolveFilePaths } from "../lib/git-runner.js";
-import { parseRestore, parseRestoreError } from "../lib/parsers.js";
+import {
+  parseRestore,
+  parseRestoreError,
+  pathIsUnderPathspec,
+  toRepoRelativePathspec,
+} from "../lib/parsers.js";
 import { formatRestore } from "../lib/formatters.js";
 import { GitRestoreSchema } from "../schemas/index.js";
 
@@ -116,13 +121,13 @@ export function registerRestoreTool(server: McpServer) {
         return dualOutput(restoreError, formatRestore);
       }
 
-      // Post-restore verification: check file status to verify restoration
+      // Post-restore verification: check file status to verify restoration.
       const statusResult = await git(["status", "--porcelain=v1"], cwd);
       let verifiedFiles: Array<{ file: string; restored: boolean }> | undefined;
       if (statusResult.exitCode === 0) {
         const statusLines = statusResult.stdout.split("\n").filter(Boolean);
-        // Build a set of files that still appear as modified/deleted in the status
-        const stillDirty = new Set<string>();
+        // Paths that still appear as modified/deleted in the status.
+        const stillDirty: string[] = [];
         for (const line of statusLines) {
           const worktreeStatus = line[1];
           const statusFile = line.slice(3).trim();
@@ -132,20 +137,31 @@ export function registerRestoreTool(server: McpServer) {
             // For staged restores, check if the file is still in the index
             const indexStatus = line[0];
             if (indexStatus && indexStatus !== " " && indexStatus !== "?") {
-              stillDirty.add(resolvedName);
+              stillDirty.push(resolvedName);
             }
           } else {
             // For working tree restores, check if the file still has worktree changes
             if (worktreeStatus === "M" || worktreeStatus === "D") {
-              stillDirty.add(resolvedName);
+              stillDirty.push(resolvedName);
             }
           }
         }
 
-        verifiedFiles = files.map((f) => ({
-          file: f,
-          restored: !stillDirty.has(f),
-        }));
+        // `git status --porcelain` paths are relative to the repository root, while
+        // the pathspecs are relative to `cwd` — translate before comparing (#1068).
+        const revParse = await git(["rev-parse", "--show-toplevel", "--show-prefix"], cwd);
+        const [repoRoot = "", prefix = ""] =
+          revParse.exitCode === 0 ? revParse.stdout.split("\n").map((l) => l.trim()) : [];
+
+        // A directory pathspec never equals a status line, so match by containment:
+        // a path is unrestored if any remaining dirty entry lies at or under it.
+        verifiedFiles = files.map((f, i) => {
+          const pathspec = toRepoRelativePathspec(resolvedFiles[i] ?? f, repoRoot, prefix);
+          return {
+            file: f,
+            restored: !stillDirty.some((dirty) => pathIsUnderPathspec(dirty, pathspec)),
+          };
+        });
       }
 
       const restoreResult = parseRestore(files, resolvedSource, staged, verifiedFiles);

--- a/packages/server-git/src/tools/worktree.ts
+++ b/packages/server-git/src/tools/worktree.ts
@@ -9,6 +9,7 @@ import {
   repoPathInput,
 } from "@paretools/shared";
 import { git } from "../lib/git-runner.js";
+import { removeWorktree } from "../lib/worktree-remove.js";
 import {
   parseWorktreeList,
   parseWorktreeResult,
@@ -272,14 +273,18 @@ export function registerWorktreeTool(server: McpServer) {
         // Execute removals for the entries cleared by the decision function.
         for (const decision of decisions) {
           if (!decision.removed) continue;
-          const rmArgs = ["worktree", "remove"];
-          // Only opting out of the clean guard uses --force (dirty merged trees).
-          if (!requireClean) rmArgs.push("--force");
-          rmArgs.push(decision.path);
-          const rm = await git(rmArgs, cwd);
-          if (rm.exitCode !== 0) {
+          const outcome = await removeWorktree(cwd, decision.path, {
+            // Only opting out of the clean guard uses --force (dirty merged trees).
+            force: !requireClean,
+            // Every candidate came straight out of `git worktree list`.
+            wasRegistered: true,
+          });
+          if (!outcome.removed) {
             decision.removed = false;
             decision.reason = "remove-failed";
+            decision.error = outcome.error;
+          } else if (outcome.cleanedUp) {
+            decision.cleanedUp = true;
           }
         }
 
@@ -440,20 +445,15 @@ export function registerWorktreeTool(server: McpServer) {
 
       assertNoFlagInjection(worktreePath, "worktreePath");
 
-      const args = ["worktree", "remove"];
-      if (params.force) {
-        args.push("--force");
-      }
-      args.push(worktreePath);
+      const outcome = await removeWorktree(cwd, worktreePath, { force: params.force });
 
-      const result = await git(args, cwd);
-
-      if (result.exitCode !== 0) {
-        throw new Error(`git worktree remove failed: ${result.stderr}`);
+      if (!outcome.removed) {
+        throw new Error(`git worktree remove failed: ${outcome.error}`);
       }
 
-      const worktreeResult = parseWorktreeResult(result.stdout, result.stderr, worktreePath, "");
+      const worktreeResult = parseWorktreeResult("", "", worktreePath, "");
       worktreeResult.action = "remove";
+      if (outcome.cleanedUp) worktreeResult.cleanedUp = true;
       return dualOutput(worktreeResult, formatWorktree);
     },
   );

--- a/tests/smoke/mocked/git-tools-3.smoke.test.ts
+++ b/tests/smoke/mocked/git-tools-3.smoke.test.ts
@@ -808,6 +808,8 @@ describe("Smoke: git.restore", () => {
     mockGit("");
     // git status --porcelain=v1 (verification)
     mockGit("");
+    // rev-parse --show-toplevel --show-prefix (pathspec -> repo-relative)
+    mockGit("/repo\n\n");
     const { parsed } = await callAndValidate({ files: ["src/index.ts"] });
     expect(parsed.restored).toContain("src/index.ts");
     expect(parsed.source).toBe("HEAD");
@@ -817,6 +819,8 @@ describe("Smoke: git.restore", () => {
   it("S2 [P0] restore staged file", async () => {
     mockGit("");
     mockGit("");
+    // rev-parse --show-toplevel --show-prefix (pathspec -> repo-relative)
+    mockGit("/repo\n\n");
     const { parsed } = await callAndValidate({ files: ["src/index.ts"], staged: true });
     expect(parsed.staged).toBe(true);
     const args = vi.mocked(git).mock.calls[0][0];
@@ -826,6 +830,8 @@ describe("Smoke: git.restore", () => {
   it("S3 [P0] restore from specific source", async () => {
     mockGit("");
     mockGit("");
+    // rev-parse --show-toplevel --show-prefix (pathspec -> repo-relative)
+    mockGit("/repo\n\n");
     const { parsed } = await callAndValidate({
       files: ["src/index.ts"],
       source: "HEAD~1",
@@ -839,6 +845,8 @@ describe("Smoke: git.restore", () => {
   it("S4 [P0] restore multiple files", async () => {
     mockGit("");
     mockGit("");
+    // rev-parse --show-toplevel --show-prefix (pathspec -> repo-relative)
+    mockGit("/repo\n\n");
     const { parsed } = await callAndValidate({
       files: ["file1.ts", "file2.ts", "file3.ts"],
     });
@@ -854,6 +862,8 @@ describe("Smoke: git.restore", () => {
   it("S6 [P1] --ours flag is passed during conflict", async () => {
     mockGit("");
     mockGit("");
+    // rev-parse --show-toplevel --show-prefix (pathspec -> repo-relative)
+    mockGit("/repo\n\n");
     await callAndValidate({ files: ["conflicted.ts"], ours: true });
     const args = vi.mocked(git).mock.calls[0][0];
     expect(args).toContain("--ours");
@@ -862,6 +872,8 @@ describe("Smoke: git.restore", () => {
   it("S7 [P1] --theirs flag is passed during conflict", async () => {
     mockGit("");
     mockGit("");
+    // rev-parse --show-toplevel --show-prefix (pathspec -> repo-relative)
+    mockGit("/repo\n\n");
     await callAndValidate({ files: ["conflicted.ts"], theirs: true });
     const args = vi.mocked(git).mock.calls[0][0];
     expect(args).toContain("--theirs");
@@ -870,6 +882,8 @@ describe("Smoke: git.restore", () => {
   it("S8 [P1] --worktree flag is passed", async () => {
     mockGit("");
     mockGit("");
+    // rev-parse --show-toplevel --show-prefix (pathspec -> repo-relative)
+    mockGit("/repo\n\n");
     await callAndValidate({ files: ["file.ts"], worktree: true });
     const args = vi.mocked(git).mock.calls[0][0];
     expect(args).toContain("--worktree");
@@ -878,6 +892,8 @@ describe("Smoke: git.restore", () => {
   it("S9 [P1] --merge flag is passed", async () => {
     mockGit("");
     mockGit("");
+    // rev-parse --show-toplevel --show-prefix (pathspec -> repo-relative)
+    mockGit("/repo\n\n");
     await callAndValidate({ files: ["file.ts"], merge: true });
     const args = vi.mocked(git).mock.calls[0][0];
     expect(args).toContain("--merge");
@@ -886,6 +902,8 @@ describe("Smoke: git.restore", () => {
   it("S10 [P1] --no-overlay flag is passed", async () => {
     mockGit("");
     mockGit("");
+    // rev-parse --show-toplevel --show-prefix (pathspec -> repo-relative)
+    mockGit("/repo\n\n");
     await callAndValidate({ files: ["file.ts"], noOverlay: true });
     const args = vi.mocked(git).mock.calls[0][0];
     expect(args).toContain("--no-overlay");
@@ -894,6 +912,8 @@ describe("Smoke: git.restore", () => {
   it("S11 [P1] --conflict style is passed", async () => {
     mockGit("");
     mockGit("");
+    // rev-parse --show-toplevel --show-prefix (pathspec -> repo-relative)
+    mockGit("/repo\n\n");
     await callAndValidate({ files: ["file.ts"], conflict: "diff3" });
     const args = vi.mocked(git).mock.calls[0][0];
     expect(args).toContain("--conflict=diff3");

--- a/tests/smoke/mocked/git-tools-4.smoke.test.ts
+++ b/tests/smoke/mocked/git-tools-4.smoke.test.ts
@@ -797,6 +797,9 @@ describe("Smoke: git.worktree", () => {
 
   // S3: Remove worktree
   it("S3 [P0] remove worktree returns success", async () => {
+    // worktree list --porcelain (pre-flight registration check, #1073)
+    mockGit("worktree /repo\nHEAD abc1234\nbranch refs/heads/main\n\n", "", 0);
+    // worktree remove
     mockGit("", "", 0);
 
     const { parsed } = await callAndValidate({
@@ -882,6 +885,9 @@ describe("Smoke: git.worktree", () => {
 
   // S11: Force remove dirty worktree
   it("S11 [P1] force remove passes --force flag", async () => {
+    // worktree list --porcelain (pre-flight registration check, #1073)
+    mockGit("worktree /repo\nHEAD abc1234\nbranch refs/heads/main\n\n", "", 0);
+    // worktree remove --force
     mockGit("", "", 0);
 
     await callAndValidate({
@@ -889,7 +895,7 @@ describe("Smoke: git.worktree", () => {
       worktreePath: "../wt-dirty",
       force: true,
     });
-    const args = vi.mocked(git).mock.calls[0][0];
+    const args = vi.mocked(git).mock.calls[1][0];
     expect(args).toContain("--force");
   });
 

--- a/tests/smoke/suite/git-tools-2.recorded.test.ts
+++ b/tests/smoke/suite/git-tools-2.recorded.test.ts
@@ -232,6 +232,8 @@ describe("Recorded: git.restore", () => {
     mockGit("");
     // Call 2: git status --porcelain=v1 (verify file is no longer modified)
     mockGit("");
+    // rev-parse --show-toplevel --show-prefix (pathspec -> repo-relative)
+    mockGit("/repo\n\n");
     const { parsed } = await callAndValidate({ files: ["modified.ts"], staged: false });
     expect(parsed.restored).toContain("modified.ts");
   });
@@ -241,6 +243,8 @@ describe("Recorded: git.restore", () => {
     mockGit("");
     // Call 2: git status --porcelain=v1
     mockGit(" M staged.ts\n");
+    // rev-parse --show-toplevel --show-prefix (pathspec -> repo-relative)
+    mockGit("/repo\n\n");
     const { parsed } = await callAndValidate({ files: ["staged.ts"], staged: true });
     expect(parsed.restored).toContain("staged.ts");
   });


### PR DESCRIPTION
Two `@paretools/git` bugs, both about a tool reporting success it had not earned.

## #1068 — `restore` verification never looked under a directory pathspec

`resolveFilePath()` was fixed by #1071, so a directory pathspec now reaches git
intact and `git restore -- some/dir` genuinely restores everything underneath.
The second half of #1068 was still open: the post-restore check built a set of
still-dirty paths from `git status --porcelain=v1` and compared them to the
requested paths **by exact string**. `git status` only ever lists individual
files, so a directory pathspec (`src`, `src/`, `.`) could never match an entry —
`restored: true, verified: true` came back unconditionally, which is worse than
no verification because a caller trusts it and proceeds on a dirty tree.

Verification now treats a path as unrestored when any remaining status entry lies
**at or under** it (`pathIsUnderPathspec`, normalizing separators, `./` and
trailing slashes). `git status --porcelain` paths are repo-root-relative while
pathspecs are relative to the tool's `cwd`, so pathspecs are translated with
`git rev-parse --show-toplevel --show-prefix` first — otherwise verification was
wrong for every call that passed `path:` at a package directory rather than the
repo root.

## #1073 — `prune-merged` reported `remove-failed` on an already-unregistered worktree

Reproduced on Windows: a worktree holding a `node_modules`-shaped tree with leaves
past `MAX_PATH`.

```
git worktree remove --force <wt>
  exit 255
  error: failed to delete '<wt>': Filename too long
  → directory still on disk, worktree list no longer contains it
```

The tool never ran `prune` — this is git's own ordering. `git worktree remove`
deletes the admin entry (`.git/worktrees/<id>`) **regardless** of whether the
recursive delete of the working directory succeeded, so the command exits non-zero
with the worktree already unregistered. `prune-merged` then reported
`removed: false, reason: "remove-failed"` with no error text, and the orphaned
directory was left behind — a later `action: remove` on it fails with
`fatal: '<path>' is not a working tree`.

Removal now goes through one helper (`removeWorktree`) that re-checks registration
after a failure:

- **still registered** ⇒ a genuine failure. `removed: false`, git's stderr in a new
  `error` field, nothing touched. `remove-failed` again means "still registered,
  still on disk".
- **no longer registered** ⇒ only the directory delete failed. The tool finishes the
  job with `fs.rm(path, { recursive: true, force: true, maxRetries: 3 })` and reports
  `removed: true, cleanedUp: true`.

The recursive delete only ever runs for a path git had registered as a worktree
*before* the attempt (checked up front), so a `not a working tree` error can never
delete a directory. `action: "remove"` uses the same helper and its thrown error now
carries git's stderr.

## Tests

- `packages/server-git/__tests__/restore-directory-pathspec.test.ts` — unit coverage
  for the path helpers, plus real-temp-repo runs proving `restore` / `reset` / `diff`
  handle a directory pathspec (and that `blame` surfaces git's error instead of
  silently blaming one child). Covers the positive case (`files: ["site"]` with three
  modified files under it ⇒ all restored, `verified: true`), the scoping case (a dirty
  file outside the directory must not drag it down), and the negative case
  (`source: HEAD~1` leaves the tree dirty ⇒ `verified: false`). That last one fails on
  the pre-fix code.
- `packages/server-git/__tests__/worktree-remove-recovery.test.ts` — git's half-done
  removal is replayed by intercepting the single `worktree remove` call and
  reproducing its end state (admin entry pruned, directory intact), so the recovery
  path is covered on every platform. Plus a Windows-only test that removes a worktree
  holding a real deeper-than-`MAX_PATH` tree, and guards that a genuine failure stays
  registered and that a non-worktree directory is never deleted.
- Smoke fixtures updated for the added `rev-parse` / pre-flight `worktree list` calls.

`pnpm build`, `pnpm test`, `pnpm smoke`, `pnpm lint`, `pnpm format:check` all green
locally on Windows.

Closes #1068
Closes #1073
