### PR TITLE
fix(github): never conclude "passed" on zero checks; cap unbounded body in pr-view/issue-view

### DIFF
--- a/.changeset/fix-1077-1067-github-checks-body.md
+++ b/.changeset/fix-1077-1067-github-checks-body.md
@@ -1,0 +1,27 @@
+---
+"@paretools/github": patch
+---
+
+fix(github): never report `conclusion: "passed"` for zero checks, and cap unbounded `body` in pr-view/issue-view
+
+**`pr-checks` (#1077)** — a PR with no reported check runs no longer reads as green:
+
+- New `conclusion` value `"none"` for zero checks. The invariant is now
+  `conclusion === "passed"` implies `checks.length > 0` and all of them succeeded, so a merge gate
+  cannot mistake "CI has not started" for "CI is green".
+- `watch: true` keeps polling until checks actually appear (previously it exited on the first poll
+  with an empty array), and gh's "no checks reported" exit is treated as "nothing started yet"
+  rather than a fatal error — new `errorType: "no-checks"`.
+- Short settle grace: while gh itself still exits `8` within the first 30s, a checks array that
+  merely looks terminal does not end the watch loop.
+- Timing out with no checks returns `conclusion: "timed_out"` and an error message saying no checks
+  were ever reported.
+
+**`pr-view` / `issue-view` (#1067)** — `body` is no longer unbounded in full-schema mode:
+
+- HTML `<details>…</details>` blocks are collapsed to their `<summary>` text plus ` […]`, then the
+  result is capped at 4000 characters. This shrinks a typical Dependabot body by ~95%.
+- New output fields `bodyTruncated` and `bodyLength` (original character count), plus a
+  `body truncated …` line in the human-readable text.
+- New input `maxBodyLength` to raise the cap, or `0` to disable both the collapse and the cap and
+  return the body verbatim. Oversized `pr-view` `reviews[].body` values are shortened the same way.

--- a/docs/tool-schemas/github/issue-view.md
+++ b/docs/tool-schemas/github/issue-view.md
@@ -6,11 +6,12 @@ Views an issue by number. Returns structured data with state, labels, assignees,
 
 ## Input Parameters
 
-| Parameter | Type    | Default | Description                                                |
-| --------- | ------- | ------- | ---------------------------------------------------------- |
-| `number`  | number  | —       | Issue number                                               |
-| `path`    | string  | cwd     | Repository path                                            |
-| `compact` | boolean | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
+| Parameter       | Type    | Default | Description                                                |
+| --------------- | ------- | ------- | ---------------------------------------------------------- |
+| `number`        | string  | —       | Issue number or URL                                        |
+| `path`          | string  | cwd     | Repository path                                            |
+| `maxBodyLength` | number  | `4000`  | Character cap on `body`; `0` returns the body verbatim     |
+| `compact`       | boolean | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
 
 ## Success
 
@@ -87,6 +88,17 @@ View this issue on GitHub: https://github.com/owner/repo/issues/100
 | --------------- | ---------- | --------- | ------------ | ------- |
 | Issue with body | ~180       | ~80       | ~45          | 56-75%  |
 | Issue not found | ~25        | ~20       | ~20          | 20%     |
+
+## Body truncation (issue #1067)
+
+In full-schema mode `body` is shortened before it is returned: HTML `<details>…</details>` blocks
+are collapsed to their `<summary>` text plus a ` […]` marker, and what remains is capped at
+`maxBodyLength` characters (default `4000`). When anything was removed the payload carries
+`bodyTruncated: true` and `bodyLength` (the original character count), and the human-readable text
+adds a `body truncated …` line.
+
+Pass `maxBodyLength: 0` to disable both the collapse and the cap and get the body exactly as GitHub
+returned it.
 
 ## Notes
 

--- a/docs/tool-schemas/github/pr-checks.md
+++ b/docs/tool-schemas/github/pr-checks.md
@@ -6,11 +6,15 @@ Lists check/status results for a pull request. Returns structured data with chec
 
 ## Input Parameters
 
-| Parameter | Type    | Default      | Description                                                |
-| --------- | ------- | ------------ | ---------------------------------------------------------- |
-| `pr`      | number  | —            | Pull request number                                        |
-| `repo`    | string  | current repo | Repository in OWNER/REPO format                            |
-| `compact` | boolean | `true`       | Auto-compact when structured output exceeds raw CLI tokens |
+| Parameter      | Type    | Default      | Description                                                  |
+| -------------- | ------- | ------------ | ------------------------------------------------------------ |
+| `number`       | string  | —            | Pull request number, URL, or branch name                     |
+| `repo`         | string  | current repo | Repository in OWNER/REPO format                              |
+| `watch`        | boolean | `false`      | Poll until checks appear **and** all complete                |
+| `interval`     | number  | `10`         | Poll interval in seconds when `watch: true` (min 5, max 300) |
+| `watchTimeout` | number  | `600`        | Wall-clock timeout in seconds for the watch loop (max 3600)  |
+| `required`     | boolean | `false`      | Filter to required checks only                               |
+| `compact`      | boolean | `true`       | Auto-compact when structured output exceeds raw CLI tokens   |
 
 ## Success
 
@@ -115,8 +119,47 @@ Some checks were not successful
 | 3 checks, 1 fail | ~200       | ~120      | ~25          | 40-88%  |
 | All passing      | ~150       | ~100      | ~25          | 33-83%  |
 
+## `conclusion` — the field to branch on
+
+| Value       | Meaning                                                                      |
+| ----------- | ---------------------------------------------------------------------------- |
+| `passed`    | At least one check exists, all are terminal, none failed or were cancelled   |
+| `failed`    | At least one check failed or was cancelled                                   |
+| `pending`   | At least one check is still queued or running                                |
+| `none`      | GitHub reports **zero** checks on this PR                                    |
+| `timed_out` | `watch: true` hit `watchTimeout` with checks still pending — or still absent |
+
+**Invariant (issue #1077): `conclusion === "passed"` implies `checks.length > 0` and all of them
+succeeded.** A freshly pushed PR whose check runs GitHub has not registered yet returns `none`, never
+`passed`, so a merge gate cannot mistake "CI has not started" for "CI is green".
+
+```json
+{
+  "pr": 1076,
+  "checks": [],
+  "summary": { "total": 0, "passed": 0, "failed": 0, "pending": 0, "skipped": 0, "cancelled": 0 },
+  "conclusion": "none",
+  "errorType": "no-checks",
+  "errorMessage": "no checks reported on the 'fix/example' branch"
+}
+```
+
+## Watch behaviour
+
+With `watch: true` the wrapper polls `gh pr checks --json …` itself (gh rejects its native `--watch`
+alongside `--json`) until **checks exist and all of them are terminal**, or `watchTimeout` elapses:
+
+- Zero checks does **not** end the loop — polling continues so the watch survives the race between
+  pushing and GitHub creating the check runs.
+- gh's "no checks reported" exit is treated as "nothing has started yet", not as a hard failure.
+- Short settle grace: while gh itself still exits `8` ("pending") within the first 30 seconds, a
+  checks array that merely _looks_ terminal does not end the loop either.
+- On timeout the tool returns the latest snapshot with `timedOut: true`,
+  `conclusion: "timed_out"` and `errorType: "watch-timeout"` rather than throwing.
+
 ## Notes
 
 - Compact mode returns only the summary counts (`pr`, `total`, `passed`, `failed`, `pending`), dropping individual check details
 - The `bucket` field classifies checks as `pass`, `fail`, `pending`, `skipping`, or `cancel`
+- `errorType` is one of `not-found`, `permission-denied`, `in-progress`, `no-checks`, `watch-timeout`, `unknown`
 - The `repo` parameter allows checking PRs in other repositories without being in that repo's working directory

--- a/docs/tool-schemas/github/pr-view.md
+++ b/docs/tool-schemas/github/pr-view.md
@@ -6,11 +6,12 @@ Views a pull request by number. Returns structured data with state, checks, revi
 
 ## Input Parameters
 
-| Parameter | Type    | Default | Description                                                |
-| --------- | ------- | ------- | ---------------------------------------------------------- |
-| `number`  | number  | —       | Pull request number                                        |
-| `path`    | string  | cwd     | Repository path                                            |
-| `compact` | boolean | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
+| Parameter       | Type    | Default | Description                                                |
+| --------------- | ------- | ------- | ---------------------------------------------------------- |
+| `number`        | string  | —       | Pull request number, URL, or branch name                   |
+| `path`          | string  | cwd     | Repository path                                            |
+| `maxBodyLength` | number  | `4000`  | Character cap on `body`; `0` returns the body verbatim     |
+| `compact`       | boolean | `true`  | Auto-compact when structured output exceeds raw CLI tokens |
 
 ## Success
 
@@ -132,6 +133,32 @@ GraphQL: Could not resolve to a PullRequest with the number of 9999.
 | ------------ | ---------- | --------- | ------------ | ------- |
 | PR with body | ~250       | ~100      | ~55          | 60-78%  |
 | PR not found | ~25        | ~20       | ~20          | 20%     |
+
+## Body truncation (issue #1067)
+
+Dependabot and release-note PR bodies routinely run past 30k characters, almost all of it inside
+collapsed `<details>` blocks. In full-schema mode `body` is therefore shortened in two steps:
+
+1. Every `<details>…</details>` block is collapsed to its `<summary>` text plus a ` […]` marker
+   (nested blocks innermost-first). This alone removes ~95% of a Dependabot body.
+2. What remains is capped at `maxBodyLength` characters (default `4000`).
+
+When anything was removed the payload carries `bodyTruncated: true` and `bodyLength` (the original
+character count), and the human-readable text adds a `body truncated …` line:
+
+```json
+{
+  "number": 1064,
+  "title": "chore(deps): bump foo from 1.0.0 to 2.0.0",
+  "body": "Bumps [foo](…) from 1.0.0 to 2.0.0.\nRelease notes […]\nCommits […]",
+  "bodyTruncated": true,
+  "bodyLength": 31842
+}
+```
+
+Pass `maxBodyLength: 0` to disable both the collapse and the cap and get the body exactly as GitHub
+returned it. Oversized `reviews[].body` values are collapsed and capped the same way and flagged
+per-review with `bodyTruncated`.
 
 ## Notes
 

--- a/packages/server-github/__tests__/body-truncate.test.ts
+++ b/packages/server-github/__tests__/body-truncate.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MAX_BODY_LENGTH,
+  applyBodyCap,
+  collapseDetailsBlocks,
+  truncateBody,
+} from "../src/lib/body-truncate.js";
+
+describe("collapseDetailsBlocks (#1067)", () => {
+  it("leaves a body without <details> untouched", () => {
+    const body = "Just a plain markdown body.\n\n- one\n- two";
+    expect(collapseDetailsBlocks(body)).toBe(body);
+  });
+
+  it("collapses a block to its summary text plus a marker", () => {
+    const body =
+      "intro\n<details>\n<summary>Release notes</summary>\n\nlots of text\n</details>\nend";
+    const out = collapseDetailsBlocks(body);
+    expect(out).toContain("Release notes […]");
+    expect(out).not.toContain("lots of text");
+    expect(out).toContain("intro");
+    expect(out).toContain("end");
+  });
+
+  it("handles a <details> tag with attributes", () => {
+    const out = collapseDetailsBlocks(
+      '<details open="true"><summary>Changelog</summary>x</details>',
+    );
+    expect(out).toBe("Changelog […]");
+  });
+
+  it("strips markup inside the summary label", () => {
+    const out = collapseDetailsBlocks(
+      "<details><summary><b>Commits</b> from <em>dep</em></summary>body</details>",
+    );
+    expect(out).toBe("Commits from dep […]");
+  });
+
+  it("emits a bare marker when there is no <summary>", () => {
+    expect(collapseDetailsBlocks("<details>hidden</details>")).toBe("[…]");
+  });
+
+  it("collapses nested blocks innermost-first", () => {
+    const body =
+      "<details><summary>Outer</summary>a<details><summary>Inner</summary>b</details>c</details>";
+    expect(collapseDetailsBlocks(body)).toBe("Outer […]");
+  });
+
+  it("collapses several sibling blocks", () => {
+    const body =
+      "<details><summary>One</summary>x</details>\n<details><summary>Two</summary>y</details>";
+    expect(collapseDetailsBlocks(body)).toBe("One […]\nTwo […]");
+  });
+
+  it("shrinks a Dependabot-shaped body dramatically", () => {
+    const body = `Bumps foo from 1.0.0 to 2.0.0.
+<details>
+<summary>Release notes</summary>
+${"release note line\n".repeat(600)}
+</details>
+<details>
+<summary>Commits</summary>
+${"- abc1234 some commit\n".repeat(600)}
+</details>
+`;
+    const out = collapseDetailsBlocks(body);
+    expect(out.length).toBeLessThan(body.length * 0.05);
+    expect(out).toContain("Bumps foo from 1.0.0 to 2.0.0.");
+    expect(out).toContain("Release notes […]");
+    expect(out).toContain("Commits […]");
+  });
+});
+
+describe("truncateBody (#1067)", () => {
+  it("returns a short body unchanged and unflagged", () => {
+    const out = truncateBody("short body");
+    expect(out.body).toBe("short body");
+    expect(out.bodyTruncated).toBe(false);
+    expect(out.bodyLength).toBe("short body".length);
+  });
+
+  it("caps at the default length and flags truncation", () => {
+    const body = "x".repeat(DEFAULT_MAX_BODY_LENGTH + 500);
+    const out = truncateBody(body);
+    expect(out.body).toHaveLength(DEFAULT_MAX_BODY_LENGTH);
+    expect(out.bodyTruncated).toBe(true);
+    expect(out.bodyLength).toBe(DEFAULT_MAX_BODY_LENGTH + 500);
+  });
+
+  it("honours an explicit cap", () => {
+    const out = truncateBody("abcdefghij", 4);
+    expect(out.body).toBe("abcd");
+    expect(out.bodyTruncated).toBe(true);
+    expect(out.bodyLength).toBe(10);
+  });
+
+  it("disables cap and <details> collapse when maxBodyLength is 0", () => {
+    const body = `<details><summary>S</summary>${"y".repeat(50_000)}</details>`;
+    const out = truncateBody(body, 0);
+    expect(out.body).toBe(body);
+    expect(out.bodyTruncated).toBe(false);
+    expect(out.bodyLength).toBe(body.length);
+  });
+
+  it("flags truncation from the <details> collapse alone, without hitting the cap", () => {
+    const body = `head\n<details><summary>S</summary>${"y".repeat(200)}</details>`;
+    const out = truncateBody(body, DEFAULT_MAX_BODY_LENGTH);
+    expect(out.body).toBe("head\nS […]");
+    expect(out.bodyTruncated).toBe(true);
+    expect(out.bodyLength).toBe(body.length);
+  });
+
+  it("treats null/undefined as an empty body", () => {
+    expect(truncateBody(null)).toEqual({ body: "", bodyTruncated: false, bodyLength: 0 });
+    expect(truncateBody(undefined)).toEqual({ body: "", bodyTruncated: false, bodyLength: 0 });
+  });
+});
+
+describe("applyBodyCap (#1067)", () => {
+  it("caps in place and sets the flags", () => {
+    const data = { number: 1, body: "z".repeat(9000) };
+    const out = applyBodyCap(data, 100);
+    expect(out.body).toHaveLength(100);
+    expect(out.bodyTruncated).toBe(true);
+    expect(out.bodyLength).toBe(9000);
+  });
+
+  it("adds no flags when nothing was removed", () => {
+    const out = applyBodyCap({ body: "fine" });
+    expect(out.body).toBe("fine");
+    expect(out.bodyTruncated).toBeUndefined();
+    expect(out.bodyLength).toBeUndefined();
+  });
+
+  it("leaves a null body alone (absent stays distinguishable from empty)", () => {
+    const out = applyBodyCap({ body: null as string | null });
+    expect(out.body).toBeNull();
+    expect(out.bodyTruncated).toBeUndefined();
+  });
+
+  it("leaves an absent body alone", () => {
+    const out = applyBodyCap({ number: 7 } as { number: number; body?: string | null });
+    expect(out.body).toBeUndefined();
+    expect(out.bodyTruncated).toBeUndefined();
+  });
+
+  it("returns the body verbatim with maxBodyLength 0", () => {
+    const body = "q".repeat(20_000);
+    const out = applyBodyCap({ body }, 0);
+    expect(out.body).toBe(body);
+    expect(out.bodyTruncated).toBeUndefined();
+  });
+});

--- a/packages/server-github/__tests__/p2-gaps.test.ts
+++ b/packages/server-github/__tests__/p2-gaps.test.ts
@@ -249,8 +249,22 @@ describe("GitHub P2 gaps", () => {
     const server = new FakeServer();
     registerPrChecksTool(server as never);
     const handler = server.tools.get("pr-checks")!.handler;
+    // A terminal check so the watch loop exits on the first poll — an empty
+    // checks array now keeps polling until the deadline (issue #1077).
     vi.mocked(ghCmd).mockResolvedValueOnce({
-      stdout: "[]",
+      stdout: JSON.stringify([
+        {
+          name: "build",
+          state: "SUCCESS",
+          bucket: "pass",
+          description: "",
+          event: "pull_request",
+          workflow: "CI",
+          link: "",
+          startedAt: "",
+          completedAt: "",
+        },
+      ]),
       stderr: "",
       exitCode: 0,
     });

--- a/packages/server-github/__tests__/pr-checks-empty.test.ts
+++ b/packages/server-github/__tests__/pr-checks-empty.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Issue #1077 — `pr-checks` must never report `conclusion: "passed"` for a PR
+ * with zero reported checks, and `watch: true` must survive the race between
+ * pushing and GitHub registering the check runs.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/lib/gh-runner.js", () => ({
+  ghCmd: vi.fn(),
+}));
+
+import { ghCmd } from "../src/lib/gh-runner.js";
+import { deriveConclusion, registerPrChecksTool, watchPrChecks } from "../src/tools/pr-checks.js";
+import { PrChecksResultSchema, type PrChecksResult } from "../src/schemas/index.js";
+
+interface CheckEntry {
+  name: string;
+  state: string;
+  bucket: string;
+}
+
+function checksJson(checks: CheckEntry[]): string {
+  return JSON.stringify(
+    checks.map((c) => ({
+      ...c,
+      description: "",
+      event: "pull_request",
+      workflow: "CI",
+      link: "",
+      startedAt: "",
+      completedAt: "",
+    })),
+  );
+}
+
+function snapshot(checks: CheckEntry[]): PrChecksResult {
+  const full = checks.map((c) => ({
+    ...c,
+    description: "",
+    event: "",
+    workflow: "",
+    link: "",
+    startedAt: "",
+    completedAt: "",
+  }));
+  return {
+    pr: 1,
+    checks: full,
+    summary: {
+      total: full.length,
+      passed: full.filter((c) => c.bucket === "pass").length,
+      failed: full.filter((c) => c.bucket === "fail").length,
+      pending: full.filter((c) => c.bucket === "pending" || c.bucket === "queued").length,
+      skipped: full.filter((c) => c.bucket === "skipping").length,
+      cancelled: full.filter((c) => c.bucket === "cancel").length,
+    },
+  };
+}
+
+/** gh's response when GitHub has not registered any check runs yet. */
+const NO_CHECKS_RESPONSE = {
+  stdout: "",
+  stderr: "no checks reported on the 'fix/some-branch' branch",
+  exitCode: 1,
+};
+
+type ToolHandler = (input: Record<string, unknown>) => Promise<{
+  content: { type: string; text: string }[];
+  structuredContent: Record<string, unknown>;
+}>;
+
+class FakeServer {
+  tools = new Map<string, { handler: ToolHandler }>();
+  registerTool(name: string, _config: Record<string, unknown>, handler: ToolHandler) {
+    this.tools.set(name, { handler });
+  }
+}
+
+function makeHandler(): ToolHandler {
+  const server = new FakeServer();
+  registerPrChecksTool(server as never);
+  return server.tools.get("pr-checks")!.handler;
+}
+
+// ── conclusion derivation ────────────────────────────────────────────
+
+describe("deriveConclusion (#1077)", () => {
+  it("returns 'none' — never 'passed' — for zero checks", () => {
+    expect(deriveConclusion(snapshot([]))).toBe("none");
+  });
+
+  it("returns 'none' when the summary is missing entirely", () => {
+    expect(deriveConclusion({ pr: 1 })).toBe("none");
+  });
+
+  it("returns 'passed' only when checks exist and all succeeded", () => {
+    expect(
+      deriveConclusion(
+        snapshot([
+          { name: "a", state: "SUCCESS", bucket: "pass" },
+          { name: "b", state: "SUCCESS", bucket: "pass" },
+        ]),
+      ),
+    ).toBe("passed");
+  });
+
+  it("returns 'pending' when any check is still running", () => {
+    expect(
+      deriveConclusion(
+        snapshot([
+          { name: "a", state: "SUCCESS", bucket: "pass" },
+          { name: "b", state: "PENDING", bucket: "pending" },
+        ]),
+      ),
+    ).toBe("pending");
+  });
+
+  it("returns 'failed' when a check failed, even alongside pending ones", () => {
+    expect(
+      deriveConclusion(
+        snapshot([
+          { name: "a", state: "FAILURE", bucket: "fail" },
+          { name: "b", state: "PENDING", bucket: "pending" },
+        ]),
+      ),
+    ).toBe("failed");
+  });
+
+  it("returns 'failed' for a cancelled check", () => {
+    expect(deriveConclusion(snapshot([{ name: "a", state: "CANCELLED", bucket: "cancel" }]))).toBe(
+      "failed",
+    );
+  });
+
+  it("upholds the invariant: 'passed' implies at least one check", () => {
+    const cases: PrChecksResult[] = [
+      snapshot([]),
+      snapshot([{ name: "a", state: "PENDING", bucket: "pending" }]),
+      snapshot([{ name: "a", state: "FAILURE", bucket: "fail" }]),
+      snapshot([{ name: "a", state: "SUCCESS", bucket: "pass" }]),
+    ];
+    for (const data of cases) {
+      if (deriveConclusion(data) === "passed") {
+        expect((data.checks ?? []).length).toBeGreaterThan(0);
+        expect(data.summary!.failed + data.summary!.pending + data.summary!.cancelled).toBe(0);
+      }
+    }
+  });
+});
+
+// ── one-shot (no watch) ──────────────────────────────────────────────
+
+describe("pr-checks one-shot with zero checks (#1077)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("reports conclusion 'none' for an empty checks array", async () => {
+    vi.mocked(ghCmd).mockResolvedValueOnce({ stdout: "[]", stderr: "", exitCode: 0 });
+    const out = await makeHandler()({ number: "12", compact: false });
+    const parsed = PrChecksResultSchema.parse(out.structuredContent);
+
+    expect(parsed.conclusion).toBe("none");
+    expect(parsed.checks).toEqual([]);
+  });
+
+  it("reports conclusion 'none' + errorType 'no-checks' when gh says none are reported", async () => {
+    vi.mocked(ghCmd).mockResolvedValueOnce(NO_CHECKS_RESPONSE);
+    const out = await makeHandler()({ number: "12", compact: false });
+    const parsed = PrChecksResultSchema.parse(out.structuredContent);
+
+    expect(parsed.conclusion).toBe("none");
+    expect(parsed.conclusion).not.toBe("passed");
+    expect(parsed.errorType).toBe("no-checks");
+    expect(parsed.summary!.total).toBe(0);
+  });
+
+  it("says so in the human-readable text rather than implying success", async () => {
+    vi.mocked(ghCmd).mockResolvedValueOnce({ stdout: "[]", stderr: "", exitCode: 0 });
+    const out = await makeHandler()({ number: "12", compact: false });
+    expect(out.content[0].text).toContain("NOT a passing state");
+  });
+
+  it("still reports 'passed' when checks exist and pass", async () => {
+    vi.mocked(ghCmd).mockResolvedValueOnce({
+      stdout: checksJson([{ name: "lint", state: "SUCCESS", bucket: "pass" }]),
+      stderr: "",
+      exitCode: 0,
+    });
+    const out = await makeHandler()({ number: "12", compact: false });
+    expect(out.structuredContent.conclusion).toBe("passed");
+  });
+});
+
+// ── watch loop ───────────────────────────────────────────────────────
+
+describe("watchPrChecks with zero checks (#1077)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function fakeClock() {
+    let nowMs = 0;
+    return {
+      now: () => nowMs,
+      sleep: async (ms: number) => {
+        nowMs += ms;
+      },
+    };
+  }
+
+  it("keeps polling while gh reports 'no checks reported', then finishes once they appear", async () => {
+    vi.mocked(ghCmd)
+      .mockResolvedValueOnce(NO_CHECKS_RESPONSE)
+      .mockResolvedValueOnce(NO_CHECKS_RESPONSE)
+      .mockResolvedValueOnce({
+        stdout: checksJson([{ name: "build", state: "PENDING", bucket: "pending" }]),
+        stderr: "",
+        exitCode: 8,
+      })
+      .mockResolvedValueOnce({
+        stdout: checksJson([{ name: "build", state: "SUCCESS", bucket: "pass" }]),
+        stderr: "",
+        exitCode: 0,
+      });
+
+    const clock = fakeClock();
+    const result = await watchPrChecks([], undefined, 42, {
+      intervalMs: 1000,
+      timeoutMs: 600_000,
+      settleGraceMs: 0,
+      ...clock,
+    });
+
+    expect(result.pollCount).toBe(4);
+    expect(result.timedOut).toBe(false);
+    expect(result.neverSawChecks).toBe(false);
+    expect(result.data.summary!.passed).toBe(1);
+    expect(result.data.errorType).toBeUndefined();
+  });
+
+  it("keeps polling on an empty checks array rather than concluding immediately", async () => {
+    vi.mocked(ghCmd)
+      .mockResolvedValueOnce({ stdout: "[]", stderr: "", exitCode: 0 })
+      .mockResolvedValueOnce({
+        stdout: checksJson([{ name: "build", state: "SUCCESS", bucket: "pass" }]),
+        stderr: "",
+        exitCode: 0,
+      });
+
+    const clock = fakeClock();
+    const result = await watchPrChecks([], undefined, 42, {
+      intervalMs: 1000,
+      timeoutMs: 600_000,
+      settleGraceMs: 0,
+      ...clock,
+    });
+
+    expect(result.pollCount).toBe(2);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("times out with neverSawChecks when no check ever appears", async () => {
+    vi.mocked(ghCmd).mockResolvedValue(NO_CHECKS_RESPONSE);
+
+    const clock = fakeClock();
+    const result = await watchPrChecks([], undefined, 42, {
+      intervalMs: 1000,
+      timeoutMs: 3000,
+      settleGraceMs: 0,
+      ...clock,
+    });
+
+    expect(result.timedOut).toBe(true);
+    expect(result.neverSawChecks).toBe(true);
+    expect(result.data.errorType).toBe("no-checks");
+  });
+
+  it("still bails out immediately on a real gh failure", async () => {
+    vi.mocked(ghCmd).mockResolvedValueOnce({
+      stdout: "",
+      stderr: "could not resolve to a pull request",
+      exitCode: 1,
+    });
+
+    const clock = fakeClock();
+    const result = await watchPrChecks([], undefined, 42, {
+      intervalMs: 1000,
+      timeoutMs: 600_000,
+      ...clock,
+    });
+
+    expect(result.pollCount).toBe(1);
+    expect(result.data.errorType).toBe("not-found");
+  });
+
+  it("keeps watching inside the settle grace while gh still exits 8", async () => {
+    // Every poll looks terminal, but gh's exit code 8 says otherwise. Inside
+    // the grace window the exit code wins; after it, the checks do.
+    vi.mocked(ghCmd)
+      .mockResolvedValueOnce({
+        stdout: checksJson([{ name: "build", state: "SUCCESS", bucket: "pass" }]),
+        stderr: "",
+        exitCode: 8,
+      })
+      .mockResolvedValueOnce({
+        stdout: checksJson([
+          { name: "build", state: "SUCCESS", bucket: "pass" },
+          { name: "test", state: "SUCCESS", bucket: "pass" },
+        ]),
+        stderr: "",
+        exitCode: 0,
+      });
+
+    const clock = fakeClock();
+    const result = await watchPrChecks([], undefined, 42, {
+      intervalMs: 1000,
+      timeoutMs: 600_000,
+      settleGraceMs: 30_000,
+      ...clock,
+    });
+
+    expect(result.pollCount).toBe(2);
+    expect(result.data.summary!.total).toBe(2);
+  });
+
+  it("trusts terminal checks once the settle grace has elapsed", async () => {
+    vi.mocked(ghCmd).mockResolvedValue({
+      stdout: checksJson([{ name: "build", state: "SUCCESS", bucket: "pass" }]),
+      stderr: "",
+      exitCode: 8,
+    });
+
+    const clock = fakeClock();
+    const result = await watchPrChecks([], undefined, 42, {
+      intervalMs: 5000,
+      timeoutMs: 600_000,
+      settleGraceMs: 10_000,
+      ...clock,
+    });
+
+    // polls at t=0 (settling), t=5000 (settling), t=10000 (grace elapsed → done)
+    expect(result.pollCount).toBe(3);
+    expect(result.timedOut).toBe(false);
+  });
+});
+
+// ── watch, through the tool handler ──────────────────────────────────
+
+describe("pr-checks tool handler, watch with zero checks (#1077)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns timed_out — never passed — when no checks ever appear", async () => {
+    vi.mocked(ghCmd).mockResolvedValue(NO_CHECKS_RESPONSE);
+
+    // interval floor is 5s and watchTimeout 1s, so the deadline trips on the
+    // first iteration without ever sleeping.
+    const out = await makeHandler()({
+      number: "12",
+      watch: true,
+      interval: 5,
+      watchTimeout: 1,
+      compact: false,
+    });
+    const parsed = PrChecksResultSchema.parse(out.structuredContent);
+
+    expect(parsed.conclusion).toBe("timed_out");
+    expect(parsed.conclusion).not.toBe("passed");
+    expect(parsed.timedOut).toBe(true);
+    expect(parsed.errorType).toBe("watch-timeout");
+    expect(parsed.errorMessage).toContain("no checks were ever reported");
+    expect(parsed.summary!.total).toBe(0);
+  });
+
+  it("returns timed_out for a persistently empty checks array too", async () => {
+    vi.mocked(ghCmd).mockResolvedValue({ stdout: "[]", stderr: "", exitCode: 0 });
+
+    const out = await makeHandler()({
+      number: "12",
+      watch: true,
+      interval: 5,
+      watchTimeout: 1,
+      compact: false,
+    });
+    const parsed = PrChecksResultSchema.parse(out.structuredContent);
+
+    expect(parsed.conclusion).toBe("timed_out");
+    expect(parsed.timedOut).toBe(true);
+  });
+});

--- a/packages/server-github/__tests__/view-body-cap.test.ts
+++ b/packages/server-github/__tests__/view-body-cap.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tool-level coverage for the `body` cap on pr-view / issue-view (issue #1067).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/lib/gh-runner.js", () => ({
+  ghCmd: vi.fn(),
+}));
+
+import { ghCmd } from "../src/lib/gh-runner.js";
+import { registerPrViewTool } from "../src/tools/pr-view.js";
+import { registerIssueViewTool } from "../src/tools/issue-view.js";
+import { DEFAULT_MAX_BODY_LENGTH } from "../src/lib/body-truncate.js";
+import { IssueViewResultSchema, PrViewResultSchema } from "../src/schemas/index.js";
+
+type ToolHandler = (input: Record<string, unknown>) => Promise<{
+  content: { type: string; text: string }[];
+  structuredContent: Record<string, unknown>;
+}>;
+
+class FakeServer {
+  tools = new Map<string, { handler: ToolHandler }>();
+  registerTool(name: string, _config: Record<string, unknown>, handler: ToolHandler) {
+    this.tools.set(name, { handler });
+  }
+}
+
+function mockGh(stdout: string) {
+  vi.mocked(ghCmd).mockResolvedValueOnce({ stdout, stderr: "", exitCode: 0 });
+}
+
+/** A Dependabot-shaped body: a one-line preamble plus two huge <details>. */
+const DEPENDABOT_BODY = `Bumps [foo](https://github.com/foo/foo) from 1.0.0 to 2.0.0.
+<details>
+<summary>Release notes</summary>
+${"a very long release note line that repeats\n".repeat(500)}
+</details>
+<details>
+<summary>Commits</summary>
+${"- 0123456 chore: bump something\n".repeat(500)}
+</details>
+`;
+
+function prJson(body: string, extra: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    number: 1064,
+    state: "OPEN",
+    title: "chore(deps): bump foo",
+    body,
+    mergeable: "MERGEABLE",
+    reviewDecision: "",
+    statusCheckRollup: [],
+    additions: 1,
+    deletions: 1,
+    changedFiles: 1,
+    author: { login: "dependabot" },
+    ...extra,
+  });
+}
+
+function issueJson(body: string) {
+  return JSON.stringify({
+    number: 1067,
+    state: "OPEN",
+    title: "unbounded body",
+    body,
+    labels: [],
+    assignees: [],
+    url: "https://github.com/Dave-London/Pare/issues/1067",
+    createdAt: "2026-08-18T04:06:29Z",
+  });
+}
+
+describe("pr-view body cap (#1067)", () => {
+  let handler: ToolHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const server = new FakeServer();
+    registerPrViewTool(server as never);
+    handler = server.tools.get("pr-view")!.handler;
+  });
+
+  it("collapses <details> and caps a Dependabot-sized body by default", async () => {
+    mockGh(prJson(DEPENDABOT_BODY));
+    const out = await handler({ number: "1064", compact: false });
+    const parsed = PrViewResultSchema.parse(out.structuredContent);
+
+    expect(parsed.body!.length).toBeLessThanOrEqual(DEFAULT_MAX_BODY_LENGTH);
+    expect(parsed.body).toContain("Bumps [foo]");
+    expect(parsed.body).toContain("Release notes […]");
+    expect(parsed.body).toContain("Commits […]");
+    expect(parsed.body).not.toContain("chore: bump something");
+    expect(parsed.bodyTruncated).toBe(true);
+    expect(parsed.bodyLength).toBe(DEPENDABOT_BODY.length);
+  });
+
+  it("leaves a short body untouched and unflagged", async () => {
+    mockGh(prJson("A short description."));
+    const out = await handler({ number: "1", compact: false });
+    const parsed = PrViewResultSchema.parse(out.structuredContent);
+
+    expect(parsed.body).toBe("A short description.");
+    expect(parsed.bodyTruncated).toBeUndefined();
+    expect(parsed.bodyLength).toBeUndefined();
+  });
+
+  it("honours an explicit maxBodyLength", async () => {
+    mockGh(prJson("y".repeat(1000)));
+    const out = await handler({ number: "1", maxBodyLength: 50, compact: false });
+    const parsed = PrViewResultSchema.parse(out.structuredContent);
+
+    expect(parsed.body).toHaveLength(50);
+    expect(parsed.bodyTruncated).toBe(true);
+    expect(parsed.bodyLength).toBe(1000);
+  });
+
+  it("returns the body verbatim with maxBodyLength: 0", async () => {
+    mockGh(prJson(DEPENDABOT_BODY));
+    const out = await handler({ number: "1064", maxBodyLength: 0, compact: false });
+    const parsed = PrViewResultSchema.parse(out.structuredContent);
+
+    expect(parsed.body).toBe(DEPENDABOT_BODY);
+    expect(parsed.bodyTruncated).toBeUndefined();
+  });
+
+  it("caps oversized review bodies too", async () => {
+    mockGh(
+      prJson("short", {
+        reviews: [
+          { author: { login: "alice" }, state: "APPROVED", body: "r".repeat(9000) },
+          { author: { login: "bob" }, state: "COMMENTED", body: "lgtm" },
+        ],
+      }),
+    );
+    const out = await handler({ number: "1", compact: false });
+    const parsed = PrViewResultSchema.parse(out.structuredContent);
+
+    expect(parsed.reviews![0].body).toHaveLength(DEFAULT_MAX_BODY_LENGTH);
+    expect(parsed.reviews![0].bodyTruncated).toBe(true);
+    expect(parsed.reviews![1].body).toBe("lgtm");
+    expect(parsed.reviews![1].bodyTruncated).toBeUndefined();
+  });
+
+  it("mentions truncation in the human-readable text", async () => {
+    mockGh(prJson(DEPENDABOT_BODY));
+    const out = await handler({ number: "1064", compact: false });
+    expect(out.content[0].text).toContain("body truncated");
+    expect(out.content[0].text).toContain(String(DEPENDABOT_BODY.length));
+  });
+});
+
+describe("issue-view body cap (#1067)", () => {
+  let handler: ToolHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const server = new FakeServer();
+    registerIssueViewTool(server as never);
+    handler = server.tools.get("issue-view")!.handler;
+  });
+
+  it("collapses <details> and caps by default", async () => {
+    mockGh(issueJson(DEPENDABOT_BODY));
+    const out = await handler({ number: "1067", compact: false });
+    const parsed = IssueViewResultSchema.parse(out.structuredContent);
+
+    expect(parsed.body!.length).toBeLessThanOrEqual(DEFAULT_MAX_BODY_LENGTH);
+    expect(parsed.bodyTruncated).toBe(true);
+    expect(parsed.bodyLength).toBe(DEPENDABOT_BODY.length);
+  });
+
+  it("leaves a short body untouched and unflagged", async () => {
+    mockGh(issueJson("Short issue text."));
+    const out = await handler({ number: "1", compact: false });
+    const parsed = IssueViewResultSchema.parse(out.structuredContent);
+
+    expect(parsed.body).toBe("Short issue text.");
+    expect(parsed.bodyTruncated).toBeUndefined();
+  });
+
+  it("returns the body verbatim with maxBodyLength: 0", async () => {
+    mockGh(issueJson(DEPENDABOT_BODY));
+    const out = await handler({ number: "1067", maxBodyLength: 0, compact: false });
+    const parsed = IssueViewResultSchema.parse(out.structuredContent);
+
+    expect(parsed.body).toBe(DEPENDABOT_BODY);
+    expect(parsed.bodyTruncated).toBeUndefined();
+  });
+
+  it("mentions truncation in the human-readable text", async () => {
+    mockGh(issueJson(DEPENDABOT_BODY));
+    const out = await handler({ number: "1067", compact: false });
+    expect(out.content[0].text).toContain("body truncated");
+  });
+});

--- a/packages/server-github/src/lib/body-truncate.ts
+++ b/packages/server-github/src/lib/body-truncate.ts
@@ -1,0 +1,127 @@
+/**
+ * Body truncation helpers (issue #1067).
+ *
+ * `gh pr view --json body` / `gh issue view --json body` pass the raw markdown
+ * body straight through. Dependabot and release-note bodies routinely run to
+ * 30k+ characters, almost all of it inside collapsed `<details>` blocks, which
+ * blows the token budget of any agent that views such a PR.
+ *
+ * The helpers here shrink a body in two stages:
+ *  1. Collapse `<details>…</details>` blocks to their `<summary>` text plus a
+ *     ` […]` marker (this alone removes ~95% of a Dependabot body).
+ *  2. Hard-cap the remaining text at `maxBodyLength` characters.
+ *
+ * Both stages are skipped when the cap is disabled (`maxBodyLength: 0`), so
+ * callers that genuinely need the full text can still get it verbatim.
+ */
+
+/** Default cap applied to `body` fields in full-schema output. */
+export const DEFAULT_MAX_BODY_LENGTH = 4000;
+
+/** Marker appended in place of a collapsed `<details>` block's contents. */
+const DETAILS_MARKER = "[…]";
+
+/**
+ * Matches the innermost `<details>` block — one whose contents do not
+ * themselves contain another `<details>` open tag. Applying this repeatedly
+ * collapses nested blocks from the inside out.
+ */
+const INNERMOST_DETAILS = /<details\b[^>]*>((?:(?!<details\b)[\s\S])*?)<\/details\s*>/gi;
+
+const SUMMARY = /<summary\b[^>]*>([\s\S]*?)<\/summary\s*>/i;
+
+/** Max collapse passes; guards against pathological nesting. */
+const MAX_COLLAPSE_PASSES = 20;
+
+/** Strips HTML tags and collapses whitespace in a `<summary>` label. */
+function cleanSummary(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Collapses every `<details>…</details>` block to its `<summary>` text plus a
+ * ` […]` marker. Nested blocks are collapsed innermost-first. Text outside
+ * `<details>` blocks is left untouched.
+ */
+export function collapseDetailsBlocks(body: string): string {
+  if (!body.includes("<details")) return body;
+
+  let out = body;
+  for (let pass = 0; pass < MAX_COLLAPSE_PASSES; pass++) {
+    INNERMOST_DETAILS.lastIndex = 0;
+    const next = out.replace(INNERMOST_DETAILS, (_match, inner: string) => {
+      const summaryMatch = SUMMARY.exec(inner);
+      const label = summaryMatch ? cleanSummary(summaryMatch[1]) : "";
+      return label ? `${label} ${DETAILS_MARKER}` : DETAILS_MARKER;
+    });
+    if (next === out) break;
+    out = next;
+  }
+  return out;
+}
+
+/** Result of applying the body cap. */
+export interface TruncatedBody {
+  /** The (possibly collapsed and capped) body text. */
+  body: string;
+  /** True when any content was removed — collapsed `<details>` and/or capped. */
+  bodyTruncated: boolean;
+  /** Length in characters of the original, untouched body. */
+  bodyLength: number;
+}
+
+/**
+ * Collapses `<details>` blocks then caps `body` at `maxBodyLength` characters.
+ *
+ * @param body - Raw body text (may be `null`/`undefined`).
+ * @param maxBodyLength - Character cap. `0` disables both the cap and the
+ *   `<details>` collapse, returning the body verbatim.
+ */
+export function truncateBody(
+  body: string | null | undefined,
+  maxBodyLength: number = DEFAULT_MAX_BODY_LENGTH,
+): TruncatedBody {
+  const original = body ?? "";
+  if (maxBodyLength <= 0) {
+    return { body: original, bodyTruncated: false, bodyLength: original.length };
+  }
+
+  const collapsed = collapseDetailsBlocks(original);
+  const capped = collapsed.length > maxBodyLength ? collapsed.slice(0, maxBodyLength) : collapsed;
+
+  return {
+    body: capped,
+    bodyTruncated: capped !== original,
+    bodyLength: original.length,
+  };
+}
+
+/** Shape of any parsed payload carrying an optional top-level `body`. */
+export interface HasBody {
+  body?: string | null;
+  bodyTruncated?: boolean;
+  bodyLength?: number;
+}
+
+/**
+ * Applies {@link truncateBody} in place of `data.body`, adding `bodyTruncated`
+ * and `bodyLength` when (and only when) the body was actually shortened.
+ *
+ * A `null`/absent body is left as-is so "no body" stays distinguishable from
+ * "empty body".
+ */
+export function applyBodyCap<T extends HasBody>(data: T, maxBodyLength?: number): T {
+  const cap = maxBodyLength ?? DEFAULT_MAX_BODY_LENGTH;
+  if (data.body === null || data.body === undefined || data.body === "") return data;
+
+  const { body, bodyTruncated, bodyLength } = truncateBody(data.body, cap);
+  data.body = body;
+  if (bodyTruncated) {
+    data.bodyTruncated = true;
+    data.bodyLength = bodyLength;
+  }
+  return data;
+}

--- a/packages/server-github/src/lib/formatters.ts
+++ b/packages/server-github/src/lib/formatters.ts
@@ -35,6 +35,18 @@ import type {
 
 // ── Full formatters ──────────────────────────────────────────────────
 
+/**
+ * Renders a one-line note when a `body` field was shortened (issue #1067), so
+ * a human reader knows the text they see is not the whole story.
+ */
+function bodyTruncationNote(data: { bodyTruncated?: boolean; bodyLength?: number }): string[] {
+  if (!data.bodyTruncated) return [];
+  const original = data.bodyLength !== undefined ? ` (original ${data.bodyLength} chars)` : "";
+  return [
+    `  body truncated${original} - <details> blocks collapsed and/or capped; raise maxBodyLength or set it to 0 for the full text`,
+  ];
+}
+
 /** Formats structured PR view data into human-readable text. */
 export function formatPrView(data: PrViewResult): string {
   const lines = [
@@ -70,6 +82,7 @@ export function formatPrView(data: PrViewResult): string {
   if (data.body) {
     lines.push(`  body: ${data.body.slice(0, 200)}${data.body.length > 200 ? "..." : ""}`);
   }
+  lines.push(...bodyTruncationNote(data));
   return lines.join("\n");
 }
 
@@ -144,6 +157,14 @@ export function formatPrChecks(data: PrChecksResult): string {
   const lines = [
     `PR #${data.pr}: ${summary.total} checks (${summary.passed} passed, ${summary.failed} failed, ${summary.pending} pending)`,
   ];
+  // Issue #1077: zero checks must never read as success.
+  if (summary.total === 0) {
+    lines.push(
+      data.timedOut
+        ? "  no checks appeared before the watch deadline - NOT a passing state"
+        : "  no checks reported - NOT a passing state (conclusion: none)",
+    );
+  }
   for (const c of data.checks ?? []) {
     const workflow = c.workflow ? ` [${c.workflow}]` : "";
     lines.push(`  ${c.name}: ${c.state} (${c.bucket})${workflow}`);
@@ -183,7 +204,9 @@ export function compactPrChecksMap(data: PrChecksResult): PrChecksCompact {
 
 export function formatPrChecksCompact(data: PrChecksCompact): string {
   const summary = data.summary ?? { total: 0, passed: 0, failed: 0, pending: 0 };
-  return `PR #${data.pr}: ${summary.total} checks (${summary.passed} passed, ${summary.failed} failed, ${summary.pending} pending)`;
+  const head = `PR #${data.pr}: ${summary.total} checks (${summary.passed} passed, ${summary.failed} failed, ${summary.pending} pending)`;
+  // Issue #1077: zero checks must never read as success.
+  return summary.total === 0 ? `${head} - no checks reported, NOT a passing state` : head;
 }
 
 /** Formats structured PR diff data into a human-readable file change summary. */
@@ -224,6 +247,7 @@ export function formatIssueView(data: IssueViewResult): string {
   if (data.body) {
     lines.push(`  body: ${data.body.slice(0, 200)}${data.body.length > 200 ? "..." : ""}`);
   }
+  lines.push(...bodyTruncationNote(data));
   return lines.join("\n");
 }
 

--- a/packages/server-github/src/schemas/index.ts
+++ b/packages/server-github/src/schemas/index.ts
@@ -14,6 +14,8 @@ export const PrReviewItemSchema = z.object({
   author: z.string(),
   state: z.string(),
   body: z.string().optional(),
+  /** True when this review body was collapsed/capped (see `maxBodyLength`). */
+  bodyTruncated: z.boolean().optional(),
   submittedAt: z.string().optional(),
 });
 
@@ -23,6 +25,13 @@ export const PrViewResultSchema = z.object({
   state: z.string(),
   title: z.string(),
   body: z.string().nullable().optional(),
+  /**
+   * True when `body` was shortened — `<details>` blocks collapsed to their
+   * `<summary>` and/or the text capped at `maxBodyLength` (issue #1067).
+   */
+  bodyTruncated: z.boolean().optional(),
+  /** Character length of the original, untruncated body. Only set when truncated. */
+  bodyLength: z.number().optional(),
   mergeable: z.string(),
   reviewDecision: z.string(),
   checks: z.array(PrCheckSchema).optional(),
@@ -157,6 +166,13 @@ export const IssueViewResultSchema = z.object({
   state: z.string(),
   title: z.string(),
   body: z.string().nullable().optional(),
+  /**
+   * True when `body` was shortened — `<details>` blocks collapsed to their
+   * `<summary>` and/or the text capped at `maxBodyLength` (issue #1067).
+   */
+  bodyTruncated: z.boolean().optional(),
+  /** Character length of the original, untruncated body. Only set when truncated. */
+  bodyLength: z.number().optional(),
   labels: z.array(z.string()),
   assignees: z.array(z.string()),
   url: z.string(),
@@ -281,16 +297,27 @@ export const PrChecksResultSchema = z.object({
   checks: z.array(PrChecksItemSchema).optional(),
   summary: PrChecksSummarySchema.optional(),
   errorType: z
-    .enum(["not-found", "permission-denied", "in-progress", "watch-timeout", "unknown"])
+    .enum([
+      "not-found",
+      "permission-denied",
+      "in-progress",
+      "no-checks",
+      "watch-timeout",
+      "unknown",
+    ])
     .optional(),
   errorMessage: z.string().optional(),
   /**
    * Aggregate outcome derived from the check buckets, so callers can branch
-   * without re-deriving from `summary`: "passed" (all terminal, none failed),
-   * "failed" (at least one failed/cancelled), "pending" (checks still running),
-   * or "timed_out" (watch mode hit its deadline with checks still pending).
+   * without re-deriving from `summary`: "passed" (at least one check, all
+   * terminal, none failed), "failed" (at least one failed/cancelled), "pending"
+   * (checks still running), "none" (GitHub reports zero checks on this PR — a
+   * merge gate must NOT treat this as success, issue #1077), or "timed_out"
+   * (watch mode hit its deadline with checks still pending or absent).
+   *
+   * Invariant: `conclusion === "passed"` implies `checks.length > 0`.
    */
-  conclusion: z.enum(["passed", "failed", "pending", "timed_out"]).optional(),
+  conclusion: z.enum(["passed", "failed", "pending", "none", "timed_out"]).optional(),
   /** True when watch mode returned because it hit `watchTimeout` (checks still pending). */
   timedOut: z.boolean().optional(),
   /** Number of times the wrapper polled gh (only set when watch=true). */

--- a/packages/server-github/src/tools/issue-view.ts
+++ b/packages/server-github/src/tools/issue-view.ts
@@ -10,6 +10,7 @@ import {
 import { ghCmd } from "../lib/gh-runner.js";
 import { parseIssueView } from "../lib/parsers.js";
 import { formatIssueView, compactIssueViewMap, formatIssueViewCompact } from "../lib/formatters.js";
+import { applyBodyCap, DEFAULT_MAX_BODY_LENGTH } from "../lib/body-truncate.js";
 import { IssueViewResultSchema } from "../schemas/index.js";
 
 // S-gap: Add stateReason, author, milestone, updatedAt, closedAt, isPinned, projectItems
@@ -23,7 +24,8 @@ export function registerIssueViewTool(server: McpServer) {
     {
       title: "Issue View",
       description:
-        "Views an issue by number or URL. Returns structured data with state, labels, assignees, author, milestone, close reason, and body.",
+        "Views an issue by number or URL. Returns structured data with state, labels, assignees, author, milestone, close reason, and body. The `body` is capped at " +
+        `${DEFAULT_MAX_BODY_LENGTH} characters (HTML <details> blocks collapsed to their <summary> first) and flagged with \`bodyTruncated\`/\`bodyLength\`; raise or lift the cap with \`maxBodyLength\` (0 = verbatim).`,
       annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         number: z.string().max(INPUT_LIMITS.STRING_MAX).describe("Issue number or URL"),
@@ -38,11 +40,20 @@ export function registerIssueViewTool(server: McpServer) {
           .optional()
           .describe("Repository in OWNER/REPO format (--repo). Default: current repo."),
         path: repoPathInput,
+        maxBodyLength: z.coerce
+          .number()
+          .int()
+          .min(0)
+          .max(1_000_000)
+          .optional()
+          .describe(
+            `Maximum characters kept in the returned body (default ${DEFAULT_MAX_BODY_LENGTH}). Before capping, HTML <details> blocks are collapsed to their <summary> text. Set to 0 to disable both and return the body verbatim.`,
+          ),
         compact: compactInput,
       },
       outputSchema: IssueViewResultSchema,
     },
-    async ({ number, comments, repo, path, compact }) => {
+    async ({ number, comments, repo, path, maxBodyLength, compact }) => {
       const cwd = path || process.cwd();
 
       if (repo) assertNoFlagInjection(repo, "repo");
@@ -59,7 +70,9 @@ export function registerIssueViewTool(server: McpServer) {
         throw new Error(`gh issue view failed: ${result.stderr}`);
       }
 
-      const data = parseIssueView(result.stdout);
+      // Issue #1067: cap the body so a very long issue description cannot blow
+      // the caller's token budget in full-schema mode.
+      const data = applyBodyCap(parseIssueView(result.stdout), maxBodyLength);
       return compactDualOutput(
         data,
         result.stdout,

--- a/packages/server-github/src/tools/pr-checks.ts
+++ b/packages/server-github/src/tools/pr-checks.ts
@@ -20,14 +20,41 @@ const MAX_INTERVAL_SECONDS = 300;
 const DEFAULT_WATCH_TIMEOUT_SECONDS = 600;
 const MAX_WATCH_TIMEOUT_SECONDS = 3600;
 
-function classifyPrChecksError(
-  stderr: string,
-): "not-found" | "permission-denied" | "in-progress" | "unknown" {
+/**
+ * Grace window (ms) during which an `exitCode: 8` ("checks pending") response
+ * from gh outranks a checks array whose entries all look terminal. GitHub
+ * registers check runs asynchronously after a push, so an early snapshot can
+ * show a complete-looking subset while more runs are still being created
+ * (issue #1077).
+ */
+const SETTLE_GRACE_MS = 30_000;
+
+type PrChecksErrorType =
+  "not-found" | "permission-denied" | "in-progress" | "no-checks" | "unknown";
+
+function classifyPrChecksError(stderr: string): PrChecksErrorType {
   const lower = stderr.toLowerCase();
+  // gh exits non-zero with this message when the PR simply has no check runs
+  // yet. That is "nothing has started", not a failure — see #1077.
+  if (/no checks reported/.test(lower)) return "no-checks";
   if (/not found|could not resolve|no pull request/.test(lower)) return "not-found";
   if (/forbidden|permission|403/.test(lower)) return "permission-denied";
   if (/pending|in progress|checks are still running/.test(lower)) return "in-progress";
   return "unknown";
+}
+
+/** An all-zero snapshot used whenever gh reports no checks at all. */
+function emptySnapshot(prNum: number): PrChecksResult {
+  return {
+    pr: prNum,
+    checks: [],
+    summary: { total: 0, passed: 0, failed: 0, pending: 0, skipped: 0, cancelled: 0 },
+  };
+}
+
+/** True when gh reported zero check runs for the PR. */
+function hasNoChecks(data: PrChecksResult): boolean {
+  return (data.checks?.length ?? 0) === 0;
 }
 
 /** Returns true when no checks are still pending (`bucket: "pending"` or `"queued"`). */
@@ -48,10 +75,15 @@ function pendingCheckNames(data: PrChecksResult): string[] {
  * Aggregate outcome from the summary buckets so callers can branch without
  * re-deriving. `failed` wins over `pending` (a red check is actionable even
  * while others run); `pending` means at least one check is still non-terminal.
+ *
+ * Zero checks yields `"none"`, never `"passed"` — a PR whose CI has not been
+ * registered yet must not read as green to a merge gate (issue #1077).
+ *
+ * Invariant: `"passed"` implies at least one check, all terminal, none failed.
  */
-function deriveConclusion(data: PrChecksResult): "passed" | "failed" | "pending" {
+export function deriveConclusion(data: PrChecksResult): "passed" | "failed" | "pending" | "none" {
   const summary = data.summary;
-  if (!summary) return "pending";
+  if (!summary || summary.total === 0 || hasNoChecks(data)) return "none";
   if (summary.failed > 0 || summary.cancelled > 0) return "failed";
   if (summary.pending > 0) return "pending";
   return "passed";
@@ -64,7 +96,9 @@ function defaultSleep(ms: number): Promise<void> {
 
 /**
  * Internal watch loop — polls `gh pr checks --json ...` every `intervalMs`
- * until all checks are non-pending or `timeoutMs` elapses.
+ * until at least one check exists AND none is still pending, or `timeoutMs`
+ * elapses. An empty checks array never ends the loop: that is the push ->
+ * check-run-registration race the watch exists to survive (issue #1077).
  *
  * Exported for unit testing; production callers should use the registered tool.
  */
@@ -75,6 +109,12 @@ export interface WatchOptions {
   sleep?: (ms: number) => Promise<void>;
   /** Replaceable for tests. Defaults to `Date.now`. */
   now?: () => number;
+  /**
+   * Window during which an `exitCode: 8` response keeps the loop running even
+   * when every reported check already looks terminal. Defaults to
+   * {@link SETTLE_GRACE_MS}; set to `0` to disable.
+   */
+  settleGraceMs?: number;
 }
 
 export interface WatchResult {
@@ -83,6 +123,8 @@ export interface WatchResult {
   waitedSeconds: number;
   timedOut: boolean;
   pending: string[];
+  /** True when the loop ended without GitHub ever reporting a single check. */
+  neverSawChecks: boolean;
 }
 
 export async function watchPrChecks(
@@ -94,12 +136,18 @@ export async function watchPrChecks(
   const sleep = opts.sleep ?? defaultSleep;
   const now = opts.now ?? Date.now;
   const start = now();
+  const settleGraceMs = opts.settleGraceMs ?? SETTLE_GRACE_MS;
   let pollCount = 0;
-  let lastData: PrChecksResult = {
-    pr: prNum,
-    checks: [],
-    summary: { total: 0, passed: 0, failed: 0, pending: 0, skipped: 0, cancelled: 0 },
-  };
+  let lastData: PrChecksResult = emptySnapshot(prNum);
+
+  const finish = (timedOut: boolean, pending: string[]): WatchResult => ({
+    data: lastData,
+    pollCount,
+    waitedSeconds: (now() - start) / 1000,
+    timedOut,
+    pending,
+    neverSawChecks: hasNoChecks(lastData),
+  });
 
   while (true) {
     pollCount++;
@@ -108,64 +156,53 @@ export async function watchPrChecks(
     // Exit code 8 means checks are still pending — gh still emits valid JSON.
     if (result.exitCode !== 0 && result.exitCode !== 8) {
       const combined = `${result.stdout}\n${result.stderr}`.trim();
-      lastData = {
-        pr: prNum,
-        checks: [],
-        summary: { total: 0, passed: 0, failed: 0, pending: 0, skipped: 0, cancelled: 0 },
-        errorType: classifyPrChecksError(combined),
-        errorMessage: combined || "gh pr checks failed",
-      };
-      const elapsed = (now() - start) / 1000;
-      return {
-        data: lastData,
-        pollCount,
-        waitedSeconds: elapsed,
-        timedOut: false,
-        pending: [],
-      };
-    }
+      const errorType = classifyPrChecksError(combined);
 
-    try {
-      lastData = parsePrChecks(result.stdout, prNum);
-    } catch {
-      const combined = `${result.stdout}\n${result.stderr}`.trim();
-      lastData = {
-        pr: prNum,
-        checks: [],
-        summary: { total: 0, passed: 0, failed: 0, pending: 0, skipped: 0, cancelled: 0 },
-        errorType: "unknown",
-        errorMessage: combined || "Failed to parse pr checks output",
-      };
-      const elapsed = (now() - start) / 1000;
-      return {
-        data: lastData,
-        pollCount,
-        waitedSeconds: elapsed,
-        timedOut: false,
-        pending: [],
-      };
-    }
+      // "no checks reported" is not a failure: GitHub has simply not registered
+      // any check runs yet. Keep polling until they appear or the watch
+      // deadline passes, rather than bailing out instantly (issue #1077).
+      if (errorType !== "no-checks") {
+        lastData = {
+          ...emptySnapshot(prNum),
+          errorType,
+          errorMessage: combined || "gh pr checks failed",
+        };
+        return finish(false, []);
+      }
 
-    if (allChecksComplete(lastData)) {
-      const elapsed = (now() - start) / 1000;
-      return {
-        data: lastData,
-        pollCount,
-        waitedSeconds: elapsed,
-        timedOut: false,
-        pending: [],
+      lastData = {
+        ...emptySnapshot(prNum),
+        errorType,
+        errorMessage: combined || "no checks reported on this pull request",
       };
+    } else {
+      try {
+        lastData = parsePrChecks(result.stdout, prNum);
+      } catch {
+        const combined = `${result.stdout}\n${result.stderr}`.trim();
+        lastData = {
+          ...emptySnapshot(prNum),
+          errorType: "unknown",
+          errorMessage: combined || "Failed to parse pr checks output",
+        };
+        return finish(false, []);
+      }
+
+      // Short settle grace: while gh itself still reports "pending" (exit 8),
+      // a checks array that merely *looks* terminal is not trusted — GitHub may
+      // still be creating the remaining check runs right after a push.
+      const settling = result.exitCode === 8 && now() - start < settleGraceMs;
+
+      // Zero checks never terminates the loop: surviving the
+      // push -> check-run-registration race is the whole point of watching.
+      if (!hasNoChecks(lastData) && allChecksComplete(lastData) && !settling) {
+        return finish(false, []);
+      }
     }
 
     const elapsed = now() - start;
     if (elapsed + opts.intervalMs > opts.timeoutMs) {
-      return {
-        data: lastData,
-        pollCount,
-        waitedSeconds: elapsed / 1000,
-        timedOut: true,
-        pending: pendingCheckNames(lastData),
-      };
+      return finish(true, pendingCheckNames(lastData));
     }
 
     await sleep(opts.intervalMs);
@@ -179,7 +216,7 @@ export function registerPrChecksTool(server: McpServer) {
     {
       title: "PR Checks",
       description:
-        'Lists check/status results for a pull request. Returns structured data with check names, states, URLs, summary counts (passed, failed, pending), and a top-level `conclusion` ("passed" | "failed" | "pending" | "timed_out") for easy branching. When watch=true, polls internally until all checks complete or watchTimeout elapses; on timeout it returns the latest snapshot with `timedOut: true` and `conclusion: "timed_out"` rather than throwing.',
+        'Lists check/status results for a pull request. Returns structured data with check names, states, URLs, summary counts (passed, failed, pending), and a top-level `conclusion` ("passed" | "failed" | "pending" | "none" | "timed_out") for easy branching. `conclusion: "passed"` is only ever returned when at least one check exists and all of them succeeded; a PR with zero reported checks returns `conclusion: "none"` (never "passed"), so a merge gate cannot mistake "CI has not started" for "CI is green". When watch=true, polls internally until checks appear AND all complete, or watchTimeout elapses; on timeout it returns the latest snapshot with `timedOut: true` and `conclusion: "timed_out"` rather than throwing.',
       annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         number: z
@@ -196,7 +233,7 @@ export function registerPrChecksTool(server: McpServer) {
           .boolean()
           .optional()
           .describe(
-            "Poll checks internally until all are non-pending. The wrapper polls gh JSON output (gh's native --watch is incompatible with --json).",
+            "Poll internally until at least one check exists AND all are non-pending, or watchTimeout elapses. A PR with no checks yet keeps the loop running instead of concluding early. The wrapper polls gh JSON output (gh's native --watch is incompatible with --json).",
           ),
         interval: z.coerce
           .number()
@@ -253,12 +290,15 @@ export function registerPrChecksTool(server: McpServer) {
         if (watchResult.timedOut) {
           // Return a structured snapshot rather than throwing, so callers can
           // branch on `conclusion`/`timedOut` instead of catching an exception.
+          const timeoutReason = watchResult.neverSawChecks
+            ? `no checks were ever reported on this pull request — CI may not have started`
+            : `checks still pending: ${watchResult.pending.join(", ") || "(none reported)"}`;
           const data: PrChecksResult = {
             ...watchResult.data,
             conclusion: "timed_out",
             timedOut: true,
             errorType: "watch-timeout",
-            errorMessage: `Watch timed out after ${timeoutSeconds}s — checks still pending: ${watchResult.pending.join(", ") || "(none reported)"}`,
+            errorMessage: `Watch timed out after ${timeoutSeconds}s — ${timeoutReason}`,
             pollCount: watchResult.pollCount,
             waitedSeconds: Math.round(watchResult.waitedSeconds * 100) / 100,
           };
@@ -294,13 +334,19 @@ export function registerPrChecksTool(server: McpServer) {
       // Exit code 8 means checks are still pending — gh still returns valid JSON
       if (result.exitCode !== 0 && result.exitCode !== 8) {
         const combined = `${result.stdout}\n${result.stderr}`.trim();
+        const errorType = classifyPrChecksError(combined);
         return compactDualOutput(
           {
-            pr: prNum,
-            checks: [],
-            summary: { total: 0, passed: 0, failed: 0, pending: 0, skipped: 0, cancelled: 0 },
-            errorType: classifyPrChecksError(combined),
-            errorMessage: combined || "gh pr checks failed",
+            ...emptySnapshot(prNum),
+            // Zero checks is reported as `conclusion: "none"`, never "passed"
+            // (issue #1077). Other failures carry no conclusion at all.
+            ...(errorType === "no-checks" ? { conclusion: "none" as const } : {}),
+            errorType,
+            errorMessage:
+              combined ||
+              (errorType === "no-checks"
+                ? "no checks reported on this pull request"
+                : "gh pr checks failed"),
           },
           result.stdout,
           formatPrChecks,
@@ -318,9 +364,7 @@ export function registerPrChecksTool(server: McpServer) {
         const combined = `${result.stdout}\n${result.stderr}`.trim();
         return compactDualOutput(
           {
-            pr: prNum,
-            checks: [],
-            summary: { total: 0, passed: 0, failed: 0, pending: 0, skipped: 0, cancelled: 0 },
+            ...emptySnapshot(prNum),
             errorType: "unknown" as const,
             errorMessage: combined || "Failed to parse pr checks output",
           },

--- a/packages/server-github/src/tools/pr-view.ts
+++ b/packages/server-github/src/tools/pr-view.ts
@@ -10,6 +10,7 @@ import {
 import { ghCmd } from "../lib/gh-runner.js";
 import { parsePrView } from "../lib/parsers.js";
 import { formatPrView, compactPrViewMap, formatPrViewCompact } from "../lib/formatters.js";
+import { applyBodyCap, truncateBody, DEFAULT_MAX_BODY_LENGTH } from "../lib/body-truncate.js";
 import { PrViewResultSchema } from "../schemas/index.js";
 
 // S-gap: Add author, labels, isDraft, assignees, createdAt, updatedAt, milestone, projectItems
@@ -24,7 +25,8 @@ export function registerPrViewTool(server: McpServer) {
     {
       title: "PR View",
       description:
-        "Views a pull request by number, URL, or branch. Returns structured data with state, checks, review decision, diff stats, author, labels, draft status, assignees, milestone, and timestamps.",
+        "Views a pull request by number, URL, or branch. Returns structured data with state, checks, review decision, diff stats, author, labels, draft status, assignees, milestone, and timestamps. The `body` is capped at " +
+        `${DEFAULT_MAX_BODY_LENGTH} characters (HTML <details> blocks collapsed to their <summary> first) and flagged with \`bodyTruncated\`/\`bodyLength\`; raise or lift the cap with \`maxBodyLength\` (0 = verbatim).`,
       annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         number: z
@@ -42,11 +44,20 @@ export function registerPrViewTool(server: McpServer) {
           .optional()
           .describe("Repository in OWNER/REPO format (--repo). Default: current repo."),
         path: repoPathInput,
+        maxBodyLength: z.coerce
+          .number()
+          .int()
+          .min(0)
+          .max(1_000_000)
+          .optional()
+          .describe(
+            `Maximum characters kept in the returned body (default ${DEFAULT_MAX_BODY_LENGTH}). Before capping, HTML <details> blocks are collapsed to their <summary> text. Set to 0 to disable both and return the body verbatim.`,
+          ),
         compact: compactInput,
       },
       outputSchema: PrViewResultSchema,
     },
-    async ({ number, comments, repo, path, compact }) => {
+    async ({ number, comments, repo, path, maxBodyLength, compact }) => {
       const cwd = path || process.cwd();
 
       if (repo) assertNoFlagInjection(repo, "repo");
@@ -63,7 +74,16 @@ export function registerPrViewTool(server: McpServer) {
         throw new Error(`gh pr view failed: ${result.stderr}`);
       }
 
-      const data = parsePrView(result.stdout);
+      // Issue #1067: cap the body (and each review body) so a Dependabot-sized
+      // changelog cannot blow the caller's token budget in full-schema mode.
+      const data = applyBodyCap(parsePrView(result.stdout), maxBodyLength);
+      if (data.reviews) {
+        data.reviews = data.reviews.map((r) => {
+          if (!r.body) return r;
+          const { body, bodyTruncated } = truncateBody(r.body, maxBodyLength);
+          return bodyTruncated ? { ...r, body, bodyTruncated } : r;
+        });
+      }
       return compactDualOutput(
         data,
         result.stdout,

--- a/tests/smoke/mocked/github-issue-tools.smoke.test.ts
+++ b/tests/smoke/mocked/github-issue-tools.smoke.test.ts
@@ -822,7 +822,7 @@ describe("Smoke: github.issue-update", () => {
 });
 
 // ═════════════════════════════════════════════════════════════════════
-// 6. issue-view (13 scenarios)
+// 6. issue-view (16 scenarios)
 // ═════════════════════════════════════════════════════════════════════
 
 describe("Smoke: github.issue-view", () => {
@@ -875,6 +875,33 @@ describe("Smoke: github.issue-view", () => {
     expect(parsed.assignees).toEqual(["octocat"]);
     expect(parsed.url).toContain("/issues/42");
     expect(parsed.createdAt).toBeDefined();
+  });
+
+  it("S14 [P0] oversized body is collapsed + capped and flagged (#1067)", async () => {
+    const body = `Report\n<details>\n<summary>Logs</summary>\n${"log line\n".repeat(
+      900,
+    )}</details>`;
+    mockGh(sampleIssueJson({ body }));
+    const { parsed } = await callAndValidate({ number: "42", compact: false });
+    expect(parsed.body!.length).toBeLessThanOrEqual(4000);
+    expect(parsed.body).toContain("Logs […]");
+    expect(parsed.bodyTruncated).toBe(true);
+    expect(parsed.bodyLength).toBe(body.length);
+  });
+
+  it("S15 [P1] maxBodyLength: 0 returns the body verbatim (#1067)", async () => {
+    const body = `<details><summary>S</summary>${"y".repeat(10_000)}</details>`;
+    mockGh(sampleIssueJson({ body }));
+    const { parsed } = await callAndValidate({ number: "42", maxBodyLength: 0, compact: false });
+    expect(parsed.body).toBe(body);
+    expect(parsed.bodyTruncated).toBeUndefined();
+  });
+
+  it("S16 [P1] short body is untouched and unflagged (#1067)", async () => {
+    mockGh(sampleIssueJson());
+    const { parsed } = await callAndValidate({ number: "42", compact: false });
+    expect(parsed.body).toBe("Issue body text");
+    expect(parsed.bodyTruncated).toBeUndefined();
   });
 
   it("S2 [P0] issue not found", async () => {

--- a/tests/smoke/mocked/github-pr-checks.smoke.test.ts
+++ b/tests/smoke/mocked/github-pr-checks.smoke.test.ts
@@ -118,6 +118,8 @@ describe("Smoke: github.pr-checks", () => {
     const { parsed } = await callAndValidate({ number: "123" });
     expect(parsed.checks).toEqual([]);
     expect(parsed.summary!.total).toBe(0);
+    // #1077: zero checks is never "passed"
+    expect(parsed.conclusion).toBe("none");
   });
 
   // ── Scenario 7: Empty JSON array from gh ───────────────────────────
@@ -359,6 +361,42 @@ describe("Smoke: github.pr-checks", () => {
     await callAndValidate({ number: "feature-branch" });
     const args = vi.mocked(ghCmd).mock.calls[0][0];
     expect(args[2]).toBe("feature-branch");
+  });
+
+  // ── Scenario 30: zero checks never conclude "passed" (BUG #1077) ───
+  it("S30 [P0] empty checks report conclusion 'none', never 'passed' (#1077)", async () => {
+    mockGh("[]");
+    const { parsed } = await callAndValidate({ number: "123" });
+    expect(parsed.conclusion).toBe("none");
+    expect(parsed.conclusion).not.toBe("passed");
+  });
+
+  // ── Scenario 31: gh "no checks reported" is not a hard failure ──────
+  it("S31 [P0] gh 'no checks reported' maps to errorType 'no-checks' + conclusion 'none' (#1077)", async () => {
+    mockGh("", "no checks reported on the 'feature' branch", 1);
+    const { parsed } = await callAndValidate({ number: "123" });
+    expect(parsed.errorType).toBe("no-checks");
+    expect(parsed.conclusion).toBe("none");
+    expect(parsed.summary!.total).toBe(0);
+  });
+
+  // ── Scenario 32: watch + zero checks times out, never "passed" ──────
+  it("S32 [P0] watch with zero checks times out rather than passing (#1077)", async () => {
+    vi.mocked(ghCmd).mockResolvedValue({
+      stdout: "",
+      stderr: "no checks reported on the 'feature' branch",
+      exitCode: 1,
+    });
+    // interval floor 5s vs watchTimeout 1s → deadline trips on poll 1
+    const { parsed } = await callAndValidate({
+      number: "123",
+      watch: true,
+      interval: 5,
+      watchTimeout: 1,
+    });
+    expect(parsed.conclusion).toBe("timed_out");
+    expect(parsed.timedOut).toBe(true);
+    expect(parsed.errorType).toBe("watch-timeout");
   });
 
   // ── Scenario 29: watch: true ────────────────────────────────────────

--- a/tests/smoke/mocked/github-pr-tools-2.smoke.test.ts
+++ b/tests/smoke/mocked/github-pr-tools-2.smoke.test.ts
@@ -714,6 +714,26 @@ describe("Smoke: github.pr-view", () => {
     await expect(callAndValidate({ number: "999999" })).rejects.toThrow(/gh pr view failed/);
   });
 
+  it("S18 [P0] oversized body is collapsed + capped and flagged (#1067)", async () => {
+    const body = `Bumps foo from 1 to 2.\n<details>\n<summary>Commits</summary>\n${"- abc1234 a commit\n".repeat(
+      800,
+    )}</details>`;
+    mockGh(JSON.stringify({ ...PR_VIEW_JSON, body }));
+    const { parsed } = await callAndValidate({ number: "123", compact: false });
+    expect(parsed.body!.length).toBeLessThanOrEqual(4000);
+    expect(parsed.body).toContain("Commits […]");
+    expect(parsed.bodyTruncated).toBe(true);
+    expect(parsed.bodyLength).toBe(body.length);
+  });
+
+  it("S19 [P1] maxBodyLength: 0 returns the body verbatim (#1067)", async () => {
+    const body = `<details><summary>S</summary>${"y".repeat(10_000)}</details>`;
+    mockGh(JSON.stringify({ ...PR_VIEW_JSON, body }));
+    const { parsed } = await callAndValidate({ number: "123", maxBodyLength: 0, compact: false });
+    expect(parsed.body).toBe(body);
+    expect(parsed.bodyTruncated).toBeUndefined();
+  });
+
   it("S3 [P0] flag injection on number", async () => {
     await expect(callAndValidate({ number: "--exec=evil" })).rejects.toThrow();
   });

--- a/tests/smoke/scenarios/github-pr-checks.md
+++ b/tests/smoke/scenarios/github-pr-checks.md
@@ -99,11 +99,19 @@
 | 28  | PR number as branch name    | `{ number: "feature-branch" }`                         | Passes branch to gh CLI correctly                                  | P2       | complete |
 | 29  | watch: true (short timeout) | `{ number: "123", watch: true }`                       | `--watch` flag in args (actual watch behavior not tested in smoke) | P2       | complete |
 
+### Zero checks never conclude "passed" (#1077)
+
+| #   | Scenario                             | Params                                                         | Expected Output                                                           | Priority | Status   |
+| --- | ------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------- | -------- | -------- |
+| 30  | Empty checks array                   | `{ number: "123" }`                                            | `conclusion: "none"` — never `"passed"`                                   | P0       | complete |
+| 31  | gh "no checks reported" (exit 1)     | `{ number: "123" }`                                            | `errorType: "no-checks"`, `conclusion: "none"`, `summary.total == 0`      | P0       | complete |
+| 32  | watch with zero checks hits deadline | `{ number: "123", watch: true, interval: 5, watchTimeout: 1 }` | `conclusion: "timed_out"`, `timedOut: true`, `errorType: "watch-timeout"` | P0       | complete |
+
 ## Summary
 
 | Priority  | Count  | Mocked | Recorded | Complete |
 | --------- | ------ | ------ | -------- | -------- |
-| P0        | 12     | 12     | 0        | 12       |
+| P0        | 15     | 15     | 0        | 15       |
 | P1        | 12     | 12     | 0        | 12       |
 | P2        | 5      | 5      | 0        | 5        |
-| **Total** | **29** | **29** | **0**    | **29**   |
+| **Total** | **32** | **32** | **0**    | **32**   |

--- a/tests/smoke/scenarios/github-tools.md
+++ b/tests/smoke/scenarios/github-tools.md
@@ -447,13 +447,14 @@ Reference: `tests/smoke/scenarios/github-pr-checks.md` for format precedent.
 
 ### Input params
 
-| Param      | Type    | Required | Notes               |
-| ---------- | ------- | -------- | ------------------- |
-| `number`   | string  | yes      | Issue number or URL |
-| `comments` | boolean | no       | Include comments    |
-| `repo`     | string  | no       | OWNER/REPO format   |
-| `path`     | string  | no       | Repository path     |
-| `compact`  | boolean | no       | Default: true       |
+| Param           | Type    | Required | Notes                         |
+| --------------- | ------- | -------- | ----------------------------- |
+| `number`        | string  | yes      | Issue number or URL           |
+| `comments`      | boolean | no       | Include comments              |
+| `repo`          | string  | no       | OWNER/REPO format             |
+| `path`          | string  | no       | Repository path               |
+| `maxBodyLength` | number  | no       | Body cap, default 4000; 0=off |
+| `compact`       | boolean | no       | Default: true                 |
 
 ### Scenarios
 
@@ -472,15 +473,18 @@ Reference: `tests/smoke/scenarios/github-pr-checks.md` for format precedent.
 | 11  | Issue with null body                     | `{ number: "42" }`                                      | `body: null`, no crash                                                          | P1       | complete |
 | 12  | Issue number as URL                      | `{ number: "https://github.com/owner/repo/issues/42" }` | Passes URL correctly                                                            | P2       | complete |
 | 13  | Issue with empty labels and assignees    | `{ number: "42" }`                                      | `labels: []`, `assignees: []`                                                   | P2       | complete |
+| 14  | Oversized body collapsed + capped        | `{ number: "42", compact: false }`                      | `<details>` collapsed, `body` <= 4000, `bodyTruncated: true`, `bodyLength` set  | P0       | complete |
+| 15  | maxBodyLength 0 returns body verbatim    | `{ number: "42", maxBodyLength: 0, compact: false }`    | `body` byte-identical to gh output, no `bodyTruncated`                          | P1       | complete |
+| 16  | Short body untouched and unflagged       | `{ number: "42", compact: false }`                      | `body` unchanged, `bodyTruncated` absent                                        | P1       | complete |
 
 ### Summary
 
 | Priority  | Count  |
 | --------- | ------ |
-| P0        | 6      |
-| P1        | 5      |
+| P0        | 7      |
+| P1        | 7      |
 | P2        | 2      |
-| **Total** | **13** |
+| **Total** | **16** |
 
 ---
 
@@ -918,44 +922,47 @@ Reference: `tests/smoke/scenarios/github-pr-checks.md` for format precedent.
 
 ### Input params
 
-| Param      | Type    | Required | Notes                          |
-| ---------- | ------- | -------- | ------------------------------ |
-| `number`   | string  | yes      | PR number, URL, or branch name |
-| `comments` | boolean | no       | Include PR comments            |
-| `repo`     | string  | no       | OWNER/REPO format              |
-| `path`     | string  | no       | Repository path                |
-| `compact`  | boolean | no       | Default: true                  |
+| Param           | Type    | Required | Notes                          |
+| --------------- | ------- | -------- | ------------------------------ |
+| `number`        | string  | yes      | PR number, URL, or branch name |
+| `comments`      | boolean | no       | Include PR comments            |
+| `repo`          | string  | no       | OWNER/REPO format              |
+| `path`          | string  | no       | Repository path                |
+| `maxBodyLength` | number  | no       | Body cap, default 4000; 0=off  |
+| `compact`       | boolean | no       | Default: true                  |
 
 ### Scenarios
 
-| #   | Scenario                         | Params                                                 | Expected Output                                                                    | Priority | Status   |
-| --- | -------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------- | -------- | -------- |
-| 1   | View PR happy path               | `{ number: "123" }`                                    | All core fields populated: number, state, title, url, headBranch, baseBranch, etc. | P0       | complete |
-| 2   | PR not found                     | `{ number: "999999" }`                                 | Error thrown: "gh pr view failed"                                                  | P0       | complete |
-| 3   | Flag injection on number         | `{ number: "--exec=evil" }`                            | `assertNoFlagInjection` throws                                                     | P0       | complete |
-| 4   | Flag injection on repo           | `{ number: "123", repo: "--exec=evil" }`               | `assertNoFlagInjection` throws                                                     | P0       | complete |
-| 5   | Merged PR                        | `{ number: "123" }`                                    | `state: "MERGED"`, `mergeable` populated                                           | P0       | complete |
-| 6   | Draft PR                         | `{ number: "123" }`                                    | `isDraft: true`                                                                    | P0       | complete |
-| 7   | Include comments                 | `{ number: "123", comments: true }`                    | --comments flag passed                                                             | P1       | complete |
-| 8   | PR with checks                   | `{ number: "123" }`                                    | `checks` array populated, `checksTotal` set                                        | P1       | complete |
-| 9   | PR with reviews                  | `{ number: "123" }`                                    | `reviews` array with author, state, body                                           | P1       | complete |
-| 10  | PR with labels and assignees     | `{ number: "123" }`                                    | `labels`, `assignees` arrays populated                                             | P1       | complete |
-| 11  | PR with null body                | `{ number: "123" }`                                    | `body: null`, no crash                                                             | P1       | complete |
-| 12  | Compact vs full output           | `{ number: "123", compact: false }`                    | Full schema output                                                                 | P1       | complete |
-| 13  | Cross-repo view                  | `{ number: "123", repo: "owner/repo" }`                | --repo flag passed                                                                 | P1       | complete |
-| 14  | Diff stats (additions/deletions) | `{ number: "123" }`                                    | `additions`, `deletions`, `changedFiles` populated                                 | P1       | complete |
-| 15  | Commit info                      | `{ number: "123" }`                                    | `commitCount`, `latestCommitSha` populated                                         | P1       | complete |
-| 16  | PR number as URL                 | `{ number: "https://github.com/owner/repo/pull/123" }` | Passes URL correctly                                                               | P2       | complete |
-| 17  | PR number as branch name         | `{ number: "feature-branch" }`                         | Passes branch to gh CLI                                                            | P2       | complete |
+| #   | Scenario                          | Params                                                 | Expected Output                                                                    | Priority | Status   |
+| --- | --------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------- | -------- | -------- |
+| 1   | View PR happy path                | `{ number: "123" }`                                    | All core fields populated: number, state, title, url, headBranch, baseBranch, etc. | P0       | complete |
+| 2   | PR not found                      | `{ number: "999999" }`                                 | Error thrown: "gh pr view failed"                                                  | P0       | complete |
+| 3   | Flag injection on number          | `{ number: "--exec=evil" }`                            | `assertNoFlagInjection` throws                                                     | P0       | complete |
+| 4   | Flag injection on repo            | `{ number: "123", repo: "--exec=evil" }`               | `assertNoFlagInjection` throws                                                     | P0       | complete |
+| 5   | Merged PR                         | `{ number: "123" }`                                    | `state: "MERGED"`, `mergeable` populated                                           | P0       | complete |
+| 6   | Draft PR                          | `{ number: "123" }`                                    | `isDraft: true`                                                                    | P0       | complete |
+| 7   | Include comments                  | `{ number: "123", comments: true }`                    | --comments flag passed                                                             | P1       | complete |
+| 8   | PR with checks                    | `{ number: "123" }`                                    | `checks` array populated, `checksTotal` set                                        | P1       | complete |
+| 9   | PR with reviews                   | `{ number: "123" }`                                    | `reviews` array with author, state, body                                           | P1       | complete |
+| 10  | PR with labels and assignees      | `{ number: "123" }`                                    | `labels`, `assignees` arrays populated                                             | P1       | complete |
+| 11  | PR with null body                 | `{ number: "123" }`                                    | `body: null`, no crash                                                             | P1       | complete |
+| 12  | Compact vs full output            | `{ number: "123", compact: false }`                    | Full schema output                                                                 | P1       | complete |
+| 13  | Cross-repo view                   | `{ number: "123", repo: "owner/repo" }`                | --repo flag passed                                                                 | P1       | complete |
+| 14  | Diff stats (additions/deletions)  | `{ number: "123" }`                                    | `additions`, `deletions`, `changedFiles` populated                                 | P1       | complete |
+| 15  | Commit info                       | `{ number: "123" }`                                    | `commitCount`, `latestCommitSha` populated                                         | P1       | complete |
+| 16  | PR number as URL                  | `{ number: "https://github.com/owner/repo/pull/123" }` | Passes URL correctly                                                               | P2       | complete |
+| 17  | PR number as branch name          | `{ number: "feature-branch" }`                         | Passes branch to gh CLI                                                            | P2       | complete |
+| 18  | Oversized body collapsed + capped | `{ number: "123", compact: false }`                    | `<details>` collapsed, `body` <= 4000, `bodyTruncated: true`, `bodyLength` set     | P0       | complete |
+| 19  | maxBodyLength 0 returns verbatim  | `{ number: "123", maxBodyLength: 0, compact: false }`  | `body` byte-identical to gh output, no `bodyTruncated`                             | P1       | complete |
 
 ### Summary
 
 | Priority  | Count  |
 | --------- | ------ |
-| P0        | 6      |
-| P1        | 9      |
+| P0        | 7      |
+| P1        | 10     |
 | P2        | 2      |
-| **Total** | **17** |
+| **Total** | **19** |
 
 ---
 
@@ -1320,7 +1327,7 @@ Reference: `tests/smoke/scenarios/github-pr-checks.md` for format precedent.
 | 5   | issue-create   | 12      | 6       | 1      | 19      |
 | 6   | issue-list     | 11      | 8       | 2      | 21      |
 | 7   | issue-update   | 14      | 8       | 1      | 23      |
-| 8   | issue-view     | 6       | 5       | 2      | 13      |
+| 8   | issue-view     | 7       | 7       | 2      | 16      |
 | 9   | pr-comment     | 7       | 5       | 1      | 13      |
 | 10  | pr-create      | 16      | 7       | 2      | 25      |
 | 11  | pr-diff        | 5       | 10      | 2      | 17      |
@@ -1328,7 +1335,7 @@ Reference: `tests/smoke/scenarios/github-pr-checks.md` for format precedent.
 | 13  | pr-merge       | 12      | 8       | 2      | 22      |
 | 14  | pr-review      | 12      | 4       | 1      | 17      |
 | 15  | pr-update      | 17      | 9       | 1      | 27      |
-| 16  | pr-view        | 6       | 9       | 2      | 17      |
+| 16  | pr-view        | 7       | 10      | 2      | 19      |
 | 17  | release-create | 12      | 9       | 4      | 25      |
 | 18  | release-list   | 5       | 7       | 1      | 13      |
 | 19  | run-list       | 9       | 10      | 2      | 21      |
@@ -1336,4 +1343,4 @@ Reference: `tests/smoke/scenarios/github-pr-checks.md` for format precedent.
 | 21  | run-view       | 6       | 8       | 1      | 15      |
 | 22  | label-list     | 6       | 4       | 0      | 10      |
 | 23  | label-create   | 9       | 2       | 1      | 12      |
-|     | **Totals**     | **216** | **159** | **37** | **412** |
+|     | **Totals**     | **218** | **162** | **37** | **417** |


### PR DESCRIPTION
Two `@paretools/github` fixes that both came out of dogfooding: a `pr-checks` result that could green-light a merge on a PR whose CI never started, and a `body` field that could dump 30k+ characters into an agent's context.

Closes #1077
Closes #1067

## #1077 — `pr-checks` reported `conclusion: "passed"` with zero checks

`conclusion` is documented as the field to branch on, so `{"checks": [], "conclusion": "passed"}` on a freshly pushed PR is a merge-gate hazard. With `watch: true` it was worse: gh exits non-zero with `no checks reported on the '<branch>' branch`, which the watch loop treated as a fatal error and returned on `pollCount: 1` — the watch never survived the race between pushing and GitHub registering the check runs.

- **New `conclusion` value `"none"`** for zero checks. The invariant is now **`conclusion === "passed"` implies `checks.length > 0` and all of them succeeded**. `deriveConclusion` is exported and unit-tested against empty / pending / mixed / cancelled inputs, including an explicit invariant test.
- **New `errorType: "no-checks"`.** gh's "no checks reported" exit is classified as "nothing has started yet" rather than an unknown failure. One-shot calls return `conclusion: "none"` alongside it — never `"passed"`.
- **`watch: true` keeps polling on zero checks** (both an empty JSON array and the "no checks reported" exit) until checks appear, then continues the normal loop. Real gh failures — not-found, permission denied, malformed JSON — still bail out on the first poll as before.
- **30s settle grace.** While gh itself still exits `8` ("pending"), a checks array that merely *looks* terminal does not end the loop. That covers the "checks all non-pending but GitHub is still creating runs" window without a second API call per poll. Injectable via `WatchOptions.settleGraceMs` for tests.
- **Timeout with no checks** returns `conclusion: "timed_out"`, `timedOut: true`, `errorType: "watch-timeout"` and an error message saying no checks were ever reported (instead of "checks still pending: (none reported)").
- Human text now prints `no checks reported - NOT a passing state (conclusion: none)` in both full and compact formatters, so the fallback path cannot read as success either.

## #1067 — unbounded `body` in full-schema `pr-view` / `issue-view`

Compact mode drops `body`, but `compactDualOutput` only switches to the compact map when the structured payload out-tokens the raw `gh --json` stdout — which it never does — so full mode always won and `body` passed through verbatim.

New helper `packages/server-github/src/lib/body-truncate.ts`:

1. **Collapse** every `<details>…</details>` block to its `<summary>` text plus ` […]`, innermost-first for nested blocks, summary markup stripped. On a Dependabot-shaped body this alone removes ~95%.
2. **Cap** what remains at `maxBodyLength` characters (default **4000**).

Wired into `pr-view` and `issue-view`:

- New output fields **`bodyTruncated: boolean`** and **`bodyLength: number`** (original character count), set only when something was actually removed.
- New input **`maxBodyLength`** (int, 0–1,000,000). `0` disables *both* the cap and the `<details>` collapse and returns the body exactly as GitHub sent it.
- Human formatter adds a `body truncated (original N chars) - …` line.
- `pr-view`'s `reviews[].body` gets the same treatment, flagged per-review with `bodyTruncated`.

Checked the other `body`-bearing surfaces: `pr-list`, `issue-list` and `discussion-list` do not request or return a `body` field, so there was nothing to apply the helper to. `pr-comment` / `issue-comment` / `pr-review` / `issue-update` only echo back the body the caller just supplied, so they are left alone.

## Output-shape changes

| Tool | Change | Compatible? |
| --- | --- | --- |
| `pr-checks` | `conclusion` enum gains `"none"` | Additive — but a caller comparing `!== "passed"` is now *correctly* stricter |
| `pr-checks` | `errorType` enum gains `"no-checks"` | Additive |
| `pr-checks` | zero checks no longer yields `"passed"` | **Intentional behaviour change** — the point of the fix |
| `pr-view` / `issue-view` | `body` capped at 4000 chars by default | **Intentional** — opt out with `maxBodyLength: 0` |
| `pr-view` / `issue-view` | new optional `bodyTruncated`, `bodyLength` | Additive |
| `pr-view` | new optional `reviews[].bodyTruncated` | Additive |
| `pr-view` / `issue-view` | new optional input `maxBodyLength` | Additive |

## Tests

- `__tests__/body-truncate.test.ts` — details collapse (attributes, nested, siblings, no-summary, markup in summary, Dependabot-shaped body), cap, no-cap, flag semantics, null/absent bodies.
- `__tests__/pr-checks-empty.test.ts` — `deriveConclusion` matrix plus the invariant; one-shot zero-checks; watch loop polling through "no checks reported" and empty arrays; settle-grace behaviour inside and after the window; timeout path through the tool handler.
- `__tests__/view-body-cap.test.ts` — tool-level `pr-view` / `issue-view` output including review bodies and the human text.
- Smoke: 3 new `pr-checks` scenarios (S30–S32), 2 new `pr-view` (S18–S19), 3 new `issue-view` (S14–S16); scenario docs and counts updated.
- `docs/tool-schemas/github/{pr-checks,pr-view,issue-view}.md` updated with the `conclusion` table, the watch contract and the body-truncation contract.

Local: `pnpm build`, `pnpm test` (60/60 tasks), `pnpm smoke` (2333 tests), `pnpm lint` (0 errors; 1 pre-existing warning in `packages/shared/src/server.ts`), `pnpm format:check` all green.
