### PR TITLE
fix(npm): derive install counts from packageDetails and collapse version bumps

### DIFF
--- a/.changeset/fix-1081-npm-install-counts.md
+++ b/.changeset/fix-1081-npm-install-counts.md
@@ -1,0 +1,16 @@
+---
+"@paretools/npm": patch
+---
+
+fix(npm): make install `added`/`removed`/`changed` agree with `packageDetails`
+
+pnpm never prints npm's "added N packages" summary sentence, so `install` on a
+pnpm project returned `added: 0, removed: 0, changed: 0` even when
+`packageDetails` listed every package that moved. Counters are now derived from
+`packageDetails` when no npm summary line is present, and fall back to pnpm's
+store-level `Packages: +N -M` line when there are no per-package details at all.
+
+A same-name version bump (pnpm prints `- pkg 1.0.0` then `+ pkg 1.1.0`) is now
+reported as a single `updated` entry with a new optional `previousVersion`
+field instead of one addition plus one removal. npm and yarn parsing is
+unchanged.

--- a/packages/server-npm/__tests__/pnpm-parsers.test.ts
+++ b/packages/server-npm/__tests__/pnpm-parsers.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { parsePnpmAuditJson, parseOutdatedJson, parseInstallOutput } from "../src/lib/parsers.js";
+import {
+  parsePnpmAuditJson,
+  parseOutdatedJson,
+  parseInstallOutput,
+  parseInstallPackageDetails,
+  parsePnpmPackagesSummary,
+  collapseVersionBumps,
+  countInstallPackageDetails,
+} from "../src/lib/parsers.js";
+import { NpmInstallSchema } from "../src/schemas/index.js";
 
 describe("parsePnpmAuditJson", () => {
   it("parses npm-compatible format (pnpm v8+)", () => {
@@ -149,6 +158,146 @@ describe("parseInstallOutput with pnpm-style output", () => {
       "Packages: +52\n\nProgress: resolved 287, reused 235, downloaded 52, added 52\n\ndone in 3.5s\n\n52 packages in 3s";
     const result = parseInstallOutput(output);
 
-    expect(result.added).toBe(0); // pnpm uses "+52" format, not "added 52"
+    // pnpm uses the "Packages: +52" store line instead of npm's
+    // "added 52 packages" sentence — both must yield a non-zero count (#1081).
+    expect(result.added).toBe(52);
+  });
+});
+
+// ─── #1081: counters must agree with packageDetails ──────────────────────────
+
+/**
+ * Real `pnpm install --frozen-lockfile` output captured from pnpm 10.29.2 on a
+ * two-project workspace after bumping @types/node, picocolors and tsx, adding
+ * nanoid and dropping left-pad. pnpm prints no "added N packages" sentence, so
+ * the old parser returned added:0/removed:0/changed:0 alongside 8 detail rows.
+ */
+const PNPM10_FROZEN_WORKSPACE_BUMP = `Scope: all 2 workspace projects
+Lockfile is up to date, resolution step is skipped
+Progress: resolved 1, reused 0, downloaded 0, added 0
+Packages: +6 -6
+++++++------
+Progress: resolved 6, reused 2, downloaded 4, added 6, done
+
+devDependencies:
+- @types/node 22.7.0
++ @types/node 22.9.0
+- left-pad 1.3.0
++ nanoid 5.0.9
+- picocolors 1.0.0
++ picocolors 1.1.1
+- tsx 4.19.0
++ tsx 4.20.3
+
+╭ Warning ─────────────────────────────────────────────────────────────────────╮
+│                                                                              │
+│   Ignored build scripts: esbuild@0.25.12.                                    │
+│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
+│   to run scripts.                                                            │
+│                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+Done in 889ms using pnpm v10.29.2
+`;
+
+/**
+ * Same workspace, but only a transitive dependency moved — pnpm prints the
+ * store-level `Packages: +1 -1` line and no per-package detail rows at all.
+ */
+const PNPM10_FROZEN_TRANSITIVE_ONLY = `Scope: all 2 workspace projects
+Lockfile is up to date, resolution step is skipped
+Progress: resolved 1, reused 0, downloaded 0, added 0
+Packages: +1 -1
++-
+Progress: resolved 1, reused 1, downloaded 0, added 1, done
+
+Done in 399ms using pnpm v10.29.2
+`;
+
+describe("#1081: pnpm 10 install counters agree with packageDetails", () => {
+  it("derives counts from packageDetails when pnpm prints no summary sentence", () => {
+    const result = parseInstallOutput(PNPM10_FROZEN_WORKSPACE_BUMP);
+
+    expect(result.added).toBe(1);
+    expect(result.removed).toBe(1);
+    expect(result.changed).toBe(3);
+  });
+
+  it("reports a same-name version bump as one updated entry with previousVersion", () => {
+    const result = parseInstallOutput(PNPM10_FROZEN_WORKSPACE_BUMP);
+    const details = result.packageDetails!;
+
+    expect(details).toContainEqual({
+      name: "@types/node",
+      version: "22.9.0",
+      action: "updated",
+      previousVersion: "22.7.0",
+    });
+    expect(details).toContainEqual({
+      name: "picocolors",
+      version: "1.1.1",
+      action: "updated",
+      previousVersion: "1.0.0",
+    });
+    expect(details).toContainEqual({
+      name: "tsx",
+      version: "4.20.3",
+      action: "updated",
+      previousVersion: "4.19.0",
+    });
+    // Genuine add / remove stay as-is
+    expect(details).toContainEqual({ name: "nanoid", version: "5.0.9", action: "added" });
+    expect(details).toContainEqual({ name: "left-pad", version: "1.3.0", action: "removed" });
+    expect(details).toHaveLength(5);
+  });
+
+  it("keeps counters consistent with the detail rows", () => {
+    const result = parseInstallOutput(PNPM10_FROZEN_WORKSPACE_BUMP);
+    const details = result.packageDetails ?? [];
+
+    expect(result.added).toBe(details.filter((d) => d.action === "added").length);
+    expect(result.removed).toBe(details.filter((d) => d.action === "removed").length);
+    expect(result.changed).toBe(details.filter((d) => d.action === "updated").length);
+  });
+
+  it("validates against the output schema", () => {
+    const result = parseInstallOutput(PNPM10_FROZEN_WORKSPACE_BUMP);
+    expect(NpmInstallSchema.safeParse({ ...result, packageManager: "pnpm" }).success).toBe(true);
+  });
+
+  it("falls back to pnpm's `Packages: +N -M` line when there are no details", () => {
+    const result = parseInstallOutput(PNPM10_FROZEN_TRANSITIVE_ONLY);
+
+    expect(result.packageDetails).toBeUndefined();
+    expect(result.added).toBe(1);
+    expect(result.removed).toBe(1);
+    expect(result.changed).toBe(0);
+  });
+
+  it("does not mistake pnpm's progress glyph line for package details", () => {
+    const details = parseInstallPackageDetails(PNPM10_FROZEN_TRANSITIVE_ONLY);
+    expect(details).toBeUndefined();
+  });
+
+  it("parses the store summary line in both directions", () => {
+    expect(parsePnpmPackagesSummary("Packages: +6 -6")).toEqual({ added: 6, removed: 6 });
+    expect(parsePnpmPackagesSummary("Packages: +52")).toEqual({ added: 52, removed: 0 });
+    expect(parsePnpmPackagesSummary("Packages: -3")).toEqual({ added: 0, removed: 3 });
+    expect(parsePnpmPackagesSummary("Progress: resolved 6, added 6")).toBeUndefined();
+  });
+
+  it("leaves an unpaired removal alone", () => {
+    expect(
+      collapseVersionBumps([{ name: "left-pad", version: "1.3.0", action: "removed" }]),
+    ).toEqual([{ name: "left-pad", version: "1.3.0", action: "removed" }]);
+  });
+
+  it("counts npm-style 'updated' entries as changed", () => {
+    expect(
+      countInstallPackageDetails([
+        { name: "a", version: "1", action: "added" },
+        { name: "b", version: "1", action: "removed" },
+        { name: "c", version: "2", action: "updated", previousVersion: "1" },
+      ]),
+    ).toEqual({ added: 1, removed: 1, changed: 1 });
   });
 });

--- a/packages/server-npm/src/lib/formatters.ts
+++ b/packages/server-npm/src/lib/formatters.ts
@@ -32,7 +32,8 @@ export function formatInstall(data: NpmInstall, duration?: number): string {
     const maxShow = 10; // Limit display to avoid huge output
     const shown = data.packageDetails.slice(0, maxShow);
     for (const pkg of shown) {
-      lines.push(`  ${pkg.action}: ${pkg.name}@${pkg.version}`);
+      const version = pkg.previousVersion ? `${pkg.previousVersion} → ${pkg.version}` : pkg.version;
+      lines.push(`  ${pkg.action}: ${pkg.name}@${version}`);
     }
     if (data.packageDetails.length > maxShow) {
       lines.push(`  ... and ${data.packageDetails.length - maxShow} more`);

--- a/packages/server-npm/src/lib/parsers.ts
+++ b/packages/server-npm/src/lib/parsers.ts
@@ -150,7 +150,85 @@ export function parseInstallPackageDetails(stdout: string): NpmInstall["packageD
     match = yarnPattern.exec(stdout);
   }
 
-  return details.length > 0 ? details : undefined;
+  const collapsed = collapseVersionBumps(details);
+  return collapsed.length > 0 ? collapsed : undefined;
+}
+
+type InstallPackageDetail = NonNullable<NpmInstall["packageDetails"]>[number];
+
+/**
+ * Collapses a matched `removed`/`added` pair for the same package name into a
+ * single `updated` entry carrying `previousVersion` → `version`.
+ *
+ * Package managers report a version bump as two lines (pnpm prints
+ * `- picocolors 1.0.0` followed by `+ picocolors 1.1.1`), which naively reads
+ * as one addition plus one removal. Agents branch on those counts, so a bump
+ * must surface as a single change. See #1081.
+ *
+ * Exported for unit tests.
+ */
+export function collapseVersionBumps(details: InstallPackageDetail[]): InstallPackageDetail[] {
+  const result = [...details];
+  for (let i = 0; i < result.length; i++) {
+    const removed = result[i];
+    if (removed.action !== "removed") continue;
+    const addedIndex = result.findIndex(
+      (d, j) => j !== i && d.action === "added" && d.name === removed.name,
+    );
+    if (addedIndex === -1) continue;
+    const added = result[addedIndex];
+    result[addedIndex] = {
+      name: added.name,
+      version: added.version,
+      action: "updated",
+      previousVersion: removed.version,
+    };
+    result.splice(i, 1);
+    i--;
+  }
+  return result;
+}
+
+/**
+ * Derives `added`/`removed`/`changed` counts from parsed package details so the
+ * top-level counters can never contradict the list they summarise (#1081).
+ *
+ * Exported for unit tests.
+ */
+export function countInstallPackageDetails(details: InstallPackageDetail[]): {
+  added: number;
+  removed: number;
+  changed: number;
+} {
+  let added = 0;
+  let removed = 0;
+  let changed = 0;
+  for (const detail of details) {
+    if (detail.action === "added") added++;
+    else if (detail.action === "removed") removed++;
+    else changed++;
+  }
+  return { added, removed, changed };
+}
+
+/**
+ * Parses pnpm's store-level summary line (`Packages: +6 -6`).
+ *
+ * pnpm never prints npm's "added N packages" sentence, so without this the
+ * counters stay at zero for every pnpm install. Used only as a fallback when
+ * no per-package details were parsed. See #1081.
+ *
+ * Exported for unit tests.
+ */
+export function parsePnpmPackagesSummary(
+  stdout: string,
+): { added: number; removed: number } | undefined {
+  const match = stdout.match(/^Packages:(?:\s+\+(\d+))?(?:\s+-(\d+))?\s*$/m);
+  if (!match || (match[1] === undefined && match[2] === undefined)) return undefined;
+  return {
+    added: parseInt(match[1] ?? "0", 10),
+    removed: parseInt(match[2] ?? "0", 10),
+  };
 }
 
 /** Parses `npm install` or `pnpm install` summary output into structured data with package counts and vulnerability info. */
@@ -171,10 +249,20 @@ export function parseInstallOutput(stdout: string, _duration?: number): NpmInsta
       : undefined;
 
     const packageDetails = parseInstallPackageDetails(stdout);
+    const hasJsonCounts =
+      installJson.added !== undefined ||
+      installJson.removed !== undefined ||
+      installJson.changed !== undefined;
+    const counts =
+      hasJsonCounts || !packageDetails
+        ? {
+            added: parseInt(String(installJson.added ?? 0), 10),
+            removed: parseInt(String(installJson.removed ?? 0), 10),
+            changed: parseInt(String(installJson.changed ?? 0), 10),
+          }
+        : countInstallPackageDetails(packageDetails);
     return {
-      added: parseInt(String(installJson.added ?? 0), 10),
-      removed: parseInt(String(installJson.removed ?? 0), 10),
-      changed: parseInt(String(installJson.changed ?? 0), 10),
+      ...counts,
       ...(packageDetails ? { packageDetails } : {}),
       ...(vulnerabilities ? { vulnerabilities } : {}),
       ...(installJson.funding !== undefined
@@ -213,10 +301,26 @@ export function parseInstallOutput(stdout: string, _duration?: number): NpmInsta
   // Best-effort: parse specific package details
   const packageDetails = parseInstallPackageDetails(stdout);
 
+  // Counter precedence (#1081): npm's own summary sentence wins when present
+  // (it counts the whole tree, while the detail lines only cover direct deps).
+  // Otherwise derive from the details so the counters can never contradict the
+  // list they summarise, and fall back to pnpm's `Packages: +N -M` store line
+  // when there are no details at all.
+  const hasTextSummary = added !== undefined || removed !== undefined || changed !== undefined;
+  const pnpmSummary =
+    hasTextSummary || packageDetails ? undefined : parsePnpmPackagesSummary(stdout);
+  const counts = hasTextSummary
+    ? {
+        added: parseInt(added ?? "0", 10),
+        removed: parseInt(removed ?? "0", 10),
+        changed: parseInt(changed ?? "0", 10),
+      }
+    : packageDetails
+      ? countInstallPackageDetails(packageDetails)
+      : { added: pnpmSummary?.added ?? 0, removed: pnpmSummary?.removed ?? 0, changed: 0 };
+
   return {
-    added: parseInt(added ?? "0", 10),
-    removed: parseInt(removed ?? "0", 10),
-    changed: parseInt(changed ?? "0", 10),
+    ...counts,
     ...(packageDetails ? { packageDetails } : {}),
     ...(vulnerabilities ? { vulnerabilities } : {}),
     ...(fundingMatch ? { funding: parseInt(fundingMatch[1], 10) } : {}),

--- a/packages/server-npm/src/schemas/index.ts
+++ b/packages/server-npm/src/schemas/index.ts
@@ -12,6 +12,12 @@ export const NpmInstallPackageSchema = z.object({
   name: z.string().describe("Package name"),
   version: z.string().describe("Installed version"),
   action: z.enum(["added", "removed", "updated"]).describe("What happened to this package"),
+  previousVersion: z
+    .string()
+    .optional()
+    .describe(
+      'Version that was replaced, when the package was updated in place (action: "updated")',
+    ),
 });
 
 /** Zod schema for structured npm install output including package counts and vulnerabilities. */


### PR DESCRIPTION
## Root cause

`parseInstallOutput` sourced `added`/`removed`/`changed` from **npm's summary sentence** (`/added (\d+) package/` etc.) or npm's `--json` payload, while `packageDetails` came from a completely separate pass over the per-package `+ pkg 1.2.3` / `- pkg 1.2.3` lines.

pnpm never prints that sentence. Its store summary is `Packages: +7 -7`, which no regex matched. So on any pnpm project the counters stayed at `0/0/0` while `packageDetails` correctly listed every package that moved — the exact contradiction in #1081. Agents branch on the counters, so `install` looked like a no-op after a real dependency change.

Second problem: pnpm reports a version bump as two lines (`- picocolors 1.0.0` then `+ picocolors 1.1.1`), so a bump surfaced as one addition plus one removal rather than one change.

## Fix

Counter precedence in `parseInstallOutput`:

1. npm's own summary (JSON or text) wins when present — it counts the whole tree, while the detail lines only cover direct deps. **npm/yarn behaviour is byte-for-byte unchanged.**
2. Otherwise counts are derived from `packageDetails`, so the counters can never contradict the list they summarise.
3. Otherwise, when there are no details at all (transitive-only install), fall back to pnpm's `Packages: +N -M` store line.

`parseInstallPackageDetails` now collapses a matched `removed`/`added` pair for the same package name into a single `updated` entry.

New exported helpers (all unit-tested): `collapseVersionBumps`, `countInstallPackageDetails`, `parsePnpmPackagesSummary`.

## Schema addition

`NpmInstallPackageSchema` gains **optional** `previousVersion: string` — the version that was replaced when `action: "updated"`. Backward compatible: existing consumers see the same `name`/`version`/`action` fields, and the field is simply absent for genuine adds/removes and for npm-style `change pkg x.y.z` lines where no prior version is available. `formatInstall` renders it as `updated: picocolors@1.0.0 → 1.1.1`.

## Before / after

Real `pnpm install --frozen-lockfile` output (pnpm 10.29.2, two-project workspace, scripts enabled) after bumping `@types/node`, `picocolors`, `tsx`, adding `nanoid`, dropping `left-pad`:

| | before | after |
|---|---|---|
| `added` | 0 | 1 (`nanoid`) |
| `removed` | 0 | 1 (`left-pad`) |
| `changed` | 0 | 3 |
| `packageDetails` | 4 added + 4 removed | 1 added + 1 removed + 3 updated with `previousVersion` |

## Tests

Regression tests in `packages/server-npm/__tests__/pnpm-parsers.test.ts` use **real captured pnpm 10.29.2 output** (two fixtures: a direct-dependency bump set, and a transitive-only install that emits `Packages: +1 -1` with no detail rows). They assert the counters equal the detail-row tallies, that the progress glyph line (`++++++------`, `+-`) is never mistaken for package details, and that the result validates against `NpmInstallSchema`.

One pre-existing test (`"parses pnpm output with packages in line"`) asserted `added: 0` with a comment documenting exactly this gap; it now asserts `52`.

- `pnpm --filter @paretools/npm test` — 407 passed (21 files), including the untouched npm and yarn parser suites
- `pnpm smoke` — 2325 passed (38 files)
- `pnpm lint` — 0 errors (1 pre-existing warning in `packages/shared/src/server.ts`, unrelated)
- `pnpm format:check` — clean

Closes #1081
