### PR TITLE
ci(release): rename changesets/action inputs for v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,10 @@ jobs:
           # Use our version script (changeset version + server.json sync) instead
           # of the action's default `changeset version`, so the "version packages"
           # PR keeps each server.json version aligned with its package.json.
-          version: pnpm version-packages
-          publish: pnpm release
-          title: "chore: version packages"
-          commit: "chore: version packages"
+          version-script: pnpm version-packages
+          publish-script: pnpm release
+          pr-title: "chore: version packages"
+          commit-message: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**Release is broken on `main`.** The `github-actions` Dependabot group bump merged today moved `changesets/action` 1.9.0 → **2.1.0**, which renamed its inputs. Every Release run since (incl. the one triggered by merging #1074) fails immediately:

```
Error: The following inputs have been renamed:
"publish" -> "publish-script"
"version" -> "version-script"
"commit" -> "commit-message"
"title" -> "pr-title"
```

Consequence: the version bumps in #1074 (git 0.x, python, test, …) are on `main` but **not published to npm**, and no new "Version Packages" PR is being opened for the npm/github changesets that landed after it (#1082, #1083).

This PR renames the four inputs. On merge, the Release run on `main` will `changeset publish` the already-bumped versions (idempotent — only versions missing from the registry get published) and open the next Version Packages PR.

CI-only, no changeset. Verified against `action.yml` at the pinned sha.