### PR TITLE
ci(release): pass the app token to changesets/action github-token input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
         id: changesets
         uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
         with:
+          # v2 requires the token as an input; the env GITHUB_TOKEN below must
+          # match it (changelog-github reads the env during `changeset version`).
+          github-token: ${{ steps.app-token.outputs.token }}
           # Use our version script (changeset version + server.json sync) instead
           # of the action's default `changeset version`, so the "version packages"
           # PR keeps each server.json version aligned with its package.json.


### PR DESCRIPTION
Follow-up to #1086. The Release run after it got one step further and failed on:

```
The GITHUB_TOKEN environment variable is set and does not match the "github-token" input.
```

`changesets/action` v2 takes the token from the `github-token` **input** (defaulting to `github.token`) and aborts if env `GITHUB_TOKEN` differs. Our env is the app-installation token, so they mismatched. This passes the same app token to the input; the env stays because `@changesets/changelog-github` reads it during `changeset version`.

Verified against `src/index.ts` at the pinned sha (`getRequiredInput("github-token")` + strict equality check). `@changesets/cli` is already 3.0.0 (v2's minimum), so no other blocker expected. Still nothing published to npm from #1074 until this lands.

CI-only, no changeset.